### PR TITLE
fix(netxlite): close quic packetconn

### DIFF
--- a/internal/engine/netx/quicdialer/system.go
+++ b/internal/engine/netx/quicdialer/system.go
@@ -11,7 +11,7 @@ import (
 
 // QUICListener listens for QUIC connections.
 type QUICListener interface {
-	// Listen creates a new listening net.PacketConn.
+	// Listen creates a new listening PacketConn.
 	Listen(addr *net.UDPAddr) (net.PacketConn, error)
 }
 

--- a/internal/netxlite/quic.go
+++ b/internal/netxlite/quic.go
@@ -30,7 +30,7 @@ type QUICDialer interface {
 
 // QUICListener listens for QUIC connections.
 type QUICListener interface {
-	// Listen creates a new listening net.PacketConn.
+	// Listen creates a new listening PacketConn.
 	Listen(addr *net.UDPAddr) (net.PacketConn, error)
 }
 
@@ -76,6 +76,26 @@ func (d *QUICDialerQUICGo) DialContext(ctx context.Context, network string,
 		return nil, err
 	}
 	udpAddr := &net.UDPAddr{IP: ip, Port: port, Zone: ""}
-	return quic.DialEarlyContext(
+	sess, err := quic.DialEarlyContext(
 		ctx, pconn, udpAddr, address, tlsConfig, quicConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &quicSessionOwnsConn{EarlySession: sess, conn: pconn}, nil
+}
+
+// quicSessionOwnsConn ensures that we close the PacketConn.
+type quicSessionOwnsConn struct {
+	quic.EarlySession
+
+	// conn is the connection we own
+	conn net.PacketConn
+}
+
+// CloseWithError implements quic.EarlySession.CloseWithError.
+func (sess *quicSessionOwnsConn) CloseWithError(
+	code quic.ApplicationErrorCode, reason string) error {
+	err := sess.EarlySession.CloseWithError(code, reason)
+	sess.conn.Close()
+	return err
 }

--- a/internal/netxlite/quic.go
+++ b/internal/netxlite/quic.go
@@ -86,6 +86,7 @@ func (d *QUICDialerQUICGo) DialContext(ctx context.Context, network string,
 
 // quicSessionOwnsConn ensures that we close the PacketConn.
 type quicSessionOwnsConn struct {
+	// EarlySession is the embedded early session
 	quic.EarlySession
 
 	// conn is the connection we own


### PR DESCRIPTION
Noticed when working on https://github.com/ooni/probe/issues/1505.

Justification for this diff:

1. [DialEarlyContext calls dialContext with the last argument set to false](https://github.com/lucas-clemente/quic-go/blob/v0.21.1/client.go#L153);

2. [the semantics of the last argument is whether we own the connection](https://github.com/lucas-clemente/quic-go/blob/v0.21.1/client.go#L187);

3. [this value is propagated to the client data structure](https://github.com/lucas-clemente/quic-go/blob/v0.21.1/client.go#L269);

4. [client.dial](https://github.com/lucas-clemente/quic-go/blob/v0.21.1/client.go#L302) runs the session in a background goroutine and only destroys the `packetHandlers` when the connection is owned;

5. [packetHandlerMap.Destroy](https://github.com/lucas-clemente/quic-go/blob/v0.21.1/packet_handler_map.go#L293) closes the underlying PacketConn.

6. also, the documentation clearly states that when you use `DialEarlyContext` you can use the same packet conn multiple times, so it does not take ownership.