### PR TITLE
chore: set version to 3.7.0-alpha

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,8 @@
-# OONI Probe CLI
+# OONI Probe Client Library and CLI
 
 [![GoDoc](https://godoc.org/github.com/ooni/probe-cli?status.svg)](https://godoc.org/github.com/ooni/probe-cli) [![Short Tests Status](https://github.com/ooni/probe-cli/workflows/shorttests/badge.svg)](https://github.com/ooni/probe-cli/actions?query=workflow%3Ashorttests) [![All Tests Status](https://github.com/ooni/probe-cli/workflows/alltests/badge.svg)](https://github.com/ooni/probe-cli/actions?query=workflow%3Aalltests) [![Coverage Status](https://coveralls.io/repos/github/ooni/probe-cli/badge.svg?branch=master)](https://coveralls.io/github/ooni/probe-cli?branch=master) [![Go Report Card](https://goreportcard.com/badge/github.com/ooni/probe-cli)](https://goreportcard.com/report/github.com/ooni/probe-cli) [![linux-debian-packages](https://github.com/ooni/probe-cli/workflows/linux-debian-packages/badge.svg)](https://github.com/ooni/probe-cli/actions?query=workflow%3Alinux-debian-packages) [![GitHub issues by-label](https://img.shields.io/github/issues/ooni/probe/ooni/probe-cli?style=plastic)](https://github.com/ooni/probe/labels/ooni%2Fprobe-cli)
 
-The next generation OONI Probe: library and Command Line Interface.
+The next generation OONI Probe: client library and Command Line Interface.
 
 ## User setup
 

--- a/internal/engine/experiment/riseupvpn/riseupvpn_test.go
+++ b/internal/engine/experiment/riseupvpn/riseupvpn_test.go
@@ -278,7 +278,9 @@ func TestFailureGeoIpServiceBlocked(t *testing.T) {
 }
 
 func TestFailureGateway(t *testing.T) {
-	t.Skip("test currently not WAI - will restore after release")
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	var testCases = [...]string{"openvpn", "obfs4"}
 	eipService, err := fetchEipService()
 	if err != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,5 +3,5 @@ package version
 
 const (
 	// Version is the software version
-	Version = "3.6.0"
+	Version = "3.7.0-alpha"
 )


### PR DESCRIPTION
While there, make sure we don't always skip a currently failing
riseupvpn test, and slightly clarify the readme.