### PR TITLE
refactor(netx/dialer): hide implementation complexity

### DIFF
--- a/internal/engine/experiment/hhfm/hhfm.go
+++ b/internal/engine/experiment/hhfm/hhfm.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/urlgetter"
 	"github.com/ooni/probe-cli/v3/internal/engine/httpheader"
 	"github.com/ooni/probe-cli/v3/internal/engine/model"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/archival"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/dialer"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/errorx"
@@ -312,7 +311,7 @@ type JSONHeaders struct {
 // guarantee that the connection is used for a single request and that
 // such a request does not contain any body.
 type Dialer struct {
-	Dialer  netx.Dialer // used for testing
+	Dialer  dialer.Dialer // used for testing
 	Headers map[string]string
 }
 
@@ -321,7 +320,7 @@ type Dialer struct {
 func (d Dialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
 	child := d.Dialer
 	if child == nil {
-		child = dialer.Default
+		child = dialer.New(&dialer.Config{}, &net.Resolver{})
 	}
 	conn, err := child.DialContext(ctx, network, address)
 	if err != nil {

--- a/internal/engine/experiment/hhfm/hhfm.go
+++ b/internal/engine/experiment/hhfm/hhfm.go
@@ -320,7 +320,9 @@ type Dialer struct {
 func (d Dialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
 	child := d.Dialer
 	if child == nil {
-		child = dialer.New(&dialer.Config{}, &net.Resolver{})
+		// TODO(bassosimone): figure out why using dialer.New here
+		// causes the experiment to fail with eof_error
+		child = &net.Dialer{Timeout: 15 * time.Second}
 	}
 	conn, err := child.DialContext(ctx, network, address)
 	if err != nil {

--- a/internal/engine/experiment/hhfm/hhfm_test.go
+++ b/internal/engine/experiment/hhfm/hhfm_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/apex/log"
 	"github.com/google/go-cmp/cmp"
-	engine "github.com/ooni/probe-cli/v3/internal/engine"
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/hhfm"
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/urlgetter"
 	"github.com/ooni/probe-cli/v3/internal/engine/internal/mockable"
@@ -55,7 +54,7 @@ func TestSuccess(t *testing.T) {
 		t.Fatal("invalid Agent")
 	}
 	if tk.Failure != nil {
-		t.Fatal("invalid Failure")
+		t.Fatal("invalid Failure", *tk.Failure)
 	}
 	if len(tk.Requests) != 1 {
 		t.Fatal("invalid Requests")
@@ -555,25 +554,6 @@ func TestTransactCannotReadBody(t *testing.T) {
 	if body != nil {
 		t.Fatal("body is not nil")
 	}
-}
-
-func newsession(t *testing.T) model.ExperimentSession {
-	sess, err := engine.NewSession(context.Background(), engine.SessionConfig{
-		AvailableProbeServices: []model.Service{{
-			Address: "https://ams-pg-test.ooni.org",
-			Type:    "https",
-		}},
-		Logger:          log.Log,
-		SoftwareName:    "ooniprobe-engine",
-		SoftwareVersion: "0.0.1",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := sess.MaybeLookupBackends(); err != nil {
-		t.Fatal(err)
-	}
-	return sess
 }
 
 func TestTestKeys_FillTampering(t *testing.T) {

--- a/internal/engine/experiment/ndt7/dial.go
+++ b/internal/engine/experiment/ndt7/dial.go
@@ -3,7 +3,6 @@ package ndt7
 import (
 	"context"
 	"crypto/tls"
-	"net"
 	"net/http"
 	"net/url"
 
@@ -40,7 +39,7 @@ func (mgr dialManager) dialWithTestName(ctx context.Context, testName string) (*
 		ContextByteCounting: true,
 		Logger:              mgr.logger,
 		ProxyURL:            mgr.proxyURL,
-	}, &net.Resolver{})
+	}, reso)
 	dialer := websocket.Dialer{
 		NetDialContext:  dlr.DialContext,
 		ReadBufferSize:  mgr.readBufferSize,

--- a/internal/engine/legacy/netx/dialer.go
+++ b/internal/engine/legacy/netx/dialer.go
@@ -64,17 +64,11 @@ func maybeWithMeasurementRoot(
 // - dialer.Default
 //
 // If you have others needs, manually build the chain you need.
-func newDNSDialer(resolver dialer.Resolver) dialer.DNSDialer {
-	return dialer.DNSDialer{
-		Dialer: EmitterDialer{
-			Dialer: dialer.ErrorWrapperDialer{
-				Dialer: dialer.ByteCounterDialer{
-					Dialer: dialer.Default,
-				},
-			},
-		},
-		Resolver: resolver,
-	}
+func newDNSDialer(resolver dialer.Resolver) dialer.Dialer {
+	return &EmitterDialer{dialer.New(&dialer.Config{
+		ContextByteCounting: true,
+		Logger:              nil,
+	}, resolver)}
 }
 
 // DialContext is like Dial but the context allows to interrupt a

--- a/internal/engine/legacy/netx/dialer.go
+++ b/internal/engine/legacy/netx/dialer.go
@@ -65,9 +65,17 @@ func maybeWithMeasurementRoot(
 //
 // If you have others needs, manually build the chain you need.
 func newDNSDialer(resolver dialer.Resolver) dialer.Dialer {
+	// Implementation note: we're wrapping the result of dialer.New
+	// on the outside, while previously we were puttting the
+	// EmitterDialer before the DNSDialer (see the above comment).
+	//
+	// Yet, this is fine because the only experiment which is
+	// using this code is tor, for which it doesn't matter.
+	//
+	// Also (and I am always scared to write this kind of
+	// comments), we should rewrite tor soon.
 	return &EmitterDialer{dialer.New(&dialer.Config{
 		ContextByteCounting: true,
-		Logger:              nil,
 	}, resolver)}
 }
 

--- a/internal/engine/netx/dialer/bytecounter.go
+++ b/internal/engine/netx/dialer/bytecounter.go
@@ -7,59 +7,49 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/bytecounter"
 )
 
-// ByteCounterDialer is a byte-counting-aware dialer. To perform byte counting, you
+// byteCounterDialer is a byte-counting-aware dialer. To perform byte counting, you
 // should make sure that you insert this dialer in the dialing chain.
-//
-// Bug
-//
-// This implementation cannot properly account for the bytes that are sent by
-// persistent connections, because they strick to the counters set when the
-// connection was established. This typically means we miss the bytes sent and
-// received when submitting a measurement. Such bytes are specifically not
-// see by the experiment specific byte counter.
-//
-// For this reason, this implementation may be heavily changed/removed.
-type ByteCounterDialer struct {
+type byteCounterDialer struct {
 	Dialer
 }
 
 // DialContext implements Dialer.DialContext
-func (d ByteCounterDialer) DialContext(
+func (d *byteCounterDialer) DialContext(
 	ctx context.Context, network, address string) (net.Conn, error) {
 	conn, err := d.Dialer.DialContext(ctx, network, address)
 	if err != nil {
 		return nil, err
 	}
-	exp := ContextExperimentByteCounter(ctx)
-	sess := ContextSessionByteCounter(ctx)
+	exp := contextExperimentByteCounter(ctx)
+	sess := contextSessionByteCounter(ctx)
 	if exp == nil && sess == nil {
 		return conn, nil // no point in wrapping
 	}
-	return byteCounterConnWrapper{Conn: conn, exp: exp, sess: sess}, nil
+	return &byteCounterConnWrapper{Conn: conn, exp: exp, sess: sess}, nil
 }
 
 type byteCounterSessionKey struct{}
 
-// ContextSessionByteCounter retrieves the session byte counter from the context
-func ContextSessionByteCounter(ctx context.Context) *bytecounter.Counter {
+// contextSessionByteCounter retrieves the session byte counter from the context
+func contextSessionByteCounter(ctx context.Context) *bytecounter.Counter {
 	counter, _ := ctx.Value(byteCounterSessionKey{}).(*bytecounter.Counter)
 	return counter
 }
 
-// WithSessionByteCounter assigns the session byte counter to the context
+// WithSessionByteCounter assigns the session byte counter to the context.
 func WithSessionByteCounter(ctx context.Context, counter *bytecounter.Counter) context.Context {
 	return context.WithValue(ctx, byteCounterSessionKey{}, counter)
 }
 
 type byteCounterExperimentKey struct{}
 
-// ContextExperimentByteCounter retrieves the experiment byte counter from the context
-func ContextExperimentByteCounter(ctx context.Context) *bytecounter.Counter {
+// contextExperimentByteCounter retrieves the experiment byte counter from the context
+func contextExperimentByteCounter(ctx context.Context) *bytecounter.Counter {
 	counter, _ := ctx.Value(byteCounterExperimentKey{}).(*bytecounter.Counter)
 	return counter
 }
 
-// WithExperimentByteCounter assigns the experiment byte counter to the context
+// WithExperimentByteCounter assigns the experiment byte counter to the context.
 func WithExperimentByteCounter(ctx context.Context, counter *bytecounter.Counter) context.Context {
 	return context.WithValue(ctx, byteCounterExperimentKey{}, counter)
 }
@@ -70,7 +60,7 @@ type byteCounterConnWrapper struct {
 	sess *bytecounter.Counter
 }
 
-func (c byteCounterConnWrapper) Read(p []byte) (int, error) {
+func (c *byteCounterConnWrapper) Read(p []byte) (int, error) {
 	count, err := c.Conn.Read(p)
 	if c.exp != nil {
 		c.exp.CountBytesReceived(count)
@@ -81,7 +71,7 @@ func (c byteCounterConnWrapper) Read(p []byte) (int, error) {
 	return count, err
 }
 
-func (c byteCounterConnWrapper) Write(p []byte) (int, error) {
+func (c *byteCounterConnWrapper) Write(p []byte) (int, error) {
 	count, err := c.Conn.Write(p)
 	if c.exp != nil {
 		c.exp.CountBytesSent(count)

--- a/internal/engine/netx/dialer/dialer.go
+++ b/internal/engine/netx/dialer/dialer.go
@@ -3,9 +3,83 @@ package dialer
 import (
 	"context"
 	"net"
+	"net/url"
+
+	"github.com/ooni/probe-cli/v3/internal/engine/netx/trace"
 )
 
-// Dialer is the interface we expect from a dialer
+// Dialer establishes network connections.
 type Dialer interface {
+	// DialContext behaves like net.Dialer.DialContext.
 	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+// Resolver is the interface we expect from a DNS resolver.
+type Resolver interface {
+	// LookupHost behaves like net.Resolver.LookupHost.
+	LookupHost(ctx context.Context, hostname string) (addrs []string, err error)
+}
+
+// Logger is the interface we expect from a logger.
+type Logger interface {
+	// Debugf formats and emits a debug message.
+	Debugf(format string, v ...interface{})
+}
+
+// Config contains the settings for New.
+type Config struct {
+	// ContextByteCounting optional configures context-based
+	// byte counting. By default we don't do that.
+	//
+	// Use WithExperimentByteCounter and WithSessionByteCounter
+	// to assign byte counters to a context. The code will use
+	// corresponding, private functions to access the configured
+	// byte counters and will notify them about I/O events.
+	//
+	// Bug
+	//
+	// This implementation cannot properly account for the bytes that are sent by
+	// persistent connections, because they strick to the counters set when the
+	// connection was established. This typically means we miss the bytes sent and
+	// received when submitting a measurement. Such bytes are specifically not
+	// see by the experiment specific byte counter.
+	//
+	// For this reason, this implementation may be heavily changed/removed.
+	ContextByteCounting bool
+
+	// DialSaver is the optional saver for dialing events. If not
+	// set, we will not save any dialing event.
+	DialSaver *trace.Saver
+
+	// Logger is the optional logger. If not set, there
+	// will be no logging from the new dialer.
+	Logger Logger
+
+	// ProxyURL is the optional proxy URL.
+	ProxyURL *url.URL
+
+	// ReadWriteSaver is like DialSaver but for I/O events.
+	ReadWriteSaver *trace.Saver
+}
+
+// New creates a new Dialer from the specified config and resolver.
+func New(config *Config, resolver Resolver) Dialer {
+	var d Dialer = systemDialer
+	d = &errorWrapperDialer{Dialer: d}
+	if config.Logger != nil {
+		d = &loggingDialer{Dialer: d, Logger: config.Logger}
+	}
+	if config.DialSaver != nil {
+		d = &saverDialer{Dialer: d, Saver: config.DialSaver}
+	}
+	if config.ReadWriteSaver != nil {
+		d = &saverConnDialer{Dialer: d, Saver: config.ReadWriteSaver}
+	}
+	d = &dnsDialer{Resolver: resolver, Dialer: d}
+	d = &proxyDialer{ProxyURL: config.ProxyURL, Dialer: d}
+	if config.ContextByteCounting {
+		d = &byteCounterDialer{Dialer: d}
+	}
+	d = &shapingDialer{Dialer: d}
+	return d
 }

--- a/internal/engine/netx/dialer/dialer.go
+++ b/internal/engine/netx/dialer/dialer.go
@@ -28,7 +28,7 @@ type Logger interface {
 
 // Config contains the settings for New.
 type Config struct {
-	// ContextByteCounting optional configures context-based
+	// ContextByteCounting optionally configures context-based
 	// byte counting. By default we don't do that.
 	//
 	// Use WithExperimentByteCounter and WithSessionByteCounter
@@ -42,7 +42,7 @@ type Config struct {
 	// persistent connections, because they strick to the counters set when the
 	// connection was established. This typically means we miss the bytes sent and
 	// received when submitting a measurement. Such bytes are specifically not
-	// see by the experiment specific byte counter.
+	// seen by the experiment specific byte counter.
 	//
 	// For this reason, this implementation may be heavily changed/removed.
 	ContextByteCounting bool

--- a/internal/engine/netx/dialer/dialer_test.go
+++ b/internal/engine/netx/dialer/dialer_test.go
@@ -1,0 +1,57 @@
+package dialer
+
+import (
+	"net"
+	"net/url"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/engine/netx/trace"
+)
+
+func TestNewCreatesTheExpectedChain(t *testing.T) {
+	saver := &trace.Saver{}
+	dlr := New(&Config{
+		ContextByteCounting: true,
+		DialSaver:           saver,
+		Logger:              log.Log,
+		ProxyURL:            &url.URL{},
+		ReadWriteSaver:      saver,
+	}, &net.Resolver{})
+	shd, ok := dlr.(*shapingDialer)
+	if !ok {
+		t.Fatal("not a shapingDialer")
+	}
+	bcd, ok := shd.Dialer.(*byteCounterDialer)
+	if !ok {
+		t.Fatal("not a byteCounterDialer")
+	}
+	pd, ok := bcd.Dialer.(*proxyDialer)
+	if !ok {
+		t.Fatal("not a proxyDialer")
+	}
+	dnsd, ok := pd.Dialer.(*dnsDialer)
+	if !ok {
+		t.Fatal("not a dnsDialer")
+	}
+	scd, ok := dnsd.Dialer.(*saverConnDialer)
+	if !ok {
+		t.Fatal("not a saverConnDialer")
+	}
+	sd, ok := scd.Dialer.(*saverDialer)
+	if !ok {
+		t.Fatal("not a saverDialer")
+	}
+	ld, ok := sd.Dialer.(*loggingDialer)
+	if !ok {
+		t.Fatal("not a loggingDialer")
+	}
+	ewd, ok := ld.Dialer.(*errorWrapperDialer)
+	if !ok {
+		t.Fatal("not an errorWrappingDialer")
+	}
+	_, ok = ewd.Dialer.(*net.Dialer)
+	if !ok {
+		t.Fatal("not a net.Dialer")
+	}
+}

--- a/internal/engine/netx/dialer/doc.go
+++ b/internal/engine/netx/dialer/doc.go
@@ -1,4 +1,4 @@
 // Package dialer allows you to create a net.Dialer-compatible
 // DialContext-enabled dialer with error wrapping, optional logging,
-// optional network-event saving, and optional proxying.
+// optional network-events saving, and optional proxying.
 package dialer

--- a/internal/engine/netx/dialer/doc.go
+++ b/internal/engine/netx/dialer/doc.go
@@ -1,0 +1,4 @@
+// Package dialer allows you to create a net.Dialer-compatible
+// DialContext-enabled dialer with error wrapping, optional logging,
+// optional network-event saving, and optional proxying.
+package dialer

--- a/internal/engine/netx/dialer/errorwrapper.go
+++ b/internal/engine/netx/dialer/errorwrapper.go
@@ -7,13 +7,13 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/errorx"
 )
 
-// ErrorWrapperDialer is a dialer that performs err wrapping
-type ErrorWrapperDialer struct {
+// errorWrapperDialer is a dialer that performs err wrapping
+type errorWrapperDialer struct {
 	Dialer
 }
 
 // DialContext implements Dialer.DialContext
-func (d ErrorWrapperDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+func (d *errorWrapperDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
 	conn, err := d.Dialer.DialContext(ctx, network, address)
 	err = errorx.SafeErrWrapperBuilder{
 		Error:     err,
@@ -22,16 +22,16 @@ func (d ErrorWrapperDialer) DialContext(ctx context.Context, network, address st
 	if err != nil {
 		return nil, err
 	}
-	return &ErrorWrapperConn{Conn: conn}, nil
+	return &errorWrapperConn{Conn: conn}, nil
 }
 
-// ErrorWrapperConn is a net.Conn that performs error wrapping.
-type ErrorWrapperConn struct {
+// errorWrapperConn is a net.Conn that performs error wrapping.
+type errorWrapperConn struct {
 	net.Conn
 }
 
 // Read implements net.Conn.Read
-func (c ErrorWrapperConn) Read(b []byte) (n int, err error) {
+func (c *errorWrapperConn) Read(b []byte) (n int, err error) {
 	n, err = c.Conn.Read(b)
 	err = errorx.SafeErrWrapperBuilder{
 		Error:     err,
@@ -41,7 +41,7 @@ func (c ErrorWrapperConn) Read(b []byte) (n int, err error) {
 }
 
 // Write implements net.Conn.Write
-func (c ErrorWrapperConn) Write(b []byte) (n int, err error) {
+func (c *errorWrapperConn) Write(b []byte) (n int, err error) {
 	n, err = c.Conn.Write(b)
 	err = errorx.SafeErrWrapperBuilder{
 		Error:     err,
@@ -51,7 +51,7 @@ func (c ErrorWrapperConn) Write(b []byte) (n int, err error) {
 }
 
 // Close implements net.Conn.Close
-func (c ErrorWrapperConn) Close() (err error) {
+func (c *errorWrapperConn) Close() (err error) {
 	err = c.Conn.Close()
 	err = errorx.SafeErrWrapperBuilder{
 		Error:     err,

--- a/internal/engine/netx/dialer/errorwrapper_test.go
+++ b/internal/engine/netx/dialer/errorwrapper_test.go
@@ -1,4 +1,4 @@
-package dialer_test
+package dialer
 
 import (
 	"context"
@@ -7,14 +7,13 @@ import (
 	"net"
 	"testing"
 
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/dialer"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/errorx"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/mockablex"
 )
 
 func TestErrorWrapperFailure(t *testing.T) {
 	ctx := context.Background()
-	d := dialer.ErrorWrapperDialer{Dialer: mockablex.Dialer{
+	d := &errorWrapperDialer{Dialer: mockablex.Dialer{
 		MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 			return nil, io.EOF
 		},
@@ -44,7 +43,7 @@ func errorWrapperCheckErr(t *testing.T, err error, op string) {
 
 func TestErrorWrapperSuccess(t *testing.T) {
 	ctx := context.Background()
-	d := dialer.ErrorWrapperDialer{Dialer: mockablex.Dialer{
+	d := &errorWrapperDialer{Dialer: mockablex.Dialer{
 		MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 			return &mockablex.Conn{
 				MockRead: func(b []byte) (int, error) {

--- a/internal/engine/netx/dialer/example_test.go
+++ b/internal/engine/netx/dialer/example_test.go
@@ -1,0 +1,30 @@
+package dialer_test
+
+import (
+	"context"
+	"net"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/engine/netx/dialer"
+	"github.com/ooni/probe-cli/v3/internal/engine/netx/trace"
+)
+
+func Example() {
+	saver := &trace.Saver{}
+
+	dlr := dialer.New(&dialer.Config{
+		DialSaver:      saver,
+		Logger:         log.Log,
+		ReadWriteSaver: saver,
+	}, &net.Resolver{})
+
+	ctx := context.Background()
+	conn, err := dlr.DialContext(ctx, "tcp", "8.8.8.8:53")
+	if err != nil {
+		log.WithError(err).Fatal("DialContext failed")
+	}
+
+	// ... use the connection ...
+
+	conn.Close()
+}

--- a/internal/engine/netx/dialer/integration_test.go
+++ b/internal/engine/netx/dialer/integration_test.go
@@ -9,19 +9,13 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/dialer"
 )
 
-func TestDNSDialerSuccess(t *testing.T) {
+func TestDialerNewSuccess(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip test in short mode")
 	}
 	log.SetLevel(log.DebugLevel)
-	dialer := dialer.DNSDialer{
-		Dialer: dialer.LoggingDialer{
-			Dialer: new(net.Dialer),
-			Logger: log.Log,
-		},
-		Resolver: new(net.Resolver),
-	}
-	txp := &http.Transport{DialContext: dialer.DialContext}
+	d := dialer.New(&dialer.Config{Logger: log.Log}, &net.Resolver{})
+	txp := &http.Transport{DialContext: d.DialContext}
 	client := &http.Client{Transport: txp}
 	resp, err := client.Get("http://www.google.com")
 	if err != nil {

--- a/internal/engine/netx/dialer/logging.go
+++ b/internal/engine/netx/dialer/logging.go
@@ -6,20 +6,14 @@ import (
 	"time"
 )
 
-// Logger is the logger assumed by this package
-type Logger interface {
-	Debugf(format string, v ...interface{})
-	Debug(message string)
-}
-
-// LoggingDialer is a Dialer with logging
-type LoggingDialer struct {
+// loggingDialer is a Dialer with logging
+type loggingDialer struct {
 	Dialer
 	Logger Logger
 }
 
 // DialContext implements Dialer.DialContext
-func (d LoggingDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+func (d *loggingDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
 	d.Logger.Debugf("dial %s/%s...", address, network)
 	start := time.Now()
 	conn, err := d.Dialer.DialContext(ctx, network, address)

--- a/internal/engine/netx/dialer/logging_test.go
+++ b/internal/engine/netx/dialer/logging_test.go
@@ -1,4 +1,4 @@
-package dialer_test
+package dialer
 
 import (
 	"context"
@@ -8,12 +8,11 @@ import (
 	"testing"
 
 	"github.com/apex/log"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/dialer"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/mockablex"
 )
 
 func TestLoggingDialerFailure(t *testing.T) {
-	d := dialer.LoggingDialer{
+	d := &loggingDialer{
 		Dialer: mockablex.Dialer{
 			MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 				return nil, io.EOF

--- a/internal/engine/netx/dialer/proxy_test.go
+++ b/internal/engine/netx/dialer/proxy_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestProxyDialerDialContextNoProxyURL(t *testing.T) {
 	expected := errors.New("mocked error")
-	d := ProxyDialer{
+	d := &proxyDialer{
 		Dialer: mockablex.Dialer{
 			MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 				return nil, expected
@@ -30,7 +30,7 @@ func TestProxyDialerDialContextNoProxyURL(t *testing.T) {
 }
 
 func TestProxyDialerDialContextInvalidScheme(t *testing.T) {
-	d := ProxyDialer{
+	d := &proxyDialer{
 		ProxyURL: &url.URL{Scheme: "antani"},
 	}
 	conn, err := d.DialContext(context.Background(), "tcp", "www.google.com:443")
@@ -44,7 +44,7 @@ func TestProxyDialerDialContextInvalidScheme(t *testing.T) {
 
 func TestProxyDialerDialContextWithEOF(t *testing.T) {
 	const expect = "10.0.0.1:9050"
-	d := ProxyDialer{
+	d := &proxyDialer{
 		Dialer: mockablex.Dialer{
 			MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 				if address != expect {

--- a/internal/engine/netx/dialer/saver_test.go
+++ b/internal/engine/netx/dialer/saver_test.go
@@ -1,4 +1,4 @@
-package dialer_test
+package dialer
 
 import (
 	"context"
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/dialer"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/errorx"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/mockablex"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/trace"
@@ -17,7 +16,7 @@ import (
 func TestSaverDialerFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	saver := &trace.Saver{}
-	dlr := dialer.SaverDialer{
+	dlr := &saverDialer{
 		Dialer: mockablex.Dialer{
 			MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 				return nil, expected
@@ -59,7 +58,7 @@ func TestSaverDialerFailure(t *testing.T) {
 func TestSaverConnDialerFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	saver := &trace.Saver{}
-	dlr := dialer.SaverConnDialer{
+	dlr := &saverConnDialer{
 		Dialer: mockablex.Dialer{
 			MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 				return nil, expected
@@ -78,8 +77,8 @@ func TestSaverConnDialerFailure(t *testing.T) {
 
 func TestSaverConnDialerSuccess(t *testing.T) {
 	saver := &trace.Saver{}
-	dlr := dialer.SaverConnDialer{
-		Dialer: dialer.SaverDialer{
+	dlr := &saverConnDialer{
+		Dialer: &saverDialer{
 			Dialer: mockablex.Dialer{
 				MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 					return &mockablex.Conn{

--- a/internal/engine/netx/dialer/shaping_disabled.go
+++ b/internal/engine/netx/dialer/shaping_disabled.go
@@ -7,15 +7,15 @@ import (
 	"net"
 )
 
-// ShapingDialer ensures we don't use too much bandwidth
+// shapingDialer ensures we don't use too much bandwidth
 // when using integration tests at GitHub. To select
 // the implementation with shaping use `-tags shaping`.
-type ShapingDialer struct {
+type shapingDialer struct {
 	Dialer
 }
 
 // DialContext implements Dialer.DialContext
-func (d ShapingDialer) DialContext(
+func (d *shapingDialer) DialContext(
 	ctx context.Context, network, address string) (net.Conn, error) {
 	return d.Dialer.DialContext(ctx, network, address)
 }

--- a/internal/engine/netx/dialer/shaping_enabled.go
+++ b/internal/engine/netx/dialer/shaping_enabled.go
@@ -8,15 +8,15 @@ import (
 	"time"
 )
 
-// ShapingDialer ensures we don't use too much bandwidth
+// shapingDialer ensures we don't use too much bandwidth
 // when using integration tests at GitHub. To select
 // the implementation with shaping use `-tags shaping`.
-type ShapingDialer struct {
+type shapingDialer struct {
 	Dialer
 }
 
 // DialContext implements Dialer.DialContext
-func (d ShapingDialer) DialContext(
+func (d *shapingDialer) DialContext(
 	ctx context.Context, network, address string) (net.Conn, error) {
 	conn, err := d.Dialer.DialContext(ctx, network, address)
 	if err != nil {
@@ -29,12 +29,12 @@ type shapingConn struct {
 	net.Conn
 }
 
-func (c shapingConn) Read(p []byte) (int, error) {
+func (c *shapingConn) Read(p []byte) (int, error) {
 	time.Sleep(100 * time.Millisecond)
 	return c.Conn.Read(p)
 }
 
-func (c shapingConn) Write(p []byte) (int, error) {
+func (c *shapingConn) Write(p []byte) (int, error) {
 	time.Sleep(100 * time.Millisecond)
 	return c.Conn.Write(p)
 }

--- a/internal/engine/netx/dialer/shaping_test.go
+++ b/internal/engine/netx/dialer/shaping_test.go
@@ -1,20 +1,14 @@
-package dialer_test
+package dialer
 
 import (
 	"net"
 	"net/http"
 	"testing"
-
-	"github.com/ooni/probe-cli/v3/internal/engine/netx"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/dialer"
 )
 
-func TestGood(t *testing.T) {
-	txp := netx.NewHTTPTransport(netx.Config{
-		Dialer: dialer.ShapingDialer{
-			Dialer: new(net.Dialer),
-		},
-	})
+func TestShapingDialerGood(t *testing.T) {
+	d := &shapingDialer{Dialer: &net.Dialer{}}
+	txp := &http.Transport{DialContext: d.DialContext}
 	client := &http.Client{Transport: txp}
 	resp, err := client.Get("https://www.google.com/")
 	if err != nil {

--- a/internal/engine/netx/dialer/system.go
+++ b/internal/engine/netx/dialer/system.go
@@ -1,24 +1,12 @@
 package dialer
 
 import (
-	"context"
 	"net"
 	"time"
 )
 
-// underlyingDialer is the underlying net.Dialer.
-var underlyingDialer = &net.Dialer{
+// systemDialer is the underlying net.Dialer.
+var systemDialer = &net.Dialer{
 	Timeout:   15 * time.Second,
 	KeepAlive: 15 * time.Second,
 }
-
-// SystemDialer is the system dialer.
-type SystemDialer struct{}
-
-// DialContext implements Dialer.DialContext
-func (d SystemDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	return underlyingDialer.DialContext(ctx, network, address)
-}
-
-// Default is the dialer we use by default.
-var Default = SystemDialer{}

--- a/internal/engine/netx/dialer/system_test.go
+++ b/internal/engine/netx/dialer/system_test.go
@@ -11,7 +11,7 @@ import (
 func TestSystemDialerWorks(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // fail immediately
-	conn, err := Default.DialContext(ctx, "tcp", "8.8.8.8:853")
+	conn, err := systemDialer.DialContext(ctx, "tcp", "8.8.8.8:853")
 	if err == nil || !strings.HasSuffix(err.Error(), "operation was canceled") {
 		t.Fatal("not the error we expected", err)
 	}
@@ -20,9 +20,9 @@ func TestSystemDialerWorks(t *testing.T) {
 	}
 }
 
-func TestUnderlyingDialerHasTimeout(t *testing.T) {
+func TestSystemDialerHasTimeout(t *testing.T) {
 	expected := 15 * time.Second
-	if underlyingDialer.Timeout != expected {
+	if systemDialer.Timeout != expected {
 		t.Fatal("unexpected timeout value")
 	}
 }

--- a/internal/engine/netx/httptransport/http3transport_test.go
+++ b/internal/engine/netx/httptransport/http3transport_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"net"
 	"net/http"
 	"strings"
 	"testing"
@@ -42,7 +43,9 @@ func TestHTTP3TransportSNI(t *testing.T) {
 	namech := make(chan string, 1)
 	sni := "sni.org"
 	txp := httptransport.NewHTTP3Transport(httptransport.Config{
-		Dialer: dialer.Default, QUICDialer: MockSNIQUICDialer{namech: namech}, TLSConfig: &tls.Config{ServerName: sni}})
+		Dialer:     dialer.New(&dialer.Config{}, &net.Resolver{}),
+		QUICDialer: MockSNIQUICDialer{namech: namech},
+		TLSConfig:  &tls.Config{ServerName: sni}})
 	req, err := http.NewRequest("GET", "https://www.google.com", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -67,7 +70,9 @@ func TestHTTP3TransportSNINoVerify(t *testing.T) {
 	namech := make(chan string, 1)
 	sni := "sni.org"
 	txp := httptransport.NewHTTP3Transport(httptransport.Config{
-		Dialer: dialer.Default, QUICDialer: MockSNIQUICDialer{namech: namech}, TLSConfig: &tls.Config{ServerName: sni, InsecureSkipVerify: true}})
+		Dialer:     dialer.New(&dialer.Config{}, &net.Resolver{}),
+		QUICDialer: MockSNIQUICDialer{namech: namech},
+		TLSConfig:  &tls.Config{ServerName: sni, InsecureSkipVerify: true}})
 	req, err := http.NewRequest("GET", "https://www.google.com", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -89,7 +94,9 @@ func TestHTTP3TransportCABundle(t *testing.T) {
 	certch := make(chan *x509.CertPool, 1)
 	certpool := x509.NewCertPool()
 	txp := httptransport.NewHTTP3Transport(httptransport.Config{
-		Dialer: dialer.Default, QUICDialer: MockCertQUICDialer{certch: certch}, TLSConfig: &tls.Config{RootCAs: certpool}})
+		Dialer:     dialer.New(&dialer.Config{}, &net.Resolver{}),
+		QUICDialer: MockCertQUICDialer{certch: certch},
+		TLSConfig:  &tls.Config{RootCAs: certpool}})
 	req, err := http.NewRequest("GET", "https://www.google.com", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -114,7 +121,8 @@ func TestHTTP3TransportCABundle(t *testing.T) {
 
 func TestUnitHTTP3TransportSuccess(t *testing.T) {
 	txp := httptransport.NewHTTP3Transport(httptransport.Config{
-		Dialer: dialer.Default, QUICDialer: MockQUICDialer{}})
+		Dialer:     dialer.New(&dialer.Config{}, &net.Resolver{}),
+		QUICDialer: MockQUICDialer{}})
 
 	req, err := http.NewRequest("GET", "https://www.google.com", nil)
 	if err != nil {
@@ -134,7 +142,8 @@ func TestUnitHTTP3TransportSuccess(t *testing.T) {
 
 func TestUnitHTTP3TransportFailure(t *testing.T) {
 	txp := httptransport.NewHTTP3Transport(httptransport.Config{
-		Dialer: dialer.Default, QUICDialer: MockQUICDialer{}})
+		Dialer:     dialer.New(&dialer.Config{}, &net.Resolver{}),
+		QUICDialer: MockQUICDialer{}})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // so that the request immediately fails

--- a/internal/engine/netx/netx.go
+++ b/internal/engine/netx/netx.go
@@ -146,24 +146,13 @@ func NewDialer(config Config) Dialer {
 	if config.FullResolver == nil {
 		config.FullResolver = NewResolver(config)
 	}
-	var d Dialer = dialer.Default
-	d = dialer.ErrorWrapperDialer{Dialer: d}
-	if config.Logger != nil {
-		d = dialer.LoggingDialer{Dialer: d, Logger: config.Logger}
-	}
-	if config.DialSaver != nil {
-		d = dialer.SaverDialer{Dialer: d, Saver: config.DialSaver}
-	}
-	if config.ReadWriteSaver != nil {
-		d = dialer.SaverConnDialer{Dialer: d, Saver: config.ReadWriteSaver}
-	}
-	d = dialer.DNSDialer{Resolver: config.FullResolver, Dialer: d}
-	d = dialer.ProxyDialer{ProxyURL: config.ProxyURL, Dialer: d}
-	if config.ContextByteCounting {
-		d = dialer.ByteCounterDialer{Dialer: d}
-	}
-	d = dialer.ShapingDialer{Dialer: d}
-	return d
+	return dialer.New(&dialer.Config{
+		ContextByteCounting: config.ContextByteCounting,
+		DialSaver:           config.DialSaver,
+		Logger:              config.Logger,
+		ProxyURL:            config.ProxyURL,
+		ReadWriteSaver:      config.ReadWriteSaver,
+	}, config.FullResolver)
 }
 
 // NewQUICDialer creates a new DNS Dialer for QUIC, with the resolver from the specified config

--- a/internal/engine/netx/netx_test.go
+++ b/internal/engine/netx/netx_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/apex/log"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/bytecounter"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/dialer"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/httptransport"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/resolver"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/tlsdialer"
@@ -210,257 +209,6 @@ func TestNewResolverWithPrefilledReadonlyCache(t *testing.T) {
 	}
 }
 
-func TestNewDialerVanilla(t *testing.T) {
-	d := netx.NewDialer(netx.Config{})
-	sd, ok := d.(dialer.ShapingDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	pd, ok := sd.Dialer.(dialer.ProxyDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if pd.ProxyURL != nil {
-		t.Fatal("not the proxy URL we expected")
-	}
-	dnsd, ok := pd.Dialer.(dialer.DNSDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if dnsd.Resolver == nil {
-		t.Fatal("not the resolver we expected")
-	}
-	ir, ok := dnsd.Resolver.(resolver.IDNAResolver)
-	if !ok {
-		t.Fatal("not the resolver we expected")
-	}
-	if _, ok := ir.Resolver.(resolver.ErrorWrapperResolver); !ok {
-		t.Fatal("not the resolver we expected")
-	}
-	ewd, ok := dnsd.Dialer.(dialer.ErrorWrapperDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if _, ok := ewd.Dialer.(dialer.SystemDialer); !ok {
-		t.Fatal("not the dialer we expected")
-	}
-}
-
-func TestNewDialerWithResolver(t *testing.T) {
-	d := netx.NewDialer(netx.Config{
-		FullResolver: resolver.BogonResolver{
-			// not initialized because it doesn't matter in this context
-		},
-	})
-	sd, ok := d.(dialer.ShapingDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	pd, ok := sd.Dialer.(dialer.ProxyDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if pd.ProxyURL != nil {
-		t.Fatal("not the proxy URL we expected")
-	}
-	dnsd, ok := pd.Dialer.(dialer.DNSDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if dnsd.Resolver == nil {
-		t.Fatal("not the resolver we expected")
-	}
-	if _, ok := dnsd.Resolver.(resolver.BogonResolver); !ok {
-		t.Fatal("not the resolver we expected")
-	}
-	ewd, ok := dnsd.Dialer.(dialer.ErrorWrapperDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if _, ok := ewd.Dialer.(dialer.SystemDialer); !ok {
-		t.Fatal("not the dialer we expected")
-	}
-}
-
-func TestNewDialerWithLogger(t *testing.T) {
-	d := netx.NewDialer(netx.Config{
-		Logger: log.Log,
-	})
-	sd, ok := d.(dialer.ShapingDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	pd, ok := sd.Dialer.(dialer.ProxyDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if pd.ProxyURL != nil {
-		t.Fatal("not the proxy URL we expected")
-	}
-	dnsd, ok := pd.Dialer.(dialer.DNSDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if dnsd.Resolver == nil {
-		t.Fatal("not the resolver we expected")
-	}
-	ir, ok := dnsd.Resolver.(resolver.IDNAResolver)
-	if !ok {
-		t.Fatal("not the resolver we expected")
-	}
-	if _, ok := ir.Resolver.(resolver.LoggingResolver); !ok {
-		t.Fatal("not the resolver we expected")
-	}
-	ld, ok := dnsd.Dialer.(dialer.LoggingDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if ld.Logger != log.Log {
-		t.Fatal("not the logger we expected")
-	}
-	ewd, ok := ld.Dialer.(dialer.ErrorWrapperDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if _, ok := ewd.Dialer.(dialer.SystemDialer); !ok {
-		t.Fatal("not the dialer we expected")
-	}
-}
-
-func TestNewDialerWithDialSaver(t *testing.T) {
-	saver := new(trace.Saver)
-	d := netx.NewDialer(netx.Config{
-		DialSaver: saver,
-	})
-	sd, ok := d.(dialer.ShapingDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	pd, ok := sd.Dialer.(dialer.ProxyDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if pd.ProxyURL != nil {
-		t.Fatal("not the proxy URL we expected")
-	}
-	dnsd, ok := pd.Dialer.(dialer.DNSDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if dnsd.Resolver == nil {
-		t.Fatal("not the resolver we expected")
-	}
-	ir, ok := dnsd.Resolver.(resolver.IDNAResolver)
-	if !ok {
-		t.Fatal("not the resolver we expected")
-	}
-	if _, ok := ir.Resolver.(resolver.ErrorWrapperResolver); !ok {
-		t.Fatal("not the resolver we expected")
-	}
-	sad, ok := dnsd.Dialer.(dialer.SaverDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if sad.Saver != saver {
-		t.Fatal("not the logger we expected")
-	}
-	ewd, ok := sad.Dialer.(dialer.ErrorWrapperDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if _, ok := ewd.Dialer.(dialer.SystemDialer); !ok {
-		t.Fatal("not the dialer we expected")
-	}
-}
-
-func TestNewDialerWithReadWriteSaver(t *testing.T) {
-	saver := new(trace.Saver)
-	d := netx.NewDialer(netx.Config{
-		ReadWriteSaver: saver,
-	})
-	sd, ok := d.(dialer.ShapingDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	pd, ok := sd.Dialer.(dialer.ProxyDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if pd.ProxyURL != nil {
-		t.Fatal("not the proxy URL we expected")
-	}
-	dnsd, ok := pd.Dialer.(dialer.DNSDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if dnsd.Resolver == nil {
-		t.Fatal("not the resolver we expected")
-	}
-	ir, ok := dnsd.Resolver.(resolver.IDNAResolver)
-	if !ok {
-		t.Fatal("not the resolver we expected")
-	}
-	if _, ok := ir.Resolver.(resolver.ErrorWrapperResolver); !ok {
-		t.Fatal("not the resolver we expected")
-	}
-	scd, ok := dnsd.Dialer.(dialer.SaverConnDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if scd.Saver != saver {
-		t.Fatal("not the logger we expected")
-	}
-	ewd, ok := scd.Dialer.(dialer.ErrorWrapperDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if _, ok := ewd.Dialer.(dialer.SystemDialer); !ok {
-		t.Fatal("not the dialer we expected")
-	}
-}
-
-func TestNewDialerWithContextByteCounting(t *testing.T) {
-	d := netx.NewDialer(netx.Config{
-		ContextByteCounting: true,
-	})
-	sd, ok := d.(dialer.ShapingDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	bcd, ok := sd.Dialer.(dialer.ByteCounterDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	pd, ok := bcd.Dialer.(dialer.ProxyDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if pd.ProxyURL != nil {
-		t.Fatal("not the proxy URL we expected")
-	}
-	dnsd, ok := pd.Dialer.(dialer.DNSDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if dnsd.Resolver == nil {
-		t.Fatal("not the resolver we expected")
-	}
-	ir, ok := dnsd.Resolver.(resolver.IDNAResolver)
-	if !ok {
-		t.Fatal("not the resolver we expected")
-	}
-	if _, ok := ir.Resolver.(resolver.ErrorWrapperResolver); !ok {
-		t.Fatal("not the resolver we expected")
-	}
-	ewd, ok := dnsd.Dialer.(dialer.ErrorWrapperDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if _, ok := ewd.Dialer.(dialer.SystemDialer); !ok {
-		t.Fatal("not the dialer we expected")
-	}
-}
-
 func TestNewTLSDialerVanilla(t *testing.T) {
 	td := netx.NewTLSDialer(netx.Config{})
 	rtd, ok := td.(tlsdialer.TLSDialer)
@@ -478,13 +226,6 @@ func TestNewTLSDialerVanilla(t *testing.T) {
 	}
 	if rtd.Dialer == nil {
 		t.Fatal("invalid Dialer")
-	}
-	sd, ok := rtd.Dialer.(dialer.ShapingDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if _, ok := sd.Dialer.(dialer.ProxyDialer); !ok {
-		t.Fatal("not the Dialer we expected")
 	}
 	if rtd.TLSHandshaker == nil {
 		t.Fatal("invalid TLSHandshaker")
@@ -518,13 +259,6 @@ func TestNewTLSDialerWithConfig(t *testing.T) {
 	}
 	if rtd.Dialer == nil {
 		t.Fatal("invalid Dialer")
-	}
-	sd, ok := rtd.Dialer.(dialer.ShapingDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if _, ok := sd.Dialer.(dialer.ProxyDialer); !ok {
-		t.Fatal("not the Dialer we expected")
 	}
 	if rtd.TLSHandshaker == nil {
 		t.Fatal("invalid TLSHandshaker")
@@ -561,13 +295,6 @@ func TestNewTLSDialerWithLogging(t *testing.T) {
 	}
 	if rtd.Dialer == nil {
 		t.Fatal("invalid Dialer")
-	}
-	sd, ok := rtd.Dialer.(dialer.ShapingDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if _, ok := sd.Dialer.(dialer.ProxyDialer); !ok {
-		t.Fatal("not the Dialer we expected")
 	}
 	if rtd.TLSHandshaker == nil {
 		t.Fatal("invalid TLSHandshaker")
@@ -613,13 +340,6 @@ func TestNewTLSDialerWithSaver(t *testing.T) {
 	if rtd.Dialer == nil {
 		t.Fatal("invalid Dialer")
 	}
-	sd, ok := rtd.Dialer.(dialer.ShapingDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if _, ok := sd.Dialer.(dialer.ProxyDialer); !ok {
-		t.Fatal("not the Dialer we expected")
-	}
 	if rtd.TLSHandshaker == nil {
 		t.Fatal("invalid TLSHandshaker")
 	}
@@ -664,13 +384,6 @@ func TestNewTLSDialerWithNoTLSVerifyAndConfig(t *testing.T) {
 	if rtd.Dialer == nil {
 		t.Fatal("invalid Dialer")
 	}
-	sd, ok := rtd.Dialer.(dialer.ShapingDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if _, ok := sd.Dialer.(dialer.ProxyDialer); !ok {
-		t.Fatal("not the Dialer we expected")
-	}
 	if rtd.TLSHandshaker == nil {
 		t.Fatal("invalid TLSHandshaker")
 	}
@@ -709,13 +422,6 @@ func TestNewTLSDialerWithNoTLSVerifyAndNoConfig(t *testing.T) {
 	}
 	if rtd.Dialer == nil {
 		t.Fatal("invalid Dialer")
-	}
-	sd, ok := rtd.Dialer.(dialer.ShapingDialer)
-	if !ok {
-		t.Fatal("not the dialer we expected")
-	}
-	if _, ok := sd.Dialer.(dialer.ProxyDialer); !ok {
-		t.Fatal("not the Dialer we expected")
 	}
 	if rtd.TLSHandshaker == nil {
 		t.Fatal("invalid TLSHandshaker")

--- a/internal/engine/netx/tlsdialer/saver_test.go
+++ b/internal/engine/netx/tlsdialer/saver_test.go
@@ -23,10 +23,7 @@ func TestSaverTLSHandshakerSuccessWithReadWrite(t *testing.T) {
 	saver := &trace.Saver{}
 	tlsdlr := tlsdialer.TLSDialer{
 		Config: &tls.Config{NextProtos: nextprotos},
-		Dialer: dialer.SaverConnDialer{
-			Dialer: new(net.Dialer),
-			Saver:  saver,
-		},
+		Dialer: dialer.New(&dialer.Config{ReadWriteSaver: saver}, &net.Resolver{}),
 		TLSHandshaker: tlsdialer.SaverTLSHandshaker{
 			TLSHandshaker: tlsdialer.SystemTLSHandshaker{},
 			Saver:         saver,


### PR DESCRIPTION
This follows the blueprint of `module.Config` and `nodule.New`
described at https://github.com/ooni/probe/issues/1591.