### PR TITLE
cleanup(all): stop using deprecated ioutil functions

### DIFF
--- a/cmd/ooniprobe/internal/autorun/autorun_darwin.go
+++ b/cmd/ooniprobe/internal/autorun/autorun_darwin.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -114,7 +113,7 @@ func (managerDarwin) writePlist() error {
 		return err
 	}
 	log.Infof("exec: writePlist(%s)", plistPath)
-	return ioutil.WriteFile(plistPath, out.Bytes(), 0644)
+	return os.WriteFile(plistPath, out.Bytes(), 0644)
 }
 
 func (managerDarwin) start() error {

--- a/cmd/ooniprobe/internal/config/parser.go
+++ b/cmd/ooniprobe/internal/config/parser.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"sync"
 
 	"github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/utils"
@@ -14,7 +14,7 @@ const ConfigVersion = 1
 
 // ReadConfig reads the configuration from the path
 func ReadConfig(path string) (*Config, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +67,7 @@ func (c *Config) Write() error {
 	if c.path == "" {
 		return errors.New("config file path is empty")
 	}
-	if err := ioutil.WriteFile(c.path, configJSON, 0644); err != nil {
+	if err := os.WriteFile(c.path, configJSON, 0644); err != nil {
 		return errors.Wrap(err, "writing config JSON")
 	}
 	return nil

--- a/cmd/ooniprobe/internal/config/parser_test.go
+++ b/cmd/ooniprobe/internal/config/parser_test.go
@@ -43,11 +43,11 @@ func TestUpdateConfig(t *testing.T) {
 	configPath := tmpFile.Name()
 	defer os.Remove(configPath)
 
-	data, err := ioutil.ReadFile("testdata/config-v0.json")
+	data, err := os.ReadFile("testdata/config-v0.json")
 	if err != nil {
 		t.Error(err)
 	}
-	err = ioutil.WriteFile(configPath, data, 0644)
+	err = os.WriteFile(configPath, data, 0644)
 	if err != nil {
 		t.Error(err)
 	}

--- a/cmd/ooniprobe/internal/database/actions.go
+++ b/cmd/ooniprobe/internal/database/actions.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -92,7 +91,7 @@ func GetMeasurementJSON(sess sqlbuilder.Database, measurementID int64) (map[stri
 		return nil, errors.New("cannot access measurement file")
 	}
 	measurementFilePath := measurement.Measurement.MeasurementFilePath.String
-	b, err := ioutil.ReadFile(measurementFilePath)
+	b, err := os.ReadFile(measurementFilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ooniprobe/internal/nettests/nettests_test.go
+++ b/cmd/ooniprobe/internal/nettests/nettests_test.go
@@ -3,6 +3,7 @@ package nettests
 import (
 	"context"
 	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -11,11 +12,11 @@ import (
 )
 
 func copyfile(source, dest string) error {
-	data, err := ioutil.ReadFile(source)
+	data, err := os.ReadFile(source)
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(dest, data, 0600)
+	return os.WriteFile(dest, data, 0600)
 }
 
 func newOONIProbe(t *testing.T) *ooni.Probe {

--- a/cmd/ooniprobe/internal/ooni/ooni.go
+++ b/cmd/ooniprobe/internal/ooni/ooni.go
@@ -265,7 +265,7 @@ func InitDefaultConfig(home string) (*config.Config, error) {
 	if err != nil {
 		if os.IsNotExist(err) {
 			log.Debugf("writing default config to %s", configPath)
-			if err = ioutil.WriteFile(configPath, defaultConfig, 0644); err != nil {
+			if err = os.WriteFile(configPath, defaultConfig, 0644); err != nil {
 				return nil, err
 			}
 			// If the user did the informed consent procedure in

--- a/internal/cmd/e2epostprocess/main.go
+++ b/internal/cmd/e2epostprocess/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -48,7 +47,7 @@ func main() {
 	}
 	var found int
 	for _, file := range files {
-		data, err := ioutil.ReadFile(file)
+		data, err := os.ReadFile(file)
 		fatalOnError(err)
 		measurements := bytes.Split(data, []byte("\n"))
 		for _, measurement := range measurements {

--- a/internal/cmd/jafar/main.go
+++ b/internal/cmd/jafar/main.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -185,11 +184,11 @@ func badProxyStartTLS() net.Listener {
 	proxy := badproxy.NewCensoringProxy()
 	listener, cert, err := proxy.StartTLS(*badProxyAddressTLS)
 	runtimex.PanicOnError(err, "proxy.StartTLS failed")
-	err = ioutil.WriteFile(*badProxyTLSOutputCA, pem.EncodeToMemory(&pem.Block{
+	err = os.WriteFile(*badProxyTLSOutputCA, pem.EncodeToMemory(&pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: cert.Raw,
 	}), 0644)
-	runtimex.PanicOnError(err, "ioutil.WriteFile failed")
+	runtimex.PanicOnError(err, "os.WriteFile failed")
 	return listener
 }
 

--- a/internal/cmd/miniooni/libminiooni.go
+++ b/internal/cmd/miniooni/libminiooni.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/url"
 	"os"
@@ -258,7 +257,7 @@ func canOpen(filepath string) bool {
 
 func maybeWriteConsentFile(yes bool, filepath string) (err error) {
 	if yes {
-		err = ioutil.WriteFile(filepath, []byte("\n"), 0644)
+		err = os.WriteFile(filepath, []byte("\n"), 0644)
 	}
 	return
 }

--- a/internal/engine/experiment/dash/collect_test.go
+++ b/internal/engine/experiment/dash/collect_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -57,7 +57,7 @@ func TestCollectInternalError(t *testing.T) {
 func TestCollectReadAllFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	txp := FakeHTTPTransport{resp: &http.Response{
-		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+		Body:       io.NopCloser(bytes.NewReader(nil)),
 		StatusCode: 200,
 	}}
 	deps := FakeDeps{
@@ -76,7 +76,7 @@ func TestCollectReadAllFailure(t *testing.T) {
 
 func TestCollectInvalidJSON(t *testing.T) {
 	txp := FakeHTTPTransport{resp: &http.Response{
-		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+		Body:       io.NopCloser(bytes.NewReader(nil)),
 		StatusCode: 200,
 	}}
 	deps := FakeDeps{
@@ -95,7 +95,7 @@ func TestCollectInvalidJSON(t *testing.T) {
 
 func TestCollectSuccess(t *testing.T) {
 	txp := FakeHTTPTransport{resp: &http.Response{
-		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+		Body:       io.NopCloser(bytes.NewReader(nil)),
 		StatusCode: 200,
 	}}
 	deps := FakeDeps{

--- a/internal/engine/experiment/dash/dash_test.go
+++ b/internal/engine/experiment/dash/dash_test.go
@@ -3,7 +3,7 @@ package dash
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -47,7 +47,7 @@ func TestRunnerLoopNegotiateFailure(t *testing.T) {
 				all: []FakeHTTPTransport{
 					{
 						resp: &http.Response{
-							Body: ioutil.NopCloser(strings.NewReader(
+							Body: io.NopCloser(strings.NewReader(
 								`{"fqdn": "ams01.measurementlab.net"}`)),
 							StatusCode: 200,
 						},
@@ -77,14 +77,14 @@ func TestRunnerLoopMeasureFailure(t *testing.T) {
 				all: []FakeHTTPTransport{
 					{
 						resp: &http.Response{
-							Body: ioutil.NopCloser(strings.NewReader(
+							Body: io.NopCloser(strings.NewReader(
 								`{"fqdn": "ams01.measurementlab.net"}`)),
 							StatusCode: 200,
 						},
 					},
 					{
 						resp: &http.Response{
-							Body: ioutil.NopCloser(strings.NewReader(
+							Body: io.NopCloser(strings.NewReader(
 								`{"authorization": "xx", "unchoked": 1}`)),
 							StatusCode: 200,
 						},
@@ -116,21 +116,21 @@ func TestRunnerLoopCollectFailure(t *testing.T) {
 				all: []FakeHTTPTransport{
 					{
 						resp: &http.Response{
-							Body: ioutil.NopCloser(strings.NewReader(
+							Body: io.NopCloser(strings.NewReader(
 								`{"fqdn": "ams01.measurementlab.net"}`)),
 							StatusCode: 200,
 						},
 					},
 					{
 						resp: &http.Response{
-							Body: ioutil.NopCloser(strings.NewReader(
+							Body: io.NopCloser(strings.NewReader(
 								`{"authorization": "xx", "unchoked": 1}`)),
 							StatusCode: 200,
 						},
 					},
 					{
 						resp: &http.Response{
-							Body:       ioutil.NopCloser(strings.NewReader(`1234567`)),
+							Body:       io.NopCloser(strings.NewReader(`1234567`)),
 							StatusCode: 200,
 						},
 					},
@@ -160,27 +160,27 @@ func TestRunnerLoopSuccess(t *testing.T) {
 				all: []FakeHTTPTransport{
 					{
 						resp: &http.Response{
-							Body: ioutil.NopCloser(strings.NewReader(
+							Body: io.NopCloser(strings.NewReader(
 								`{"fqdn": "ams01.measurementlab.net"}`)),
 							StatusCode: 200,
 						},
 					},
 					{
 						resp: &http.Response{
-							Body: ioutil.NopCloser(strings.NewReader(
+							Body: io.NopCloser(strings.NewReader(
 								`{"authorization": "xx", "unchoked": 1}`)),
 							StatusCode: 200,
 						},
 					},
 					{
 						resp: &http.Response{
-							Body:       ioutil.NopCloser(strings.NewReader(`1234567`)),
+							Body:       io.NopCloser(strings.NewReader(`1234567`)),
 							StatusCode: 200,
 						},
 					},
 					{
 						resp: &http.Response{
-							Body:       ioutil.NopCloser(strings.NewReader(`[]`)),
+							Body:       io.NopCloser(strings.NewReader(`[]`)),
 							StatusCode: 200,
 						},
 					},

--- a/internal/engine/experiment/dash/download_test.go
+++ b/internal/engine/experiment/dash/download_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -50,7 +50,7 @@ func TestDownloadInternalError(t *testing.T) {
 func TestDownloadReadAllFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	txp := FakeHTTPTransport{resp: &http.Response{
-		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+		Body:       io.NopCloser(bytes.NewReader(nil)),
 		StatusCode: 200,
 	}}
 	_, err := download(context.Background(), downloadConfig{
@@ -70,7 +70,7 @@ func TestDownloadReadAllFailure(t *testing.T) {
 
 func TestDownloadSuccess(t *testing.T) {
 	txp := FakeHTTPTransport{resp: &http.Response{
-		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+		Body:       io.NopCloser(bytes.NewReader(nil)),
 		StatusCode: 200,
 	}}
 	result, err := download(context.Background(), downloadConfig{

--- a/internal/engine/experiment/dash/negotiate_test.go
+++ b/internal/engine/experiment/dash/negotiate_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -69,7 +69,7 @@ func TestNegotiateInternalError(t *testing.T) {
 func TestNegotiateReadAllFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	txp := FakeHTTPTransport{resp: &http.Response{
-		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+		Body:       io.NopCloser(bytes.NewReader(nil)),
 		StatusCode: 200,
 	}}
 	deps := FakeDeps{
@@ -91,7 +91,7 @@ func TestNegotiateReadAllFailure(t *testing.T) {
 
 func TestNegotiateInvalidJSON(t *testing.T) {
 	txp := FakeHTTPTransport{resp: &http.Response{
-		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+		Body:       io.NopCloser(bytes.NewReader(nil)),
 		StatusCode: 200,
 	}}
 	deps := FakeDeps{
@@ -113,7 +113,7 @@ func TestNegotiateInvalidJSON(t *testing.T) {
 
 func TestNegotiateServerBusyFirstCase(t *testing.T) {
 	txp := FakeHTTPTransport{resp: &http.Response{
-		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+		Body:       io.NopCloser(bytes.NewReader(nil)),
 		StatusCode: 200,
 	}}
 	deps := FakeDeps{
@@ -135,7 +135,7 @@ func TestNegotiateServerBusyFirstCase(t *testing.T) {
 
 func TestNegotiateServerBusyThirdCase(t *testing.T) {
 	txp := FakeHTTPTransport{resp: &http.Response{
-		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+		Body:       io.NopCloser(bytes.NewReader(nil)),
 		StatusCode: 200,
 	}}
 	deps := FakeDeps{
@@ -157,7 +157,7 @@ func TestNegotiateServerBusyThirdCase(t *testing.T) {
 
 func TestNegotiateSuccess(t *testing.T) {
 	txp := FakeHTTPTransport{resp: &http.Response{
-		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+		Body:       io.NopCloser(bytes.NewReader(nil)),
 		StatusCode: 200,
 	}}
 	deps := FakeDeps{

--- a/internal/engine/experiment/hhfm/hhfm_test.go
+++ b/internal/engine/experiment/hhfm/hhfm_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -521,7 +521,7 @@ func TestInvalidJSONBody(t *testing.T) {
 
 func TestTransactStatusCodeFailure(t *testing.T) {
 	txp := FakeTransport{Resp: &http.Response{
-		Body:       ioutil.NopCloser(strings.NewReader("")),
+		Body:       io.NopCloser(strings.NewReader("")),
 		StatusCode: 500,
 	}}
 	resp, body, err := hhfm.Transact(txp, &http.Request{},

--- a/internal/engine/experiment/urlgetter/runner.go
+++ b/internal/engine/experiment/urlgetter/runner.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -92,7 +92,7 @@ func (r Runner) httpGet(ctx context.Context, url string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	if _, err = iox.CopyContext(ctx, ioutil.Discard, resp.Body); err != nil {
+	if _, err = iox.CopyContext(ctx, io.Discard, resp.Body); err != nil {
 		return err
 	}
 	// Implementation note: we shall check for this error once we have read the

--- a/internal/engine/geolocate/ubuntu_test.go
+++ b/internal/engine/geolocate/ubuntu_test.go
@@ -2,7 +2,7 @@ package geolocate
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -18,7 +18,7 @@ func TestUbuntuParseError(t *testing.T) {
 		&http.Client{Transport: FakeTransport{
 			Resp: &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(strings.NewReader("<")),
+				Body:       io.NopCloser(strings.NewReader("<")),
 			},
 		}},
 		log.Log,

--- a/internal/engine/legacy/netx/dialer.go
+++ b/internal/engine/legacy/netx/dialer.go
@@ -6,8 +6,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"io/ioutil"
 	"net"
+	"os"
 	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/engine/legacy/netx/handlers"
@@ -130,7 +130,7 @@ func (d *Dialer) DialTLSContext(
 // function is not goroutine safe. Make sure you call it before starting
 // to use this specific dialer.
 func (d *Dialer) SetCABundle(path string) error {
-	cert, err := ioutil.ReadFile(path)
+	cert, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}

--- a/internal/engine/netx/dialer/bytecounter_test.go
+++ b/internal/engine/netx/dialer/bytecounter_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"testing"
@@ -28,7 +27,7 @@ func dorequest(ctx context.Context, url string) error {
 	if err != nil {
 		return err
 	}
-	if _, err := iox.CopyContext(ctx, ioutil.Discard, resp.Body); err != nil {
+	if _, err := iox.CopyContext(ctx, io.Discard, resp.Body); err != nil {
 		return err
 	}
 	return resp.Body.Close()

--- a/internal/engine/netx/httptransport/bytecounter_test.go
+++ b/internal/engine/netx/httptransport/bytecounter_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -50,7 +49,7 @@ func TestByteCounterSuccess(t *testing.T) {
 		Counter: counter,
 		RoundTripper: httptransport.FakeTransport{
 			Resp: &http.Response{
-				Body: ioutil.NopCloser(strings.NewReader("1234567")),
+				Body: io.NopCloser(strings.NewReader("1234567")),
 				Header: http.Header{
 					"Server": []string{"antani/0.1.0"},
 				},

--- a/internal/engine/netx/httptransport/logging_test.go
+++ b/internal/engine/netx/httptransport/logging_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -61,7 +60,7 @@ func TestLoggingSuccess(t *testing.T) {
 		Logger: log.Log,
 		RoundTripper: httptransport.FakeTransport{
 			Resp: &http.Response{
-				Body: ioutil.NopCloser(strings.NewReader("")),
+				Body: io.NopCloser(strings.NewReader("")),
 				Header: http.Header{
 					"Server": []string{"antani/0.1.0"},
 				},

--- a/internal/engine/netx/httptransport/saver_test.go
+++ b/internal/engine/netx/httptransport/saver_test.go
@@ -3,7 +3,7 @@ package httptransport_test
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -256,7 +256,7 @@ func TestSaverBodySuccess(t *testing.T) {
 				}
 				return &http.Response{
 					StatusCode: 501,
-					Body:       ioutil.NopCloser(strings.NewReader("abad1dea")),
+					Body:       io.NopCloser(strings.NewReader("abad1dea")),
 				}, nil
 			},
 		},

--- a/internal/engine/netx/resolver/dnsoverhttps_test.go
+++ b/internal/engine/netx/resolver/dnsoverhttps_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -47,7 +47,7 @@ func TestDNSOverHTTPSHTTPFailure(t *testing.T) {
 		Do: func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 500,
-				Body:       ioutil.NopCloser(strings.NewReader("")),
+				Body:       io.NopCloser(strings.NewReader("")),
 			}, nil
 		},
 		URL: "https://cloudflare-dns.com/dns-query",
@@ -66,7 +66,7 @@ func TestDNSOverHTTPSMissingContentType(t *testing.T) {
 		Do: func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(strings.NewReader("")),
+				Body:       io.NopCloser(strings.NewReader("")),
 			}, nil
 		},
 		URL: "https://cloudflare-dns.com/dns-query",
@@ -86,7 +86,7 @@ func TestDNSOverHTTPSSuccess(t *testing.T) {
 		Do: func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader(body)),
+				Body:       io.NopCloser(bytes.NewReader(body)),
 				Header: http.Header{
 					"Content-Type": []string{"application/dns-message"},
 				},

--- a/internal/engine/probeservices/collector_test.go
+++ b/internal/engine/probeservices/collector_test.go
@@ -3,9 +3,9 @@ package probeservices_test
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -238,7 +238,7 @@ func TestEndToEnd(t *testing.T) {
 				if err != nil {
 					panic(err)
 				}
-				sdata, err := ioutil.ReadFile("../testdata/collector-expected.jsonl")
+				sdata, err := os.ReadFile("../testdata/collector-expected.jsonl")
 				if err != nil {
 					panic(err)
 				}

--- a/internal/engine/session_integration_test.go
+++ b/internal/engine/session_integration_test.go
@@ -3,7 +3,7 @@ package engine
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -32,7 +32,7 @@ func TestSessionByteCounter(t *testing.T) {
 	}
 	defer resp.Body.Close()
 	ctx := context.Background()
-	if _, err := iox.CopyContext(ctx, ioutil.Discard, resp.Body); err != nil {
+	if _, err := iox.CopyContext(ctx, io.Discard, resp.Body); err != nil {
 		t.Fatal(err)
 	}
 	if s.KibiBytesSent() <= 0 || s.KibiBytesReceived() <= 0 {

--- a/internal/tunnel/tor_test.go
+++ b/internal/tunnel/tor_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -278,20 +277,20 @@ func TestMaybeCleanupTunnelDir(t *testing.T) {
 	}
 	fakeData := []byte("deadbeef\n")
 	logfile := filepath.Join(fakeTunDir, "tor.log")
-	if err := ioutil.WriteFile(logfile, fakeData, 0600); err != nil {
+	if err := os.WriteFile(logfile, fakeData, 0600); err != nil {
 		t.Fatal(err)
 	}
 	for idx := 0; idx < 3; idx++ {
 		filename := filepath.Join(fakeTunDir, fmt.Sprintf("torrc-%d", idx))
-		if err := ioutil.WriteFile(filename, fakeData, 0600); err != nil {
+		if err := os.WriteFile(filename, fakeData, 0600); err != nil {
 			t.Fatal(err)
 		}
 		filename = filepath.Join(fakeTunDir, fmt.Sprintf("control-port-%d", idx))
-		if err := ioutil.WriteFile(filename, fakeData, 0600); err != nil {
+		if err := os.WriteFile(filename, fakeData, 0600); err != nil {
 			t.Fatal(err)
 		}
 		filename = filepath.Join(fakeTunDir, fmt.Sprintf("antani-%d", idx))
-		if err := ioutil.WriteFile(filename, fakeData, 0600); err != nil {
+		if err := os.WriteFile(filename, fakeData, 0600); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
Spotted while working on https://github.com/ooni/probe/issues/1417

See https://golang.org/pkg/io/ioutil/