### PR TITLE
refactor(netxlite): let NewHTTPTransport work with single-use dialers

### DIFF
--- a/internal/netxlite/http_test.go
+++ b/internal/netxlite/http_test.go
@@ -324,28 +324,6 @@ func TestHTTPDialerWithReadTimeoutDialingFailure(t *testing.T) {
 	}
 }
 
-func TestHTTPDialerWithReadTimeoutDialingSuccess(t *testing.T) {
-	origConn := &mocks.Conn{}
-	d := &httpDialerWithReadTimeout{
-		Dialer: &mocks.Dialer{
-			MockDialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
-				return origConn, nil
-			},
-		},
-	}
-	conn, err := d.DialContext(context.Background(), "", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	uconn, okay := conn.(*httpConnWithReadTimeout)
-	if !okay {
-		t.Fatal("invalid type")
-	}
-	if uconn.Conn != origConn {
-		t.Fatal("invalid underlying conn")
-	}
-}
-
 func TestHTTPTLSDialerWithReadTimeoutDialingFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	d := &httpTLSDialerWithReadTimeout{
@@ -387,27 +365,5 @@ func TestHTTPTLSDialerWithInvalidConnType(t *testing.T) {
 	}
 	if !called {
 		t.Fatal("not called")
-	}
-}
-
-func TestHTTPTLSDialerWithReadTimeoutDialingSuccess(t *testing.T) {
-	origConn := &mocks.TLSConn{}
-	d := &httpTLSDialerWithReadTimeout{
-		TLSDialer: &mocks.TLSDialer{
-			MockDialTLSContext: func(ctx context.Context, network, address string) (net.Conn, error) {
-				return origConn, nil
-			},
-		},
-	}
-	conn, err := d.DialTLSContext(context.Background(), "", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	uconn, okay := conn.(*httpTLSConnWithReadTimeout)
-	if !okay {
-		t.Fatal("invalid type")
-	}
-	if uconn.TLSConn != origConn {
-		t.Fatal("invalid underlying conn")
 	}
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1591
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

To make this happen, we need to take as argument a TLSDialer rather than
a TLSHandshaker. Then, we need to arrange the code so that we always
enforce a timeout for both TCP and TLS connections.

Because a TLSDialer can be constructed with a custom TLSConfig, we cover
also the case where the users wants to provide such a config.

While there, make sure we have better unit tests of the HTTP code.

See https://github.com/ooni/probe/issues/1591