### PR TITLE
chore: release 3.7.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,5 +3,5 @@ package version
 
 const (
 	// Version is the software version
-	Version = "3.7.0-alpha"
+	Version = "3.7.0"
 )


### PR DESCRIPTION
This comes just a few days after 3.6.0. It contains small
improvements required by ooni/probe-desktop.

For this reason, I am going to skeep the normal release
process and I am just bumping the version number.