### PR TITLE
refactor(dialer): it should close idle connections

### DIFF
--- a/internal/cmd/oohelperd/internal/websteps/generate.go
+++ b/internal/cmd/oohelperd/internal/websteps/generate.go
@@ -22,7 +22,7 @@ type Generator interface {
 
 // DefaultGenerator is the default Generator.
 type DefaultGenerator struct {
-	dialer     netxlite.Dialer
+	dialer     netxlite.DialerLegacy
 	quicDialer netxlite.QUICContextDialer
 	resolver   netxlite.ResolverLegacy
 	transport  http.RoundTripper

--- a/internal/engine/experiment/websteps/factory.go
+++ b/internal/engine/experiment/websteps/factory.go
@@ -33,12 +33,12 @@ func NewRequest(ctx context.Context, URL *url.URL, headers http.Header) *http.Re
 
 // NewDialerResolver contructs a new dialer for TCP connections,
 // with default, errorwrapping and resolve functionalities
-func NewDialerResolver(resolver netxlite.ResolverLegacy) netxlite.Dialer {
-	var d netxlite.Dialer = netxlite.DefaultDialer
+func NewDialerResolver(resolver netxlite.ResolverLegacy) netxlite.DialerLegacy {
+	var d netxlite.DialerLegacy = netxlite.DefaultDialer
 	d = &errorsx.ErrorWrapperDialer{Dialer: d}
 	d = &netxlite.DialerResolver{
 		Resolver: netxlite.NewResolverLegacyAdapter(resolver),
-		Dialer:   d,
+		Dialer:   netxlite.NewDialerLegacyAdapter(d),
 	}
 	return d
 }
@@ -80,12 +80,12 @@ func NewSingleTransport(conn net.Conn) http.RoundTripper {
 }
 
 // NewSingleTransport creates a new HTTP transport with a custom dialer and handshaker.
-func NewTransportWithDialer(dialer netxlite.Dialer, tlsConfig *tls.Config, handshaker netxlite.TLSHandshaker) http.RoundTripper {
+func NewTransportWithDialer(dialer netxlite.DialerLegacy, tlsConfig *tls.Config, handshaker netxlite.TLSHandshaker) http.RoundTripper {
 	transport := newBaseTransport()
 	transport.DialContext = dialer.DialContext
 	transport.DialTLSContext = (&netxlite.TLSDialer{
 		Config:        tlsConfig,
-		Dialer:        dialer,
+		Dialer:        netxlite.NewDialerLegacyAdapter(dialer),
 		TLSHandshaker: handshaker,
 	}).DialTLSContext
 	return transport

--- a/internal/engine/experiment/websteps/tcp.go
+++ b/internal/engine/experiment/websteps/tcp.go
@@ -8,7 +8,7 @@ import (
 )
 
 type TCPConfig struct {
-	Dialer   netxlite.Dialer
+	Dialer   netxlite.DialerLegacy
 	Endpoint string
 	Resolver netxlite.ResolverLegacy
 }

--- a/internal/engine/legacy/netx/dialer.go
+++ b/internal/engine/legacy/netx/dialer.go
@@ -106,7 +106,7 @@ func (d *Dialer) DialTLS(network, address string) (net.Conn, error) {
 func newTLSDialer(d dialer.Dialer, config *tls.Config) *netxlite.TLSDialer {
 	return &netxlite.TLSDialer{
 		Config: config,
-		Dialer: d,
+		Dialer: netxlite.NewDialerLegacyAdapter(d),
 		TLSHandshaker: tlsdialer.EmitterTLSHandshaker{
 			TLSHandshaker: &errorsx.ErrorWrapperTLSHandshaker{
 				TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},

--- a/internal/engine/netx/dialer/dialer.go
+++ b/internal/engine/netx/dialer/dialer.go
@@ -72,7 +72,10 @@ func New(config *Config, resolver Resolver) Dialer {
 	var d Dialer = netxlite.DefaultDialer
 	d = &errorsx.ErrorWrapperDialer{Dialer: d}
 	if config.Logger != nil {
-		d = &netxlite.DialerLogger{Dialer: d, Logger: config.Logger}
+		d = &netxlite.DialerLogger{
+			Dialer: netxlite.NewDialerLegacyAdapter(d),
+			Logger: config.Logger,
+		}
 	}
 	if config.DialSaver != nil {
 		d = &saverDialer{Dialer: d, Saver: config.DialSaver}
@@ -82,7 +85,7 @@ func New(config *Config, resolver Resolver) Dialer {
 	}
 	d = &netxlite.DialerResolver{
 		Resolver: netxlite.NewResolverLegacyAdapter(resolver),
-		Dialer:   d,
+		Dialer:   netxlite.NewDialerLegacyAdapter(d),
 	}
 	d = &proxyDialer{ProxyURL: config.ProxyURL, Dialer: d}
 	if config.ContextByteCounting {

--- a/internal/engine/netx/dialer/dialer_test.go
+++ b/internal/engine/netx/dialer/dialer_test.go
@@ -36,7 +36,11 @@ func TestNewCreatesTheExpectedChain(t *testing.T) {
 	if !ok {
 		t.Fatal("not a dnsDialer")
 	}
-	scd, ok := dnsd.Dialer.(*saverConnDialer)
+	dad, ok := dnsd.Dialer.(*netxlite.DialerLegacyAdapter)
+	if !ok {
+		t.Fatal("invalid type")
+	}
+	scd, ok := dad.DialerLegacy.(*saverConnDialer)
 	if !ok {
 		t.Fatal("not a saverConnDialer")
 	}
@@ -48,12 +52,16 @@ func TestNewCreatesTheExpectedChain(t *testing.T) {
 	if !ok {
 		t.Fatal("not a loggingDialer")
 	}
-	ewd, ok := ld.Dialer.(*errorsx.ErrorWrapperDialer)
+	dad, ok = ld.Dialer.(*netxlite.DialerLegacyAdapter)
+	if !ok {
+		t.Fatal("invalid type")
+	}
+	ewd, ok := dad.DialerLegacy.(*errorsx.ErrorWrapperDialer)
 	if !ok {
 		t.Fatal("not an errorWrappingDialer")
 	}
-	_, ok = ewd.Dialer.(*net.Dialer)
+	_, ok = ewd.Dialer.(*netxlite.DialerSystem)
 	if !ok {
-		t.Fatal("not a net.Dialer")
+		t.Fatal("not a DialerSystem")
 	}
 }

--- a/internal/engine/netx/netx.go
+++ b/internal/engine/netx/netx.go
@@ -209,7 +209,7 @@ func NewTLSDialer(config Config) TLSDialer {
 	config.TLSConfig.InsecureSkipVerify = config.NoTLSVerify
 	return &netxlite.TLSDialer{
 		Config:        config.TLSConfig,
-		Dialer:        config.Dialer,
+		Dialer:        netxlite.NewDialerLegacyAdapter(config.Dialer),
 		TLSHandshaker: h,
 	}
 }

--- a/internal/engine/netx/tlsdialer/integration_test.go
+++ b/internal/engine/netx/tlsdialer/integration_test.go
@@ -1,7 +1,6 @@
 package tlsdialer_test
 
 import (
-	"net"
 	"net/http"
 	"testing"
 
@@ -14,7 +13,7 @@ func TestTLSDialerSuccess(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 	log.SetLevel(log.DebugLevel)
-	dialer := &netxlite.TLSDialer{Dialer: new(net.Dialer),
+	dialer := &netxlite.TLSDialer{Dialer: netxlite.DefaultDialer,
 		TLSHandshaker: &netxlite.TLSHandshakerLogger{
 			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
 			Logger:        log.Log,

--- a/internal/engine/netx/tlsdialer/saver_test.go
+++ b/internal/engine/netx/tlsdialer/saver_test.go
@@ -24,7 +24,9 @@ func TestSaverTLSHandshakerSuccessWithReadWrite(t *testing.T) {
 	saver := &trace.Saver{}
 	tlsdlr := &netxlite.TLSDialer{
 		Config: &tls.Config{NextProtos: nextprotos},
-		Dialer: dialer.New(&dialer.Config{ReadWriteSaver: saver}, &net.Resolver{}),
+		Dialer: netxlite.NewDialerLegacyAdapter(
+			dialer.New(&dialer.Config{ReadWriteSaver: saver}, &net.Resolver{}),
+		),
 		TLSHandshaker: tlsdialer.SaverTLSHandshaker{
 			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
 			Saver:         saver,
@@ -117,7 +119,7 @@ func TestSaverTLSHandshakerSuccess(t *testing.T) {
 	saver := &trace.Saver{}
 	tlsdlr := &netxlite.TLSDialer{
 		Config: &tls.Config{NextProtos: nextprotos},
-		Dialer: new(net.Dialer),
+		Dialer: netxlite.DefaultDialer,
 		TLSHandshaker: tlsdialer.SaverTLSHandshaker{
 			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
 			Saver:         saver,
@@ -182,7 +184,7 @@ func TestSaverTLSHandshakerHostnameError(t *testing.T) {
 	}
 	saver := &trace.Saver{}
 	tlsdlr := &netxlite.TLSDialer{
-		Dialer: new(net.Dialer),
+		Dialer: netxlite.DefaultDialer,
 		TLSHandshaker: tlsdialer.SaverTLSHandshaker{
 			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
 			Saver:         saver,
@@ -215,7 +217,7 @@ func TestSaverTLSHandshakerInvalidCertError(t *testing.T) {
 	}
 	saver := &trace.Saver{}
 	tlsdlr := &netxlite.TLSDialer{
-		Dialer: new(net.Dialer),
+		Dialer: netxlite.DefaultDialer,
 		TLSHandshaker: tlsdialer.SaverTLSHandshaker{
 			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
 			Saver:         saver,
@@ -248,7 +250,7 @@ func TestSaverTLSHandshakerAuthorityError(t *testing.T) {
 	}
 	saver := &trace.Saver{}
 	tlsdlr := &netxlite.TLSDialer{
-		Dialer: new(net.Dialer),
+		Dialer: netxlite.DefaultDialer,
 		TLSHandshaker: tlsdialer.SaverTLSHandshaker{
 			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
 			Saver:         saver,
@@ -282,7 +284,7 @@ func TestSaverTLSHandshakerNoTLSVerify(t *testing.T) {
 	saver := &trace.Saver{}
 	tlsdlr := &netxlite.TLSDialer{
 		Config: &tls.Config{InsecureSkipVerify: true},
-		Dialer: new(net.Dialer),
+		Dialer: netxlite.DefaultDialer,
 		TLSHandshaker: tlsdialer.SaverTLSHandshaker{
 			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
 			Saver:         saver,

--- a/internal/netxlite/legacy_test.go
+++ b/internal/netxlite/legacy_test.go
@@ -82,3 +82,21 @@ func TestResolverLegacyAdapterDefaults(t *testing.T) {
 	}
 	r.CloseIdleConnections() // does not crash
 }
+
+func TestDialerLegacyAdapterWithCompatibleType(t *testing.T) {
+	var called bool
+	r := NewDialerLegacyAdapter(&mocks.Dialer{
+		MockCloseIdleConnections: func() {
+			called = true
+		},
+	})
+	r.CloseIdleConnections()
+	if !called {
+		t.Fatal("not called")
+	}
+}
+
+func TestDialerLegacyAdapterDefaults(t *testing.T) {
+	r := NewDialerLegacyAdapter(&net.Dialer{})
+	r.CloseIdleConnections() // does not crash
+}

--- a/internal/netxlite/mocks/dialer.go
+++ b/internal/netxlite/mocks/dialer.go
@@ -7,10 +7,16 @@ import (
 
 // Dialer is a mockable Dialer.
 type Dialer struct {
-	MockDialContext func(ctx context.Context, network, address string) (net.Conn, error)
+	MockDialContext          func(ctx context.Context, network, address string) (net.Conn, error)
+	MockCloseIdleConnections func()
 }
 
 // DialContext calls MockDialContext.
 func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
 	return d.MockDialContext(ctx, network, address)
+}
+
+// CloseIdleConnections calls MockCloseIdleConnections.
+func (d *Dialer) CloseIdleConnections() {
+	d.MockCloseIdleConnections()
 }

--- a/internal/netxlite/mocks/dialer_test.go
+++ b/internal/netxlite/mocks/dialer_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestDialerWorks(t *testing.T) {
+func TestDialerDialContext(t *testing.T) {
 	expected := errors.New("mocked error")
 	d := Dialer{
 		MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
@@ -21,5 +21,18 @@ func TestDialerWorks(t *testing.T) {
 	}
 	if conn != nil {
 		t.Fatal("expected nil conn")
+	}
+}
+
+func TestDialerCloseIdleConnections(t *testing.T) {
+	var called bool
+	d := &Dialer{
+		MockCloseIdleConnections: func() {
+			called = true
+		},
+	}
+	d.CloseIdleConnections()
+	if !called {
+		t.Fatal("not called")
 	}
 }

--- a/internal/netxlite/tls_test.go
+++ b/internal/netxlite/tls_test.go
@@ -294,7 +294,7 @@ func TestTLSDialerFailureSplitHostPort(t *testing.T) {
 func TestTLSDialerFailureDialing(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately fail
-	dialer := TLSDialer{Dialer: &net.Dialer{}}
+	dialer := TLSDialer{Dialer: defaultDialer}
 	conn, err := dialer.DialTLSContext(ctx, "tcp", "www.google.com:443")
 	if err == nil || !strings.HasSuffix(err.Error(), "operation was canceled") {
 		t.Fatal("not the error we expected", err)


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1591
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

Like we did before for the resolver, a dialer should propagate the
request to close idle connections to underlying types.

See https://github.com/ooni/probe/issues/1591