### PR TITLE
refactor(tunnel): simplify tor implementation

### DIFF
--- a/internal/engine/tunnel/psiphon.go
+++ b/internal/engine/tunnel/psiphon.go
@@ -13,10 +13,14 @@ import (
 
 // psiphonTunnel is a psiphon tunnel
 type psiphonTunnel struct {
-	tunnel   *clientlib.PsiphonTunnel
+	// tunnel is the underlying psiphon tunnel
+	tunnel *clientlib.PsiphonTunnel
+
+	// duration is the duration of the bootstrap
 	duration time.Duration
 }
 
+// makeworkingdir creates the working directory
 func makeworkingdir(config *Config) (string, error) {
 	const testdirname = "oonipsiphon"
 	workdir := filepath.Join(config.WorkDir, testdirname)

--- a/internal/engine/tunnel/psiphon_test.go
+++ b/internal/engine/tunnel/psiphon_test.go
@@ -26,7 +26,7 @@ func TestPsiphonFetchPsiphonConfigFailure(t *testing.T) {
 	}
 }
 
-func TestPsiphonMakeMkdirAllFailure(t *testing.T) {
+func TestPsiphonMkdirAllFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	sess := &mockable.Session{
 		MockableFetchPsiphonConfigResult: []byte(`{}`),
@@ -45,7 +45,7 @@ func TestPsiphonMakeMkdirAllFailure(t *testing.T) {
 	}
 }
 
-func TestPsiphonMakeRemoveAllFailure(t *testing.T) {
+func TestPsiphonRemoveAllFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	sess := &mockable.Session{
 		MockableFetchPsiphonConfigResult: []byte(`{}`),
@@ -64,7 +64,7 @@ func TestPsiphonMakeRemoveAllFailure(t *testing.T) {
 	}
 }
 
-func TestPsiphonMakeStartFailure(t *testing.T) {
+func TestPsiphonStartFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	sess := &mockable.Session{
 		MockableFetchPsiphonConfigResult: []byte(`{}`),

--- a/internal/engine/tunnel/tunnel.go
+++ b/internal/engine/tunnel/tunnel.go
@@ -41,7 +41,7 @@ func Start(ctx context.Context, config *Config) (Tunnel, error) {
 		return enforceNilContract(tun, err)
 	case "tor":
 		logger.Infof("starting %s tunnel; please be patient...", config.Name)
-		tun, err := torStart(ctx, config.Session)
+		tun, err := torStart(ctx, config)
 		return enforceNilContract(tun, err)
 	default:
 		return nil, errors.New("unsupported tunnel")


### PR DESCRIPTION
Simplify interaction within the package by avoiding to have
a tor specific config. Use a Config instead.

Part of https://github.com/ooni/probe/issues/985.