### PR TITLE
turn off printing of each command in the help section

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,6 +42,8 @@ case $1 in
     ;;
 
   *)
+
+    set +x
     echo "Usage: $0 darwin|linux|macos|windows|release"
     echo ""
     echo "You need a C compiler and Go >= 1.14. The C compiler must be a"


### PR DESCRIPTION
When I was trying to build the cli for the very first time I typed build.sh --help and the output was confusing on the first glance

```
+ git describe --tags
+ v=v3.0.8-2-g10c806b
+ echo Usage: ./build.sh darwin|linux|macos|windows|release
Usage: ./build.sh darwin|linux|macos|windows|release
+ echo 

+ echo You need a C compiler and Go >= 1.14. The C compiler must be a
You need a C compiler and Go >= 1.14. The C compiler must be a
+ echo UNIX like compiler like GCC, Clang, Mingw-w64.
UNIX like compiler like GCC, Clang, Mingw-w64.
+ echo 

+ echo To build a static Linux binary, we use Docker and Alpine.
To build a static Linux binary, we use Docker and Alpine.
+ echo 

+ echo You can cross compile for Windows from macOS or Linux. You can
You can cross compile for Windows from macOS or Linux. You can
+ echo compile for Linux as long as you have Docker. Cross compiling for
compile for Linux as long as you have Docker. Cross compiling for
+ echo macOS has never been tested. We have a bunch of cross compiling
macOS has never been tested. We have a bunch of cross compiling
+ echo checks inside the .github/workflows/cross.yml file.
checks inside the .github/workflows/cross.yml file.
+ echo 

+ echo The macos rule is an alias for the darwin rule. The generated
The macos rule is an alias for the darwin rule. The generated
+ echo binary file is named ooniprobe__darwin_.tar.gz
binary file is named ooniprobe__darwin_.tar.gz
+ echo because the platform name is darwin.
because the platform name is darwin.
+ echo 
```

This PR turns `set -x` off for a better formatted help output:

```
+ git describe --tags
+ v=v3.0.8-2-g10c806b
+ set +x
Usage: ./build.sh darwin|linux|macos|windows|release

You need a C compiler and Go >= 1.14. The C compiler must be a
UNIX like compiler like GCC, Clang, Mingw-w64.

To build a static Linux binary, we use Docker and Alpine.

You can cross compile for Windows from macOS or Linux. You can
compile for Linux as long as you have Docker. Cross compiling for
macOS has never been tested. We have a bunch of cross compiling
checks inside the .github/workflows/cross.yml file.

The macos rule is an alias for the darwin rule. The generated
binary file is named ooniprobe__darwin_.tar.gz
because the platform name is darwin.
```


