### PR TITLE
feat(ooniprobe): introduce websites_max_runtime

### DIFF
--- a/cmd/ooniprobe/internal/config/settings.go
+++ b/cmd/ooniprobe/internal/config/settings.go
@@ -1,38 +1,5 @@
 package config
 
-var websiteCategories = []string{
-	"ALDR",
-	"ANON",
-	"COMM",
-	"COMT",
-	"CTRL",
-	"CULTR",
-	"DATE",
-	"ECON",
-	"ENV",
-	"FILE",
-	"GAME",
-	"GMB",
-	"GOVT",
-	"GRP",
-	"HACK",
-	"HATE",
-	"HOST",
-	"HUMR",
-	"IGO",
-	"LGBT",
-	"MILX",
-	"MMED",
-	"NEWS",
-	"POLR",
-	"PORN",
-	"PROV",
-	"PUBH",
-	"REL",
-	"SRCH",
-	"XED",
-}
-
 // Sharing settings
 type Sharing struct {
 	UploadResults bool `json:"upload_results"`
@@ -45,6 +12,7 @@ type Advanced struct {
 
 // Nettests related settings
 type Nettests struct {
+	WebsitesMaxRuntime           int64    `json:"websites_max_runtime"`
 	WebsitesURLLimit             int64    `json:"websites_url_limit"`
 	WebsitesEnabledCategoryCodes []string `json:"websites_enabled_category_codes"`
 }

--- a/cmd/ooniprobe/internal/config/testdata/valid-config.json
+++ b/cmd/ooniprobe/internal/config/testdata/valid-config.json
@@ -5,7 +5,7 @@
     "upload_results": true
   },
   "nettests": {
-    "websites_url_limit": 0
+    "websites_max_runtime": 0
   },
   "advanced": {
     "send_crash_reports": true

--- a/cmd/ooniprobe/internal/nettests/nettests.go
+++ b/cmd/ooniprobe/internal/nettests/nettests.go
@@ -111,10 +111,16 @@ func (c *Controller) Run(builder *engine.ExperimentBuilder, inputs []string) err
 		}
 	}
 
-	c.ntStartTime = time.Now()
+	maxRuntime := time.Duration(c.Probe.Config().Nettests.WebsitesMaxRuntime) * time.Second
+	start := time.Now()
+	c.ntStartTime = start
 	for idx, input := range inputs {
-		if c.Probe.IsTerminated() == true {
-			log.Debug("isTerminated == true, breaking the input loop")
+		if c.Probe.IsTerminated() {
+			log.Info("user requested us to terminate using Ctrl-C")
+			break
+		}
+		if maxRuntime > 0 && time.Since(start) > maxRuntime {
+			log.Info("exceeded maximum runtime")
 			break
 		}
 		c.curInputIdx = idx // allow for precise progress

--- a/cmd/ooniprobe/internal/nettests/web_connectivity.go
+++ b/cmd/ooniprobe/internal/nettests/web_connectivity.go
@@ -9,16 +9,10 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/engine/model"
 )
 
-// TODO(bassosimone): we should remove the limit argument and
-// we should also remove it from the config.
-
 // TODO(bassosimone): we should propagate the kind of run
 // to here such that we get the right runType.
 
-// TODO(bassosimone): we are breaking the use case in which
-// someone choose the number of URLs explicitly via the config.
-
-func lookupURLs(ctl *Controller, limit int64, categories []string) ([]string, map[int64]int64, error) {
+func lookupURLs(ctl *Controller, categories []string) ([]string, map[int64]int64, error) {
 	inputloader := &engine.InputLoader{
 		CheckInConfig: &model.CheckInConfig{
 			WebConnectivity: model.CheckInConfigWebConnectivity{
@@ -53,13 +47,12 @@ func lookupURLs(ctl *Controller, limit int64, categories []string) ([]string, ma
 }
 
 // WebConnectivity test implementation
-type WebConnectivity struct {
-}
+type WebConnectivity struct{}
 
 // Run starts the test
 func (n WebConnectivity) Run(ctl *Controller) error {
 	log.Debugf("Enabled category codes are the following %v", ctl.Probe.Config().Nettests.WebsitesEnabledCategoryCodes)
-	urls, urlIDMap, err := lookupURLs(ctl, ctl.Probe.Config().Nettests.WebsitesURLLimit, ctl.Probe.Config().Nettests.WebsitesEnabledCategoryCodes)
+	urls, urlIDMap, err := lookupURLs(ctl, ctl.Probe.Config().Nettests.WebsitesEnabledCategoryCodes)
 	if err != nil {
 		return err
 	}

--- a/cmd/ooniprobe/internal/ooni/default-config.json
+++ b/cmd/ooniprobe/internal/ooni/default-config.json
@@ -5,7 +5,7 @@
     "upload_results": true
   },
   "nettests": {
-    "websites_url_limit": 0
+    "websites_max_runtime": 0
   },
   "advanced": {
     "send_crash_reports": true

--- a/cmd/ooniprobe/testdata/testing-config.json
+++ b/cmd/ooniprobe/testdata/testing-config.json
@@ -5,7 +5,7 @@
     "upload_results": true
   },
   "nettests": {
-    "websites_url_limit": 10
+    "websites_max_runtime": 15
   },
   "advanced": {
     "send_crash_reports": true

--- a/debian/ooniprobe.conf.disabled
+++ b/debian/ooniprobe.conf.disabled
@@ -6,7 +6,7 @@
     "upload_results": true
   },
   "nettests": {
-    "websites_url_limit": 0,
+    "websites_max_runtime": 0,
     "websites_enabled_category_codes": null
   },
   "advanced": {


### PR DESCRIPTION
We cannot control anymore the maximum number of URLs using the API
because now we are using check-in, that has no such limit.

We could theoretically clamp the number of URLs to measure after
the call to check-in, and still honour the setting.

Yet, the right thing to do seems to introduce a max runtime variable
because that is what desktop and mobile do.

Thus, introduce code that warns the user about the change in the
settings, should they have set the URL limit to nonzero.

We are going to do a best effort conversion from the URL limit to
the maximum runtime for the rest of 2021.

Since then, we will silently ignore the URL limit.

This work is part of https://github.com/ooni/probe/issues/1299.