### PR TITLE
Handle the SIGINT and SIGTERM signals to support stopping a test cleanly

### DIFF
--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -27,7 +27,7 @@ func listenForSignals(ctx *ooni.Context) {
 
 	go func() {
 		<-s
-		log.Debugf("caught a signal, shutting down cleanly")
+		log.Info("caught a stop signal, shutting down cleanly")
 		ctx.Terminate()
 	}()
 }

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -18,7 +18,9 @@ import (
 
 // listenForSignals will listen for SIGINT and SIGTERM. When it receives those
 // signals it will set isTerminated to true, which will cleanly shutdown the
-// test logic
+// test logic.
+// TODO refactor this to use a cancellable context.Context instead of a bool
+// flag, probably as part of: https://github.com/ooni/probe-cli/issues/45
 func listenForSignals(ctx *ooni.Context) {
 	s := make(chan os.Signal, 1)
 	signal.Notify(s, os.Interrupt, syscall.SIGTERM)

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -17,8 +17,8 @@ import (
 )
 
 // listenForSignals will listen for SIGINT and SIGTERM. When it receives those
-// signals it will set isTerminated to true, which will cleanly shutdown the
-// test logic.
+// signals it will set isTerminatedAtomicInt to non-zero, which will cleanly
+// shutdown the test logic.
 // TODO refactor this to use a cancellable context.Context instead of a bool
 // flag, probably as part of: https://github.com/ooni/probe-cli/issues/45
 func listenForSignals(ctx *ooni.Context) {
@@ -28,7 +28,7 @@ func listenForSignals(ctx *ooni.Context) {
 	go func() {
 		<-s
 		log.Debugf("caught a signal, shutting down cleanly")
-		ctx.IsTerminated = true
+		ctx.Terminate()
 	}()
 }
 
@@ -48,7 +48,7 @@ func runNettestGroup(tg string, ctx *ooni.Context, network *database.Network) er
 
 	listenForSignals(ctx)
 	for i, nt := range group.Nettests {
-		if ctx.IsTerminated == true {
+		if ctx.IsTerminated() == true {
 			log.Debugf("context is terminated, breaking")
 			break
 		}

--- a/nettests/nettests.go
+++ b/nettests/nettests.go
@@ -77,7 +77,6 @@ func (c *Controller) SetNettestIndex(i, n int) {
 // This function will continue to run in most cases but will
 // immediately halt if something's wrong with the file system.
 func (c *Controller) Run(builder *engine.ExperimentBuilder, inputs []string) error {
-
 	// This will configure the controller as handler for the callbacks
 	// called by ooni/probe-engine/experiment.Experiment.
 	builder.SetCallbacks(engine.Callbacks(c))
@@ -108,6 +107,10 @@ func (c *Controller) Run(builder *engine.ExperimentBuilder, inputs []string) err
 
 	c.ntStartTime = time.Now()
 	for idx, input := range inputs {
+		if c.Ctx.IsTerminated == true {
+			log.Debug("isTerminated == true, breaking the input loop")
+			break
+		}
 		c.curInputIdx = idx // allow for precise progress
 		idx64 := int64(idx)
 		log.Debug(color.RedString("status.measurement_start"))

--- a/nettests/nettests.go
+++ b/nettests/nettests.go
@@ -107,7 +107,7 @@ func (c *Controller) Run(builder *engine.ExperimentBuilder, inputs []string) err
 
 	c.ntStartTime = time.Now()
 	for idx, input := range inputs {
-		if c.Ctx.IsTerminated == true {
+		if c.Ctx.IsTerminated() == true {
 			log.Debug("isTerminated == true, breaking the input loop")
 			break
 		}

--- a/ooni.go
+++ b/ooni.go
@@ -19,10 +19,11 @@ import (
 
 // Context for OONI Probe
 type Context struct {
-	Config  *config.Config
-	DB      sqlbuilder.Database
-	IsBatch bool
-	Session *engine.Session
+	Config       *config.Config
+	DB           sqlbuilder.Database
+	IsBatch      bool
+	IsTerminated bool
+	Session      *engine.Session
 
 	Home    string
 	TempDir string
@@ -94,9 +95,10 @@ func (c *Context) Init() error {
 // NewContext creates a new context instance.
 func NewContext(configPath string, homePath string) *Context {
 	return &Context{
-		Home:       homePath,
-		Config:     &config.Config{},
-		configPath: configPath,
+		Home:         homePath,
+		Config:       &config.Config{},
+		configPath:   configPath,
+		IsTerminated: false,
 	}
 }
 


### PR DESCRIPTION
This fixes: #76