### PR TITLE
refactor: rename i/e/n/mockablex => i/netxmocks

### DIFF
--- a/internal/bytecounter/conn_test.go
+++ b/internal/bytecounter/conn_test.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/mockablex"
+	"github.com/ooni/probe-cli/v3/internal/netxmocks"
 )
 
 func TestConnWorksOnSuccess(t *testing.T) {
 	counter := New()
-	underlying := &mockablex.Conn{
+	underlying := &netxmocks.Conn{
 		MockRead: func(b []byte) (int, error) {
 			return 10, nil
 		},
@@ -39,7 +39,7 @@ func TestConnWorksOnFailure(t *testing.T) {
 	readError := errors.New("read error")
 	writeError := errors.New("write error")
 	counter := New()
-	underlying := &mockablex.Conn{
+	underlying := &netxmocks.Conn{
 		MockRead: func(b []byte) (int, error) {
 			return 0, readError
 		},

--- a/internal/engine/legacy/netx/emitterdialer_test.go
+++ b/internal/engine/legacy/netx/emitterdialer_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ooni/probe-cli/v3/internal/engine/legacy/netx/handlers"
 	"github.com/ooni/probe-cli/v3/internal/engine/legacy/netx/modelx"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/mockablex"
+	"github.com/ooni/probe-cli/v3/internal/netxmocks"
 )
 
 func TestEmitterFailure(t *testing.T) {
@@ -20,7 +20,7 @@ func TestEmitterFailure(t *testing.T) {
 		Beginning: time.Now(),
 		Handler:   saver,
 	})
-	d := EmitterDialer{Dialer: mockablex.Dialer{
+	d := EmitterDialer{Dialer: netxmocks.Dialer{
 		MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 			return nil, io.EOF
 		},
@@ -69,9 +69,9 @@ func TestEmitterSuccess(t *testing.T) {
 		Beginning: time.Now(),
 		Handler:   saver,
 	})
-	d := EmitterDialer{Dialer: mockablex.Dialer{
+	d := EmitterDialer{Dialer: netxmocks.Dialer{
 		MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
-			return &mockablex.Conn{
+			return &netxmocks.Conn{
 				MockRead: func(b []byte) (int, error) {
 					return 0, io.EOF
 				},

--- a/internal/engine/netx/dialer/bytecounter_test.go
+++ b/internal/engine/netx/dialer/bytecounter_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/ooni/probe-cli/v3/internal/bytecounter"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/mockablex"
 	"github.com/ooni/probe-cli/v3/internal/iox"
+	"github.com/ooni/probe-cli/v3/internal/netxmocks"
 )
 
 func dorequest(ctx context.Context, url string) error {
@@ -76,7 +76,7 @@ func TestByteCounterNoHandlers(t *testing.T) {
 }
 
 func TestByteCounterConnectFailure(t *testing.T) {
-	dialer := &byteCounterDialer{Dialer: mockablex.Dialer{
+	dialer := &byteCounterDialer{Dialer: netxmocks.Dialer{
 		MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 			return nil, io.EOF
 		},

--- a/internal/engine/netx/dialer/errorwrapper_test.go
+++ b/internal/engine/netx/dialer/errorwrapper_test.go
@@ -8,12 +8,12 @@ import (
 	"testing"
 
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/errorx"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/mockablex"
+	"github.com/ooni/probe-cli/v3/internal/netxmocks"
 )
 
 func TestErrorWrapperFailure(t *testing.T) {
 	ctx := context.Background()
-	d := &errorWrapperDialer{Dialer: mockablex.Dialer{
+	d := &errorWrapperDialer{Dialer: netxmocks.Dialer{
 		MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 			return nil, io.EOF
 		},
@@ -43,9 +43,9 @@ func errorWrapperCheckErr(t *testing.T, err error, op string) {
 
 func TestErrorWrapperSuccess(t *testing.T) {
 	ctx := context.Background()
-	d := &errorWrapperDialer{Dialer: mockablex.Dialer{
+	d := &errorWrapperDialer{Dialer: netxmocks.Dialer{
 		MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
-			return &mockablex.Conn{
+			return &netxmocks.Conn{
 				MockRead: func(b []byte) (int, error) {
 					return 0, io.EOF
 				},

--- a/internal/engine/netx/dialer/proxy_test.go
+++ b/internal/engine/netx/dialer/proxy_test.go
@@ -8,13 +8,13 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/mockablex"
+	"github.com/ooni/probe-cli/v3/internal/netxmocks"
 )
 
 func TestProxyDialerDialContextNoProxyURL(t *testing.T) {
 	expected := errors.New("mocked error")
 	d := &proxyDialer{
-		Dialer: mockablex.Dialer{
+		Dialer: netxmocks.Dialer{
 			MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 				return nil, expected
 			},
@@ -45,7 +45,7 @@ func TestProxyDialerDialContextInvalidScheme(t *testing.T) {
 func TestProxyDialerDialContextWithEOF(t *testing.T) {
 	const expect = "10.0.0.1:9050"
 	d := &proxyDialer{
-		Dialer: mockablex.Dialer{
+		Dialer: netxmocks.Dialer{
 			MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 				if address != expect {
 					return nil, errors.New("unexpected address")

--- a/internal/engine/netx/dialer/saver_test.go
+++ b/internal/engine/netx/dialer/saver_test.go
@@ -9,15 +9,15 @@ import (
 	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/errorx"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/mockablex"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/trace"
+	"github.com/ooni/probe-cli/v3/internal/netxmocks"
 )
 
 func TestSaverDialerFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	saver := &trace.Saver{}
 	dlr := &saverDialer{
-		Dialer: mockablex.Dialer{
+		Dialer: netxmocks.Dialer{
 			MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 				return nil, expected
 			},
@@ -59,7 +59,7 @@ func TestSaverConnDialerFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	saver := &trace.Saver{}
 	dlr := &saverConnDialer{
-		Dialer: mockablex.Dialer{
+		Dialer: netxmocks.Dialer{
 			MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 				return nil, expected
 			},
@@ -79,9 +79,9 @@ func TestSaverConnDialerSuccess(t *testing.T) {
 	saver := &trace.Saver{}
 	dlr := &saverConnDialer{
 		Dialer: &saverDialer{
-			Dialer: mockablex.Dialer{
+			Dialer: netxmocks.Dialer{
 				MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
-					return &mockablex.Conn{
+					return &netxmocks.Conn{
 						MockRead: func(b []byte) (int, error) {
 							return 0, io.EOF
 						},

--- a/internal/engine/netx/mockablex/doc.go
+++ b/internal/engine/netx/mockablex/doc.go
@@ -1,2 +1,0 @@
-// Package mockable contains mocks for netx types.
-package mockablex

--- a/internal/netxlite/dialer_test.go
+++ b/internal/netxlite/dialer_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/apex/log"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/mockablex"
+	"github.com/ooni/probe-cli/v3/internal/netxmocks"
 )
 
 func TestDialerResolverNoPort(t *testing.T) {
@@ -69,7 +69,7 @@ func (r MockableResolver) Address() string {
 }
 
 func TestDialerResolverDialForSingleIPFails(t *testing.T) {
-	dialer := &DialerResolver{Dialer: mockablex.Dialer{
+	dialer := &DialerResolver{Dialer: netxmocks.Dialer{
 		MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 			return nil, io.EOF
 		},
@@ -85,7 +85,7 @@ func TestDialerResolverDialForSingleIPFails(t *testing.T) {
 
 func TestDialerResolverDialForManyIPFails(t *testing.T) {
 	dialer := &DialerResolver{
-		Dialer: mockablex.Dialer{
+		Dialer: netxmocks.Dialer{
 			MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 				return nil, io.EOF
 			},
@@ -102,9 +102,9 @@ func TestDialerResolverDialForManyIPFails(t *testing.T) {
 }
 
 func TestDialerResolverDialForManyIPSuccess(t *testing.T) {
-	dialer := &DialerResolver{Dialer: mockablex.Dialer{
+	dialer := &DialerResolver{Dialer: netxmocks.Dialer{
 		MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
-			return &mockablex.Conn{
+			return &netxmocks.Conn{
 				MockClose: func() error {
 					return nil
 				},
@@ -125,7 +125,7 @@ func TestDialerResolverDialForManyIPSuccess(t *testing.T) {
 
 func TestDialerLoggerFailure(t *testing.T) {
 	d := &DialerLogger{
-		Dialer: mockablex.Dialer{
+		Dialer: netxmocks.Dialer{
 			MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 				return nil, io.EOF
 			},

--- a/internal/netxmocks/conn.go
+++ b/internal/netxmocks/conn.go
@@ -1,4 +1,4 @@
-package mockablex
+package netxmocks
 
 import (
 	"net"

--- a/internal/netxmocks/conn_test.go
+++ b/internal/netxmocks/conn_test.go
@@ -1,4 +1,4 @@
-package mockablex
+package netxmocks
 
 import (
 	"errors"

--- a/internal/netxmocks/dialer.go
+++ b/internal/netxmocks/dialer.go
@@ -1,4 +1,4 @@
-package mockablex
+package netxmocks
 
 import (
 	"context"

--- a/internal/netxmocks/dialer_test.go
+++ b/internal/netxmocks/dialer_test.go
@@ -1,4 +1,4 @@
-package mockablex
+package netxmocks
 
 import (
 	"context"

--- a/internal/netxmocks/doc.go
+++ b/internal/netxmocks/doc.go
@@ -1,0 +1,2 @@
+// Package netxmocks contains mocks for netx types.
+package netxmocks

--- a/internal/ptx/obfs4_test.go
+++ b/internal/ptx/obfs4_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/ooni/probe-cli/v3/internal/atomicx"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/mockablex"
+	"github.com/ooni/probe-cli/v3/internal/netxmocks"
 )
 
 func TestOBFS4DialerWorks(t *testing.T) {
@@ -48,7 +48,7 @@ func TestOBFS4DialerFailsWithInvalidCert(t *testing.T) {
 func TestOBFS4DialerFailsWithConnectionErrorAndNoContextExpiration(t *testing.T) {
 	expected := errors.New("mocked error")
 	o4d := DefaultTestingOBFS4Bridge()
-	o4d.UnderlyingDialer = &mockablex.Dialer{
+	o4d.UnderlyingDialer = &netxmocks.Dialer{
 		MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 			return nil, expected
 		},
@@ -67,7 +67,7 @@ func TestOBFS4DialerFailsWithConnectionErrorAndContextExpiration(t *testing.T) {
 	defer cancel()
 	expected := errors.New("mocked error")
 	o4d := DefaultTestingOBFS4Bridge()
-	o4d.UnderlyingDialer = &mockablex.Dialer{
+	o4d.UnderlyingDialer = &netxmocks.Dialer{
 		MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 			// We cancel the context before returning the error, which makes
 			// the context cancellation happen before us returning.
@@ -101,7 +101,7 @@ func TestOBFS4DialerWorksWithContextExpiration(t *testing.T) {
 	defer cancel()
 	called := &atomicx.Int64{}
 	o4d := DefaultTestingOBFS4Bridge()
-	o4d.UnderlyingDialer = &mockablex.Dialer{
+	o4d.UnderlyingDialer = &netxmocks.Dialer{
 		MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 			// We cancel the context before returning the error, which makes
 			// the context cancellation happen before us returning.

--- a/internal/ptx/ptx_test.go
+++ b/internal/ptx/ptx_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/apex/log"
 	"github.com/ooni/probe-cli/v3/internal/atomicx"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/mockablex"
 	"github.com/ooni/probe-cli/v3/internal/iox"
+	"github.com/ooni/probe-cli/v3/internal/netxmocks"
 )
 
 func TestListenerLoggerWorks(t *testing.T) {
@@ -96,8 +96,8 @@ func TestListenerCastListenerWorksFineOnError(t *testing.T) {
 
 // mockableSocksConn is a mockable ptxSocksConn.
 type mockableSocksConn struct {
-	// mockablex.Conn allows to mock all net.Conn functionality.
-	*mockablex.Conn
+	// netxmocks.Conn allows to mock all net.Conn functionality.
+	*netxmocks.Conn
 
 	// MockGrant allows to mock the Grant function.
 	MockGrant func(addr *net.TCPAddr) error
@@ -160,7 +160,7 @@ func TestListenerHandleSocksConnWithDialContextFailure(t *testing.T) {
 	}
 	lst := &Listener{PTDialer: d}
 	c := &mockableSocksConn{
-		Conn: &mockablex.Conn{
+		Conn: &netxmocks.Conn{
 			MockClose: func() error {
 				return nil
 			},

--- a/internal/ptx/snowflake_test.go
+++ b/internal/ptx/snowflake_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/ooni/probe-cli/v3/internal/atomicx"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx/mockablex"
+	"github.com/ooni/probe-cli/v3/internal/netxmocks"
 )
 
 func TestSnowflakeDialerWorks(t *testing.T) {
@@ -50,7 +50,7 @@ func TestSnowflakeDialerWorksWithMocks(t *testing.T) {
 		newClientTransport: func(brokerURL, frontDomain string, iceAddresses []string, keepLocalAddresses bool, maxSnowflakes int) (snowflakeTransport, error) {
 			return &mockableSnowflakeTransport{
 				MockDial: func() (net.Conn, error) {
-					return &mockablex.Conn{
+					return &netxmocks.Conn{
 						MockClose: func() error {
 							return nil
 						},
@@ -144,7 +144,7 @@ func TestSnowflakeDialerWorksWithWithCancelledContext(t *testing.T) {
 			return &mockableSnowflakeTransport{
 				MockDial: func() (net.Conn, error) {
 					cancel() // cause a cancel before we can really have a conn
-					return &mockablex.Conn{
+					return &netxmocks.Conn{
 						MockClose: func() error {
 							called.Add(1)
 							return nil


### PR DESCRIPTION
Needed to more easily do https://github.com/ooni/probe/issues/1505