### PR TITLE
feat(netxlite): implement single use {,tls} dialer

### DIFF
--- a/internal/engine/experiment/websteps/factory.go
+++ b/internal/engine/experiment/websteps/factory.go
@@ -83,7 +83,7 @@ func NewSingleTransport(conn net.Conn) http.RoundTripper {
 func NewTransportWithDialer(dialer netxlite.DialerLegacy, tlsConfig *tls.Config, handshaker netxlite.TLSHandshaker) http.RoundTripper {
 	transport := newBaseTransport()
 	transport.DialContext = dialer.DialContext
-	transport.DialTLSContext = (&netxlite.TLSDialer{
+	transport.DialTLSContext = (&netxlite.TLSDialerLegacy{
 		Config:        tlsConfig,
 		Dialer:        netxlite.NewDialerLegacyAdapter(dialer),
 		TLSHandshaker: handshaker,

--- a/internal/engine/legacy/netx/dialer.go
+++ b/internal/engine/legacy/netx/dialer.go
@@ -103,8 +103,8 @@ func (d *Dialer) DialTLS(network, address string) (net.Conn, error) {
 // - SystemTLSHandshaker
 //
 // If you have others needs, manually build the chain you need.
-func newTLSDialer(d dialer.Dialer, config *tls.Config) *netxlite.TLSDialer {
-	return &netxlite.TLSDialer{
+func newTLSDialer(d dialer.Dialer, config *tls.Config) *netxlite.TLSDialerLegacy {
+	return &netxlite.TLSDialerLegacy{
 		Config: config,
 		Dialer: netxlite.NewDialerLegacyAdapter(d),
 		TLSHandshaker: tlsdialer.EmitterTLSHandshaker{

--- a/internal/engine/netx/netx.go
+++ b/internal/engine/netx/netx.go
@@ -207,7 +207,7 @@ func NewTLSDialer(config Config) TLSDialer {
 	}
 	config.TLSConfig.RootCAs = config.CertPool
 	config.TLSConfig.InsecureSkipVerify = config.NoTLSVerify
-	return &netxlite.TLSDialer{
+	return &netxlite.TLSDialerLegacy{
 		Config:        config.TLSConfig,
 		Dialer:        netxlite.NewDialerLegacyAdapter(config.Dialer),
 		TLSHandshaker: h,

--- a/internal/engine/netx/netx_test.go
+++ b/internal/engine/netx/netx_test.go
@@ -255,7 +255,7 @@ func TestNewResolverWithPrefilledReadonlyCache(t *testing.T) {
 
 func TestNewTLSDialerVanilla(t *testing.T) {
 	td := netx.NewTLSDialer(netx.Config{})
-	rtd, ok := td.(*netxlite.TLSDialer)
+	rtd, ok := td.(*netxlite.TLSDialerLegacy)
 	if !ok {
 		t.Fatal("not the TLSDialer we expected")
 	}
@@ -287,7 +287,7 @@ func TestNewTLSDialerWithConfig(t *testing.T) {
 	td := netx.NewTLSDialer(netx.Config{
 		TLSConfig: new(tls.Config),
 	})
-	rtd, ok := td.(*netxlite.TLSDialer)
+	rtd, ok := td.(*netxlite.TLSDialerLegacy)
 	if !ok {
 		t.Fatal("not the TLSDialer we expected")
 	}
@@ -316,7 +316,7 @@ func TestNewTLSDialerWithLogging(t *testing.T) {
 	td := netx.NewTLSDialer(netx.Config{
 		Logger: log.Log,
 	})
-	rtd, ok := td.(*netxlite.TLSDialer)
+	rtd, ok := td.(*netxlite.TLSDialerLegacy)
 	if !ok {
 		t.Fatal("not the TLSDialer we expected")
 	}
@@ -356,7 +356,7 @@ func TestNewTLSDialerWithSaver(t *testing.T) {
 	td := netx.NewTLSDialer(netx.Config{
 		TLSSaver: saver,
 	})
-	rtd, ok := td.(*netxlite.TLSDialer)
+	rtd, ok := td.(*netxlite.TLSDialerLegacy)
 	if !ok {
 		t.Fatal("not the TLSDialer we expected")
 	}
@@ -396,7 +396,7 @@ func TestNewTLSDialerWithNoTLSVerifyAndConfig(t *testing.T) {
 		TLSConfig:   new(tls.Config),
 		NoTLSVerify: true,
 	})
-	rtd, ok := td.(*netxlite.TLSDialer)
+	rtd, ok := td.(*netxlite.TLSDialerLegacy)
 	if !ok {
 		t.Fatal("not the TLSDialer we expected")
 	}
@@ -428,7 +428,7 @@ func TestNewTLSDialerWithNoTLSVerifyAndNoConfig(t *testing.T) {
 	td := netx.NewTLSDialer(netx.Config{
 		NoTLSVerify: true,
 	})
-	rtd, ok := td.(*netxlite.TLSDialer)
+	rtd, ok := td.(*netxlite.TLSDialerLegacy)
 	if !ok {
 		t.Fatal("not the TLSDialer we expected")
 	}
@@ -488,7 +488,7 @@ func TestNewWithDialer(t *testing.T) {
 
 func TestNewWithTLSDialer(t *testing.T) {
 	expected := errors.New("mocked error")
-	tlsDialer := &netxlite.TLSDialer{
+	tlsDialer := &netxlite.TLSDialerLegacy{
 		Config: new(tls.Config),
 		Dialer: &mocks.Dialer{
 			MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {

--- a/internal/engine/netx/tlsdialer/integration_test.go
+++ b/internal/engine/netx/tlsdialer/integration_test.go
@@ -13,7 +13,7 @@ func TestTLSDialerSuccess(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 	log.SetLevel(log.DebugLevel)
-	dialer := &netxlite.TLSDialer{Dialer: netxlite.DefaultDialer,
+	dialer := &netxlite.TLSDialerLegacy{Dialer: netxlite.DefaultDialer,
 		TLSHandshaker: &netxlite.TLSHandshakerLogger{
 			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
 			Logger:        log.Log,

--- a/internal/engine/netx/tlsdialer/saver_test.go
+++ b/internal/engine/netx/tlsdialer/saver_test.go
@@ -22,7 +22,7 @@ func TestSaverTLSHandshakerSuccessWithReadWrite(t *testing.T) {
 	}
 	nextprotos := []string{"h2"}
 	saver := &trace.Saver{}
-	tlsdlr := &netxlite.TLSDialer{
+	tlsdlr := &netxlite.TLSDialerLegacy{
 		Config: &tls.Config{NextProtos: nextprotos},
 		Dialer: netxlite.NewDialerLegacyAdapter(
 			dialer.New(&dialer.Config{ReadWriteSaver: saver}, &net.Resolver{}),
@@ -117,7 +117,7 @@ func TestSaverTLSHandshakerSuccess(t *testing.T) {
 	}
 	nextprotos := []string{"h2"}
 	saver := &trace.Saver{}
-	tlsdlr := &netxlite.TLSDialer{
+	tlsdlr := &netxlite.TLSDialerLegacy{
 		Config: &tls.Config{NextProtos: nextprotos},
 		Dialer: netxlite.DefaultDialer,
 		TLSHandshaker: tlsdialer.SaverTLSHandshaker{
@@ -183,7 +183,7 @@ func TestSaverTLSHandshakerHostnameError(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 	saver := &trace.Saver{}
-	tlsdlr := &netxlite.TLSDialer{
+	tlsdlr := &netxlite.TLSDialerLegacy{
 		Dialer: netxlite.DefaultDialer,
 		TLSHandshaker: tlsdialer.SaverTLSHandshaker{
 			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
@@ -216,7 +216,7 @@ func TestSaverTLSHandshakerInvalidCertError(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 	saver := &trace.Saver{}
-	tlsdlr := &netxlite.TLSDialer{
+	tlsdlr := &netxlite.TLSDialerLegacy{
 		Dialer: netxlite.DefaultDialer,
 		TLSHandshaker: tlsdialer.SaverTLSHandshaker{
 			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
@@ -249,7 +249,7 @@ func TestSaverTLSHandshakerAuthorityError(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 	saver := &trace.Saver{}
-	tlsdlr := &netxlite.TLSDialer{
+	tlsdlr := &netxlite.TLSDialerLegacy{
 		Dialer: netxlite.DefaultDialer,
 		TLSHandshaker: tlsdialer.SaverTLSHandshaker{
 			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
@@ -282,7 +282,7 @@ func TestSaverTLSHandshakerNoTLSVerify(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 	saver := &trace.Saver{}
-	tlsdlr := &netxlite.TLSDialer{
+	tlsdlr := &netxlite.TLSDialerLegacy{
 		Config: &tls.Config{InsecureSkipVerify: true},
 		Dialer: netxlite.DefaultDialer,
 		TLSHandshaker: tlsdialer.SaverTLSHandshaker{

--- a/internal/netxlite/dialer_test.go
+++ b/internal/netxlite/dialer_test.go
@@ -235,3 +235,24 @@ func TestNewDialerWithoutResolverChain(t *testing.T) {
 		t.Fatal("invalid type")
 	}
 }
+
+func TestNewSingleUseDialerWorksAsIntended(t *testing.T) {
+	conn := &mocks.Conn{}
+	d := NewSingleUseDialer(conn)
+	outconn, err := d.DialContext(context.Background(), "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conn != outconn {
+		t.Fatal("invalid outconn")
+	}
+	for i := 0; i < 4; i++ {
+		outconn, err = d.DialContext(context.Background(), "", "")
+		if !errors.Is(err, ErrNoConnReuse) {
+			t.Fatal("not the error we expected", err)
+		}
+		if outconn != nil {
+			t.Fatal("expected nil outconn here")
+		}
+	}
+}

--- a/internal/netxlite/http.go
+++ b/internal/netxlite/http.go
@@ -73,7 +73,7 @@ func NewHTTPTransport(dialer Dialer, tlsConfig *tls.Config,
 	txp := http.DefaultTransport.(*http.Transport).Clone()
 	dialer = &httpDialerWithReadTimeout{dialer}
 	txp.DialContext = dialer.DialContext
-	txp.DialTLSContext = (&TLSDialer{
+	txp.DialTLSContext = (&tlsDialer{
 		Config:        tlsConfig,
 		Dialer:        dialer,
 		TLSHandshaker: handshaker,

--- a/internal/netxlite/legacy.go
+++ b/internal/netxlite/legacy.go
@@ -62,6 +62,7 @@ type (
 	TLSHandshakerConfigurable = tlsHandshakerConfigurable
 	TLSHandshakerLogger       = tlsHandshakerLogger
 	DialerSystem              = dialerSystem
+	TLSDialerLegacy           = tlsDialer
 )
 
 // ResolverLegacy performs domain name resolutions.


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request:  https://github.com/ooni/probe/issues/1591
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

This basically adapts already existing code inside websteps to
instead be into the netxlite package, where it belongs.

In the process, abstract the TLSDialer but keep a reference to the
previous name to avoid refactoring existing code (just for now).

While there, notice that the right name is CloseIdleConnections (i.e.,
plural not singular) and change the name.

While there, since we abstracted TLSDialer to be an interface, create
suitable factories for making a TLSDialer type from a Dialer and a
TLSHandshaker.

See https://github.com/ooni/probe/issues/1591
