### PR TITLE
cleanup(shellx): do not directly depend on apex/log

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,9 +59,9 @@ run `go mod tidy` to minimize such changes.
 
 - use `./internal/atomicx` rather than `atomic/sync`
 
-- use `./internal/fsx.OpenFile` when you need to open a file
+- do not use `os/exec`, use `x/sys/execabs` or `./internal/shellx`
 
-Do now use `os/exec`, use `x/sys/execabs`.
+- use `./internal/fsx.OpenFile` when you need to open a file
 
 ## Code testing requirements
 

--- a/cmd/ooniprobe/internal/autorun/autorun_darwin.go
+++ b/cmd/ooniprobe/internal/autorun/autorun_darwin.go
@@ -80,12 +80,12 @@ func (managerDarwin) LogShow() error {
 	if major < 20 /* macOS 11.0 Big Sur */ {
 		return errNotImplemented
 	}
-	return shellx.Run("log", "show", "--info", "--debug",
+	return shellx.Run(log.Log, "log", "show", "--info", "--debug",
 		"--process", "ooniprobe", "--style", "compact")
 }
 
 func (managerDarwin) LogStream() error {
-	return shellx.Run("log", "stream", "--style", "compact", "--level",
+	return shellx.Run(log.Log, "log", "stream", "--style", "compact", "--level",
 		"debug", "--process", "ooniprobe")
 }
 

--- a/internal/cmd/jafar/iptables/iptables_integration_test.go
+++ b/internal/cmd/jafar/iptables/iptables_integration_test.go
@@ -291,7 +291,7 @@ func TestHijackHTTP(t *testing.T) {
 	if err := policy.Apply(); err != nil {
 		t.Fatal(err)
 	}
-	err = shellx.Run("sudo", "-u", "nobody", "--",
+	err = shellx.Run(log.Log, "sudo", "-u", "nobody", "--",
 		"curl", "-sf", "http://example.com")
 	if err == nil {
 		t.Fatal("expected an error here")
@@ -330,7 +330,7 @@ func TestHijackHTTPS(t *testing.T) {
 	if err := policy.Apply(); err != nil {
 		t.Fatal(err)
 	}
-	err = shellx.Run("sudo", "-u", "nobody", "--",
+	err = shellx.Run(log.Log, "sudo", "-u", "nobody", "--",
 		"curl", "-sf", "https://example.com")
 	if err == nil {
 		t.Fatal("expected an error here")

--- a/internal/cmd/jafar/iptables/iptables_linux.go
+++ b/internal/cmd/jafar/iptables/iptables_linux.go
@@ -15,17 +15,17 @@ func (s *linuxShell) createChains() (err error) {
 			// JUST KNOW WE'VE BEEN HERE
 		}
 	}()
-	err = shellx.Run("sudo", "iptables", "-N", "JAFAR_INPUT")
+	err = shellx.Run(log.Log, "sudo", "iptables", "-N", "JAFAR_INPUT")
 	runtimex.PanicOnError(err, "cannot create JAFAR_INPUT chain")
-	err = shellx.Run("sudo", "iptables", "-N", "JAFAR_OUTPUT")
+	err = shellx.Run(log.Log, "sudo", "iptables", "-N", "JAFAR_OUTPUT")
 	runtimex.PanicOnError(err, "cannot create JAFAR_OUTPUT chain")
-	err = shellx.Run("sudo", "iptables", "-t", "nat", "-N", "JAFAR_NAT_OUTPUT")
+	err = shellx.Run(log.Log, "sudo", "iptables", "-t", "nat", "-N", "JAFAR_NAT_OUTPUT")
 	runtimex.PanicOnError(err, "cannot create JAFAR_NAT_OUTPUT chain")
-	err = shellx.Run("sudo", "iptables", "-I", "OUTPUT", "-j", "JAFAR_OUTPUT")
+	err = shellx.Run(log.Log, "sudo", "iptables", "-I", "OUTPUT", "-j", "JAFAR_OUTPUT")
 	runtimex.PanicOnError(err, "cannot insert jump to JAFAR_OUTPUT")
-	err = shellx.Run("sudo", "iptables", "-I", "INPUT", "-j", "JAFAR_INPUT")
+	err = shellx.Run(log.Log, "sudo", "iptables", "-I", "INPUT", "-j", "JAFAR_INPUT")
 	runtimex.PanicOnError(err, "cannot insert jump to JAFAR_INPUT")
-	err = shellx.Run("sudo", "iptables", "-t", "nat", "-I", "OUTPUT", "-j", "JAFAR_NAT_OUTPUT")
+	err = shellx.Run(log.Log, "sudo", "iptables", "-t", "nat", "-I", "OUTPUT", "-j", "JAFAR_NAT_OUTPUT")
 	runtimex.PanicOnError(err, "cannot insert jump to JAFAR_NAT_OUTPUT")
 	return nil
 }
@@ -35,35 +35,35 @@ func (s *linuxShell) dropIfDestinationEquals(ip string) error {
 }
 
 func (s *linuxShell) rstIfDestinationEqualsAndIsTCP(ip string) error {
-	return shellx.Run(
+	return shellx.Run(log.Log,
 		"sudo", "iptables", "-A", "JAFAR_OUTPUT", "--proto", "tcp", "-d", ip,
 		"-j", "REJECT", "--reject-with", "tcp-reset",
 	)
 }
 
 func (s *linuxShell) dropIfContainsKeywordHex(keyword string) error {
-	return shellx.Run(
+	return shellx.Run(log.Log,
 		"sudo", "iptables", "-A", "JAFAR_OUTPUT", "-m", "string", "--algo", "kmp",
 		"--hex-string", keyword, "-j", "DROP",
 	)
 }
 
 func (s *linuxShell) dropIfContainsKeyword(keyword string) error {
-	return shellx.Run(
+	return shellx.Run(log.Log,
 		"sudo", "iptables", "-A", "JAFAR_OUTPUT", "-m", "string", "--algo", "kmp",
 		"--string", keyword, "-j", "DROP",
 	)
 }
 
 func (s *linuxShell) rstIfContainsKeywordHexAndIsTCP(keyword string) error {
-	return shellx.Run(
+	return shellx.Run(log.Log,
 		"sudo", "iptables", "-A", "JAFAR_OUTPUT", "-m", "string", "--proto", "tcp", "--algo",
 		"kmp", "--hex-string", keyword, "-j", "REJECT", "--reject-with", "tcp-reset",
 	)
 }
 
 func (s *linuxShell) rstIfContainsKeywordAndIsTCP(keyword string) error {
-	return shellx.Run(
+	return shellx.Run(log.Log,
 		"sudo", "iptables", "-A", "JAFAR_OUTPUT", "-m", "string", "--proto", "tcp", "--algo",
 		"kmp", "--string", keyword, "-j", "REJECT", "--reject-with", "tcp-reset",
 	)
@@ -73,7 +73,7 @@ func (s *linuxShell) hijackDNS(address string) error {
 	// Hijack any DNS query, like the Vodafone station does when using the
 	// secure network feature. Our transparent proxies will use DoT, in order
 	// to bypass this restriction and avoid routing loop.
-	return shellx.Run(
+	return shellx.Run(log.Log,
 		"sudo", "iptables", "-t", "nat", "-A", "JAFAR_NAT_OUTPUT", "-p", "udp",
 		"--dport", "53", "-j", "DNAT", "--to", address,
 	)
@@ -82,7 +82,7 @@ func (s *linuxShell) hijackDNS(address string) error {
 func (s *linuxShell) hijackHTTPS(address string) error {
 	// We need to whitelist root otherwise the traffic sent by Jafar
 	// itself will match the rule and loop.
-	return shellx.Run(
+	return shellx.Run(log.Log,
 		"sudo", "iptables", "-t", "nat", "-A", "JAFAR_NAT_OUTPUT", "-p", "tcp",
 		"--dport", "443", "-m", "owner", "!", "--uid-owner", "0",
 		"-j", "DNAT", "--to", address,
@@ -92,7 +92,7 @@ func (s *linuxShell) hijackHTTPS(address string) error {
 func (s *linuxShell) hijackHTTP(address string) error {
 	// We need to whitelist root otherwise the traffic sent by Jafar
 	// itself will match the rule and loop.
-	return shellx.Run(
+	return shellx.Run(log.Log,
 		"sudo", "iptables", "-t", "nat", "-A", "JAFAR_NAT_OUTPUT", "-p", "tcp",
 		"--dport", "80", "-m", "owner", "!", "--uid-owner", "0",
 		"-j", "DNAT", "--to", address,
@@ -100,15 +100,15 @@ func (s *linuxShell) hijackHTTP(address string) error {
 }
 
 func (s *linuxShell) waive() error {
-	shellx.RunQuiet("sudo", "iptables", "-D", "OUTPUT", "-j", "JAFAR_OUTPUT")
-	shellx.RunQuiet("sudo", "iptables", "-D", "INPUT", "-j", "JAFAR_INPUT")
-	shellx.RunQuiet("sudo", "iptables", "-t", "nat", "-D", "OUTPUT", "-j", "JAFAR_NAT_OUTPUT")
-	shellx.RunQuiet("sudo", "iptables", "-F", "JAFAR_INPUT")
-	shellx.RunQuiet("sudo", "iptables", "-X", "JAFAR_INPUT")
-	shellx.RunQuiet("sudo", "iptables", "-F", "JAFAR_OUTPUT")
-	shellx.RunQuiet("sudo", "iptables", "-X", "JAFAR_OUTPUT")
-	shellx.RunQuiet("sudo", "iptables", "-t", "nat", "-F", "JAFAR_NAT_OUTPUT")
-	shellx.RunQuiet("sudo", "iptables", "-t", "nat", "-X", "JAFAR_NAT_OUTPUT")
+	shellx.RunQuiet(log.Log, "sudo", "iptables", "-D", "OUTPUT", "-j", "JAFAR_OUTPUT")
+	shellx.RunQuiet(log.Log, "sudo", "iptables", "-D", "INPUT", "-j", "JAFAR_INPUT")
+	shellx.RunQuiet(log.Log, "sudo", "iptables", "-t", "nat", "-D", "OUTPUT", "-j", "JAFAR_NAT_OUTPUT")
+	shellx.RunQuiet(log.Log, "sudo", "iptables", "-F", "JAFAR_INPUT")
+	shellx.RunQuiet(log.Log, "sudo", "iptables", "-X", "JAFAR_INPUT")
+	shellx.RunQuiet(log.Log, "sudo", "iptables", "-F", "JAFAR_OUTPUT")
+	shellx.RunQuiet(log.Log, "sudo", "iptables", "-X", "JAFAR_OUTPUT")
+	shellx.RunQuiet(log.Log, "sudo", "iptables", "-t", "nat", "-F", "JAFAR_NAT_OUTPUT")
+	shellx.RunQuiet(log.Log, "sudo", "iptables", "-t", "nat", "-X", "JAFAR_NAT_OUTPUT")
 	return nil
 }
 

--- a/internal/cmd/jafar/iptables/iptables_linux.go
+++ b/internal/cmd/jafar/iptables/iptables_linux.go
@@ -3,6 +3,7 @@
 package iptables
 
 import (
+	"github.com/apex/log"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 	"github.com/ooni/probe-cli/v3/internal/shellx"
 )
@@ -31,7 +32,8 @@ func (s *linuxShell) createChains() (err error) {
 }
 
 func (s *linuxShell) dropIfDestinationEquals(ip string) error {
-	return shellx.Run("sudo", "iptables", "-A", "JAFAR_OUTPUT", "-d", ip, "-j", "DROP")
+	return shellx.Run(log.Log,
+		"sudo", "iptables", "-A", "JAFAR_OUTPUT", "-d", ip, "-j", "DROP")
 }
 
 func (s *linuxShell) rstIfDestinationEqualsAndIsTCP(ip string) error {
@@ -100,15 +102,15 @@ func (s *linuxShell) hijackHTTP(address string) error {
 }
 
 func (s *linuxShell) waive() error {
-	shellx.RunQuiet(log.Log, "sudo", "iptables", "-D", "OUTPUT", "-j", "JAFAR_OUTPUT")
-	shellx.RunQuiet(log.Log, "sudo", "iptables", "-D", "INPUT", "-j", "JAFAR_INPUT")
-	shellx.RunQuiet(log.Log, "sudo", "iptables", "-t", "nat", "-D", "OUTPUT", "-j", "JAFAR_NAT_OUTPUT")
-	shellx.RunQuiet(log.Log, "sudo", "iptables", "-F", "JAFAR_INPUT")
-	shellx.RunQuiet(log.Log, "sudo", "iptables", "-X", "JAFAR_INPUT")
-	shellx.RunQuiet(log.Log, "sudo", "iptables", "-F", "JAFAR_OUTPUT")
-	shellx.RunQuiet(log.Log, "sudo", "iptables", "-X", "JAFAR_OUTPUT")
-	shellx.RunQuiet(log.Log, "sudo", "iptables", "-t", "nat", "-F", "JAFAR_NAT_OUTPUT")
-	shellx.RunQuiet(log.Log, "sudo", "iptables", "-t", "nat", "-X", "JAFAR_NAT_OUTPUT")
+	shellx.RunQuiet("sudo", "iptables", "-D", "OUTPUT", "-j", "JAFAR_OUTPUT")
+	shellx.RunQuiet("sudo", "iptables", "-D", "INPUT", "-j", "JAFAR_INPUT")
+	shellx.RunQuiet("sudo", "iptables", "-t", "nat", "-D", "OUTPUT", "-j", "JAFAR_NAT_OUTPUT")
+	shellx.RunQuiet("sudo", "iptables", "-F", "JAFAR_INPUT")
+	shellx.RunQuiet("sudo", "iptables", "-X", "JAFAR_INPUT")
+	shellx.RunQuiet("sudo", "iptables", "-F", "JAFAR_OUTPUT")
+	shellx.RunQuiet("sudo", "iptables", "-X", "JAFAR_OUTPUT")
+	shellx.RunQuiet("sudo", "iptables", "-t", "nat", "-F", "JAFAR_NAT_OUTPUT")
+	shellx.RunQuiet("sudo", "iptables", "-t", "nat", "-X", "JAFAR_NAT_OUTPUT")
 	return nil
 }
 

--- a/internal/cmd/jafar/main.go
+++ b/internal/cmd/jafar/main.go
@@ -276,7 +276,7 @@ func main() {
 	policy := iptablesStart()
 	var err error
 	if *mainCommand != "" {
-		err = shellx.RunCommandline(fmt.Sprintf(
+		err = shellx.RunCommandline(log.Log, fmt.Sprintf(
 			"sudo -u '%s' -- %s", *mainUser, *mainCommand,
 		))
 	} else {

--- a/internal/cmd/jafar/main_test.go
+++ b/internal/cmd/jafar/main_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/apex/log"
 	"github.com/ooni/probe-cli/v3/internal/cmd/jafar/iptables"
 	"github.com/ooni/probe-cli/v3/internal/shellx"
 )
@@ -74,7 +75,7 @@ func TestMustx(t *testing.T) {
 			called   int
 			exitcode int
 		)
-		err := shellx.Run("curl", "-sf", "") // cause exitcode == 3
+		err := shellx.Run(log.Log, "curl", "-sf", "") // cause exitcode == 3
 		mustx(err, "", func(ec int) {
 			called++
 			exitcode = ec

--- a/internal/shellx/shellx.go
+++ b/internal/shellx/shellx.go
@@ -3,13 +3,17 @@ package shellx
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"strings"
 
 	"github.com/google/shlex"
 	"golang.org/x/sys/execabs"
 )
+
+// Logger is the logger expected by this package.
+type Logger interface {
+	Infof(format string, v ...interface{})
+}
 
 // runconfig is the configuration for run.
 type runconfig struct {
@@ -43,17 +47,12 @@ func run(config runconfig) error {
 	return err
 }
 
-// noisyInfof is an infof function printing on the stderr.
-func noisyInfof(format string, v ...interface{}) {
-	fmt.Fprintf(os.Stderr, format, v...)
-}
-
 // Run executes the specified command with the specified args.
-func Run(name string, arg ...string) error {
+func Run(logger Logger, name string, arg ...string) error {
 	return run(runconfig{
 		args:     arg,
 		command:  name,
-		loginfof: noisyInfof,
+		loginfof: logger.Infof,
 		stdout:   os.Stdout,
 		stderr:   os.Stderr,
 	})
@@ -77,7 +76,7 @@ func RunQuiet(name string, arg ...string) error {
 var ErrNoCommandToExecute = errors.New("shellx: no command to execute")
 
 // RunCommandline executes the given command line.
-func RunCommandline(cmdline string) error {
+func RunCommandline(logger Logger, cmdline string) error {
 	args, err := shlex.Split(cmdline)
 	if err != nil {
 		return err
@@ -85,5 +84,5 @@ func RunCommandline(cmdline string) error {
 	if len(args) < 1 {
 		return ErrNoCommandToExecute
 	}
-	return Run(args[0], args[1:]...)
+	return Run(logger, args[0], args[1:]...)
 }

--- a/internal/shellx/shellx.go
+++ b/internal/shellx/shellx.go
@@ -36,14 +36,14 @@ type runconfig struct {
 // run is the internal function for running commands.
 func run(config runconfig) error {
 	config.loginfof(
-		"exec: %s %s\n", config.command, strings.Join(config.args, " "))
+		"exec: %s %s", config.command, strings.Join(config.args, " "))
 	// implementation note: here we're using execabs because
 	// of https://blog.golang.org/path-security.
 	cmd := execabs.Command(config.command, config.args...)
 	cmd.Stdout = config.stdout
 	cmd.Stderr = config.stderr
 	err := cmd.Run()
-	config.loginfof("exec result: %+v\n", err)
+	config.loginfof("exec result: %+v", err)
 	return err
 }
 

--- a/internal/shellx/shellx_test.go
+++ b/internal/shellx/shellx_test.go
@@ -1,12 +1,16 @@
 package shellx
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/apex/log"
+)
 
 func TestRun(t *testing.T) {
-	if err := Run("whoami"); err != nil {
+	if err := Run(log.Log, "whoami"); err != nil {
 		t.Fatal(err)
 	}
-	if err := Run("./nonexistent/command"); err == nil {
+	if err := Run(log.Log, "./nonexistent/command"); err == nil {
 		t.Fatal("expected an error here")
 	}
 }
@@ -22,22 +26,22 @@ func TestRunQuiet(t *testing.T) {
 
 func TestRunCommandline(t *testing.T) {
 	t.Run("when the command does not parse", func(t *testing.T) {
-		if err := RunCommandline(`"foobar`); err == nil {
+		if err := RunCommandline(log.Log, `"foobar`); err == nil {
 			t.Fatal("expected an error here")
 		}
 	})
 	t.Run("when we have no arguments", func(t *testing.T) {
-		if err := RunCommandline(""); err == nil {
+		if err := RunCommandline(log.Log, ""); err == nil {
 			t.Fatal("expected an error here")
 		}
 	})
 	t.Run("when we have a single argument", func(t *testing.T) {
-		if err := RunCommandline("ls"); err != nil {
+		if err := RunCommandline(log.Log, "ls"); err != nil {
 			t.Fatal(err)
 		}
 	})
 	t.Run("when we have more than one argument", func(t *testing.T) {
-		if err := RunCommandline("ls ."); err != nil {
+		if err := RunCommandline(log.Log, "ls ."); err != nil {
 			t.Fatal(err)
 		}
 	})


### PR DESCRIPTION
We usually do not depend on `apex/log` directly for library-like code.