### PR TITLE
Start increasing testing and code coverage

### DIFF
--- a/internal/cli/geoip/geoip.go
+++ b/internal/cli/geoip/geoip.go
@@ -12,28 +12,28 @@ func init() {
 
 	cmd.Action(func(_ *kingpin.ParseContext) error {
 		output.SectionTitle("GeoIP lookup")
-		ctx, err := root.Init()
+		probeCLI, err := root.Init()
 		if err != nil {
 			return err
 		}
 
-		sess, err := ctx.NewSession()
+		engine, err := probeCLI.NewProbeEngine()
 		if err != nil {
 			return err
 		}
-		defer sess.Close()
+		defer engine.Close()
 
-		err = sess.MaybeLookupLocation()
+		err = engine.MaybeLookupLocation()
 		if err != nil {
 			return err
 		}
 
 		log.WithFields(log.Fields{
 			"type":         "table",
-			"asn":          sess.ProbeASNString(),
-			"network_name": sess.ProbeNetworkName(),
-			"country_code": sess.ProbeCC(),
-			"ip":           sess.ProbeIP(),
+			"asn":          engine.ProbeASNString(),
+			"network_name": engine.ProbeNetworkName(),
+			"country_code": engine.ProbeCC(),
+			"ip":           engine.ProbeIP(),
 		}).Info("Looked up your location")
 
 		return nil

--- a/internal/cli/geoip/geoip.go
+++ b/internal/cli/geoip/geoip.go
@@ -4,38 +4,54 @@ import (
 	"github.com/alecthomas/kingpin"
 	"github.com/apex/log"
 	"github.com/ooni/probe-cli/internal/cli/root"
+	"github.com/ooni/probe-cli/internal/ooni"
 	"github.com/ooni/probe-cli/internal/output"
 )
 
 func init() {
 	cmd := root.Command("geoip", "Perform a geoip lookup")
-
 	cmd.Action(func(_ *kingpin.ParseContext) error {
-		output.SectionTitle("GeoIP lookup")
-		probeCLI, err := root.Init()
-		if err != nil {
-			return err
-		}
-
-		engine, err := probeCLI.NewProbeEngine()
-		if err != nil {
-			return err
-		}
-		defer engine.Close()
-
-		err = engine.MaybeLookupLocation()
-		if err != nil {
-			return err
-		}
-
-		log.WithFields(log.Fields{
-			"type":         "table",
-			"asn":          engine.ProbeASNString(),
-			"network_name": engine.ProbeNetworkName(),
-			"country_code": engine.ProbeCC(),
-			"ip":           engine.ProbeIP(),
-		}).Info("Looked up your location")
-
-		return nil
+		return dogeoip(defaultconfig)
 	})
+}
+
+type dogeoipconfig struct {
+	Logger       log.Interface
+	NewProbeCLI  func() (ooni.ProbeCLI, error)
+	SectionTitle func(string)
+}
+
+var defaultconfig = dogeoipconfig{
+	Logger:       log.Log,
+	NewProbeCLI:  root.NewProbeCLI,
+	SectionTitle: output.SectionTitle,
+}
+
+func dogeoip(config dogeoipconfig) error {
+	config.SectionTitle("GeoIP lookup")
+	probeCLI, err := config.NewProbeCLI()
+	if err != nil {
+		return err
+	}
+
+	engine, err := probeCLI.NewProbeEngine()
+	if err != nil {
+		return err
+	}
+	defer engine.Close()
+
+	err = engine.MaybeLookupLocation()
+	if err != nil {
+		return err
+	}
+
+	config.Logger.WithFields(log.Fields{
+		"type":         "table",
+		"asn":          engine.ProbeASNString(),
+		"network_name": engine.ProbeNetworkName(),
+		"country_code": engine.ProbeCC(),
+		"ip":           engine.ProbeIP(),
+	}).Info("Looked up your location")
+
+	return nil
 }

--- a/internal/cli/geoip/geoip_test.go
+++ b/internal/cli/geoip/geoip_test.go
@@ -1,0 +1,134 @@
+package geoip
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-cli/internal/ooni"
+	"github.com/ooni/probe-cli/internal/oonitest"
+)
+
+func TestNewProbeCLIFailed(t *testing.T) {
+	fo := &oonitest.FakeOutput{}
+	expected := errors.New("mocked error")
+	err := dogeoip(dogeoipconfig{
+		SectionTitle: fo.SectionTitle,
+		NewProbeCLI: func() (ooni.ProbeCLI, error) {
+			return nil, expected
+		},
+	})
+	if !errors.Is(err, expected) {
+		t.Fatalf("not the error we expected: %+v", err)
+	}
+	if len(fo.FakeSectionTitle) != 1 {
+		t.Fatal("invalid section title list size")
+	}
+	if fo.FakeSectionTitle[0] != "GeoIP lookup" {
+		t.Fatal("unexpected string")
+	}
+}
+
+func TestNewProbeEngineFailed(t *testing.T) {
+	fo := &oonitest.FakeOutput{}
+	expected := errors.New("mocked error")
+	cli := &oonitest.FakeProbeCLI{
+		FakeProbeEngineErr: expected,
+	}
+	err := dogeoip(dogeoipconfig{
+		SectionTitle: fo.SectionTitle,
+		NewProbeCLI: func() (ooni.ProbeCLI, error) {
+			return cli, nil
+		},
+	})
+	if !errors.Is(err, expected) {
+		t.Fatalf("not the error we expected: %+v", err)
+	}
+	if len(fo.FakeSectionTitle) != 1 {
+		t.Fatal("invalid section title list size")
+	}
+	if fo.FakeSectionTitle[0] != "GeoIP lookup" {
+		t.Fatal("unexpected string")
+	}
+}
+
+func TestMaybeLookupLocationFailed(t *testing.T) {
+	fo := &oonitest.FakeOutput{}
+	expected := errors.New("mocked error")
+	engine := &oonitest.FakeProbeEngine{
+		FakeMaybeLookupLocation: expected,
+	}
+	cli := &oonitest.FakeProbeCLI{
+		FakeProbeEnginePtr: engine,
+	}
+	err := dogeoip(dogeoipconfig{
+		SectionTitle: fo.SectionTitle,
+		NewProbeCLI: func() (ooni.ProbeCLI, error) {
+			return cli, nil
+		},
+	})
+	if !errors.Is(err, expected) {
+		t.Fatalf("not the error we expected: %+v", err)
+	}
+	if len(fo.FakeSectionTitle) != 1 {
+		t.Fatal("invalid section title list size")
+	}
+	if fo.FakeSectionTitle[0] != "GeoIP lookup" {
+		t.Fatal("unexpected string")
+	}
+}
+
+func TestMaybeLookupLocationSuccess(t *testing.T) {
+	fo := &oonitest.FakeOutput{}
+	engine := &oonitest.FakeProbeEngine{
+		FakeProbeASNString:   "AS30722",
+		FakeProbeCC:          "IT",
+		FakeProbeNetworkName: "Vodafone Italia S.p.A.",
+		FakeProbeIP:          "130.25.90.216",
+	}
+	cli := &oonitest.FakeProbeCLI{
+		FakeProbeEnginePtr: engine,
+	}
+	handler := &oonitest.FakeLoggerHandler{}
+	err := dogeoip(dogeoipconfig{
+		SectionTitle: fo.SectionTitle,
+		NewProbeCLI: func() (ooni.ProbeCLI, error) {
+			return cli, nil
+		},
+		Logger: &log.Logger{
+			Handler: handler,
+			Level:   log.DebugLevel,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fo.FakeSectionTitle) != 1 {
+		t.Fatal("invalid section title list size")
+	}
+	if fo.FakeSectionTitle[0] != "GeoIP lookup" {
+		t.Fatal("unexpected string")
+	}
+	if len(handler.FakeEntries) != 1 {
+		t.Fatal("invalid number of written entries")
+	}
+	entry := handler.FakeEntries[0]
+	if entry.Level != log.InfoLevel {
+		t.Fatal("invalid log level")
+	}
+	if entry.Message != "Looked up your location" {
+		t.Fatal("invalid .Message")
+	}
+	if entry.Fields["asn"].(string) != "AS30722" {
+		t.Fatal("invalid asn")
+	}
+	if entry.Fields["country_code"].(string) != "IT" {
+		t.Fatal("invalid asn")
+	}
+	if entry.Fields["network_name"].(string) != "Vodafone Italia S.p.A." {
+		t.Fatal("invalid asn")
+	}
+	if entry.Fields["ip"].(string) != "130.25.90.216" {
+		t.Fatal("invalid asn")
+	}
+}

--- a/internal/cli/info/info.go
+++ b/internal/cli/info/info.go
@@ -4,24 +4,33 @@ import (
 	"github.com/alecthomas/kingpin"
 	"github.com/apex/log"
 	"github.com/ooni/probe-cli/internal/cli/root"
+	"github.com/ooni/probe-cli/internal/ooni"
 )
 
 func init() {
 	cmd := root.Command("info", "Display information about OONI Probe")
-
 	cmd.Action(func(_ *kingpin.ParseContext) error {
-		probeCLI, err := root.Init()
-		if err != nil {
-			log.Errorf("%s", err)
-			return err
-		}
-		log.WithFields(log.Fields{
-			"path": probeCLI.Home(),
-		}).Info("Home")
-		log.WithFields(log.Fields{
-			"path": probeCLI.TempDir(),
-		}).Info("TempDir")
-
-		return nil
+		return doinfo(defaultconfig)
 	})
+}
+
+type doinfoconfig struct {
+	Logger      log.Interface
+	NewProbeCLI func() (ooni.ProbeCLI, error)
+}
+
+var defaultconfig = doinfoconfig{
+	Logger:      log.Log,
+	NewProbeCLI: root.NewProbeCLI,
+}
+
+func doinfo(config doinfoconfig) error {
+	probeCLI, err := config.NewProbeCLI()
+	if err != nil {
+		config.Logger.Errorf("%s", err)
+		return err
+	}
+	config.Logger.WithFields(log.Fields{"path": probeCLI.Home()}).Info("Home")
+	config.Logger.WithFields(log.Fields{"path": probeCLI.TempDir()}).Info("TempDir")
+	return nil
 }

--- a/internal/cli/info/info.go
+++ b/internal/cli/info/info.go
@@ -10,16 +10,16 @@ func init() {
 	cmd := root.Command("info", "Display information about OONI Probe")
 
 	cmd.Action(func(_ *kingpin.ParseContext) error {
-		ctx, err := root.Init()
+		probeCLI, err := root.Init()
 		if err != nil {
 			log.Errorf("%s", err)
 			return err
 		}
 		log.WithFields(log.Fields{
-			"path": ctx.Home,
+			"path": probeCLI.Home(),
 		}).Info("Home")
 		log.WithFields(log.Fields{
-			"path": ctx.TempDir,
+			"path": probeCLI.TempDir(),
 		}).Info("TempDir")
 
 		return nil

--- a/internal/cli/info/info_test.go
+++ b/internal/cli/info/info_test.go
@@ -1,0 +1,80 @@
+package info
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-cli/internal/ooni"
+	"github.com/ooni/probe-cli/internal/oonitest"
+)
+
+func TestNewProbeCLIFailed(t *testing.T) {
+	expected := errors.New("mocked error")
+	handler := &oonitest.FakeLoggerHandler{}
+	err := doinfo(doinfoconfig{
+		NewProbeCLI: func() (ooni.ProbeCLI, error) {
+			return nil, expected
+		},
+		Logger: &log.Logger{
+			Handler: handler,
+			Level:   log.DebugLevel,
+		},
+	})
+	if !errors.Is(err, expected) {
+		t.Fatalf("not the error we expected: %+v", err)
+	}
+	if len(handler.FakeEntries) != 1 {
+		t.Fatal("invalid number of log entries")
+	}
+	entry := handler.FakeEntries[0]
+	if entry.Level != log.ErrorLevel {
+		t.Fatal("invalid log level")
+	}
+	if entry.Message != "mocked error" {
+		t.Fatal("invalid .Message")
+	}
+}
+
+func TestSuccess(t *testing.T) {
+	handler := &oonitest.FakeLoggerHandler{}
+	cli := &oonitest.FakeProbeCLI{
+		FakeHome:    "fakehome",
+		FakeTempDir: "faketempdir",
+	}
+	err := doinfo(doinfoconfig{
+		NewProbeCLI: func() (ooni.ProbeCLI, error) {
+			return cli, nil
+		},
+		Logger: &log.Logger{
+			Handler: handler,
+			Level:   log.DebugLevel,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(handler.FakeEntries) != 2 {
+		t.Fatal("invalid number of log entries")
+	}
+	entry := handler.FakeEntries[0]
+	if entry.Level != log.InfoLevel {
+		t.Fatal("invalid log level")
+	}
+	if entry.Message != "Home" {
+		t.Fatal("invalid .Message")
+	}
+	if entry.Fields["path"].(string) != "fakehome" {
+		t.Fatal("invalid path")
+	}
+	entry = handler.FakeEntries[1]
+	if entry.Level != log.InfoLevel {
+		t.Fatal("invalid log level")
+	}
+	if entry.Message != "TempDir" {
+		t.Fatal("invalid .Message")
+	}
+	if entry.Fields["path"].(string) != "faketempdir" {
+		t.Fatal("invalid path")
+	}
+}

--- a/internal/cli/list/list.go
+++ b/internal/cli/list/list.go
@@ -12,13 +12,13 @@ func init() {
 	cmd := root.Command("list", "List results")
 	resultID := cmd.Arg("id", "the id of the result to list measurements for").Int64()
 	cmd.Action(func(_ *kingpin.ParseContext) error {
-		ctx, err := root.Init()
+		probeCLI, err := root.Init()
 		if err != nil {
 			log.WithError(err).Error("failed to initialize root context")
 			return err
 		}
 		if *resultID > 0 {
-			measurements, err := database.ListMeasurements(ctx.DB, *resultID)
+			measurements, err := database.ListMeasurements(probeCLI.DB(), *resultID)
 			if err != nil {
 				log.WithError(err).Error("failed to list measurements")
 				return err
@@ -61,7 +61,7 @@ func init() {
 			}
 			output.MeasurementSummary(msmtSummary)
 		} else {
-			doneResults, incompleteResults, err := database.ListResults(ctx.DB)
+			doneResults, incompleteResults, err := database.ListResults(probeCLI.DB())
 			if err != nil {
 				log.WithError(err).Error("failed to list results")
 				return err
@@ -91,11 +91,11 @@ func init() {
 			netCount := make(map[uint]int)
 			output.SectionTitle("Results")
 			for idx, result := range doneResults {
-				totalCount, anmlyCount, err := database.GetMeasurementCounts(ctx.DB, result.Result.ID)
+				totalCount, anmlyCount, err := database.GetMeasurementCounts(probeCLI.DB(), result.Result.ID)
 				if err != nil {
 					log.WithError(err).Error("failed to list measurement counts")
 				}
-				testKeys, err := database.GetResultTestKeys(ctx.DB, result.Result.ID)
+				testKeys, err := database.GetResultTestKeys(probeCLI.DB(), result.Result.ID)
 				if err != nil {
 					log.WithError(err).Error("failed to get testKeys")
 				}

--- a/internal/cli/onboard/onboard.go
+++ b/internal/cli/onboard/onboard.go
@@ -138,11 +138,11 @@ func Onboarding(config *config.Config) error {
 // MaybeOnboarding will run the onboarding process only if the informed consent
 // config option is set to false
 func MaybeOnboarding(probe *ooni.Probe) error {
-	if probe.Config.InformedConsent == false {
-		if probe.IsBatch == true {
+	if probe.Config().InformedConsent == false {
+		if probe.IsBatch() == true {
 			return errors.New("cannot run onboarding in batch mode")
 		}
-		if err := Onboarding(probe.Config); err != nil {
+		if err := Onboarding(probe.Config()); err != nil {
 			return errors.Wrap(err, "onboarding")
 		}
 	}
@@ -161,20 +161,20 @@ func init() {
 		}
 
 		if *yes == true {
-			probe.Config.Lock()
-			probe.Config.InformedConsent = true
-			probe.Config.Unlock()
+			probe.Config().Lock()
+			probe.Config().InformedConsent = true
+			probe.Config().Unlock()
 
-			if err := probe.Config.Write(); err != nil {
+			if err := probe.Config().Write(); err != nil {
 				log.WithError(err).Error("failed to write config file")
 				return err
 			}
 			return nil
 		}
-		if probe.IsBatch == true {
+		if probe.IsBatch() == true {
 			return errors.New("cannot do onboarding in batch mode")
 		}
 
-		return Onboarding(probe.Config)
+		return Onboarding(probe.Config())
 	})
 }

--- a/internal/cli/reset/reset.go
+++ b/internal/cli/reset/reset.go
@@ -20,16 +20,16 @@ func init() {
 		}
 		// We need to first the DB otherwise the DB will be rewritten on close when
 		// we delete the home directory.
-		err = ctx.DB.Close()
+		err = ctx.DB().Close()
 		if err != nil {
 			log.WithError(err).Error("failed to close the DB")
 			return err
 		}
 		if *force == true {
-			os.RemoveAll(ctx.Home)
-			log.Infof("Deleted %s", ctx.Home)
+			os.RemoveAll(ctx.Home())
+			log.Infof("Deleted %s", ctx.Home())
 		} else {
-			log.Infof("Run with --force to delete %s", ctx.Home)
+			log.Infof("Run with --force to delete %s", ctx.Home())
 		}
 
 		return nil

--- a/internal/cli/rm/rm.go
+++ b/internal/cli/rm/rm.go
@@ -65,11 +65,11 @@ func init() {
 		}
 
 		if *all == true {
-			return deleteAll(ctx.DB, *yes)
+			return deleteAll(ctx.DB(), *yes)
 		}
 
 		if *yes == true {
-			err = database.DeleteResult(ctx.DB, *resultID)
+			err = database.DeleteResult(ctx.DB(), *resultID)
 			if err == db.ErrNoMoreRows {
 				return errors.New("result not found")
 			}
@@ -85,7 +85,7 @@ func init() {
 		if answer == "false" {
 			return errors.New("canceled by user")
 		}
-		err = database.DeleteResult(ctx.DB, *resultID)
+		err = database.DeleteResult(ctx.DB(), *resultID)
 		if err == db.ErrNoMoreRows {
 			return errors.New("result not found")
 		}

--- a/internal/cli/root/root.go
+++ b/internal/cli/root/root.go
@@ -57,7 +57,7 @@ func init() {
 				return nil, err
 			}
 			if *isBatch {
-				probe.IsBatch = true
+				probe.SetIsBatch(true)
 			}
 
 			return probe, nil

--- a/internal/cli/root/root.go
+++ b/internal/cli/root/root.go
@@ -19,6 +19,15 @@ var Command = Cmd.Command
 // Init should be called by all subcommand that care to have a ooni.Context instance
 var Init func() (*ooni.Probe, error)
 
+// NewProbeCLI is like Init but returns a ooni.ProbeCLI instead.
+func NewProbeCLI() (ooni.ProbeCLI, error) {
+	probeCLI, err := Init()
+	if err != nil {
+		return nil, err
+	}
+	return probeCLI, nil
+}
+
 func init() {
 	configPath := Cmd.Flag("config", "Set a custom config file path").Short('c').String()
 

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -31,7 +31,7 @@ func runNettestGroup(tg string, ctx *ooni.Probe, network *database.Network) erro
 		log.WithError(err).Error("Failed to lookup the location of the probe")
 		return err
 	}
-	network, err = database.CreateNetwork(ctx.DB, sess)
+	network, err = database.CreateNetwork(ctx.DB(), sess)
 	if err != nil {
 		log.WithError(err).Error("Failed to create the network row")
 		return err
@@ -48,7 +48,7 @@ func runNettestGroup(tg string, ctx *ooni.Probe, network *database.Network) erro
 	}
 	log.Debugf("Running test group %s", group.Label)
 
-	result, err := database.CreateResult(ctx.DB, ctx.Home, tg, network.ID)
+	result, err := database.CreateResult(ctx.DB(), ctx.Home(), tg, network.ID)
 	if err != nil {
 		log.Errorf("DB result error: %s", err)
 		return err
@@ -69,7 +69,7 @@ func runNettestGroup(tg string, ctx *ooni.Probe, network *database.Network) erro
 		}
 	}
 
-	if err = result.Finished(ctx.DB); err != nil {
+	if err = result.Finished(ctx.DB()); err != nil {
 		return err
 	}
 	return nil
@@ -102,7 +102,7 @@ func init() {
 		}
 
 		if *noCollector == true {
-			probe.Config.Sharing.UploadResults = false
+			probe.Config().Sharing.UploadResults = false
 		}
 		return nil
 	})

--- a/internal/cli/show/show.go
+++ b/internal/cli/show/show.go
@@ -17,7 +17,7 @@ func init() {
 			log.WithError(err).Error("failed to initialize root context")
 			return err
 		}
-		msmt, err := database.GetMeasurementJSON(ctx.DB, *msmtID)
+		msmt, err := database.GetMeasurementJSON(ctx.DB(), *msmtID)
 		if err != nil {
 			log.Errorf("error: %v", err)
 			return err

--- a/internal/nettests/nettests_test.go
+++ b/internal/nettests/nettests_test.go
@@ -38,11 +38,11 @@ func TestRun(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	network, err := database.CreateNetwork(probe.DB, sess)
+	network, err := database.CreateNetwork(probe.DB(), sess)
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := database.CreateResult(probe.DB, probe.Home, "middlebox", network.ID)
+	res, err := database.CreateResult(probe.DB(), probe.Home(), "middlebox", network.ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/nettests/web_connectivity.go
+++ b/internal/nettests/web_connectivity.go
@@ -19,7 +19,7 @@ func lookupURLs(ctl *Controller, limit int64, categories []string) ([]string, ma
 	for idx, url := range testlist.Result {
 		log.Debugf("Going over URL %d", idx)
 		urlID, err := database.CreateOrUpdateURL(
-			ctl.Probe.DB, url.URL, url.CategoryCode, url.CountryCode,
+			ctl.Probe.DB(), url.URL, url.CategoryCode, url.CountryCode,
 		)
 		if err != nil {
 			log.Error("failed to add to the URL table")
@@ -38,8 +38,8 @@ type WebConnectivity struct {
 
 // Run starts the test
 func (n WebConnectivity) Run(ctl *Controller) error {
-	log.Debugf("Enabled category codes are the following %v", ctl.Probe.Config.Nettests.WebsitesEnabledCategoryCodes)
-	urls, urlIDMap, err := lookupURLs(ctl, ctl.Probe.Config.Nettests.WebsitesURLLimit, ctl.Probe.Config.Nettests.WebsitesEnabledCategoryCodes)
+	log.Debugf("Enabled category codes are the following %v", ctl.Probe.Config().Nettests.WebsitesEnabledCategoryCodes)
+	urls, urlIDMap, err := lookupURLs(ctl, ctl.Probe.Config().Nettests.WebsitesURLLimit, ctl.Probe.Config().Nettests.WebsitesEnabledCategoryCodes)
 	if err != nil {
 		return err
 	}

--- a/internal/oonitest/oonitest.go
+++ b/internal/oonitest/oonitest.go
@@ -1,0 +1,126 @@
+// Package oonitest contains code used for testing.
+package oonitest
+
+import (
+	"sync"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-cli/internal/config"
+	"github.com/ooni/probe-cli/internal/ooni"
+	"upper.io/db.v3/lib/sqlbuilder"
+)
+
+// FakeOutput allows to fake the output package.
+type FakeOutput struct {
+	FakeSectionTitle []string
+	mu               sync.Mutex
+}
+
+// SectionTitle writes the section title.
+func (fo *FakeOutput) SectionTitle(s string) {
+	fo.mu.Lock()
+	defer fo.mu.Unlock()
+	fo.FakeSectionTitle = append(fo.FakeSectionTitle, s)
+}
+
+// FakeProbeCLI fakes ooni.ProbeCLI
+type FakeProbeCLI struct {
+	FakeConfig         *config.Config
+	FakeDB             sqlbuilder.Database
+	FakeIsBatch        bool
+	FakeHome           string
+	FakeTempDir        string
+	FakeProbeEnginePtr ooni.ProbeEngine
+	FakeProbeEngineErr error
+}
+
+// Config implements ProbeCLI.Config
+func (cli *FakeProbeCLI) Config() *config.Config {
+	return cli.FakeConfig
+}
+
+// DB implements ProbeCLI.DB
+func (cli *FakeProbeCLI) DB() sqlbuilder.Database {
+	return cli.FakeDB
+}
+
+// IsBatch implements ProbeCLI.IsBatch
+func (cli *FakeProbeCLI) IsBatch() bool {
+	return cli.FakeIsBatch
+}
+
+// Home implements ProbeCLI.Home
+func (cli *FakeProbeCLI) Home() string {
+	return cli.FakeHome
+}
+
+// TempDir implements ProbeCLI.TempDir
+func (cli *FakeProbeCLI) TempDir() string {
+	return cli.FakeTempDir
+}
+
+// NewProbeEngine implements ProbeCLI.NewProbeEngine
+func (cli *FakeProbeCLI) NewProbeEngine() (ooni.ProbeEngine, error) {
+	return cli.FakeProbeEnginePtr, cli.FakeProbeEngineErr
+}
+
+var _ ooni.ProbeCLI = &FakeProbeCLI{}
+
+// FakeProbeEngine fakes ooni.ProbeEngine
+type FakeProbeEngine struct {
+	FakeClose               error
+	FakeMaybeLookupLocation error
+	FakeProbeASNString      string
+	FakeProbeCC             string
+	FakeProbeIP             string
+	FakeProbeNetworkName    string
+}
+
+// Close implements ProbeEngine.Close
+func (eng *FakeProbeEngine) Close() error {
+	return eng.FakeClose
+}
+
+// MaybeLookupLocation implements ProbeEngine.MaybeLookupLocation
+func (eng *FakeProbeEngine) MaybeLookupLocation() error {
+	return eng.FakeMaybeLookupLocation
+}
+
+// ProbeASNString implements ProbeEngine.ProbeASNString
+func (eng *FakeProbeEngine) ProbeASNString() string {
+	return eng.FakeProbeASNString
+}
+
+// ProbeCC implements ProbeEngine.ProbeCC
+func (eng *FakeProbeEngine) ProbeCC() string {
+	return eng.FakeProbeCC
+}
+
+// ProbeIP implements ProbeEngine.ProbeIP
+func (eng *FakeProbeEngine) ProbeIP() string {
+	return eng.FakeProbeIP
+}
+
+// ProbeNetworkName implements ProbeEngine.ProbeNetworkName
+func (eng *FakeProbeEngine) ProbeNetworkName() string {
+	return eng.FakeProbeNetworkName
+}
+
+var _ ooni.ProbeEngine = &FakeProbeEngine{}
+
+// FakeLoggerHandler fakes apex.log.Handler.
+type FakeLoggerHandler struct {
+	FakeEntries []*log.Entry
+	FakeErr     error
+	mu          sync.Mutex
+}
+
+// HandleLog implements Handler.HandleLog.
+func (handler *FakeLoggerHandler) HandleLog(entry *log.Entry) error {
+	handler.mu.Lock()
+	defer handler.mu.Unlock()
+	handler.FakeEntries = append(handler.FakeEntries, entry)
+	return handler.FakeErr
+}
+
+var _ log.Handler = &FakeLoggerHandler{}


### PR DESCRIPTION
This diff starts increasing the code coverage in some parts of the codebase. The general approach is that of adding some extra abstraction that allows us to mock what's happening in all internal/cli packages. Until this refactoring for testability process is complete, we will have a bit of duplication. Yet, doing everything in a single step requires us to write a too large diff and seems not the right approach here. This work is part of https://github.com/ooni/probe/issues/948.

There are two reasons why I'm starting to refactor the code base now. The first is that the code is now settled for quite some time and it's more or less clear what are our needs, so the time seems ripe to add tests to ensure we WAI. The second is that I am planning on further integrating probe-cli and probe-engine. To this end, we need good testing in place.

As a final remark, one of the most important objectives of testing this codebase is ensuring that we're not breaking the contract with probe-desktop as far as the `--batch` command line option is concerned.