### PR TITLE
refactor(netx): towards removing connid, dialid, etc

### DIFF
--- a/internal/engine/legacy/netx/dialer.go
+++ b/internal/engine/legacy/netx/dialer.go
@@ -66,7 +66,7 @@ func maybeWithMeasurementRoot(
 // If you have others needs, manually build the chain you need.
 func newDNSDialer(resolver dialer.Resolver) dialer.DNSDialer {
 	return dialer.DNSDialer{
-		Dialer: dialer.EmitterDialer{
+		Dialer: EmitterDialer{
 			Dialer: dialer.ErrorWrapperDialer{
 				Dialer: dialer.ByteCounterDialer{
 					Dialer: dialer.Default,

--- a/internal/engine/legacy/netx/emitterdialer.go
+++ b/internal/engine/legacy/netx/emitterdialer.go
@@ -1,18 +1,20 @@
-package dialer
+package netx
 
 import (
 	"context"
 	"net"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/engine/legacy/netx/connid"
 	"github.com/ooni/probe-cli/v3/internal/engine/legacy/netx/dialid"
 	"github.com/ooni/probe-cli/v3/internal/engine/legacy/netx/modelx"
 	"github.com/ooni/probe-cli/v3/internal/engine/legacy/netx/transactionid"
+	"github.com/ooni/probe-cli/v3/internal/engine/netx/dialer"
 )
 
 // EmitterDialer is a Dialer that emits events
 type EmitterDialer struct {
-	Dialer
+	dialer.Dialer
 }
 
 // DialContext implements Dialer.DialContext
@@ -100,4 +102,15 @@ func (c EmitterConn) Close() (err error) {
 		},
 	})
 	return
+}
+
+func safeLocalAddress(conn net.Conn) (s string) {
+	if conn != nil && conn.LocalAddr() != nil {
+		s = conn.LocalAddr().String()
+	}
+	return
+}
+
+func safeConnID(network string, conn net.Conn) int64 {
+	return connid.Compute(network, safeLocalAddress(conn))
 }

--- a/internal/engine/legacy/netx/emitterdialer_test.go
+++ b/internal/engine/legacy/netx/emitterdialer_test.go
@@ -1,4 +1,4 @@
-package dialer_test
+package netx
 
 import (
 	"context"
@@ -12,7 +12,6 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/engine/legacy/netx/handlers"
 	"github.com/ooni/probe-cli/v3/internal/engine/legacy/netx/modelx"
 	"github.com/ooni/probe-cli/v3/internal/engine/legacy/netx/transactionid"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/dialer"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/mockablex"
 )
 
@@ -24,7 +23,7 @@ func TestEmitterFailure(t *testing.T) {
 		Handler:   saver,
 	})
 	ctx = transactionid.WithTransactionID(ctx)
-	d := dialer.EmitterDialer{Dialer: mockablex.Dialer{
+	d := EmitterDialer{Dialer: mockablex.Dialer{
 		MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 			return nil, io.EOF
 		},
@@ -83,7 +82,7 @@ func TestEmitterSuccess(t *testing.T) {
 		Handler:   saver,
 	})
 	ctx = transactionid.WithTransactionID(ctx)
-	d := dialer.EmitterDialer{Dialer: mockablex.Dialer{
+	d := EmitterDialer{Dialer: mockablex.Dialer{
 		MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 			return &mockablex.Conn{
 				MockRead: func(b []byte) (int, error) {

--- a/internal/engine/netx/dialer/dns_test.go
+++ b/internal/engine/netx/dialer/dns_test.go
@@ -6,10 +6,7 @@ import (
 	"io"
 	"net"
 	"testing"
-	"time"
 
-	"github.com/ooni/probe-cli/v3/internal/engine/legacy/netx/handlers"
-	"github.com/ooni/probe-cli/v3/internal/engine/legacy/netx/modelx"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/dialer"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/errorx"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/mockablex"
@@ -117,46 +114,8 @@ func TestDNSDialerDialForManyIPSuccess(t *testing.T) {
 	conn.Close()
 }
 
-func TestDNSDialerDialSetsDialID(t *testing.T) {
-	saver := &handlers.SavingHandler{}
-	ctx := modelx.WithMeasurementRoot(context.Background(), &modelx.MeasurementRoot{
-		Beginning: time.Now(),
-		Handler:   saver,
-	})
-	dialer := dialer.DNSDialer{Dialer: dialer.EmitterDialer{
-		Dialer: mockablex.Dialer{
-			MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
-				return &mockablex.Conn{
-					MockClose: func() error {
-						return nil
-					},
-					MockLocalAddr: func() net.Addr {
-						return &net.TCPAddr{}
-					},
-				}, nil
-			},
-		},
-	}, Resolver: MockableResolver{
-		Addresses: []string{"1.1.1.1", "8.8.8.8"},
-	}}
-	conn, err := dialer.DialContext(ctx, "tcp", "dot.dns:853")
-	if err != nil {
-		t.Fatal("expected nil error here")
-	}
-	if conn == nil {
-		t.Fatal("expected non-nil conn")
-	}
-	conn.Close()
-	events := saver.Read()
-	if len(events) != 2 {
-		t.Fatal("unexpected number of events")
-	}
-	for _, ev := range events {
-		if ev.Connect != nil && ev.Connect.DialID == 0 {
-			t.Fatal("unexpected DialID")
-		}
-	}
-}
+// TODO(bassosimone): remove the dialID etc since the only
+// test still using legacy/netx does not care.
 
 func TestReduceErrors(t *testing.T) {
 	t.Run("no errors", func(t *testing.T) {


### PR DESCRIPTION
I have verified that experiment/tor does not depend on this
functionality, therefore we can safely remove it.

Part of https://github.com/ooni/probe-engine/issues/897