### PR TITLE
refactor: signal et al. are now experimental nettests

### DIFF
--- a/cmd/ooniprobe/internal/cli/run/run.go
+++ b/cmd/ooniprobe/internal/cli/run/run.go
@@ -69,7 +69,8 @@ func init() {
 		})
 	})
 
-	easyRuns := []string{"im", "performance", "circumvention", "middlebox"}
+	easyRuns := []string{
+		"im", "performance", "circumvention", "middlebox", "experimental"}
 	for _, name := range easyRuns {
 		cmd.Command(name, "").Action(genRunWithGroupName(name))
 	}

--- a/cmd/ooniprobe/internal/log/handlers/cli/results.go
+++ b/cmd/ooniprobe/internal/log/handlers/cli/results.go
@@ -76,6 +76,13 @@ var summarizers = map[string]func(uint64, uint64, string) []string{
 			"",
 		}
 	},
+	"experimental": func(totalCount uint64, anomalyCount uint64, ss string) []string {
+		return []string{
+			fmt.Sprintf("%d tested", totalCount),
+			fmt.Sprintf("%d blocked", anomalyCount),
+			"",
+		}
+	},
 }
 
 func makeSummary(name string, totalCount uint64, anomalyCount uint64, ss string) []string {

--- a/cmd/ooniprobe/internal/nettests/dnscheck.go
+++ b/cmd/ooniprobe/internal/nettests/dnscheck.go
@@ -1,0 +1,56 @@
+package nettests
+
+import (
+	"encoding/json"
+
+	"github.com/ooni/probe-cli/v3/internal/engine/experiment/dnscheck"
+	"github.com/ooni/probe-cli/v3/internal/engine/experiment/run"
+	"github.com/ooni/probe-cli/v3/internal/engine/runtimex"
+)
+
+// DNSCheck test implementation.
+type DNSCheck struct{}
+
+var dnsCheckDefaultInput []string
+
+func dnsCheckMustMakeInput(input *run.StructuredInput) string {
+	data, err := json.Marshal(input)
+	runtimex.PanicOnError(err, "json.Marshal failed")
+	return string(data)
+}
+
+func init() {
+	// The following code just adds a minimal set of URLs to
+	// test using DNSCheck, so we start exposing it.
+	//
+	// TODO(bassosimone):
+	//
+	// 1. we should be getting input from the backend instead of
+	// having an hardcoded list of inputs here.
+	//
+	// 2. we should modify dnscheck to accept http3://... as a
+	// shortcut for https://... with h3. If we don't do that, we
+	// are stuck with the h3 results hidin h2 results in OONI
+	// Explorer because they use the same URL.
+	dnsCheckDefaultInput = append(dnsCheckDefaultInput, dnsCheckMustMakeInput(
+		&run.StructuredInput{
+			DNSCheck: dnscheck.Config{},
+			Name:     "dnscheck",
+			Input:    "https://dns.google/dns-query",
+		}))
+	dnsCheckDefaultInput = append(dnsCheckDefaultInput, dnsCheckMustMakeInput(
+		&run.StructuredInput{
+			DNSCheck: dnscheck.Config{},
+			Name:     "dnscheck",
+			Input:    "https://cloudflare-dns.com/dns-query",
+		}))
+}
+
+// Run starts the nettest.
+func (n DNSCheck) Run(ctl *Controller) error {
+	builder, err := ctl.Session.NewExperimentBuilder("run")
+	if err != nil {
+		return err
+	}
+	return ctl.Run(builder, dnsCheckDefaultInput)
+}

--- a/cmd/ooniprobe/internal/nettests/dnscheck.go
+++ b/cmd/ooniprobe/internal/nettests/dnscheck.go
@@ -30,7 +30,7 @@ func init() {
 	//
 	// 2. we should modify dnscheck to accept http3://... as a
 	// shortcut for https://... with h3. If we don't do that, we
-	// are stuck with the h3 results hidin h2 results in OONI
+	// are stuck with the h3 results hiding h2 results in OONI
 	// Explorer because they use the same URL.
 	dnsCheckDefaultInput = append(dnsCheckDefaultInput, dnsCheckMustMakeInput(
 		&run.StructuredInput{

--- a/cmd/ooniprobe/internal/nettests/dnscheck.go
+++ b/cmd/ooniprobe/internal/nettests/dnscheck.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/engine/runtimex"
 )
 
-// DNSCheck test implementation.
+// DNSCheck nettest implementation.
 type DNSCheck struct{}
 
 var dnsCheckDefaultInput []string
@@ -32,6 +32,10 @@ func init() {
 	// shortcut for https://... with h3. If we don't do that, we
 	// are stuck with the h3 results hiding h2 results in OONI
 	// Explorer because they use the same URL.
+	//
+	// 3. it seems we have the problem that dnscheck results
+	// appear as the `run` nettest in `ooniprobe list <ID>` because
+	// dnscheck is run using the `run` functionality.
 	dnsCheckDefaultInput = append(dnsCheckDefaultInput, dnsCheckMustMakeInput(
 		&run.StructuredInput{
 			DNSCheck: dnscheck.Config{},

--- a/cmd/ooniprobe/internal/nettests/groups.go
+++ b/cmd/ooniprobe/internal/nettests/groups.go
@@ -35,7 +35,6 @@ var All = map[string]Group{
 		Label: "Instant Messaging",
 		Nettests: []Nettest{
 			FacebookMessenger{},
-			Signal{},
 			Telegram{},
 			WhatsApp{},
 		},
@@ -49,5 +48,13 @@ var All = map[string]Group{
 			Tor{},
 		},
 		UnattendedOK: true,
+	},
+	"experimental": {
+		Label: "Experimental Nettests",
+		Nettests: []Nettest{
+			DNSCheck{},
+			STUNReachability{},
+			Signal{},
+		},
 	},
 }

--- a/cmd/ooniprobe/internal/nettests/signal.go
+++ b/cmd/ooniprobe/internal/nettests/signal.go
@@ -1,10 +1,9 @@
 package nettests
 
-// Signal test implementation
-type Signal struct {
-}
+// Signal nettest implementation.
+type Signal struct{}
 
-// Run starts the test
+// Run starts the nettest.
 func (h Signal) Run(ctl *Controller) error {
 	builder, err := ctl.Session.NewExperimentBuilder(
 		"signal",
@@ -12,6 +11,5 @@ func (h Signal) Run(ctl *Controller) error {
 	if err != nil {
 		return err
 	}
-
 	return ctl.Run(builder, []string{""})
 }

--- a/cmd/ooniprobe/internal/nettests/stunreachability.go
+++ b/cmd/ooniprobe/internal/nettests/stunreachability.go
@@ -1,0 +1,13 @@
+package nettests
+
+// STUNReachability test implementation.
+type STUNReachability struct{}
+
+// Run starts the nettest.
+func (n STUNReachability) Run(ctl *Controller) error {
+	builder, err := ctl.Session.NewExperimentBuilder("stun_reachability")
+	if err != nil {
+		return err
+	}
+	return ctl.Run(builder, []string{""})
+}

--- a/cmd/ooniprobe/internal/nettests/stunreachability.go
+++ b/cmd/ooniprobe/internal/nettests/stunreachability.go
@@ -1,6 +1,6 @@
 package nettests
 
-// STUNReachability test implementation.
+// STUNReachability nettest implementation.
 type STUNReachability struct{}
 
 // Run starts the nettest.


### PR DESCRIPTION
We move signal into the experimental nettests group. While there,
also start adding dnscheck and stunreachability as well.

It seems there's more work to be done to correctly represent
the results of dnscheck, but this is fine!

The experimental section is here exactly for this reason!

In terms of UI, the new command is `ooniprobe run experimental`.

We will most likely move signal out of experimental soon, since it's
already working quite well. We need to keep it here for one more
cycle because the desktop app is not ready for it.

See the following issues:

1. https://github.com/ooni/probe/issues/1378

2. https://github.com/ooni/probe/issues/1262