### PR TITLE
travis: remove macOS from the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,6 @@ matrix:
     - docker
     env:
     - OS_NAME: linux
-  - os: osx
-    language: minimal
-    env:
-    - OS_NAME: macos
-    osx_image: xcode10.2
-    cache:
-      directories:
-        - $HOME/Library/Caches/Homebrew
-        - /usr/local/Homebrew
 script:
 - ./build.sh _travis-${TRAVIS_OS_NAME}
 - ./scripts/travis_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
-matrix:
-  include:
-  - os: linux
-    dist: xenial
-    language: minimal
-    services:
-    - docker
-    env:
-    - OS_NAME: linux
+os: linux
+dist: xenial
+language: minimal
+services:
+- docker
+env:
+- OS_NAME: linux
 script:
 - ./build.sh _travis-${TRAVIS_OS_NAME}
 - ./scripts/travis_test.sh


### PR DESCRIPTION
There is a trade off between correctness and wasting one's time.

We have already determined that we want to rewrite all of the OONI
engine in Go because maintaining a C++ codebase across all these
systems and platforms is a burden. This is a policy decision that
we have taken and it should inform our subsequent choices.

We are already spending time rewriting the engine because that is
what will make our future burden smaller.

In this vein, wrestling with the Travis CI macOS build that does
not build because there are many moving parts everywhere is a
challanging task and possibly also a waste of our time.

Both @hellais and @bassosimone use macOS as their main development
environment. So, if things are spectacularly wrong on macOS they
are going to notice, quite likely.

For both of them, spending their time wrestling with CI and/or with
burden induced by the C++ ecosystem is counter productive now.

This is the reason why I am choosing to remove the CI for macOS
from this repository. It is not a light choice and I am not super
happy about this, but still I think it's the right thing to do.

Our time is better spent in making the Go engine happening sooner.