### PR TITLE
refactor(netx): dialer does not use legacy/netx anymore

### DIFF
--- a/internal/engine/netx/dialer/dialer.go
+++ b/internal/engine/netx/dialer/dialer.go
@@ -3,27 +3,9 @@ package dialer
 import (
 	"context"
 	"net"
-
-	"github.com/ooni/probe-cli/v3/internal/engine/legacy/netx/connid"
 )
 
 // Dialer is the interface we expect from a dialer
 type Dialer interface {
 	DialContext(ctx context.Context, network, address string) (net.Conn, error)
-}
-
-// Resolver is the interface we expect from a resolver
-type Resolver interface {
-	LookupHost(ctx context.Context, hostname string) (addrs []string, err error)
-}
-
-func safeLocalAddress(conn net.Conn) (s string) {
-	if conn != nil && conn.LocalAddr() != nil {
-		s = conn.LocalAddr().String()
-	}
-	return
-}
-
-func safeConnID(network string, conn net.Conn) int64 {
-	return connid.Compute(network, safeLocalAddress(conn))
 }

--- a/internal/engine/netx/dialer/dns.go
+++ b/internal/engine/netx/dialer/dns.go
@@ -6,9 +6,13 @@ import (
 	"net"
 	"strings"
 
-	"github.com/ooni/probe-cli/v3/internal/engine/legacy/netx/dialid"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/errorx"
 )
+
+// Resolver is the interface we expect from a resolver
+type Resolver interface {
+	LookupHost(ctx context.Context, hostname string) (addrs []string, err error)
+}
 
 // DNSDialer is a dialer that uses the configured Resolver to resolver a
 // domain name to IP addresses, and the configured Dialer to connect.
@@ -23,7 +27,6 @@ func (d DNSDialer) DialContext(ctx context.Context, network, address string) (ne
 	if err != nil {
 		return nil, err
 	}
-	ctx = dialid.WithDialID(ctx) // important to create before lookupHost
 	var addrs []string
 	addrs, err = d.LookupHost(ctx, onlyhost)
 	if err != nil {

--- a/internal/engine/netx/dialer/errorwrapper_test.go
+++ b/internal/engine/netx/dialer/errorwrapper_test.go
@@ -7,14 +7,13 @@ import (
 	"net"
 	"testing"
 
-	"github.com/ooni/probe-cli/v3/internal/engine/legacy/netx/dialid"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/dialer"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/errorx"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/mockablex"
 )
 
 func TestErrorWrapperFailure(t *testing.T) {
-	ctx := dialid.WithDialID(context.Background())
+	ctx := context.Background()
 	d := dialer.ErrorWrapperDialer{Dialer: mockablex.Dialer{
 		MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 			return nil, io.EOF
@@ -35,9 +34,6 @@ func errorWrapperCheckErr(t *testing.T, err error, op string) {
 	if !errors.As(err, &errWrapper) {
 		t.Fatal("cannot cast to ErrWrapper")
 	}
-	if errWrapper.DialID == 0 {
-		t.Fatal("unexpected DialID")
-	}
 	if errWrapper.Operation != op {
 		t.Fatal("unexpected Operation")
 	}
@@ -47,7 +43,7 @@ func errorWrapperCheckErr(t *testing.T, err error, op string) {
 }
 
 func TestErrorWrapperSuccess(t *testing.T) {
-	ctx := dialid.WithDialID(context.Background())
+	ctx := context.Background()
 	d := dialer.ErrorWrapperDialer{Dialer: mockablex.Dialer{
 		MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 			return &mockablex.Conn{


### PR DESCRIPTION
Part of https://github.com/ooni/probe-engine/issues/897