### PR TITLE
refactor(.github/workflows): macos, windows: use ./make, run less frequently

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-# Build and test macOS binary
+# macos builds ooniprobe for macos
 name: macos
 on:
   push:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,19 +2,12 @@
 name: macos
 on:
   push:
-  schedule:
-    - cron: "14 17 * * 3"
+    branches:
+      - "release/**"
 jobs:
   build:
-    runs-on: "macos-latest"
+    runs-on: "macos-10.15"
     steps:
-      - uses: actions/setup-go@v1
-        with:
-          go-version: "1.16"
       - uses: actions/checkout@v2
-      - run: ./build.sh darwin
+      - run: ./make --disable-embedding-psiphon-config -t ./CLI/darwin/amd64/ooniprobe
       - run: ./smoketest.sh ./CLI/darwin/amd64/ooniprobe
-      - uses: actions/upload-artifact@v1
-        with:
-          name: ooniprobe-darwin-amd64
-          path: ./CLI/darwin/amd64/ooniprobe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,20 +1,26 @@
-# Build and test Windows binary
+# windows builds ooniprobe for Windows
 name: windows
 on:
   push:
-  schedule:
-    - cron: "14 17 * * 3"
+    branches:
+      - "release/**"
 jobs:
   build:
-    runs-on: "windows-latest"
+    runs-on: "ubuntu-20.04"
     steps:
-      - uses: actions/setup-go@v1
-        with:
-          go-version: "1.16"
       - uses: actions/checkout@v2
-      - run: bash.exe ./build.sh windows_amd64  # TODO(bassosimone): make windows_386 work
-      - run: bash.exe ./smoketest.sh ./CLI/windows/amd64/ooniprobe.exe
-      - uses: actions/upload-artifact@v1
+      - run: sudo apt install mingw-w64
+      - run: ./make --disable-embedding-psiphon-config -t ./CLI/windows/amd64/ooniprobe.exe
+      - uses: actions/upload-artifact@v2
         with:
-          name: ooniprobe-windows-amd64
+          name: ooniprobe.exe
           path: ./CLI/windows/amd64/ooniprobe.exe
+  test:
+    needs: build
+    runs-on: "windows-2019"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: ooniprobe.exe
+      - run: bash.exe ./smoketest.sh ./ooniprobe.exe


### PR DESCRIPTION
Like in the previous PR, here we make macos and windows builds only run when we're preparing a release. While there, migrate the code to use the `./make` script. Tested in https://github.com/ooni/probe-cli/pull/331.

Reference issue is https://github.com/ooni/probe/issues/1466