### PR TITLE
refactor(quicdialer): separate saving from listening

### DIFF
--- a/internal/engine/netx/netx.go
+++ b/internal/engine/netx/netx.go
@@ -160,7 +160,16 @@ func NewQUICDialer(config Config) QUICDialer {
 	if config.FullResolver == nil {
 		config.FullResolver = NewResolver(config)
 	}
-	var d quicdialer.ContextDialer = &quicdialer.SystemDialer{Saver: config.ReadWriteSaver}
+	var ql quicdialer.QUICListener = &quicdialer.QUICListenerStdlib{}
+	if config.ReadWriteSaver != nil {
+		ql = &quicdialer.QUICListenerSaver{
+			QUICListener: ql,
+			Saver:        config.ReadWriteSaver,
+		}
+	}
+	var d quicdialer.ContextDialer = &quicdialer.SystemDialer{
+		QUICListener: ql,
+	}
 	d = quicdialer.ErrorWrapperDialer{Dialer: d}
 	if config.TLSSaver != nil {
 		d = quicdialer.HandshakeSaver{Saver: config.TLSSaver, Dialer: d}

--- a/internal/engine/netx/quicdialer/dns_test.go
+++ b/internal/engine/netx/quicdialer/dns_test.go
@@ -25,7 +25,9 @@ func (r MockableResolver) LookupHost(ctx context.Context, host string) ([]string
 func TestDNSDialerSuccess(t *testing.T) {
 	tlsConf := &tls.Config{NextProtos: []string{"h3"}}
 	dialer := quicdialer.DNSDialer{
-		Resolver: new(net.Resolver), Dialer: quicdialer.SystemDialer{}}
+		Resolver: new(net.Resolver), Dialer: quicdialer.SystemDialer{
+			QUICListener: &quicdialer.QUICListenerStdlib{},
+		}}
 	sess, err := dialer.DialContext(
 		context.Background(), "udp", "www.google.com:443",
 		tlsConf, &quic.Config{})
@@ -88,7 +90,9 @@ func TestDNSDialerLookupHostFailure(t *testing.T) {
 func TestDNSDialerInvalidPort(t *testing.T) {
 	tlsConf := &tls.Config{NextProtos: []string{"h3"}}
 	dialer := quicdialer.DNSDialer{
-		Resolver: new(net.Resolver), Dialer: quicdialer.SystemDialer{}}
+		Resolver: new(net.Resolver), Dialer: quicdialer.SystemDialer{
+			QUICListener: &quicdialer.QUICListenerStdlib{},
+		}}
 	sess, err := dialer.DialContext(
 		context.Background(), "udp", "www.google.com:0",
 		tlsConf, &quic.Config{})
@@ -107,7 +111,9 @@ func TestDNSDialerInvalidPort(t *testing.T) {
 func TestDNSDialerInvalidPortSyntax(t *testing.T) {
 	tlsConf := &tls.Config{NextProtos: []string{"h3"}}
 	dialer := quicdialer.DNSDialer{
-		Resolver: new(net.Resolver), Dialer: quicdialer.SystemDialer{}}
+		Resolver: new(net.Resolver), Dialer: quicdialer.SystemDialer{
+			QUICListener: &quicdialer.QUICListenerStdlib{},
+		}}
 	sess, err := dialer.DialContext(
 		context.Background(), "udp", "www.google.com:port",
 		tlsConf, &quic.Config{})

--- a/internal/engine/netx/quicdialer/errorwrapper_test.go
+++ b/internal/engine/netx/quicdialer/errorwrapper_test.go
@@ -48,7 +48,9 @@ func TestErrorWrapperInvalidCertificate(t *testing.T) {
 		ServerName: servername,
 	}
 
-	dlr := quicdialer.ErrorWrapperDialer{Dialer: &quicdialer.SystemDialer{}}
+	dlr := quicdialer.ErrorWrapperDialer{Dialer: &quicdialer.SystemDialer{
+		QUICListener: &quicdialer.QUICListenerStdlib{},
+	}}
 	// use Google IP
 	sess, err := dlr.DialContext(context.Background(), "udp",
 		"216.58.212.164:443", tlsConf, &quic.Config{})
@@ -69,7 +71,9 @@ func TestErrorWrapperSuccess(t *testing.T) {
 		NextProtos: []string{"h3"},
 		ServerName: "www.google.com",
 	}
-	d := quicdialer.ErrorWrapperDialer{Dialer: quicdialer.SystemDialer{}}
+	d := quicdialer.ErrorWrapperDialer{Dialer: quicdialer.SystemDialer{
+		QUICListener: &quicdialer.QUICListenerStdlib{},
+	}}
 	sess, err := d.DialContext(ctx, "udp", "216.58.212.164:443", tlsConf, &quic.Config{})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/engine/netx/quicdialer/saver_test.go
+++ b/internal/engine/netx/quicdialer/saver_test.go
@@ -36,8 +36,10 @@ func TestHandshakeSaverSuccess(t *testing.T) {
 	}
 	saver := &trace.Saver{}
 	dlr := quicdialer.HandshakeSaver{
-		Dialer: quicdialer.SystemDialer{},
-		Saver:  saver,
+		Dialer: quicdialer.SystemDialer{
+			QUICListener: &quicdialer.QUICListenerStdlib{},
+		},
+		Saver: saver,
 	}
 	sess, err := dlr.DialContext(context.Background(), "udp",
 		"216.58.212.164:443", tlsConf, &quic.Config{})
@@ -92,8 +94,10 @@ func TestHandshakeSaverHostNameError(t *testing.T) {
 	}
 	saver := &trace.Saver{}
 	dlr := quicdialer.HandshakeSaver{
-		Dialer: quicdialer.SystemDialer{},
-		Saver:  saver,
+		Dialer: quicdialer.SystemDialer{
+			QUICListener: &quicdialer.QUICListenerStdlib{},
+		},
+		Saver: saver,
 	}
 	sess, err := dlr.DialContext(context.Background(), "udp",
 		"216.58.212.164:443", tlsConf, &quic.Config{})

--- a/internal/engine/netx/quicdialer/system_test.go
+++ b/internal/engine/netx/quicdialer/system_test.go
@@ -18,7 +18,10 @@ func TestSystemDialerInvalidIPFailure(t *testing.T) {
 	}
 	saver := &trace.Saver{}
 	systemdialer := quicdialer.SystemDialer{
-		Saver: saver,
+		QUICListener: &quicdialer.QUICListenerSaver{
+			QUICListener: &quicdialer.QUICListenerStdlib{},
+			Saver:        saver,
+		},
 	}
 	sess, err := systemdialer.DialContext(context.Background(), "udp", "a.b.c.d:0", tlsConf, &quic.Config{})
 	if err == nil {
@@ -39,7 +42,12 @@ func TestSystemDialerSuccessWithReadWrite(t *testing.T) {
 		ServerName: "www.google.com",
 	}
 	saver := &trace.Saver{}
-	systemdialer := quicdialer.SystemDialer{Saver: saver}
+	systemdialer := quicdialer.SystemDialer{
+		QUICListener: &quicdialer.QUICListenerSaver{
+			QUICListener: &quicdialer.QUICListenerStdlib{},
+			Saver:        saver,
+		},
+	}
 	_, err := systemdialer.DialContext(context.Background(), "udp",
 		"216.58.212.164:443", tlsConf, &quic.Config{})
 	if err != nil {


### PR DESCRIPTION
With this change, we will soon be able to move the creation of
a QUIC session inside of the netxlite package.

Part of https://github.com/ooni/probe/issues/1505.