### PR TITLE
refactor: introduce factory for stdlib http transport

### DIFF
--- a/internal/engine/netx/httptransport/http3transport.go
+++ b/internal/engine/netx/httptransport/http3transport.go
@@ -5,6 +5,10 @@ import (
 )
 
 // NewHTTP3Transport creates a new HTTP3Transport instance.
+//
+// Deprecation warning
+//
+// New code should use netxlite.NewHTTP3Transport instead.
 func NewHTTP3Transport(config Config) RoundTripper {
 	return netxlite.NewHTTP3Transport(config.QUICDialer, config.TLSConfig)
 }

--- a/internal/engine/netx/httptransport/system.go
+++ b/internal/engine/netx/httptransport/system.go
@@ -6,6 +6,10 @@ import (
 
 // NewSystemTransport creates a new "system" HTTP transport. That is a transport
 // using the Go standard library with custom dialer and TLS dialer.
+//
+// Deprecation warning
+//
+// New code should use netxlite.NewHTTPTransport instead.
 func NewSystemTransport(config Config) RoundTripper {
 	txp := http.DefaultTransport.(*http.Transport).Clone()
 	txp.DialContext = config.Dialer.DialContext

--- a/internal/netxlite/http3.go
+++ b/internal/netxlite/http3.go
@@ -47,8 +47,13 @@ func NewHTTP3Transport(
 	dialer QUICContextDialer, tlsConfig *tls.Config) HTTPTransport {
 	return &http3Transport{
 		child: &http3.RoundTripper{
-			Dial:            (&http3Dialer{dialer}).dial,
-			TLSClientConfig: tlsConfig,
+			Dial: (&http3Dialer{dialer}).dial,
+			// The following (1) reduces the number of headers that Go will
+			// automatically send for us and (2) ensures that we always receive
+			// back the true headers, such as Content-Length. This change is
+			// functional to OONI's goal of observing the network.
+			DisableCompression: true,
+			TLSClientConfig:    tlsConfig,
 		},
 	}
 }


### PR DESCRIPTION
With this factory, we want to construct ourselves the TLS dialer
so that we can use a dialer wrapper that always sets timeouts when
reading, addressing https://github.com/ooni/probe/issues/1609.

As a result, we cannot immediately replace the i/e/netx factory
for creating a new HTTP transport, since the functions signatures
are not directly compatible.

Refactoring is part of https://github.com/ooni/probe/issues/1505.