### PR TITLE
refactor: move bytecounter to internal

### DIFF
--- a/internal/bytecounter/bytecounter.go
+++ b/internal/bytecounter/bytecounter.go
@@ -1,11 +1,18 @@
+// Package bytecounter contains code to track the number of
+// bytes sent and received by a probe.
 package bytecounter
 
 import "github.com/ooni/probe-cli/v3/internal/atomicx"
 
 // Counter counts bytes sent and received.
 type Counter struct {
+	// Received contains the bytes received. You MUST initialize
+	// this field, or you can just use the New factory.
 	Received *atomicx.Int64
-	Sent     *atomicx.Int64
+
+	// Sent contains the bytes sent. You MUST initialize
+	// this field, or you can just use the New factory.
+	Sent *atomicx.Int64
 }
 
 // New creates a new Counter.

--- a/internal/bytecounter/bytecounter_test.go
+++ b/internal/bytecounter/bytecounter_test.go
@@ -1,13 +1,9 @@
-package bytecounter_test
+package bytecounter
 
-import (
-	"testing"
-
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/bytecounter"
-)
+import "testing"
 
 func TestGood(t *testing.T) {
-	counter := bytecounter.New()
+	counter := New()
 	counter.CountBytesReceived(16384)
 	counter.CountKibiBytesReceived(10)
 	counter.CountBytesSent(2048)

--- a/internal/engine/experiment.go
+++ b/internal/engine/experiment.go
@@ -9,9 +9,9 @@ import (
 	"os"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/bytecounter"
 	"github.com/ooni/probe-cli/v3/internal/engine/geolocate"
 	"github.com/ooni/probe-cli/v3/internal/engine/model"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/bytecounter"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/dialer"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/httptransport"
 	"github.com/ooni/probe-cli/v3/internal/engine/probeservices"

--- a/internal/engine/internal/sessionresolver/resolvermaker.go
+++ b/internal/engine/internal/sessionresolver/resolvermaker.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/bytecounter"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/bytecounter"
 )
 
 // resolvemaker contains rules for making a resolver.

--- a/internal/engine/internal/sessionresolver/resolvermaker_test.go
+++ b/internal/engine/internal/sessionresolver/resolvermaker_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/apex/log"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/bytecounter"
+	"github.com/ooni/probe-cli/v3/internal/bytecounter"
 )
 
 func TestDefaultByteCounter(t *testing.T) {

--- a/internal/engine/internal/sessionresolver/sessionresolver.go
+++ b/internal/engine/internal/sessionresolver/sessionresolver.go
@@ -33,7 +33,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/bytecounter"
+	"github.com/ooni/probe-cli/v3/internal/bytecounter"
 	"github.com/ooni/probe-cli/v3/internal/multierror"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )

--- a/internal/engine/netx/dialer/bytecounter.go
+++ b/internal/engine/netx/dialer/bytecounter.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net"
 
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/bytecounter"
+	"github.com/ooni/probe-cli/v3/internal/bytecounter"
 )
 
 // byteCounterDialer is a byte-counting-aware dialer. To perform byte counting, you

--- a/internal/engine/netx/dialer/bytecounter_test.go
+++ b/internal/engine/netx/dialer/bytecounter_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/bytecounter"
+	"github.com/ooni/probe-cli/v3/internal/bytecounter"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/mockablex"
 	"github.com/ooni/probe-cli/v3/internal/iox"
 )

--- a/internal/engine/netx/httptransport/bytecounter.go
+++ b/internal/engine/netx/httptransport/bytecounter.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/bytecounter"
+	"github.com/ooni/probe-cli/v3/internal/bytecounter"
 )
 
 // ByteCountingTransport is a RoundTripper that counts bytes.

--- a/internal/engine/netx/httptransport/bytecounter_test.go
+++ b/internal/engine/netx/httptransport/bytecounter_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/bytecounter"
+	"github.com/ooni/probe-cli/v3/internal/bytecounter"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/httptransport"
 	"github.com/ooni/probe-cli/v3/internal/iox"
 )

--- a/internal/engine/netx/integration_test.go
+++ b/internal/engine/netx/integration_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/bytecounter"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/bytecounter"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/errorx"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/trace"
 	"github.com/ooni/probe-cli/v3/internal/iox"

--- a/internal/engine/netx/netx.go
+++ b/internal/engine/netx/netx.go
@@ -31,7 +31,7 @@ import (
 	"net/url"
 
 	"github.com/lucas-clemente/quic-go"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/bytecounter"
+	"github.com/ooni/probe-cli/v3/internal/bytecounter"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/dialer"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/httptransport"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/quicdialer"

--- a/internal/engine/netx/netx_test.go
+++ b/internal/engine/netx/netx_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/bytecounter"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/bytecounter"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/httptransport"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/resolver"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/tlsdialer"

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -11,11 +11,11 @@ import (
 	"sync"
 
 	"github.com/ooni/probe-cli/v3/internal/atomicx"
+	"github.com/ooni/probe-cli/v3/internal/bytecounter"
 	"github.com/ooni/probe-cli/v3/internal/engine/geolocate"
 	"github.com/ooni/probe-cli/v3/internal/engine/internal/sessionresolver"
 	"github.com/ooni/probe-cli/v3/internal/engine/model"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/bytecounter"
 	"github.com/ooni/probe-cli/v3/internal/engine/probeservices"
 	"github.com/ooni/probe-cli/v3/internal/kvstore"
 	"github.com/ooni/probe-cli/v3/internal/platform"


### PR DESCRIPTION
It's generic enough to live outside of engine/netx.

Occurred to me while working on https://github.com/ooni/probe/issues/1687.