### PR TITLE
refactor(netxlite): make sure we always use netxmocks

### DIFF
--- a/internal/netxlite/legacy_test.go
+++ b/internal/netxlite/legacy_test.go
@@ -14,7 +14,6 @@ func TestReduceErrors(t *testing.T) {
 			t.Fatal("wrong result")
 		}
 	})
-
 	t.Run("single error", func(t *testing.T) {
 		err := errors.New("mocked error")
 		result := ReduceErrors([]error{err})
@@ -22,7 +21,6 @@ func TestReduceErrors(t *testing.T) {
 			t.Fatal("wrong result")
 		}
 	})
-
 	t.Run("multiple errors", func(t *testing.T) {
 		err1 := errors.New("mocked error #1")
 		err2 := errors.New("mocked error #2")
@@ -31,7 +29,6 @@ func TestReduceErrors(t *testing.T) {
 			t.Fatal("wrong result")
 		}
 	})
-
 	t.Run("multiple errors with meaningful ones", func(t *testing.T) {
 		err1 := errors.New("mocked error #1")
 		err2 := &errorx.ErrWrapper{

--- a/internal/netxlite/resolver.go
+++ b/internal/netxlite/resolver.go
@@ -48,9 +48,13 @@ func (r ResolverLogger) LookupHost(ctx context.Context, hostname string) ([]stri
 	r.Logger.Debugf("resolve %s...", hostname)
 	start := time.Now()
 	addrs, err := r.Resolver.LookupHost(ctx, hostname)
-	stop := time.Now()
-	r.Logger.Debugf("resolve %s... (%+v, %+v) in %s", hostname, addrs, err, stop.Sub(start))
-	return addrs, err
+	elapsed := time.Since(start)
+	if err != nil {
+		r.Logger.Debugf("resolve %s... %s in %s", hostname, err, elapsed)
+		return nil, err
+	}
+	r.Logger.Debugf("resolve %s... %+v in %s", hostname, addrs, elapsed)
+	return addrs, nil
 }
 
 type resolverNetworker interface {

--- a/internal/netxlite/resolver_test.go
+++ b/internal/netxlite/resolver_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/apex/log"
+	"github.com/google/go-cmp/cmp"
 	"github.com/ooni/probe-cli/v3/internal/netxmocks"
 )
 
@@ -28,6 +29,25 @@ func TestResolverSystemWorksAsIntended(t *testing.T) {
 	}
 	if addrs == nil {
 		t.Fatal("expected non-nil result here")
+	}
+}
+
+func TestResolverLoggerWithSuccess(t *testing.T) {
+	expected := []string{"1.1.1.1"}
+	r := ResolverLogger{
+		Logger: log.Log,
+		Resolver: &netxmocks.Resolver{
+			MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
+				return expected, nil
+			},
+		},
+	}
+	addrs, err := r.LookupHost(context.Background(), "dns.google")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(expected, addrs); diff != "" {
+		t.Fatal(diff)
 	}
 }
 

--- a/internal/netxlite/resolver_test.go
+++ b/internal/netxlite/resolver_test.go
@@ -2,13 +2,15 @@ package netxlite
 
 import (
 	"context"
+	"errors"
 	"net"
 	"testing"
 
 	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/netxmocks"
 )
 
-func TestResolverSystemLookupHost(t *testing.T) {
+func TestResolverSystemNetworkAddress(t *testing.T) {
 	r := ResolverSystem{}
 	if r.Network() != "system" {
 		t.Fatal("invalid Network")
@@ -16,6 +18,10 @@ func TestResolverSystemLookupHost(t *testing.T) {
 	if r.Address() != "" {
 		t.Fatal("invalid Address")
 	}
+}
+
+func TestResolverSystemWorksAsIntended(t *testing.T) {
+	r := ResolverSystem{}
 	addrs, err := r.LookupHost(context.Background(), "dns.google.com")
 	if err != nil {
 		t.Fatal(err)
@@ -26,26 +32,35 @@ func TestResolverSystemLookupHost(t *testing.T) {
 }
 
 func TestResolverLoggerWithFailure(t *testing.T) {
+	expected := errors.New("mocked error")
 	r := ResolverLogger{
-		Logger:   log.Log,
-		Resolver: DefaultResolver,
+		Logger: log.Log,
+		Resolver: &netxmocks.Resolver{
+			MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
+				return nil, expected
+			},
+		},
 	}
-	if r.Network() != "system" {
-		t.Fatal("invalid Network")
-	}
-	if r.Address() != "" {
-		t.Fatal("invalid Address")
-	}
-	addrs, err := r.LookupHost(context.Background(), "nonexistent.antani")
-	if err == nil {
-		t.Fatal("expected an error here")
+	addrs, err := r.LookupHost(context.Background(), "dns.google")
+	if !errors.Is(err, expected) {
+		t.Fatal("not the error we expected", err)
 	}
 	if addrs != nil {
 		t.Fatal("expected nil addr here")
 	}
 }
 
-func TestResolverLoggerDefaultNetworkAddress(t *testing.T) {
+func TestResolverLoggerChildNetworkAddress(t *testing.T) {
+	r := &ResolverLogger{Logger: log.Log, Resolver: DefaultResolver}
+	if r.Network() != "system" {
+		t.Fatal("invalid Network")
+	}
+	if r.Address() != "" {
+		t.Fatal("invalid Address")
+	}
+}
+
+func TestResolverLoggerNoChildNetworkAddress(t *testing.T) {
 	r := &ResolverLogger{Logger: log.Log, Resolver: &net.Resolver{}}
 	if r.Network() != "logger" {
 		t.Fatal("invalid Network")

--- a/internal/netxmocks/conn.go
+++ b/internal/netxmocks/conn.go
@@ -17,42 +17,42 @@ type Conn struct {
 	MockSetWriteDeadline func(t time.Time) error
 }
 
-// Read implements net.Conn.Read
+// Read calls MockRead.
 func (c *Conn) Read(b []byte) (int, error) {
 	return c.MockRead(b)
 }
 
-// Write implements net.Conn.Write
+// Write calls MockWrite.
 func (c *Conn) Write(b []byte) (int, error) {
 	return c.MockWrite(b)
 }
 
-// Close implements net.Conn.Close
+// Close calls MockClose.
 func (c *Conn) Close() error {
 	return c.MockClose()
 }
 
-// LocalAddr returns the local address
+// LocalAddr class MockLocalAddr.
 func (c *Conn) LocalAddr() net.Addr {
 	return c.MockLocalAddr()
 }
 
-// RemoteAddr returns the remote address
+// RemoteAddr calls MockRemoteAddr.
 func (c *Conn) RemoteAddr() net.Addr {
 	return c.MockRemoteAddr()
 }
 
-// SetDeadline sets the connection deadline.
+// SetDeadline calls MockSetDeadline.
 func (c *Conn) SetDeadline(t time.Time) error {
 	return c.MockSetDeadline(t)
 }
 
-// SetReadDeadline sets the read deadline.
+// SetReadDeadline calls MockSetReadDeadline.
 func (c *Conn) SetReadDeadline(t time.Time) error {
 	return c.MockSetReadDeadline(t)
 }
 
-// SetWriteDeadline sets the write deadline.
+// SetWriteDeadline calls MockSetWriteDeadline.
 func (c *Conn) SetWriteDeadline(t time.Time) error {
 	return c.MockSetWriteDeadline(t)
 }

--- a/internal/netxmocks/dialer.go
+++ b/internal/netxmocks/dialer.go
@@ -15,7 +15,7 @@ type Dialer struct {
 	MockDialContext func(ctx context.Context, network, address string) (net.Conn, error)
 }
 
-// DialContext implements Dialer.DialContext.
+// DialContext calls MockDialContext.
 func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
 	return d.MockDialContext(ctx, network, address)
 }

--- a/internal/netxmocks/resolver.go
+++ b/internal/netxmocks/resolver.go
@@ -16,17 +16,17 @@ type Resolver struct {
 	MockAddress    func() string
 }
 
-// LookupHost implements Resolver.LookupHost.
+// LookupHost calls MockLookupHost.
 func (r *Resolver) LookupHost(ctx context.Context, domain string) ([]string, error) {
 	return r.MockLookupHost(ctx, domain)
 }
 
-// Address implements Resolver.Address.
+// Address calls MockAddress.
 func (r *Resolver) Address() string {
 	return r.MockAddress()
 }
 
-// Network implements Resolver.Network.
+// Network calls MockNetwork.
 func (r *Resolver) Network() string {
 	return r.MockNetwork()
 }


### PR DESCRIPTION
While there, improve logging and make sure we test 100% of the
package with unit tests only. (We don't need to have integration
testing in this package because it's fairly simple/obvious.)

Part of https://github.com/ooni/probe/issues/1505