### PR TITLE
refactor(errorsx): directly return ErrWrapper when needed

### DIFF
--- a/internal/errorsx/dialer.go
+++ b/internal/errorsx/dialer.go
@@ -11,55 +11,67 @@ type Dialer interface {
 	DialContext(ctx context.Context, network, address string) (net.Conn, error)
 }
 
-// ErrorWrapperDialer is a dialer that performs error wrapping.
+// ErrorWrapperDialer is a dialer that performs error wrapping. The connection
+// returned by the DialContext function will also perform error wrapping.
 type ErrorWrapperDialer struct {
+	// Dialer is the underlying dialer.
 	Dialer
 }
 
 // DialContext implements Dialer.DialContext.
 func (d *ErrorWrapperDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
 	conn, err := d.Dialer.DialContext(ctx, network, address)
-	err = SafeErrWrapperBuilder{
-		Error:     err,
-		Operation: ConnectOperation,
-	}.MaybeBuild()
 	if err != nil {
-		return nil, err
+		return nil, &ErrWrapper{
+			Failure:    toFailureString(err),
+			Operation:  ConnectOperation,
+			WrappedErr: err,
+		}
 	}
 	return &errorWrapperConn{Conn: conn}, nil
 }
 
 // errorWrapperConn is a net.Conn that performs error wrapping.
 type errorWrapperConn struct {
+	// Conn is the underlying connection.
 	net.Conn
 }
 
 // Read implements net.Conn.Read.
-func (c *errorWrapperConn) Read(b []byte) (n int, err error) {
-	n, err = c.Conn.Read(b)
-	err = SafeErrWrapperBuilder{
-		Error:     err,
-		Operation: ReadOperation,
-	}.MaybeBuild()
-	return
+func (c *errorWrapperConn) Read(b []byte) (int, error) {
+	count, err := c.Conn.Read(b)
+	if err != nil {
+		return 0, &ErrWrapper{
+			Failure:    toFailureString(err),
+			Operation:  ReadOperation,
+			WrappedErr: err,
+		}
+	}
+	return count, nil
 }
 
 // Write implements net.Conn.Write.
-func (c *errorWrapperConn) Write(b []byte) (n int, err error) {
-	n, err = c.Conn.Write(b)
-	err = SafeErrWrapperBuilder{
-		Error:     err,
-		Operation: WriteOperation,
-	}.MaybeBuild()
-	return
+func (c *errorWrapperConn) Write(b []byte) (int, error) {
+	count, err := c.Conn.Write(b)
+	if err != nil {
+		return 0, &ErrWrapper{
+			Failure:    toFailureString(err),
+			Operation:  WriteOperation,
+			WrappedErr: err,
+		}
+	}
+	return count, nil
 }
 
 // Close implements net.Conn.Close.
-func (c *errorWrapperConn) Close() (err error) {
-	err = c.Conn.Close()
-	err = SafeErrWrapperBuilder{
-		Error:     err,
-		Operation: CloseOperation,
-	}.MaybeBuild()
-	return
+func (c *errorWrapperConn) Close() error {
+	err := c.Conn.Close()
+	if err != nil {
+		return &ErrWrapper{
+			Failure:    toFailureString(err),
+			Operation:  CloseOperation,
+			WrappedErr: err,
+		}
+	}
+	return nil
 }

--- a/internal/errorsx/errorsx.go
+++ b/internal/errorsx/errorsx.go
@@ -105,6 +105,8 @@ func toFailureString(err error) string {
 	// The list returned here matches the values used by MK unless
 	// explicitly noted otherwise with a comment.
 
+	// TODO(bassosimone): we need to always apply this rule not only here
+	// when we're making the most generic conversion.
 	var errwrapper *ErrWrapper
 	if errors.As(err, &errwrapper) {
 		return errwrapper.Error() // we've already wrapped it


### PR DESCRIPTION
The utility of SafeErrWrapperBuilder is low. Let us instead change the
code to always create ErrWrapper when we're in this package.

While there, also note some TODO-next items.

Part of https://github.com/ooni/probe/issues/1505.