### PR TITLE
feat(ooniprobe): propagate the RunType CheckIn hint

### DIFF
--- a/cmd/ooniprobe/internal/nettests/nettests.go
+++ b/cmd/ooniprobe/internal/nettests/nettests.go
@@ -53,6 +53,10 @@ type Controller struct {
 	// using the command line using the --input flag.
 	Inputs []string
 
+	// RunType contains the run_type hint for the CheckIn API. If
+	// not set, the underlying code defaults to "timed".
+	RunType string
+
 	// numInputs is the total number of inputs
 	numInputs int
 
@@ -115,6 +119,8 @@ func (c *Controller) Run(builder *engine.ExperimentBuilder, inputs []string) err
 	start := time.Now()
 	c.ntStartTime = start
 	for idx, input := range inputs {
+		// TODO(bassosimone): should we allow for interruption when running
+		// in unattended mode? Likewise, should we honor MaxRuntime?
 		if c.Probe.IsTerminated() {
 			log.Info("user requested us to terminate using Ctrl-C")
 			break
@@ -172,7 +178,7 @@ func (c *Controller) Run(builder *engine.ExperimentBuilder, inputs []string) err
 			}
 		}
 		// We only save the measurement to disk if we failed to upload the measurement
-		if saveToDisk == true {
+		if saveToDisk {
 			if err := exp.SaveMeasurement(measurement, msmt.MeasurementFilePath.String); err != nil {
 				return errors.Wrap(err, "failed to save measurement on disk")
 			}
@@ -204,6 +210,8 @@ func (c *Controller) Run(builder *engine.ExperimentBuilder, inputs []string) err
 
 // OnProgress should be called when a new progress event is available.
 func (c *Controller) OnProgress(perc float64, msg string) {
+	// TODO(bassosimone): should we adjust this algorithm when we have a
+	// maximum runtime that we would like to honor?
 	log.Debugf("OnProgress: %f - %s", perc, msg)
 	var eta float64
 	eta = -1.0
@@ -213,7 +221,7 @@ func (c *Controller) OnProgress(perc float64, msg string) {
 		step := 1.0 / float64(c.numInputs)
 		perc = floor + perc*step
 		if c.curInputIdx > 0 {
-			eta = (time.Now().Sub(c.ntStartTime).Seconds() / float64(c.curInputIdx)) * float64(c.numInputs-c.curInputIdx)
+			eta = (time.Since(c.ntStartTime).Seconds() / float64(c.curInputIdx)) * float64(c.numInputs-c.curInputIdx)
 		}
 	}
 	if c.ntCount > 0 {

--- a/cmd/ooniprobe/internal/nettests/web_connectivity.go
+++ b/cmd/ooniprobe/internal/nettests/web_connectivity.go
@@ -9,12 +9,15 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/engine/model"
 )
 
-// TODO(bassosimone): we should propagate the kind of run
-// to here such that we get the right runType.
-
 func lookupURLs(ctl *Controller, categories []string) ([]string, map[int64]int64, error) {
 	inputloader := &engine.InputLoader{
 		CheckInConfig: &model.CheckInConfig{
+			// Setting Charging and OnWiFi to true causes the CheckIn
+			// API to return to us as much URL as possible with the
+			// given RunType hint.
+			Charging: true,
+			OnWiFi:   true,
+			RunType:  ctl.RunType,
 			WebConnectivity: model.CheckInConfigWebConnectivity{
 				CategoryCodes: categories,
 			},
@@ -24,6 +27,7 @@ func lookupURLs(ctl *Controller, categories []string) ([]string, map[int64]int64
 		SourceFiles:  ctl.InputFiles,
 		StaticInputs: ctl.Inputs,
 	}
+	log.Infof("Calling CheckIn API with %s runType", ctl.RunType)
 	testlist, err := inputloader.Load(context.Background())
 	var urls []string
 	urlIDMap := make(map[int64]int64)


### PR DESCRIPTION
This diff propagates the RunType CheckIn hint such that we run
using less URLs when running in the background.

Part of https://github.com/ooni/probe/issues/1299.