### PR TITLE
fix(run): run unattended short also on Windows

### DIFF
--- a/cmd/ooniprobe/internal/cli/run/run.go
+++ b/cmd/ooniprobe/internal/cli/run/run.go
@@ -76,10 +76,11 @@ func init() {
 
 	unattendedCmd := cmd.Command("unattended", "")
 	unattendedCmd.Action(func(_ *kingpin.ParseContext) error {
-		if runtime.GOOS == "darwin" {
-			// Until we have enabled the check-in API we're called every
-			// hour on darwin and we need to self throttle.
-			// TODO(bassosimone): switch to check-in and remove this hack.
+		// Until we have enabled the check-in API we're called every
+		// hour on darwin and we need to self throttle.
+		// TODO(bassosimone): switch to check-in and remove this hack.
+		switch runtime.GOOS {
+		case "darwin", "windows":
 			const veryFew = 10
 			probe.Config().Nettests.WebsitesURLLimit = veryFew
 		}


### PR DESCRIPTION
We already have a short run unattended on macOS and we wanna do
the same for Windows. See https://github.com/ooni/probe/issues/1377.