### PR TITLE
CLI, debian, make: misc cleanup and changes

### DIFF
--- a/CLI/linux/build
+++ b/CLI/linux/build
@@ -1,4 +1,7 @@
 #!/bin/sh
+# This script is executed by `./make` when building inside
+# an Alpine Linux docker container. Using Alpine Linux, which
+# uses musl libc, allows us to emit static binaries.
 set -e
 if [ "$GOARCH" = "" ]; then
     echo 'fatal: $GOARCH is not set' 1>&2

--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -1,0 +1,7 @@
+/bin
+/.debhelper/
+/debhelper-build-stamp
+/files
+/ooniprobe-cli/
+/ooniprobe-cli.postrm.debhelper
+/ooniprobe-cli.substvars

--- a/debian/TODO
+++ b/debian/TODO
@@ -1,4 +1,0 @@
-create bintray repo
-detect tags in github CI
- /etc conf file
- shared unix group

--- a/debian/ooniprobe-cli.service
+++ b/debian/ooniprobe-cli.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=OONI Probe CLI
 Documentation=man:ooniprobe-cli
-#Documentation=file:///usr/share/doc/ooniprobe-cli/html/index.html
 Documentation=https://ooni.org/
 After=network.target tor.target
 Wants=network-online.target
@@ -22,7 +21,6 @@ LimitNOFILE=65536
 WorkingDirectory=/var/lib/ooniprobe
 RuntimeDirectory=ooniprobe
 StateDirectory=ooniprobe
-#CacheDirectory=ooniprobe
 LogsDirectory=ooniprobe
 ConfigurationDirectory=ooniprobe
 

--- a/debian/rules
+++ b/debian/rules
@@ -6,12 +6,10 @@ export DH_VERBOSE=1
 	dh $@
 
 override_dh_auto_clean:
-	rm -f debian/ooniprobe.1
 	dh_auto_clean
 
 override_dh_auto_build:
 	# The ooniprobe binary is provided
-	./CLI/linux/amd64/ooniprobe --help-man > debian/ooniprobe.1
 
 override_dh_dwz:
 	true

--- a/make
+++ b/make
@@ -440,9 +440,9 @@ class Environ:
     def __exit__(self, type: Any, value: Any, traceback: Any) -> bool:
         if self._prev is None:
             self._engine.unsetenv(self._key)
-            return False # progagate exc
+            return False  # propagate exc
         self._engine.setenv(self._key, self._prev)
-        return False # progagate exc
+        return False  # propagate exc
 
 
 class AugmentedPath(Environ):
@@ -1281,22 +1281,31 @@ OONIPROBE_TARGETS: List[Target] = [
 OONIPROBE_SIGNED_TARGETS: List[Target] = [Sign(x) for x in OONIPROBE_TARGETS]
 
 # OONIPROBE_RELEASE_DARWIN contains the release darwin targets
-OONIPROBE_RELEASE_DARWIN = Phony("ooniprobe_release_darwin", [
-    Sign(OONIProbeDarwin("amd64")),
-    Sign(OONIProbeDarwin("arm64")),
-])
+OONIPROBE_RELEASE_DARWIN = Phony(
+    "ooniprobe_release_darwin",
+    [
+        Sign(OONIProbeDarwin("amd64")),
+        Sign(OONIProbeDarwin("arm64")),
+    ],
+)
 
 # OONIPROBE_RELEASE_LINUX contains the release linux targets
-OONIPROBE_RELEASE_LINUX = Phony("ooniprobe_release_linux", [
-    Sign(OONIProbeLinux("amd64")),
-    Sign(OONIProbeLinux("arm64")),
-])
+OONIPROBE_RELEASE_LINUX = Phony(
+    "ooniprobe_release_linux",
+    [
+        Sign(OONIProbeLinux("amd64")),
+        Sign(OONIProbeLinux("arm64")),
+    ],
+)
 
 # OONIPROBE_RELEASE_WINDOWS contains the release windows targets
-OONIPROBE_RELEASE_WINDOWS = Phony("ooniprobe_release_windows", [
-    Sign(OONIProbeWindows("amd64")),
-    Sign(OONIProbeWindows("386")),
-])
+OONIPROBE_RELEASE_WINDOWS = Phony(
+    "ooniprobe_release_windows",
+    [
+        Sign(OONIProbeWindows("amd64")),
+        Sign(OONIProbeWindows("386")),
+    ],
+)
 
 # MOBILE_TARGETS contains the top-level mobile targets.
 MOBILE_TARGETS: List[Target] = [

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -6,4 +6,4 @@ if [ "$#" != 1 ]; then
 fi
 $1 onboard --yes
 # Important! DO NOT run performance from CI b/c it will overload m-lab servers
-$1 run websites --config cmd/ooniprobe/testdata/testing-config.json -v --no-collector
+$1 run websites --config cmd/ooniprobe/testdata/testing-config.json --no-collector


### PR DESCRIPTION
This PR	groups misc cleanup and changes from #331.

* CLI/linux/build: add documentation

* debian/.gitignore: ignore generated files

* debian/TODO: unnecessary at this point

* debian/ooniprobe-cli.service: remove commented out lines

* debian/rules: remove unnecessary actions

* make: reindent and fix spelling

* smoketest.sh: don't run in verbose mode

Part of ooni/probe#1466