### PR TITLE
Make sure `ooniprobe show <id>` is WAI

### DIFF
--- a/internal/cli/list/list.go
+++ b/internal/cli/list/list.go
@@ -10,9 +10,7 @@ import (
 
 func init() {
 	cmd := root.Command("list", "List results")
-
 	resultID := cmd.Arg("id", "the id of the result to list measurements for").Int64()
-
 	cmd.Action(func(_ *kingpin.ParseContext) error {
 		ctx, err := root.Init()
 		if err != nil {
@@ -25,7 +23,6 @@ func init() {
 				log.WithError(err).Error("failed to list measurements")
 				return err
 			}
-
 			msmtSummary := output.MeasurementSummaryData{
 				TotalCount:         0,
 				AnomalyCount:       0,
@@ -45,7 +42,6 @@ func init() {
 				if idx == len(measurements)-1 {
 					isLast = true
 				}
-
 				// We assume that since these are summary level information the first
 				// item will contain the information necessary.
 				if isFirst {
@@ -70,7 +66,6 @@ func init() {
 				log.WithError(err).Error("failed to list results")
 				return err
 			}
-
 			if len(incompleteResults) > 0 {
 				output.SectionTitle("Incomplete results")
 			}
@@ -92,7 +87,6 @@ func init() {
 					DataUsageDown:           result.DataUsageDown,
 				})
 			}
-
 			resultSummary := output.ResultSummaryData{}
 			netCount := make(map[uint]int)
 			output.SectionTitle("Results")
@@ -117,9 +111,9 @@ func init() {
 					TestKeys:                testKeys,
 					MeasurementCount:        totalCount,
 					MeasurementAnomalyCount: anmlyCount,
-					Done:          result.IsDone,
-					DataUsageUp:   result.DataUsageUp,
-					DataUsageDown: result.DataUsageDown,
+					Done:                    result.IsDone,
+					DataUsageUp:             result.DataUsageUp,
+					DataUsageDown:           result.DataUsageDown,
 				})
 				resultSummary.TotalTests++
 				netCount[result.Network.ASN]++
@@ -127,10 +121,8 @@ func init() {
 				resultSummary.TotalDataUsageDown += result.DataUsageDown
 			}
 			resultSummary.TotalNetworks = int64(len(netCount))
-
 			output.ResultSummary(resultSummary)
 		}
-
 		return nil
 	})
 }

--- a/internal/cli/show/show.go
+++ b/internal/cli/show/show.go
@@ -10,9 +10,7 @@ import (
 
 func init() {
 	cmd := root.Command("show", "Show a specific measurement")
-
-	msmtID := cmd.Arg("id", "the id of the measurement to show").Int64()
-
+	msmtID := cmd.Arg("id", "the id of the measurement to show").Required().Int64()
 	cmd.Action(func(_ *kingpin.ParseContext) error {
 		ctx, err := root.Init()
 		if err != nil {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"os"
@@ -30,6 +29,8 @@ var ansiEscapes = regexp.MustCompile(`[\x1B\x9B][[\]()#;?]*` +
 	`(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\\d]*)*)?\x07)` +
 	`|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PRZcf-ntqry=><~]))`)
 
+// EscapeAwareRuneCountInString counts the number of runes in a
+// string taking into account escape sequences.
 func EscapeAwareRuneCountInString(s string) int {
 	n := utf8.RuneCountInString(s)
 	for _, sm := range ansiEscapes.FindAllString(s, -1) {
@@ -38,6 +39,7 @@ func EscapeAwareRuneCountInString(s string) int {
 	return n
 }
 
+// RightPadd adds right padding in from of a string
 func RightPad(str string, length int) string {
 	c := length - EscapeAwareRuneCountInString(str)
 	if c < 0 {
@@ -112,18 +114,4 @@ func WrapString(s string, lim uint) string {
 	}
 
 	return buf.String()
-}
-
-// ReadLine will read a single line from a bufio.Reader
-func ReadLine(r *bufio.Reader) (string, error) {
-	var (
-		isPrefix bool
-		err      error
-		line, ln []byte
-	)
-	for isPrefix && err == nil {
-		line, isPrefix, err = r.ReadLine()
-		ln = append(ln, line...)
-	}
-	return string(ln), err
 }


### PR DESCRIPTION
1. the description of the command and the helper function are
clear hints that the command is intended to show a single JSON
measurement at a time (also the use case seems clear) [*]

2. the function used to read lines was failing for all my
measurements that take input. Since that was not the optimal
pattern anyway, use a better pattern to fix it.

3. some changes are automatically applied by my editor (VSCode
with the Go plugin) and I am fine with them.

4. while reading code, I also applied my preferred pattern
wrt whitespaces, i.e.: no whitespace inside functions, if a
function feels too long in this way, just break it.

Closes #57

[*] Even if we want to show many measurements at a time, which
does not seem needed, given the UI patterns, this functionality
won't be P0. What is P0 is to bless a new beta and give to
@sarathms binaries for all archs that support a basic `show`.