### PR TITLE
Allow to specify custom software name and version

### DIFF
--- a/internal/cli/root/root.go
+++ b/internal/cli/root/root.go
@@ -25,6 +25,13 @@ func init() {
 	isVerbose := Cmd.Flag("verbose", "Enable verbose log output.").Short('v').Bool()
 	isBatch := Cmd.Flag("batch", "Enable batch command line usage.").Bool()
 
+	softwareName := Cmd.Flag(
+		"software-name", "Override application name",
+	).Default("ooniprobe-cli").String()
+	softwareVersion := Cmd.Flag(
+		"software-version", "Override the application version",
+	).Default(version.Version).String()
+
 	Cmd.PreAction(func(ctx *kingpin.ParseContext) error {
 		if *isBatch {
 			log.SetHandler(batch.Default)
@@ -45,7 +52,7 @@ func init() {
 			}
 
 			ctx := ooni.NewContext(*configPath, homePath)
-			err = ctx.Init()
+			err = ctx.Init(*softwareName, *softwareVersion)
 			if err != nil {
 				return nil, err
 			}

--- a/nettests/nettests_test.go
+++ b/nettests/nettests_test.go
@@ -19,7 +19,9 @@ func newTestingContext(t *testing.T) *ooni.Context {
 	testingConfig := path.Join("..", "testdata", "testing-config.json")
 	shutil.Copy(testingConfig, configPath, false)
 	ctx := ooni.NewContext(configPath, homePath)
-	err = ctx.Init()
+	swName := "ooniprobe-cli-tests"
+	swVersion := "3.0.0-alpha"
+	err = ctx.Init(swName, swVersion)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ooni.go
+++ b/ooni.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ooni/probe-cli/internal/enginex"
 	"github.com/ooni/probe-cli/internal/legacy"
 	"github.com/ooni/probe-cli/utils"
-	"github.com/ooni/probe-cli/version"
 	engine "github.com/ooni/probe-engine"
 	"github.com/pkg/errors"
 	"upper.io/db.v3/lib/sqlbuilder"
@@ -48,12 +47,13 @@ func (c *Context) IsTerminated() bool {
 	return i != 0
 }
 
+// Terminate interrupts the running context
 func (c *Context) Terminate() {
 	atomic.AddInt64(&c.isTerminatedAtomicInt, 1)
 }
 
 // Init the OONI manager
-func (c *Context) Init() error {
+func (c *Context) Init(softwareName, softwareVersion string) error {
 	var err error
 
 	if err = legacy.MaybeMigrateHome(); err != nil {
@@ -102,8 +102,8 @@ func (c *Context) Init() error {
 	sess, err := engine.NewSession(engine.SessionConfig{
 		KVStore:         kvstore,
 		Logger:          enginex.Logger,
-		SoftwareName:    "ooniprobe-desktop",
-		SoftwareVersion: version.Version,
+		SoftwareName:    softwareName,
+		SoftwareVersion: softwareVersion,
 		AssetsDir:       utils.AssetsDir(c.Home),
 		TempDir:         c.TempDir,
 	})

--- a/ooni_test.go
+++ b/ooni_test.go
@@ -15,7 +15,9 @@ func TestInit(t *testing.T) {
 	defer os.RemoveAll(ooniHome)
 
 	ctx := NewContext("", ooniHome)
-	if err := ctx.Init(); err != nil {
+	swName := "ooniprobe-cli-tests"
+	swVersion := "3.0.0-alpha"
+	if err := ctx.Init(swName, swVersion); err != nil {
 		t.Error(err)
 		t.Fatal("failed to init the context")
 	}


### PR DESCRIPTION
In turn, this allows us to identify as ooniprobe-cli v3.0.0-rc.5.

Closes #41.