### PR TITLE
feat(ExperimentOrchestraClient): add CheckIn

### DIFF
--- a/internal/engine/inputloader_test.go
+++ b/internal/engine/inputloader_test.go
@@ -80,6 +80,10 @@ func TestInputLoaderNewOrchestraClientFailure(t *testing.T) {
 
 type InputLoaderBrokenOrchestraClient struct{}
 
+func (InputLoaderBrokenOrchestraClient) CheckIn(ctx context.Context, config model.CheckInConfig) (*model.CheckInInfo, error) {
+	return nil, io.EOF
+}
+
 func (InputLoaderBrokenOrchestraClient) FetchPsiphonConfig(ctx context.Context) ([]byte, error) {
 	return nil, io.EOF
 }

--- a/internal/engine/internal/mockable/mockable.go
+++ b/internal/engine/internal/mockable/mockable.go
@@ -162,12 +162,20 @@ var _ torx.Session = &Session{}
 // ExperimentOrchestraClient is the experiment's view of
 // a client for querying the OONI orchestra.
 type ExperimentOrchestraClient struct {
+	MockableCheckInInfo              *model.CheckInInfo
+	MockableCheckInErr               error
 	MockableFetchPsiphonConfigResult []byte
 	MockableFetchPsiphonConfigErr    error
 	MockableFetchTorTargetsResult    map[string]model.TorTarget
 	MockableFetchTorTargetsErr       error
 	MockableFetchURLListResult       []model.URLInfo
 	MockableFetchURLListErr          error
+}
+
+// CheckIn implements ExperimentOrchestraClient.CheckIn.
+func (c ExperimentOrchestraClient) CheckIn(
+	ctx context.Context, config model.CheckInConfig) (*model.CheckInInfo, error) {
+	return c.MockableCheckInInfo, c.MockableCheckInErr
 }
 
 // FetchPsiphonConfig implements ExperimentOrchestraClient.FetchPsiphonConfig

--- a/internal/engine/model/experiment.go
+++ b/internal/engine/model/experiment.go
@@ -8,8 +8,17 @@ import (
 // ExperimentOrchestraClient is the experiment's view of
 // a client for querying the OONI orchestra API.
 type ExperimentOrchestraClient interface {
+	// CheckIn calls the check-in API.
+	CheckIn(ctx context.Context, config CheckInConfig) (*CheckInInfo, error)
+
+	// FetchPsiphonConfig returns psiphon config from the API.
 	FetchPsiphonConfig(ctx context.Context) ([]byte, error)
+
+	// FetchTorTargets returns tor targets from the API.
 	FetchTorTargets(ctx context.Context, cc string) (map[string]TorTarget, error)
+
+	// FetchURLList returns URLs from the API.
+	// This method is deprecated and will be removed soon.
 	FetchURLList(ctx context.Context, config URLListConfig) ([]URLInfo, error)
 }
 

--- a/pkg/oonimkall/task_integration_test.go
+++ b/pkg/oonimkall/task_integration_test.go
@@ -315,7 +315,7 @@ func TestMaxRuntime(t *testing.T) {
 	// In case there are further timeouts, e.g. in the sessionresolver, the
 	// time used by the experiment will be much more. This is for example the
 	// case in https://github.com/ooni/probe-engine/issues/1005.
-	if time.Now().Sub(begin) > 10*time.Second {
+	if time.Since(begin) > 10*time.Second {
 		t.Fatal("expected shorter runtime")
 	}
 }


### PR DESCRIPTION
We use ExperimentOrchestraClient in several places to help us
calling probe-services APIs. We need to call CheckIn because we
want to use CheckIn in InputLoader.

(We also want to remove the URLs API, but that is not something
doable now, since the mobile app is still using this API via
the wrappers at pkg/oonimkall.)

Work part of https://github.com/ooni/probe/issues/1299.