### PR TITLE
build.sh: re-enable psiphon

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ if [ "$GOPATH" != "" ]; then
   unset GOPATH
 fi
 
-buildtags="-tags nopsiphon"
+buildtags=""
 ldflags="-s -w"
 
 if [ "$1" = "windows" ]; then


### PR DESCRIPTION
To test this, I'll create a fake release locally and make sure
the resulting binary is much larger. If you see this commit landing
on a PR, then it means I successfully run this check.

Closes #79 