### PR TITLE
refactor(.github/workflows): linux: use ./make, run less frequently

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,24 +1,34 @@
-# Build and test Linux binary
+# linux builds ooniprobe for Linux
 name: linux
 on:
+  pull_request:
   push:
-  schedule:
-    - cron: "14 17 * * 3"
+    branches:
+      - "issue/1466b"
+      - "release/**"
 jobs:
-  build:
-    runs-on: "ubuntu-latest"
+
+  build_amd64:
+    runs-on: "ubuntu-20.04"
     steps:
-      - name: Docker
-        run: |
+      - run: |
           echo $'{\n    "experimental": true\n}' | sudo tee /etc/docker/daemon.json
           sudo service docker restart
-      - uses: actions/setup-go@v1
-        with:
-          go-version: "1.16"
       - uses: actions/checkout@v2
-      - run: DOCKER_CLI_EXPERIMENTAL=enabled ./build.sh linux
+      - run: ./make --disable-embedding-psiphon-config -t ./CLI/linux/amd64/ooniprobe
+        env:
+          DOCKER_CLI_EXPERIMENTAL: enabled
       - run: ./smoketest.sh ./CLI/linux/amd64/ooniprobe
-      - uses: actions/upload-artifact@v1
-        with:
-          name: ooniprobe-linux-amd64
-          path: ./CLI/linux/amd64/ooniprobe
+
+  build_arm64:
+    runs-on: "ubuntu-20.04"
+    steps:
+      - run: |
+          echo $'{\n    "experimental": true\n}' | sudo tee /etc/docker/daemon.json
+          sudo service docker restart
+      - uses: actions/checkout@v2
+      - run: sudo apt-get install qemu-user-static
+      - run: ./make --disable-embedding-psiphon-config -t ./CLI/linux/arm64/ooniprobe
+        env:
+          DOCKER_CLI_EXPERIMENTAL: enabled
+      - run: ./smoketest.sh ./CLI/linux/arm64/ooniprobe

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,10 +1,8 @@
 # linux builds ooniprobe for Linux
 name: linux
 on:
-  pull_request:
   push:
     branches:
-      - "issue/1466b"
       - "release/**"
 jobs:
 

--- a/make
+++ b/make
@@ -121,8 +121,8 @@ def sdkmanager_install_cmd(binpath: str) -> List[str]:
 
 
 def log(msg: str) -> None:
-    """log prints a message on the standard error."""
-    print(msg, file=sys.stderr)
+    """log prints a message on the standard output."""
+    print(msg, flush=True)
 
 
 class Options(Protocol):
@@ -1151,7 +1151,6 @@ class OONIProbeLinux:
             "linux/{}".format(self._arch),
             "-e",
             "GOARCH={}".format(self._arch),
-            "-it",
             "-v",
             "{}:/ooni".format(os.getcwd()),
             "-w",


### PR DESCRIPTION
While there, flush `print`s in `./make` to have more understandable logging.

Also part of https://github.com/ooni/probe/issues/1466