### PR TITLE
release 3.9.0 process: reduce warnings

### DIFF
--- a/cmd/ooniprobe/internal/utils/utils.go
+++ b/cmd/ooniprobe/internal/utils/utils.go
@@ -39,7 +39,7 @@ func EscapeAwareRuneCountInString(s string) int {
 	return n
 }
 
-// RightPadd adds right padding in from of a string
+// RightPad adds right padding in from of a string
 func RightPad(str string, length int) string {
 	c := length - EscapeAwareRuneCountInString(str)
 	if c < 0 {

--- a/internal/engine/experiment/riseupvpn/riseupvpn_test.go
+++ b/internal/engine/experiment/riseupvpn/riseupvpn_test.go
@@ -746,7 +746,7 @@ func generateMockGetter(requestResponse map[string]string, responseStatus map[st
 			FailedOperation:    failedOperation,
 			HTTPResponseStatus: responseStatus,
 			HTTPResponseBody:   responseBody,
-			Requests: []archival.RequestEntry{archival.RequestEntry{
+			Requests: []archival.RequestEntry{{
 				Failure: failure,
 				Request: archival.HTTPRequest{
 					URL:             url,

--- a/internal/engine/experiment/riseupvpn/riseupvpn_test.go
+++ b/internal/engine/experiment/riseupvpn/riseupvpn_test.go
@@ -555,6 +555,9 @@ func TestMissingTransport(t *testing.T) {
 	transports = transports[:len(transports)-1]
 	eipService.Gateways[1].Capabilities.Transport = transports
 	eipservicejson, err := json.Marshal(eipservice)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	requestResponseMap := map[string]string{
 		eipserviceurl: string(eipservicejson),

--- a/internal/engine/experiment/tlstool/internal/splitter.go
+++ b/internal/engine/experiment/tlstool/internal/splitter.go
@@ -29,7 +29,6 @@ func SNISplitter(input []byte, sni []byte) (output [][]byte) {
 	}
 	if len(buf) > 0 {
 		output = append(output, buf)
-		buf = nil
 	}
 	output = append(output, input[idx+len(sni):])
 	return

--- a/internal/engine/inputloader.go
+++ b/internal/engine/inputloader.go
@@ -159,7 +159,7 @@ func (il *InputLoader) loadLocal() ([]model.URLInfo, error) {
 type inputLoaderOpenFn func(filepath string) (fs.File, error)
 
 // readfile reads inputs from the specified file. The open argument should be
-// compatibile with stdlib's fs.Open and helps us with unit testing.
+// compatible with stdlib's fs.Open and helps us with unit testing.
 func (il *InputLoader) readfile(filepath string, open inputLoaderOpenFn) ([]model.URLInfo, error) {
 	inputs := []model.URLInfo{}
 	filep, err := open(filepath)

--- a/internal/engine/legacy/netx/dialer_test.go
+++ b/internal/engine/legacy/netx/dialer_test.go
@@ -101,6 +101,9 @@ func TestDialerSetCABundleWAI(t *testing.T) {
 func TestDialerForceSpecificSNI(t *testing.T) {
 	dialer := netx.NewDialer()
 	err := dialer.ForceSpecificSNI("www.facebook.com")
+	if err != nil {
+		t.Fatal(err)
+	}
 	conn, err := dialer.DialTLS("tcp", "www.google.com:443")
 	if err == nil {
 		t.Fatal("expected an error here")

--- a/internal/engine/legacy/netx/modelx/modelx_test.go
+++ b/internal/engine/legacy/netx/modelx/modelx_test.go
@@ -56,7 +56,7 @@ func TestMeasurementRootWithMeasurementRootPanic(t *testing.T) {
 		}
 	}()
 	ctx := context.Background()
-	ctx = WithMeasurementRoot(ctx, nil)
+	_ = WithMeasurementRoot(ctx, nil)
 }
 
 func TestErrWrapperPublicAPI(t *testing.T) {

--- a/internal/engine/netx/errorx/errorx_test.go
+++ b/internal/engine/netx/errorx/errorx_test.go
@@ -175,6 +175,9 @@ func TestToFailureString(t *testing.T) {
 		defer cancel() // fail immediately
 		udpAddr := &net.UDPAddr{IP: net.ParseIP("216.58.212.164"), Port: 80, Zone: ""}
 		udpConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+		if err != nil {
+			t.Fatal(err)
+		}
 		sess, err := quic.DialEarlyContext(ctx, udpConn, udpAddr, "google.com:80", &tls.Config{}, &quic.Config{})
 		if err == nil {
 			t.Fatal("expected an error here")

--- a/pkg/oonimkall/session_integration_test.go
+++ b/pkg/oonimkall/session_integration_test.go
@@ -78,7 +78,7 @@ func TestMaybeUpdateResourcesWithCancelledContext(t *testing.T) {
 	ctx := sess.NewContext()
 	ctx.Cancel() // cause immediate failure
 	err = sess.MaybeUpdateResources(ctx)
-	// Explaination: we embed resources. We should change the API
+	// Explanation: we embed resources. We should change the API
 	// and remove the context. Until we do that, let us just assert
 	// that we have embedding and the context does not matter.
 	if err != nil {


### PR DESCRIPTION
This basically means going over the Go report card at https://goreportcard.com/report/github.com/ooni/probe-cli and reducing the number of warnings that are listed there. This work is part of the check list at https://github.com/ooni/probe/issues/1369.