### PR TITLE
fix(internal/fsx): remove pre Go 1.16 definitions

### DIFF
--- a/internal/engine/inputloader.go
+++ b/internal/engine/inputloader.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 
 	"github.com/ooni/probe-cli/v3/internal/engine/internal/fsx"
 	"github.com/ooni/probe-cli/v3/internal/engine/model"
@@ -182,7 +183,7 @@ func (il inputLoader) loadLocal() ([]model.URLInfo, error) {
 }
 
 // inputLoaderOpenFn is the type of the function to open a file.
-type inputLoaderOpenFn func(filepath string) (fsx.File, error)
+type inputLoaderOpenFn func(filepath string) (fs.File, error)
 
 // readfile reads inputs from the specified file. The open argument should be
 // compatibile with stdlib's fs.Open and helps us with unit testing.

--- a/internal/engine/inputloader_test.go
+++ b/internal/engine/inputloader_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"io"
+	"io/fs"
 	"os"
 	"syscall"
 	"testing"
 
 	"github.com/apex/log"
 	"github.com/google/go-cmp/cmp"
-	"github.com/ooni/probe-cli/v3/internal/engine/internal/fsx"
 	"github.com/ooni/probe-cli/v3/internal/engine/kvstore"
 	"github.com/ooni/probe-cli/v3/internal/engine/model"
 )
@@ -284,7 +284,7 @@ func TestInputLoaderInputOrQueryBackendWithEmptyFile(t *testing.T) {
 
 type InputLoaderBrokenFS struct{}
 
-func (InputLoaderBrokenFS) Open(filepath string) (fsx.File, error) {
+func (InputLoaderBrokenFS) Open(filepath string) (fs.File, error) {
 	return InputLoaderBrokenFile{}, nil
 }
 

--- a/internal/engine/internal/fsx/fsx_test.go
+++ b/internal/engine/internal/fsx/fsx_test.go
@@ -2,6 +2,7 @@ package fsx_test
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"sync/atomic"
 	"syscall"
@@ -26,8 +27,8 @@ func (FailingStatFile) Stat() (os.FileInfo, error) {
 	return nil, errStatFailed
 }
 
-func (fs FailingStatFS) Open(pathname string) (fsx.File, error) {
-	return FailingStatFile{CloseCount: fs.CloseCount}, nil
+func (f FailingStatFS) Open(pathname string) (fs.File, error) {
+	return FailingStatFile(f), nil
 }
 
 func (fs FailingStatFile) Close() error {


### PR DESCRIPTION
Occurred to me while working on https://github.com/ooni/probe/issues/1299.