### PR TITLE
feat(ooniprobe): discard lists not in selected categories

### DIFF
--- a/cmd/ooniprobe/internal/nettests/web_connectivity.go
+++ b/cmd/ooniprobe/internal/nettests/web_connectivity.go
@@ -9,6 +9,26 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/engine/model"
 )
 
+// preventMistakes makes the code more robust with respect to any possible
+// integration issue where the backend returns to us URLs that don't
+// belong to the category codes we requested.
+func preventMistakes(input []model.URLInfo, categories []string) (output []model.URLInfo) {
+	for _, entry := range input {
+		var found bool
+		for _, cat := range categories {
+			if entry.CategoryCode == cat {
+				found = true
+				break
+			}
+		}
+		if len(categories) > 0 && !found {
+			log.Warnf("URL %+v not in %+v; skipping", entry, categories)
+		}
+		output = append(output, entry)
+	}
+	return
+}
+
 func lookupURLs(ctl *Controller, categories []string) ([]string, map[int64]int64, error) {
 	inputloader := &engine.InputLoader{
 		CheckInConfig: &model.CheckInConfig{
@@ -29,11 +49,12 @@ func lookupURLs(ctl *Controller, categories []string) ([]string, map[int64]int64
 	}
 	log.Infof("Calling CheckIn API with %s runType", ctl.RunType)
 	testlist, err := inputloader.Load(context.Background())
-	var urls []string
-	urlIDMap := make(map[int64]int64)
 	if err != nil {
 		return nil, nil, err
 	}
+	testlist = preventMistakes(testlist, categories)
+	var urls []string
+	urlIDMap := make(map[int64]int64)
 	for idx, url := range testlist {
 		log.Debugf("Going over URL %d", idx)
 		urlID, err := database.CreateOrUpdateURL(


### PR DESCRIPTION
One day we may make an integration mistake and for any reason
we may end up with URLs that do not belong to the categories
originally selected by the user. If that happens, it's nice to
have a safety net where we remove URLs that do not belong to
the right category before proceeding with testing.

This diff was conceived while discussing the robustness of
https://github.com/ooni/probe/issues/1299 with @hellais.