### PR TITLE
Fix/one msmt

### DIFF
--- a/internal/database/actions.go
+++ b/internal/database/actions.go
@@ -68,6 +68,8 @@ func GetMeasurementJSON(sess sqlbuilder.Database, measurementID int64) (map[stri
 		return nil, err
 	}
 	if err := json.Unmarshal(b, &msmtJSON); err != nil {
+		log.Error("failed to unmarshal the measurement_json")
+		log.Error("backup your OONI_HOME and run `ooniprobe reset`")
 		return nil, err
 	}
 	return msmtJSON, nil

--- a/internal/database/actions.go
+++ b/internal/database/actions.go
@@ -176,7 +176,10 @@ func DeleteResult(sess sqlbuilder.Database, resultID int64) error {
 // CreateMeasurement writes the measurement to the database a returns a pointer
 // to the Measurement
 func CreateMeasurement(sess sqlbuilder.Database, reportID sql.NullString, testName string, measurementDir string, idx int, resultID int64, urlID sql.NullInt64) (*Measurement, error) {
-	msmtFilePath := filepath.Join(measurementDir, fmt.Sprintf("msmt-%d.json", idx))
+	// TODO we should look into generating this file path in a more robust way.
+	// If there are two identical test_names in the same test group there is
+	// going to be a clash of test_name
+	msmtFilePath := filepath.Join(measurementDir, fmt.Sprintf("msmt-%s-%d.json", testName, idx))
 	msmt := Measurement{
 		ReportID:            reportID,
 		TestName:            testName,


### PR DESCRIPTION
We were writing to the same measurement_file_path for a given test
group, because we were using a different filename only in the case of a
many input test, but not in the case of many test_names inside of a
given test group.
