### PR TITLE
Improve the output and extraction of psiphon metrics

### DIFF
--- a/internal/log/handlers/cli/results.go
+++ b/internal/log/handlers/cli/results.go
@@ -71,8 +71,8 @@ var summarizers = map[string]func(uint64, uint64, string) []string{
 	},
 	"circumvention": func(totalCount uint64, anomalyCount uint64, ss string) []string {
 		return []string{
-			fmt.Sprintf("Detected: %v", anomalyCount > 0),
-			"",
+			fmt.Sprintf("%d tested", totalCount),
+			fmt.Sprintf("%d blocked", anomalyCount),
 			"",
 		}
 	},

--- a/nettests/psiphon.go
+++ b/nettests/psiphon.go
@@ -26,16 +26,19 @@ type PsiphonTestKeys struct {
 
 // GetTestKeys generates a summary for a test run
 func (h Psiphon) GetTestKeys(tk map[string]interface{}) (interface{}, error) {
-	var err error
+	var (
+		err error
+		ok  bool
+	)
 	testKeys := PsiphonTestKeys{IsAnomaly: false, Failure: ""}
 	if tk["failure"] != nil {
 		testKeys.IsAnomaly = true
-		testKeys.Failure, ok := tk["failure"].(string)
+		testKeys.Failure, ok = tk["failure"].(string)
 		if !ok {
 			err = errors.Wrap(err, "failure key invalid")
 		}
 	}
-	testKeys.BootstrapTime, ok := tk["bootstrap_time"].(float64)
+	testKeys.BootstrapTime, ok = tk["bootstrap_time"].(float64)
 	if !ok {
 		err = errors.Wrap(err, "bootstrap_time key invalid")
 	}

--- a/nettests/psiphon.go
+++ b/nettests/psiphon.go
@@ -30,12 +30,12 @@ func (h Psiphon) GetTestKeys(tk map[string]interface{}) (interface{}, error) {
 	testKeys := PsiphonTestKeys{IsAnomaly: false, Failure: ""}
 	if tk["failure"] != nil {
 		testKeys.IsAnomaly = true
-		testKeys.Failure, ok = tk["failure"].(string)
+		testKeys.Failure, ok := tk["failure"].(string)
 		if !ok {
 			err = errors.Wrap(err, "failure key invalid")
 		}
 	}
-	testKeys.BootstrapTime, ok = tk["bootstrap_time"].(float64)
+	testKeys.BootstrapTime, ok := tk["bootstrap_time"].(float64)
 	if !ok {
 		err = errors.Wrap(err, "bootstrap_time key invalid")
 	}

--- a/nettests/psiphon.go
+++ b/nettests/psiphon.go
@@ -1,5 +1,7 @@
 package nettests
 
+import "github.com/pkg/errors"
+
 // Psiphon test implementation
 type Psiphon struct {
 }
@@ -17,14 +19,27 @@ func (h Psiphon) Run(ctl *Controller) error {
 
 // PsiphonTestKeys contains the test keys
 type PsiphonTestKeys struct {
-	IsAnomaly bool `json:"-"`
+	IsAnomaly     bool    `json:"-"`
+	BootstrapTime float64 `json:"bootstrap_time"`
+	Failure       string  `json:"failure"`
 }
 
 // GetTestKeys generates a summary for a test run
 func (h Psiphon) GetTestKeys(tk map[string]interface{}) (interface{}, error) {
-	return PsiphonTestKeys{
-		IsAnomaly: tk["failure"] != nil,
-	}, nil
+	var err error
+	testKeys := PsiphonTestKeys{IsAnomaly: false, Failure: ""}
+	if tk["failure"] != nil {
+		testKeys.IsAnomaly = true
+		testKeys.Failure, ok = tk["failure"].(string)
+		if !ok {
+			err = errors.Wrap(err, "failure key invalid")
+		}
+	}
+	testKeys.BootstrapTime, ok = tk["bootstrap_time"].(float64)
+	if !ok {
+		err = errors.Wrap(err, "bootstrap_time key invalid")
+	}
+	return testKeys, err
 }
 
 // LogSummary writes the summary to the standard output


### PR DESCRIPTION
This add support for exposing additional metadata in the psiphon test results.

See:
<img width="429" alt="Screenshot 2020-01-07 at 16 48 15" src="https://user-images.githubusercontent.com/424620/71903798-8b827380-316d-11ea-91e0-de50b23bd31a.png">
<img width="430" alt="Screenshot 2020-01-07 at 16 48 22" src="https://user-images.githubusercontent.com/424620/71903799-8b827380-316d-11ea-8bb2-e90449ad89a8.png">
