### PR TITLE
fix(geolocate): no proxy when discovering our IP address

### DIFF
--- a/internal/engine/geolocate/geolocate_test.go
+++ b/internal/engine/geolocate/geolocate_test.go
@@ -393,3 +393,10 @@ func TestNewTaskWithNoResourcesManager(t *testing.T) {
 		t.Fatal("expected nil task here")
 	}
 }
+
+func TestASNStringWorks(t *testing.T) {
+	r := Results{ASN: 1234}
+	if r.ASNString() != "AS1234" {
+		t.Fatal("unexpected result")
+	}
+}

--- a/internal/engine/geolocate/iplookup_test.go
+++ b/internal/engine/geolocate/iplookup_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net"
-	"net/http"
 	"testing"
 
 	"github.com/apex/log"
@@ -12,9 +11,8 @@ import (
 
 func TestIPLookupGood(t *testing.T) {
 	ip, err := (ipLookupClient{
-		HTTPClient: http.DefaultClient,
-		Logger:     log.Log,
-		UserAgent:  "ooniprobe-engine/0.1.0",
+		Logger:    log.Log,
+		UserAgent: "ooniprobe-engine/0.1.0",
 	}).LookupProbeIP(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -28,9 +26,8 @@ func TestIPLookupAllFailed(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately cancel to cause Do() to fail
 	ip, err := (ipLookupClient{
-		HTTPClient: http.DefaultClient,
-		Logger:     log.Log,
-		UserAgent:  "ooniprobe-engine/0.1.0",
+		Logger:    log.Log,
+		UserAgent: "ooniprobe-engine/0.1.0",
 	}).LookupProbeIP(ctx)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatal("expected an error here")
@@ -43,9 +40,8 @@ func TestIPLookupAllFailed(t *testing.T) {
 func TestIPLookupInvalidIP(t *testing.T) {
 	ctx := context.Background()
 	ip, err := (ipLookupClient{
-		HTTPClient: http.DefaultClient,
-		Logger:     log.Log,
-		UserAgent:  "ooniprobe-engine/0.1.0",
+		Logger:    log.Log,
+		UserAgent: "ooniprobe-engine/0.1.0",
 	}).doWithCustomFunc(ctx, invalidIPLookup)
 	if !errors.Is(err, ErrInvalidIPAddress) {
 		t.Fatal("expected an error here")

--- a/internal/engine/geolocate/stun.go
+++ b/internal/engine/geolocate/stun.go
@@ -7,6 +7,11 @@ import (
 	"github.com/pion/stun"
 )
 
+// TODO(bassosimone): we should modify the stun code to use
+// the session resolver rather than using its own.
+//
+// See https://github.com/ooni/probe/issues/1383.
+
 type stunClient interface {
 	Close() error
 	Start(m *stun.Message, h stun.Handler) error

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -491,7 +491,6 @@ func (s *Session) LookupLocationContext(ctx context.Context) (*geolocate.Results
 	// when we are using a proxy because that might leak information.
 	task := geolocate.Must(geolocate.NewTask(geolocate.Config{
 		EnableResolverLookup: s.proxyURL == nil,
-		HTTPClient:           s.DefaultHTTPClient(),
 		Logger:               s.Logger(),
 		ResourcesManager:     s,
 		UserAgent:            s.UserAgent(),

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -492,6 +492,7 @@ func (s *Session) LookupLocationContext(ctx context.Context) (*geolocate.Results
 	task := geolocate.Must(geolocate.NewTask(geolocate.Config{
 		EnableResolverLookup: s.proxyURL == nil,
 		Logger:               s.Logger(),
+		Resolver:             s.resolver,
 		ResourcesManager:     s,
 		UserAgent:            s.UserAgent(),
 	}))


### PR DESCRIPTION
The use case of --proxy is that you cannot contact the OONI
backend otherwise. It is wrong, though, using the proxy when
discovering our IP address. The measurement won't use the
proxy anyway. Therefore, we need to use the IP address that
is performing the measurement. Not the one of the proxy.

What's more, stun is not using a proxy. Therefore, it does
not make much sense that http IP resolvers use a proxy. This
leads to inconsistencies. So, here's anothe reason why this
patch is a good thing (TM).

Finally, because knowing the IP address enables us to sanitize
the data, it's important we discover the correct IP.

Now, up until this point, the `--proxy` option has mostly
been a developers toy. But, users have asked us to have the
possibility of configuring a proxy.

This explains why I have been looking into making `--proxy`
right for a couple of hours now.

See https://github.com/ooni/probe/issues/1382