### PR TITLE
nettests.go: don't stop when measurement is failed

### DIFF
--- a/nettests/nettests.go
+++ b/nettests/nettests.go
@@ -125,7 +125,10 @@ func (c *Controller) Run(builder *engine.ExperimentBuilder, inputs []string) err
 			if err := c.msmts[idx64].Failed(c.Ctx.DB, err.Error()); err != nil {
 				return errors.Wrap(err, "failed to mark measurement as failed")
 			}
-			continue
+			// Even with a failed measurement, we want to continue. We want to
+			// record and submit the information we have. Saving the information
+			// is useful for local inspection. Submitting it is useful to us to
+			// undertsand what went wrong (censorship? bug? anomaly?).
 		}
 
 		if c.Ctx.Config.Sharing.UploadResults {


### PR DESCRIPTION
Closes https://github.com/ooni/probe-engine/issues/316

Rationale: a measurement may fail for a bunch of reasons including
buts in the code. The original determination was that we won't
return an error from the measurement in case of anomaly. But doing
that is error prone, and indeed the Psiphon experiment was not
following this pattern. I claim that this pattern was wrong, and
it's much more in our interest to submit and store on disk anything
that we get from a measurement. This data can be useful to look
into bugs, as well as to discover novel anomalies we didnt' anticipate.