### PR TITLE
Revert "fix(riseupvpn): skip currently failing tests (#212)"

### DIFF
--- a/internal/engine/experiment/riseupvpn/riseupvpn_test.go
+++ b/internal/engine/experiment/riseupvpn/riseupvpn_test.go
@@ -33,7 +33,6 @@ func TestNewExperimentMeasurer(t *testing.T) {
 }
 
 func TestGood(t *testing.T) {
-	t.Skip("broken test; see https://github.com/ooni/probe/issues/1338")
 	if testing.Short() {
 		t.Skip("skip test in short mode")
 	}
@@ -279,7 +278,6 @@ func TestFailureGeoIpServiceBlocked(t *testing.T) {
 }
 
 func TestFailureGateway(t *testing.T) {
-	t.Skip("broken test; see https://github.com/ooni/probe/issues/1338")
 	var testCases = [...]string{"openvpn", "obfs4"}
 	eipService, err := fetchEipService()
 	if err != nil {


### PR DESCRIPTION
This reverts commit 43f95e2c9a57e227dba35b3060fe56d6c56b0967.

We can now safely close https://github.com/ooni/probe/issues/1338,
since the upstream issue is gone. I think this issue we have seen is
also possibly related to https://github.com/ooni/probe/issues/1348.

Cc: @cyberta.