### PR TITLE
Replace ooni with ooniprobe in example usage

### DIFF
--- a/internal/log/handlers/cli/results.go
+++ b/internal/log/handlers/cli/results.go
@@ -84,7 +84,7 @@ func makeSummary(name string, totalCount uint64, anomalyCount uint64, ss string)
 
 func logResultItem(w io.Writer, f log.Fields) error {
 	colWidth := 24
-
+Try running
 	rID := f.Get("id").(int64)
 	name := f.Get("name").(string)
 	isDone := f.Get("is_done").(bool)
@@ -141,7 +141,7 @@ func logResultSummary(w io.Writer, f log.Fields) error {
 	if tests == 0 {
 		fmt.Fprintf(w, "No results\n")
 		fmt.Fprintf(w, "Try running:\n")
-		fmt.Fprintf(w, "  ooni run websites\n")
+		fmt.Fprintf(w, "  ooniprobe run websites\n")
 		return nil
 	}
 	//              └┬──────────────┬─────────────┬───────────────┬


### PR DESCRIPTION
Comes up when there are no results to show.
```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Results                  ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━┛
No results
Try running:
  ooni run websites
```