### PR TITLE
fix: completely remove support for h3-29

### DIFF
--- a/internal/cmd/oohelperd/internal/websteps/explore.go
+++ b/internal/cmd/oohelperd/internal/websteps/explore.go
@@ -56,7 +56,7 @@ func (e *DefaultExplorer) Explore(URL *url.URL, headers map[string][]string) ([]
 }
 
 // rearrange takes in input the final response of an HTTP transaction and an optional h3URL
-// (which is needed to derive the type of h3 protocol, i.e. h3 or h3-29),
+// (which is needed to derive the type of h3 protocol, typically h3),
 // and produces in output a list of round trips sorted
 // such that the first round trip is the first element in the out array.
 func (e *DefaultExplorer) rearrange(resp *http.Response, h3URL *h3URL) (out []*RoundTrip) {

--- a/internal/engine/experiment/websteps/model.go
+++ b/internal/engine/experiment/websteps/model.go
@@ -46,7 +46,7 @@ type URLMeasurement struct {
 // _inside_ the test helper to describe the discovery phase where
 // we gather all the URLs that can derive from a given URL.
 type RoundTripInfo struct {
-	// Proto is the protocol used, it can be "h2", "http/1.1", "h3", "h3-29".
+	// Proto is the protocol used, it can be "h2", "http/1.1", "h3".
 	Proto string
 
 	// Request is the original HTTP request. Headers also include cookies.
@@ -83,7 +83,7 @@ type EndpointMeasurement struct {
 	// Endpoint is the endpoint we're measuring.
 	Endpoint string `json:"endpoint"`
 
-	// Protocol is one of "http", "https", "h3", and "h3-29".
+	// Protocol is one of "http", "https", and "h3".
 	Protocol string `json:"protocol"`
 
 	// TCPConnect is the TCP connect measurement. This field
@@ -91,7 +91,7 @@ type EndpointMeasurement struct {
 	TCPConnect *TCPConnectMeasurement `json:"tcp_connect"`
 
 	// QUICHandshake is the QUIC handshake measurement. This field
-	// is only meaningful when the protocol is one of "h3" and "h3-29".
+	// is only meaningful when the protocol is "h3".
 	QUICHandshake *QUICHandshakeMeasurement `json:"quic_handshake"`
 
 	// TLSHandshake is the TLS handshake measurement. This field

--- a/internal/engine/experiment/websteps/websteps.go
+++ b/internal/engine/experiment/websteps/websteps.go
@@ -67,7 +67,6 @@ func (m Measurer) ExperimentVersion() string {
 // SupportedQUICVersions are the H3 over QUIC versions we currently support
 var SupportedQUICVersions = map[string]bool{
 	"h3":    true,
-	"h3-29": true,
 }
 
 var (


### PR DESCRIPTION
The quic-go library does not support it anymore. So, let us be consistent
and remove any reference to h3-29 from our codebase.

Closes https://github.com/ooni/probe/issues/1740.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1740
- [x] related ooni/spec pull request: https://github.com/ooni/spec/pull/224

Location of the issue tracker: https://github.com/ooni/probe

## Description

Please, insert here a more detailed description.
