### PR TITLE
refactor(tunnel): provide TorArgs and TorBinary directly

### DIFF
--- a/internal/engine/experiment/urlgetter/getter.go
+++ b/internal/engine/experiment/urlgetter/getter.go
@@ -95,9 +95,11 @@ func (g Getter) get(ctx context.Context, saver *trace.Saver) (TestKeys, error) {
 	var proxyURL *url.URL
 	if g.Config.Tunnel != "" {
 		tun, err := tunnel.Start(ctx, &tunnel.Config{
-			Name:    g.Config.Tunnel,
-			Session: g.Session,
-			WorkDir: filepath.Join(g.Session.TempDir(), "urlgetter-tunnel"),
+			Name:      g.Config.Tunnel,
+			Session:   g.Session,
+			TorArgs:   g.Session.TorArgs(),
+			TorBinary: g.Session.TorBinary(),
+			WorkDir:   filepath.Join(g.Session.TempDir(), "urlgetter-tunnel"),
 		})
 		if err != nil {
 			return tk, err

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -359,8 +359,10 @@ func (s *Session) MaybeStartTunnel(ctx context.Context, name string) error {
 	}
 	s.logger.Infof("starting '%s' tunnel; please be patient...", name)
 	tunnel, err := tunnel.Start(ctx, &tunnel.Config{
-		Name:    name,
-		Session: s,
+		Name:      name,
+		Session:   s,
+		TorArgs:   s.TorArgs(),
+		TorBinary: s.TorBinary(),
 	})
 	if err != nil {
 		s.logger.Warnf("cannot start tunnel: %+v", err)

--- a/internal/engine/tunnel/config.go
+++ b/internal/engine/tunnel/config.go
@@ -18,6 +18,16 @@ type Config struct {
 	// Session is the current measurement session.
 	Session Session
 
+	// TorArgs contains the arguments that you want us to pass
+	// to the tor binary when invoking it. By default we do not
+	// pass any extra argument. This flag might be useful to
+	// configure pluggable transports.
+	TorArgs []string
+
+	// TorBinary is the path of the TorBinary we SHOULD be
+	// executing. When not set, we execute `tor`.
+	TorBinary string
+
 	// WorkDir is the directory in which the tunnel SHOULD
 	// store its state, if any.
 	WorkDir string

--- a/internal/engine/tunnel/tor.go
+++ b/internal/engine/tunnel/tor.go
@@ -60,7 +60,7 @@ func torStart(ctx context.Context, config *Config) (Tunnel, error) {
 	default:
 	}
 	logfile := LogFile(config.Session)
-	extraArgs := append([]string{}, config.Session.TorArgs()...)
+	extraArgs := append([]string{}, config.TorArgs...)
 	extraArgs = append(extraArgs, "Log")
 	extraArgs = append(extraArgs, "notice stderr")
 	extraArgs = append(extraArgs, "Log")
@@ -68,7 +68,7 @@ func torStart(ctx context.Context, config *Config) (Tunnel, error) {
 	instance, err := config.torStart(ctx, &tor.StartConf{
 		DataDir:   path.Join(config.Session.TempDir(), "tor"),
 		ExtraArgs: extraArgs,
-		ExePath:   config.Session.TorBinary(),
+		ExePath:   config.TorBinary,
 		NoHush:    true,
 	})
 	if err != nil {

--- a/internal/engine/tunnel/tunnel.go
+++ b/internal/engine/tunnel/tunnel.go
@@ -13,8 +13,6 @@ import (
 type Session interface {
 	FetchPsiphonConfig(ctx context.Context) ([]byte, error)
 	TempDir() string
-	TorArgs() []string
-	TorBinary() string
 }
 
 // Tunnel is a tunnel used by the session


### PR DESCRIPTION
We're trying to remove a circular dependency between the measurement
Session and the tunnel package. To this end, continue to reduce the
dependency scope by providing TorArgs and TorBinary directly.

Part of https://github.com/ooni/probe/issues/985