### PR TITLE
cleanup(netx): remove unused proxy-via-context codepath

### DIFF
--- a/internal/engine/httpx/jsonapi.go
+++ b/internal/engine/httpx/jsonapi.go
@@ -10,8 +10,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/dialer"
 )
 
 // Logger is the definition of Logger used by this package.
@@ -39,10 +37,6 @@ type Client struct {
 
 	// Logger is the logger to use.
 	Logger Logger
-
-	// ProxyURL allows to force a proxy URL to fallback to a
-	// tunnel, e.g., Psiphon.
-	ProxyURL *url.URL
 
 	// UserAgent is the user agent to use.
 	UserAgent string
@@ -93,11 +87,6 @@ func (c Client) NewRequest(ctx context.Context, method, resourcePath string,
 		request.Header.Set("Accept", c.Accept)
 	}
 	request.Header.Set("User-Agent", c.UserAgent)
-	// Implementation note: the following allows tunneling if c.ProxyURL
-	// is not nil. Because the proxy URL is set as part of each request
-	// generated using this function, every request that eventually needs
-	// to reconnect will always do so using the proxy.
-	ctx = dialer.WithProxyURL(ctx, c.ProxyURL)
 	return request.WithContext(ctx), nil
 }
 

--- a/internal/engine/httpx/jsonapi_test.go
+++ b/internal/engine/httpx/jsonapi_test.go
@@ -10,9 +10,7 @@ import (
 	"testing"
 
 	"github.com/apex/log"
-	"github.com/google/go-cmp/cmp"
 	"github.com/ooni/probe-cli/v3/internal/engine/httpx"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/dialer"
 )
 
 const userAgent = "miniooni/0.1.0-dev"
@@ -153,21 +151,6 @@ func TestNewRequestUserAgentIsSet(t *testing.T) {
 	}
 }
 
-func TestNewRequestTunnelingIsPossible(t *testing.T) {
-	client := newClient()
-	client.ProxyURL = &url.URL{Scheme: "socks5", Host: "[::1]:54321"}
-	req, err := client.NewRequest(
-		context.Background(), "GET", "/", nil, nil,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	cmp := cmp.Diff(dialer.ContextProxyURL(req.Context()), client.ProxyURL)
-	if cmp != "" {
-		t.Fatal(cmp)
-	}
-}
-
 func TestClientDoJSONClientDoFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	client := newClient()
@@ -263,10 +246,6 @@ func TestCreateJSONSuccess(t *testing.T) {
 	if response.Data != `{"headers":{"Foo":"bar"}}` {
 		t.Fatal(response.Data)
 	}
-}
-
-type httpbinput struct {
-	Data string `json:"data"`
 }
 
 func TestUpdateJSONSuccess(t *testing.T) {

--- a/internal/engine/netx/dialer/proxy.go
+++ b/internal/engine/netx/dialer/proxy.go
@@ -12,36 +12,14 @@ import (
 // ProxyDialer is a dialer that uses a proxy. If the ProxyURL is not configured, this
 // dialer is a passthrough for the next Dialer in chain. Otherwise, it will internally
 // create a SOCKS5 dialer that will connect to the proxy using the underlying Dialer.
-//
-// As a special case, you can force a proxy to be used only extemporarily. To this end,
-// you can use the WithProxyURL function, to store the proxy URL in the context. This
-// will take precedence over any otherwise configured proxy. The use case for this
-// functionality is when you need a tunnel to contact OONI probe services.
 type ProxyDialer struct {
 	Dialer
 	ProxyURL *url.URL
 }
 
-type proxyKey struct{}
-
-// ContextProxyURL retrieves the proxy URL from the context. This is mainly used
-// to force a tunnel when we fail contacting OONI probe services otherwise.
-func ContextProxyURL(ctx context.Context) *url.URL {
-	url, _ := ctx.Value(proxyKey{}).(*url.URL)
-	return url
-}
-
-// WithProxyURL assigns the proxy URL to the context
-func WithProxyURL(ctx context.Context, url *url.URL) context.Context {
-	return context.WithValue(ctx, proxyKey{}, url)
-}
-
 // DialContext implements Dialer.DialContext
 func (d ProxyDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	url := ContextProxyURL(ctx) // context URL takes precedence
-	if url == nil {
-		url = d.ProxyURL
-	}
+	url := d.ProxyURL
 	if url == nil {
 		return d.Dialer.DialContext(ctx, network, address)
 	}

--- a/internal/engine/netx/dialer/proxy_test.go
+++ b/internal/engine/netx/dialer/proxy_test.go
@@ -24,23 +24,6 @@ func TestProxyDialerDialContextNoProxyURL(t *testing.T) {
 	}
 }
 
-func TestProxyDialerContextTakesPrecedence(t *testing.T) {
-	expected := errors.New("mocked error")
-	d := dialer.ProxyDialer{
-		Dialer:   dialer.FakeDialer{Err: expected},
-		ProxyURL: &url.URL{Scheme: "antani"},
-	}
-	ctx := context.Background()
-	ctx = dialer.WithProxyURL(ctx, &url.URL{Scheme: "socks5", Host: "[::1]:443"})
-	conn, err := d.DialContext(ctx, "tcp", "www.google.com:443")
-	if !errors.Is(err, expected) {
-		t.Fatal("not the error we expected")
-	}
-	if conn != nil {
-		t.Fatal("conn is not nil")
-	}
-}
-
 func TestProxyDialerDialContextInvalidScheme(t *testing.T) {
 	d := dialer.ProxyDialer{
 		Dialer:   dialer.FakeDialer{},

--- a/internal/engine/probeservices/probeservices.go
+++ b/internal/engine/probeservices/probeservices.go
@@ -95,7 +95,6 @@ func NewClient(sess Session, endpoint model.Service) (*Client, error) {
 			BaseURL:    endpoint.Address,
 			HTTPClient: sess.DefaultHTTPClient(),
 			Logger:     sess.Logger(),
-			ProxyURL:   sess.ProxyURL(),
 			UserAgent:  sess.UserAgent(),
 		},
 		LoginCalls:    &atomicx.Int64{},


### PR DESCRIPTION
We always set the proxy explicitly now. So, let us remove this
extra bit of code we're not using.

Part of https://github.com/ooni/probe/issues/1507.