### PR TITLE
chore(miniooni): print start time

### DIFF
--- a/internal/libminiooni/libminiooni.go
+++ b/internal/libminiooni/libminiooni.go
@@ -284,6 +284,9 @@ func MainWithConfiguration(experimentName string, currentOptions Options) {
 	}
 	log.Log = logger
 
+	//Mon Jan 2 15:04:05 -0700 MST 2006
+	log.Infof("Current time: %s", time.Now().Format("2006-01-02 15:04:05 MST"))
+
 	homeDir := gethomedir(currentOptions.HomeDir)
 	fatalIfFalse(homeDir != "", "home directory is empty")
 	miniooniDir := path.Join(homeDir, ".miniooni")


### PR DESCRIPTION
This is useful when someone is running manual measurements and is
sharing their measurements with us, because it means we don't need
manually keep track of this bit of information.

Closes https://github.com/ooni/probe-engine/issues/1194