### PR TITLE
fix(netxlite): improve TLS auto-configuration

### DIFF
--- a/internal/engine/legacy/netx/dialer.go
+++ b/internal/engine/legacy/netx/dialer.go
@@ -108,7 +108,7 @@ func newTLSDialer(d dialer.Dialer, config *tls.Config) *netxlite.TLSDialer {
 		Dialer: d,
 		TLSHandshaker: tlsdialer.EmitterTLSHandshaker{
 			TLSHandshaker: tlsdialer.ErrorWrapperTLSHandshaker{
-				TLSHandshaker: &netxlite.TLSHandshakerStdlib{},
+				TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
 			},
 		},
 	}

--- a/internal/engine/netx/netx.go
+++ b/internal/engine/netx/netx.go
@@ -184,7 +184,7 @@ func NewTLSDialer(config Config) TLSDialer {
 	if config.Dialer == nil {
 		config.Dialer = NewDialer(config)
 	}
-	var h tlsHandshaker = &netxlite.TLSHandshakerStdlib{}
+	var h tlsHandshaker = &netxlite.TLSHandshakerConfigurable{}
 	h = tlsdialer.ErrorWrapperTLSHandshaker{TLSHandshaker: h}
 	if config.Logger != nil {
 		h = &netxlite.TLSHandshakerLogger{Logger: config.Logger, TLSHandshaker: h}

--- a/internal/engine/netx/netx_test.go
+++ b/internal/engine/netx/netx_test.go
@@ -234,7 +234,7 @@ func TestNewTLSDialerVanilla(t *testing.T) {
 	if !ok {
 		t.Fatal("not the TLSHandshaker we expected")
 	}
-	if _, ok := ewth.TLSHandshaker.(*netxlite.TLSHandshakerStdlib); !ok {
+	if _, ok := ewth.TLSHandshaker.(*netxlite.TLSHandshakerConfigurable); !ok {
 		t.Fatal("not the TLSHandshaker we expected")
 	}
 }
@@ -263,7 +263,7 @@ func TestNewTLSDialerWithConfig(t *testing.T) {
 	if !ok {
 		t.Fatal("not the TLSHandshaker we expected")
 	}
-	if _, ok := ewth.TLSHandshaker.(*netxlite.TLSHandshakerStdlib); !ok {
+	if _, ok := ewth.TLSHandshaker.(*netxlite.TLSHandshakerConfigurable); !ok {
 		t.Fatal("not the TLSHandshaker we expected")
 	}
 }
@@ -302,7 +302,7 @@ func TestNewTLSDialerWithLogging(t *testing.T) {
 	if !ok {
 		t.Fatal("not the TLSHandshaker we expected")
 	}
-	if _, ok := ewth.TLSHandshaker.(*netxlite.TLSHandshakerStdlib); !ok {
+	if _, ok := ewth.TLSHandshaker.(*netxlite.TLSHandshakerConfigurable); !ok {
 		t.Fatal("not the TLSHandshaker we expected")
 	}
 }
@@ -342,7 +342,7 @@ func TestNewTLSDialerWithSaver(t *testing.T) {
 	if !ok {
 		t.Fatal("not the TLSHandshaker we expected")
 	}
-	if _, ok := ewth.TLSHandshaker.(*netxlite.TLSHandshakerStdlib); !ok {
+	if _, ok := ewth.TLSHandshaker.(*netxlite.TLSHandshakerConfigurable); !ok {
 		t.Fatal("not the TLSHandshaker we expected")
 	}
 }
@@ -375,7 +375,7 @@ func TestNewTLSDialerWithNoTLSVerifyAndConfig(t *testing.T) {
 	if !ok {
 		t.Fatal("not the TLSHandshaker we expected")
 	}
-	if _, ok := ewth.TLSHandshaker.(*netxlite.TLSHandshakerStdlib); !ok {
+	if _, ok := ewth.TLSHandshaker.(*netxlite.TLSHandshakerConfigurable); !ok {
 		t.Fatal("not the TLSHandshaker we expected")
 	}
 }
@@ -410,7 +410,7 @@ func TestNewTLSDialerWithNoTLSVerifyAndNoConfig(t *testing.T) {
 	if !ok {
 		t.Fatal("not the TLSHandshaker we expected")
 	}
-	if _, ok := ewth.TLSHandshaker.(*netxlite.TLSHandshakerStdlib); !ok {
+	if _, ok := ewth.TLSHandshaker.(*netxlite.TLSHandshakerConfigurable); !ok {
 		t.Fatal("not the TLSHandshaker we expected")
 	}
 }
@@ -447,7 +447,7 @@ func TestNewWithTLSDialer(t *testing.T) {
 	tlsDialer := &netxlite.TLSDialer{
 		Config:        new(tls.Config),
 		Dialer:        netx.FakeDialer{Err: expected},
-		TLSHandshaker: &netxlite.TLSHandshakerStdlib{},
+		TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
 	}
 	txp := netx.NewHTTPTransport(netx.Config{
 		TLSDialer: tlsDialer,

--- a/internal/engine/netx/tlsdialer/integration_test.go
+++ b/internal/engine/netx/tlsdialer/integration_test.go
@@ -16,7 +16,7 @@ func TestTLSDialerSuccess(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	dialer := &netxlite.TLSDialer{Dialer: new(net.Dialer),
 		TLSHandshaker: &netxlite.TLSHandshakerLogger{
-			TLSHandshaker: &netxlite.TLSHandshakerStdlib{},
+			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
 			Logger:        log.Log,
 		},
 	}

--- a/internal/engine/netx/tlsdialer/saver_test.go
+++ b/internal/engine/netx/tlsdialer/saver_test.go
@@ -26,7 +26,7 @@ func TestSaverTLSHandshakerSuccessWithReadWrite(t *testing.T) {
 		Config: &tls.Config{NextProtos: nextprotos},
 		Dialer: dialer.New(&dialer.Config{ReadWriteSaver: saver}, &net.Resolver{}),
 		TLSHandshaker: tlsdialer.SaverTLSHandshaker{
-			TLSHandshaker: &netxlite.TLSHandshakerStdlib{},
+			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
 			Saver:         saver,
 		},
 	}
@@ -119,7 +119,7 @@ func TestSaverTLSHandshakerSuccess(t *testing.T) {
 		Config: &tls.Config{NextProtos: nextprotos},
 		Dialer: new(net.Dialer),
 		TLSHandshaker: tlsdialer.SaverTLSHandshaker{
-			TLSHandshaker: &netxlite.TLSHandshakerStdlib{},
+			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
 			Saver:         saver,
 		},
 	}
@@ -184,7 +184,7 @@ func TestSaverTLSHandshakerHostnameError(t *testing.T) {
 	tlsdlr := &netxlite.TLSDialer{
 		Dialer: new(net.Dialer),
 		TLSHandshaker: tlsdialer.SaverTLSHandshaker{
-			TLSHandshaker: &netxlite.TLSHandshakerStdlib{},
+			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
 			Saver:         saver,
 		},
 	}
@@ -217,7 +217,7 @@ func TestSaverTLSHandshakerInvalidCertError(t *testing.T) {
 	tlsdlr := &netxlite.TLSDialer{
 		Dialer: new(net.Dialer),
 		TLSHandshaker: tlsdialer.SaverTLSHandshaker{
-			TLSHandshaker: &netxlite.TLSHandshakerStdlib{},
+			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
 			Saver:         saver,
 		},
 	}
@@ -250,7 +250,7 @@ func TestSaverTLSHandshakerAuthorityError(t *testing.T) {
 	tlsdlr := &netxlite.TLSDialer{
 		Dialer: new(net.Dialer),
 		TLSHandshaker: tlsdialer.SaverTLSHandshaker{
-			TLSHandshaker: &netxlite.TLSHandshakerStdlib{},
+			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
 			Saver:         saver,
 		},
 	}
@@ -284,7 +284,7 @@ func TestSaverTLSHandshakerNoTLSVerify(t *testing.T) {
 		Config: &tls.Config{InsecureSkipVerify: true},
 		Dialer: new(net.Dialer),
 		TLSHandshaker: tlsdialer.SaverTLSHandshaker{
-			TLSHandshaker: &netxlite.TLSHandshakerStdlib{},
+			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
 			Saver:         saver,
 		},
 	}

--- a/internal/engine/netx/tlsdialer/tls_test.go
+++ b/internal/engine/netx/tlsdialer/tls_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestSystemTLSHandshakerEOFError(t *testing.T) {
-	h := &netxlite.TLSHandshakerStdlib{}
+	h := &netxlite.TLSHandshakerConfigurable{}
 	conn, _, err := h.Handshake(context.Background(), tlsdialer.EOFConn{}, &tls.Config{
 		ServerName: "x.org",
 	})

--- a/internal/netxlite/tlsconn.go
+++ b/internal/netxlite/tlsconn.go
@@ -1,0 +1,18 @@
+package netxlite
+
+import (
+	"crypto/tls"
+	"net"
+)
+
+// TLSConn is any tls.Conn-like structure.
+type TLSConn interface {
+	// net.Conn is the embedded conn.
+	net.Conn
+
+	// ConnectionState returns the TLS connection state.
+	ConnectionState() tls.ConnectionState
+
+	// Handshake performs the handshake.
+	Handshake() error
+}

--- a/internal/netxlite/tlsdialer.go
+++ b/internal/netxlite/tlsdialer.go
@@ -43,8 +43,6 @@ func (d *TLSDialer) DialTLSContext(ctx context.Context, network, address string)
 // We set the ServerName field if not already set.
 //
 // We set the ALPN if the port is 443 or 853, if not already set.
-//
-// We force using our root CA, unless it's already set.
 func (d *TLSDialer) config(host, port string) *tls.Config {
 	config := d.Config
 	if config == nil {
@@ -61,9 +59,6 @@ func (d *TLSDialer) config(host, port string) *tls.Config {
 		case "853":
 			config.NextProtos = []string{"dot"}
 		}
-	}
-	if config.RootCAs == nil {
-		config.RootCAs = NewDefaultCertPool()
 	}
 	return config
 }

--- a/internal/netxmocks/quic.go
+++ b/internal/netxmocks/quic.go
@@ -1,6 +1,12 @@
 package netxmocks
 
-import "net"
+import (
+	"context"
+	"crypto/tls"
+	"net"
+
+	"github.com/lucas-clemente/quic-go"
+)
 
 // QUICListener is a mockable netxlite.QUICListener.
 type QUICListener struct {
@@ -10,4 +16,16 @@ type QUICListener struct {
 // Listen calls MockListen.
 func (ql *QUICListener) Listen(addr *net.UDPAddr) (net.PacketConn, error) {
 	return ql.MockListen(addr)
+}
+
+// QUICContextDialer is a mockable netxlite.QUICContextDialer.
+type QUICContextDialer struct {
+	MockDialContext func(ctx context.Context, network, address string,
+		tlsConfig *tls.Config, quicConfig *quic.Config) (quic.EarlySession, error)
+}
+
+// DialContext calls MockDialContext.
+func (qcd *QUICContextDialer) DialContext(ctx context.Context, network, address string,
+	tlsConfig *tls.Config, quicConfig *quic.Config) (quic.EarlySession, error) {
+	return qcd.MockDialContext(ctx, network, address, tlsConfig, quicConfig)
 }

--- a/internal/netxmocks/quic_test.go
+++ b/internal/netxmocks/quic_test.go
@@ -1,9 +1,13 @@
 package netxmocks
 
 import (
+	"context"
+	"crypto/tls"
 	"errors"
 	"net"
 	"testing"
+
+	"github.com/lucas-clemente/quic-go"
 )
 
 func TestQUICListenerListen(t *testing.T) {
@@ -19,5 +23,24 @@ func TestQUICListenerListen(t *testing.T) {
 	}
 	if pconn != nil {
 		t.Fatal("expected nil conn here")
+	}
+}
+
+func TestQUICContextDialerDialContext(t *testing.T) {
+	expected := errors.New("mocked error")
+	qcd := &QUICContextDialer{
+		MockDialContext: func(ctx context.Context, network string, address string, tlsConfig *tls.Config, quicConfig *quic.Config) (quic.EarlySession, error) {
+			return nil, expected
+		},
+	}
+	ctx := context.Background()
+	tlsConfig := &tls.Config{}
+	quicConfig := &quic.Config{}
+	sess, err := qcd.DialContext(ctx, "udp", "dns.google:443", tlsConfig, quicConfig)
+	if !errors.Is(err, expected) {
+		t.Fatal("not the error we expected")
+	}
+	if sess != nil {
+		t.Fatal("expected nil session")
 	}
 }

--- a/internal/netxmocks/tlsconn.go
+++ b/internal/netxmocks/tlsconn.go
@@ -1,0 +1,25 @@
+package netxmocks
+
+import "crypto/tls"
+
+// TLSConn allows to mock netxlite.TLSConn.
+type TLSConn struct {
+	// Conn is the embedded mockable Conn.
+	Conn
+
+	// MockConnectionState allows to mock the ConnectionState method.
+	MockConnectionState func() tls.ConnectionState
+
+	// MockHandshake allows to mock the Handshake method.
+	MockHandshake func() error
+}
+
+// ConnectionState calls MockConnectionState.
+func (c *TLSConn) ConnectionState() tls.ConnectionState {
+	return c.MockConnectionState()
+}
+
+// Handshake calls MockHandshake.
+func (c *TLSConn) Handshake() error {
+	return c.MockHandshake()
+}


### PR DESCRIPTION
Auto-configure every relevant TLS field as close as possible to
where it's actually used.

As a side effect, add support for mocking the creation of a TLS
connection, which should possibly be useful for uTLS?

Refactoring as part of https://github.com/ooni/probe/issues/1505