### PR TITLE
fix(cross.yml): only run on the release branch

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -2,6 +2,8 @@
 name: cross
 on:
   push:
+    branches:
+      - 'release/**'
   schedule:
     - cron: "14 17 * * 3"
 jobs:


### PR DESCRIPTION
Part of https://github.com/ooni/probe/issues/1335.

Motivation: we want all workflows to be green only when we are
approaching a release. It's fine if some less core tests are
failing during the development process. We have daily builds anyway
so we know of new breakages the day after, which is OK.