### PR TITLE
feat: implement syslog logging

### DIFF
--- a/cmd/ooniprobe/main.go
+++ b/cmd/ooniprobe/main.go
@@ -1,9 +1,8 @@
 package main
 
 import (
-	// commands
-
 	"github.com/apex/log"
+	"github.com/ooni/probe-cli/internal/cli/app"
 	_ "github.com/ooni/probe-cli/internal/cli/geoip"
 	_ "github.com/ooni/probe-cli/internal/cli/info"
 	_ "github.com/ooni/probe-cli/internal/cli/list"
@@ -15,13 +14,10 @@ import (
 	_ "github.com/ooni/probe-cli/internal/cli/upload"
 	_ "github.com/ooni/probe-cli/internal/cli/version"
 	"github.com/ooni/probe-cli/internal/crashreport"
-
-	"github.com/ooni/probe-cli/internal/cli/app"
 )
 
 func main() {
-	err, _ := crashreport.CapturePanic(app.Run, nil)
-	if err != nil {
+	if err, _ := crashreport.CapturePanic(app.Run, nil); err != nil {
 		log.WithError(err.(error)).Error("panic in app.Run")
 		crashreport.Wait()
 	}

--- a/internal/log/handlers/syslog/syslog.c
+++ b/internal/log/handlers/syslog/syslog.c
@@ -1,0 +1,15 @@
+#ifndef _WIN32
+#include <syslog.h>
+#endif
+
+void ooniprobe_openlog(void) {
+#ifndef _WIN32
+    (void)openlog("ooniprobe", LOG_PID, LOG_USER);
+#endif
+}
+
+void ooniprobe_syslog(int level, const char *message) {
+#ifndef _WIN32
+    (void)syslog(level, "%s", message);
+#endif
+}

--- a/internal/log/handlers/syslog/syslog.c
+++ b/internal/log/handlers/syslog/syslog.c
@@ -8,8 +8,32 @@ void ooniprobe_openlog(void) {
 #endif
 }
 
-void ooniprobe_syslog(int level, const char *message) {
+void ooniprobe_log_debug(const char *message) {
 #ifndef _WIN32
-    (void)syslog(level, "%s", message);
+    (void)syslog(LOG_DEBUG, "%s", message);
+#endif
+}
+
+void ooniprobe_log_info(const char *message) {
+#ifndef _WIN32
+    (void)syslog(LOG_INFO, "%s", message);
+#endif
+}
+
+void ooniprobe_log_warning(const char *message) {
+#ifndef _WIN32
+    (void)syslog(LOG_WARNING, "%s", message);
+#endif
+}
+
+void ooniprobe_log_err(const char *message) {
+#ifndef _WIN32
+    (void)syslog(LOG_ERR, "%s", message);
+#endif
+}
+
+void ooniprobe_log_crit(const char *message) {
+#ifndef _WIN32
+    (void)syslog(LOG_CRIT, "%s", message);
 #endif
 }

--- a/internal/log/handlers/syslog/syslog.go
+++ b/internal/log/handlers/syslog/syslog.go
@@ -1,0 +1,51 @@
+// Package syslog contains a syslog handler.
+package syslog
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/apex/log"
+)
+
+/*
+#include<stdlib.h>
+#include<syslog.h>
+
+void ooniprobe_openlog(void);
+void ooniprobe_syslog(int level, const char *message);
+*/
+import "C"
+
+// Default is the handler that emits logs with syslog
+var Default log.Handler = newhandler()
+
+type handler struct{}
+
+func newhandler() handler {
+	C.ooniprobe_openlog()
+	return handler{}
+}
+
+var levelmap = map[log.Level]C.int{
+	log.DebugLevel: C.LOG_DEBUG,
+	log.InfoLevel:  C.LOG_INFO,
+	log.WarnLevel:  C.LOG_WARNING,
+	log.ErrorLevel: C.LOG_ERR,
+	log.FatalLevel: C.LOG_CRIT,
+}
+
+func getlevel(level log.Level) C.int {
+	if value, found := levelmap[level]; found {
+		return value
+	}
+	return C.LOG_CRIT
+}
+
+func (h handler) HandleLog(e *log.Entry) error {
+	message := fmt.Sprintf("%s %+v", e.Message, e.Fields)
+	cstr := C.CString(message)
+	defer C.free(unsafe.Pointer(cstr))
+	C.ooniprobe_syslog(getlevel(e.Level), cstr)
+	return nil
+}

--- a/internal/log/handlers/syslog/syslog.go
+++ b/internal/log/handlers/syslog/syslog.go
@@ -10,7 +10,6 @@ import (
 
 /*
 #include<stdlib.h>
-#include<syslog.h>
 
 void ooniprobe_openlog(void);
 void ooniprobe_syslog(int level, const char *message);


### PR DESCRIPTION
With this functionality in tree, macOS users could easily access ooniprobe logs by filtering by process name in the console app. See https://github.com/ooni/probe-cli/pull/181#issuecomment-736508139 for a nice screenshot.

Part of https://github.com/ooni/probe/issues/1289