### PR TITLE
chore: adapt android scripts to use maven central

### DIFF
--- a/MOBILE/template.pom
+++ b/MOBILE/template.pom
@@ -2,13 +2,16 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
+
   <groupId>org.ooni</groupId>
   <artifactId>oonimkall</artifactId>
   <version>@VERSION@</version>
   <packaging>aar</packaging>
+
   <name>oonimkall</name>
-  <description>OONI Probe Engine for Android</description>
-  <url>https://github.com/ooni/probe-engine</url>
+  <description>OONI Probe for Android</description>
+  <url>https://github.com/ooni/probe-cli</url>
+
   <licenses>
     <license>
       <name>The 3-Clause BSD License</name>
@@ -16,18 +19,21 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <scm>
     <url>https://github.com/ooni/probe-engine</url>
     <connection>https://github.com/ooni/probe-engine.git</connection>
   </scm>
+
   <developers>
     <developer>
       <name>Simone Basso</name>
       <email>simone@openobservatory.org</email>
       <roles>
-        <role>developer</role>
+        <role>Core developer</role>
       </roles>
       <timezone>Europe/Rome</timezone>
     </developer>
   </developers>
+
 </project>


### PR DESCRIPTION
The main changes here are two. First, tweak some bits of the POM template
to make sure it's current, including referencing the correct repo. (We were
still referencing probe-engine in there, weirdly enough).

Second, change the android build script to create the same bundle that
mavan would build. What remains to do is uploading manually.

(Because it seems my PGP key is required, I guess this development rules
out automatically generating releases at GitHub. We will see about it
later on and possibly zap the publish-android.sh script.)

Reference issue: https://github.com/ooni/probe/issues/1437.

The release 2021.04.07-180801 has been created by me using this
diff from the v3.9.0 tag. I will update the release notes as soon
as this new release becomes available from Maven Central.