### PR TITLE
fix(tunnel/tor): keep tunneldir clean

### DIFF
--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -168,6 +168,8 @@ func NewSession(ctx context.Context, config SessionConfig) (*Session, error) {
 	if proxyURL != nil {
 		switch proxyURL.Scheme {
 		case "psiphon", "tor", "fake":
+			config.Logger.Infof(
+				"starting '%s' tunnel; please be patient...", proxyURL.Scheme)
 			tunnel, err := tunnel.Start(ctx, &tunnel.Config{
 				Name:      proxyURL.Scheme,
 				Session:   &sessionTunnelEarlySession{},
@@ -178,6 +180,7 @@ func NewSession(ctx context.Context, config SessionConfig) (*Session, error) {
 			if err != nil {
 				return nil, err
 			}
+			config.Logger.Infof("tunnel '%s' running...", proxyURL.Scheme)
 			sess.tunnel = tunnel
 			proxyURL = tunnel.SOCKS5ProxyURL()
 		}


### PR DESCRIPTION
This diff ensures that we don't keep the log file growing and
we also remove the temporary files created by the library we
are currently using for running tor from golang.

Part of https://github.com/ooni/probe/issues/985