### PR TITLE
Add support for calculating the estimate time remaining

### DIFF
--- a/internal/log/handlers/cli/cli.go
+++ b/internal/log/handlers/cli/cli.go
@@ -109,9 +109,11 @@ func (h *Handler) TypedLog(t string, e *log.Entry) error {
 		return nil
 	case "progress":
 		perc := e.Fields.Get("percentage").(float64) * 100
-		s := fmt.Sprintf("   %s %-25s",
+		eta := e.Fields.Get("eta").(float64)
+		s := fmt.Sprintf("   %s %-25s (%ss left)",
 			bold.Sprintf("%.2f%%", perc),
-			e.Message)
+			e.Message,
+			bold.Sprintf("%.2f", eta))
 		fmt.Fprint(h.Writer, s)
 		fmt.Fprintln(h.Writer)
 		return nil

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -14,17 +14,18 @@ import (
 // MeasurementJSON prints the JSON of a measurement
 func MeasurementJSON(j map[string]interface{}) {
 	log.WithFields(log.Fields{
-		"type":       "measurement_json",
+		"type":             "measurement_json",
 		"measurement_json": j,
 	}).Info("Measurement JSON")
 }
 
 // Progress logs a progress type event
-func Progress(key string, perc float64, msg string) {
+func Progress(key string, perc float64, eta float64, msg string) {
 	log.WithFields(log.Fields{
 		"type":       "progress",
 		"key":        key,
 		"percentage": perc,
+		"eta":        eta,
 	}).Info(msg)
 }
 
@@ -42,13 +43,13 @@ type MeasurementSummaryData struct {
 
 func MeasurementSummary(msmt MeasurementSummaryData) {
 	log.WithFields(log.Fields{
-		"type":            "measurement_summary",
-		"total_runtime":   msmt.TotalRuntime,
-		"total_count":     msmt.TotalCount,
-		"anomaly_count":   msmt.AnomalyCount,
-		"data_usage_down": msmt.DataUsageDown,
-		"data_usage_up":   msmt.DataUsageUp,
-		"asn":             msmt.ASN,
+		"type":                 "measurement_summary",
+		"total_runtime":        msmt.TotalRuntime,
+		"total_count":          msmt.TotalCount,
+		"anomaly_count":        msmt.AnomalyCount,
+		"data_usage_down":      msmt.DataUsageDown,
+		"data_usage_up":        msmt.DataUsageUp,
+		"asn":                  msmt.ASN,
 		"network_country_code": msmt.NetworkCountryCode,
 		"network_name":         msmt.NetworkName,
 		"start_time":           msmt.StartTime,


### PR DESCRIPTION
This is needed by the desktop app which currently uses a hardcoded 60 second default for the ETA.