### PR TITLE
fix(netxlite): make default resolver converge faster

### DIFF
--- a/internal/engine/experiment/ndt7/dial_test.go
+++ b/internal/engine/experiment/ndt7/dial_test.go
@@ -18,8 +18,8 @@ func TestDialDownloadWithCancelledContext(t *testing.T) {
 	cancel() // immediately halt
 	mgr := newDialManager("wss://hostname.fake", log.Log, "miniooni/0.1.0-dev")
 	conn, err := mgr.dialDownload(ctx)
-	if err == nil || !strings.HasSuffix(err.Error(), "operation was canceled") {
-		t.Fatal("not the error we expected")
+	if err == nil || !strings.HasSuffix(err.Error(), "context canceled") {
+		t.Fatal("not the error we expected", err)
 	}
 	if conn != nil {
 		t.Fatal("expected nil conn here")
@@ -31,8 +31,8 @@ func TestDialUploadWithCancelledContext(t *testing.T) {
 	cancel() // immediately halt
 	mgr := newDialManager("wss://hostname.fake", log.Log, "miniooni/0.1.0-dev")
 	conn, err := mgr.dialUpload(ctx)
-	if err == nil || !strings.HasSuffix(err.Error(), "operation was canceled") {
-		t.Fatal("not the error we expected")
+	if err == nil || !strings.HasSuffix(err.Error(), "context canceled") {
+		t.Fatal("not the error we expected", err)
 	}
 	if conn != nil {
 		t.Fatal("expected nil conn here")

--- a/internal/engine/experiment/ndt7/ndt7_test.go
+++ b/internal/engine/experiment/ndt7/ndt7_test.go
@@ -52,8 +52,8 @@ func TestDoDownloadWithCancelledContext(t *testing.T) {
 	err := m.doDownload(
 		ctx, sess, model.NewPrinterCallbacks(log.Log), new(TestKeys),
 		"ws://host.name")
-	if err == nil || !strings.HasSuffix(err.Error(), "operation was canceled") {
-		t.Fatal("not the error we expected")
+	if err == nil || !strings.HasSuffix(err.Error(), "context canceled") {
+		t.Fatal("not the error we expected", err)
 	}
 }
 
@@ -69,8 +69,8 @@ func TestDoUploadWithCancelledContext(t *testing.T) {
 	err := m.doUpload(
 		ctx, sess, model.NewPrinterCallbacks(log.Log), new(TestKeys),
 		"ws://host.name")
-	if err == nil || !strings.HasSuffix(err.Error(), "operation was canceled") {
-		t.Fatal("not the error we expected")
+	if err == nil || !strings.HasSuffix(err.Error(), "context canceled") {
+		t.Fatal("not the error we expected", err)
 	}
 }
 
@@ -132,8 +132,8 @@ func TestFailDownload(t *testing.T) {
 		new(model.Measurement),
 		model.NewPrinterCallbacks(log.Log),
 	)
-	if err == nil || !strings.HasSuffix(err.Error(), "operation was canceled") {
-		t.Fatal(err)
+	if err == nil || !strings.HasSuffix(err.Error(), "context canceled") {
+		t.Fatal("not the error we expected", err)
 	}
 }
 
@@ -153,8 +153,8 @@ func TestFailUpload(t *testing.T) {
 		new(model.Measurement),
 		model.NewPrinterCallbacks(log.Log),
 	)
-	if err == nil || !strings.HasSuffix(err.Error(), "operation was canceled") {
-		t.Fatal(err)
+	if err == nil || !strings.HasSuffix(err.Error(), "context canceled") {
+		t.Fatal("not the error we expected", err)
 	}
 }
 

--- a/internal/netxlite/resolver.go
+++ b/internal/netxlite/resolver.go
@@ -40,13 +40,52 @@ func NewResolver(config *ResolverConfig) Resolver {
 }
 
 // resolverSystem is the system resolver.
-type resolverSystem struct{}
+type resolverSystem struct {
+	testableTimeout    time.Duration
+	testableLookupHost func(ctx context.Context, domain string) ([]string, error)
+}
 
 var _ Resolver = &resolverSystem{}
 
 // LookupHost implements Resolver.LookupHost.
 func (r *resolverSystem) LookupHost(ctx context.Context, hostname string) ([]string, error) {
-	return net.DefaultResolver.LookupHost(ctx, hostname)
+	// This code of forces adding a shorter timeout to domain name
+	// resolutions when using the system resolver. We have seen cases
+	// in which such a timeout becomes too large. One such case is
+	// described in https://github.com/ooni/probe/issues/1726.
+	addrsch, errch := make(chan []string, 1), make(chan error, 1)
+	ctx, cancel := context.WithTimeout(ctx, r.timeout())
+	defer cancel()
+	go func() {
+		addrs, err := r.lookupHost()(ctx, hostname)
+		if err != nil {
+			errch <- err
+			return
+		}
+		addrsch <- addrs
+	}()
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case addrs := <-addrsch:
+		return addrs, nil
+	case err := <-errch:
+		return nil, err
+	}
+}
+
+func (r *resolverSystem) timeout() time.Duration {
+	if r.testableTimeout > 0 {
+		return r.testableTimeout
+	}
+	return 15 * time.Second
+}
+
+func (r *resolverSystem) lookupHost() func(ctx context.Context, domain string) ([]string, error) {
+	if r.testableLookupHost != nil {
+		return r.testableLookupHost
+	}
+	return net.DefaultResolver.LookupHost
 }
 
 // Network implements Resolver.Network.


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1726
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

Closes https://github.com/ooni/probe/issues/1726
