### PR TITLE
fix(sessionresolver): proxy check conditional on existing proxy

### DIFF
--- a/internal/engine/internal/sessionresolver/resolvermaker.go
+++ b/internal/engine/internal/sessionresolver/resolvermaker.go
@@ -97,7 +97,7 @@ func (r *Resolver) newresolver(URL string) (childResolver, error) {
 func (r *Resolver) getresolver(URL string) (childResolver, error) {
 	defer r.mu.Unlock()
 	r.mu.Lock()
-	if re, found := r.res[URL]; found == true {
+	if re, found := r.res[URL]; found {
 		return re, nil // already created
 	}
 	re, err := r.newresolver(URL)

--- a/internal/engine/internal/sessionresolver/sessionresolver_test.go
+++ b/internal/engine/internal/sessionresolver/sessionresolver_test.go
@@ -294,7 +294,7 @@ func TestResolverWorksWithProxy(t *testing.T) {
 	<-done
 	// check results
 	if !errors.Is(err, ErrLookupHost) {
-		t.Fatal("not the error we expected")
+		t.Fatal("not the error we expected", err)
 	}
 	if addrs != nil {
 		t.Fatal("expected nil addrs")


### PR DESCRIPTION
There was a face-palming error in the implementation causing the proxy
check to be implemented also without a proxy.

This meant that we were ALWAYS skipping http3 and system resolvers.

The bug has been introduced in 3.8.0. So, the currently released
version of the probe, sadly, has this beheavior :-(.

Reference issue https://github.com/ooni/probe/issues/1426.