### PR TITLE
fix: disable maxRuntime when not WebConnectivity

### DIFF
--- a/cmd/ooniprobe/internal/nettests/nettests.go
+++ b/cmd/ooniprobe/internal/nettests/nettests.go
@@ -120,6 +120,11 @@ func (c *Controller) Run(builder *engine.ExperimentBuilder, inputs []string) err
 		log.Debug("disabling maxRuntime when running in the background")
 		maxRuntime = 0
 	}
+	_, isWebConnectivity := c.nt.(WebConnectivity)
+	if !isWebConnectivity {
+		log.Debug("disabling maxRuntime without Web Connectivity")
+		maxRuntime = 0
+	}
 	start := time.Now()
 	c.ntStartTime = start
 	for idx, input := range inputs {
@@ -214,7 +219,8 @@ func (c *Controller) Run(builder *engine.ExperimentBuilder, inputs []string) err
 func (c *Controller) OnProgress(perc float64, msg string) {
 	// when we have maxRuntime, honor it
 	maxRuntime := time.Duration(c.Probe.Config().Nettests.WebsitesMaxRuntime) * time.Second
-	if c.RunType == "manual" && maxRuntime > 0 {
+	_, isWebConnectivity := c.nt.(WebConnectivity)
+	if c.RunType == "manual" && maxRuntime > 0 && isWebConnectivity {
 		elapsed := time.Since(c.ntStartTime)
 		perc = float64(elapsed) / float64(maxRuntime)
 		eta := maxRuntime.Seconds() - elapsed.Seconds()


### PR DESCRIPTION
This commit cherry-picks https://github.com/ooni/probe-cli/commit/6306c09963c3e05f5a1eb1a48ae226baa40ff3a1

See https://github.com/ooni/probe/issues/1433

Conflicts:
	internal/version/version.go