### PR TITLE
chore: release 3.4.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,5 +3,5 @@ package version
 
 const (
 	// Version is the software version
-	Version = "3.4.0-alpha"
+	Version = "3.4.0"
 )


### PR DESCRIPTION
This release only contains updates in debian packaging. All other platforms
could safely continue to use 3.2.0 or 3.3.0.

I didn't want to make a path release, though, because I didn't want to convey
the meaning that something was fixed.

Related to https://github.com/ooni/ooni.org/issues/677