### PR TITLE
feat: implement the unattended group

### DIFF
--- a/internal/nettests/groups.go
+++ b/internal/nettests/groups.go
@@ -1,18 +1,20 @@
 package nettests
 
-// NettestGroup base structure
-type NettestGroup struct {
-	Label    string
-	Nettests []Nettest
+// Group is a group of nettests
+type Group struct {
+	Label        string
+	Nettests     []Nettest
+	UnattendedOK bool
 }
 
-// NettestGroups that can be run by the user
-var NettestGroups = map[string]NettestGroup{
+// All contains all the nettests that can be run by the user
+var All = map[string]Group{
 	"websites": {
 		Label: "Websites",
 		Nettests: []Nettest{
 			WebConnectivity{},
 		},
+		UnattendedOK: true,
 	},
 	"performance": {
 		Label: "Performance",
@@ -27,6 +29,7 @@ var NettestGroups = map[string]NettestGroup{
 			HTTPInvalidRequestLine{},
 			HTTPHeaderFieldManipulation{},
 		},
+		UnattendedOK: true,
 	},
 	"im": {
 		Label: "Instant Messaging",
@@ -35,6 +38,7 @@ var NettestGroups = map[string]NettestGroup{
 			Telegram{},
 			WhatsApp{},
 		},
+		UnattendedOK: true,
 	},
 	"circumvention": {
 		Label: "Circumvention Tools",
@@ -42,5 +46,6 @@ var NettestGroups = map[string]NettestGroup{
 			Psiphon{},
 			Tor{},
 		},
+		UnattendedOK: true,
 	},
 }

--- a/internal/nettests/run.go
+++ b/internal/nettests/run.go
@@ -44,7 +44,7 @@ func RunGroup(config RunGroupConfig) error {
 		return err
 	}
 
-	group, ok := NettestGroups[config.GroupName]
+	group, ok := All[config.GroupName]
 	if !ok {
 		log.Errorf("No test group named %s", config.GroupName)
 		return errors.New("invalid test group name")


### PR DESCRIPTION
We don't want to run performance in the background because this
causes too much traffic towards m-lab servers.

When we'll have the check-in API, this will be the entry point we'll
use to contact such an API and get things to do.

Part of https://github.com/ooni/probe/issues/1289.