### PR TITLE
feat(netxlite): add CloseIdleConnections to quic dialer

### DIFF
--- a/internal/engine/experiment/websteps/factory.go
+++ b/internal/engine/experiment/websteps/factory.go
@@ -54,7 +54,7 @@ func NewQUICDialerResolver(resolver netxlite.ResolverLegacy) netxlite.QUICContex
 	dialer = &errorsx.ErrorWrapperQUICDialer{Dialer: dialer}
 	dialer = &netxlite.QUICDialerResolver{
 		Resolver: netxlite.NewResolverLegacyAdapter(resolver),
-		Dialer:   dialer,
+		Dialer:   netxlite.NewQUICDialerFromContextDialerAdapter(dialer),
 	}
 	return dialer
 }

--- a/internal/engine/netx/netx.go
+++ b/internal/engine/netx/netx.go
@@ -181,7 +181,7 @@ func NewQUICDialer(config Config) QUICDialer {
 	}
 	d = &netxlite.QUICDialerResolver{
 		Resolver: netxlite.NewResolverLegacyAdapter(config.FullResolver),
-		Dialer:   d,
+		Dialer:   netxlite.NewQUICDialerFromContextDialerAdapter(d),
 	}
 	return d
 }

--- a/internal/netxlite/legacy_test.go
+++ b/internal/netxlite/legacy_test.go
@@ -60,3 +60,21 @@ func TestDialerLegacyAdapterDefaults(t *testing.T) {
 	r := NewDialerLegacyAdapter(&net.Dialer{})
 	r.CloseIdleConnections() // does not crash
 }
+
+func TestQUICContextDialerAdapterWithCompatibleType(t *testing.T) {
+	var called bool
+	d := NewQUICDialerFromContextDialerAdapter(&mocks.QUICDialer{
+		MockCloseIdleConnections: func() {
+			called = true
+		},
+	})
+	d.CloseIdleConnections()
+	if !called {
+		t.Fatal("not called")
+	}
+}
+
+func TestQUICContextDialerAdapterDefaults(t *testing.T) {
+	d := NewQUICDialerFromContextDialerAdapter(&mocks.QUICContextDialer{})
+	d.CloseIdleConnections() // does not crash
+}

--- a/internal/netxlite/mocks/legacy.go
+++ b/internal/netxlite/mocks/legacy.go
@@ -1,0 +1,22 @@
+package mocks
+
+import (
+	"context"
+	"crypto/tls"
+
+	"github.com/lucas-clemente/quic-go"
+)
+
+// QUICContextDialer is a mockable netxlite.QUICContextDialer.
+//
+// DEPRECATED: please use QUICDialer.
+type QUICContextDialer struct {
+	MockDialContext func(ctx context.Context, network, address string,
+		tlsConfig *tls.Config, quicConfig *quic.Config) (quic.EarlySession, error)
+}
+
+// DialContext calls MockDialContext.
+func (qcd *QUICContextDialer) DialContext(ctx context.Context, network, address string,
+	tlsConfig *tls.Config, quicConfig *quic.Config) (quic.EarlySession, error) {
+	return qcd.MockDialContext(ctx, network, address, tlsConfig, quicConfig)
+}

--- a/internal/netxlite/mocks/legacy_test.go
+++ b/internal/netxlite/mocks/legacy_test.go
@@ -1,0 +1,29 @@
+package mocks
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"testing"
+
+	"github.com/lucas-clemente/quic-go"
+)
+
+func TestQUICContextDialerDialContext(t *testing.T) {
+	expected := errors.New("mocked error")
+	qcd := &QUICContextDialer{
+		MockDialContext: func(ctx context.Context, network string, address string, tlsConfig *tls.Config, quicConfig *quic.Config) (quic.EarlySession, error) {
+			return nil, expected
+		},
+	}
+	ctx := context.Background()
+	tlsConfig := &tls.Config{}
+	quicConfig := &quic.Config{}
+	sess, err := qcd.DialContext(ctx, "udp", "dns.google:443", tlsConfig, quicConfig)
+	if !errors.Is(err, expected) {
+		t.Fatal("not the error we expected")
+	}
+	if sess != nil {
+		t.Fatal("expected nil session")
+	}
+}

--- a/internal/netxlite/mocks/quic.go
+++ b/internal/netxlite/mocks/quic.go
@@ -21,16 +21,25 @@ func (ql *QUICListener) Listen(addr *net.UDPAddr) (quicx.UDPLikeConn, error) {
 	return ql.MockListen(addr)
 }
 
-// QUICContextDialer is a mockable netxlite.QUICContextDialer.
-type QUICContextDialer struct {
+// QUICDialer is a mockable netxlite.QUICDialer.
+type QUICDialer struct {
+	// MockDialContext allows mocking DialContext.
 	MockDialContext func(ctx context.Context, network, address string,
 		tlsConfig *tls.Config, quicConfig *quic.Config) (quic.EarlySession, error)
+
+	// MockCloseIdleConnections allows mocking CloseIdleConnections.
+	MockCloseIdleConnections func()
 }
 
 // DialContext calls MockDialContext.
-func (qcd *QUICContextDialer) DialContext(ctx context.Context, network, address string,
+func (qcd *QUICDialer) DialContext(ctx context.Context, network, address string,
 	tlsConfig *tls.Config, quicConfig *quic.Config) (quic.EarlySession, error) {
 	return qcd.MockDialContext(ctx, network, address, tlsConfig, quicConfig)
+}
+
+// CloseIdleConnections calls MockCloseIdleConnections.
+func (qcd *QUICDialer) CloseIdleConnections() {
+	qcd.MockCloseIdleConnections()
 }
 
 // QUICEarlySession is a mockable quic.EarlySession.

--- a/internal/netxlite/mocks/quic_test.go
+++ b/internal/netxlite/mocks/quic_test.go
@@ -31,9 +31,9 @@ func TestQUICListenerListen(t *testing.T) {
 	}
 }
 
-func TestQUICContextDialerDialContext(t *testing.T) {
+func TestQUICDialerDialContext(t *testing.T) {
 	expected := errors.New("mocked error")
-	qcd := &QUICContextDialer{
+	qcd := &QUICDialer{
 		MockDialContext: func(ctx context.Context, network string, address string, tlsConfig *tls.Config, quicConfig *quic.Config) (quic.EarlySession, error) {
 			return nil, expected
 		},
@@ -47,6 +47,19 @@ func TestQUICContextDialerDialContext(t *testing.T) {
 	}
 	if sess != nil {
 		t.Fatal("expected nil session")
+	}
+}
+
+func TestQUICDialerCloseIdleConnections(t *testing.T) {
+	var called bool
+	qcd := &QUICDialer{
+		MockCloseIdleConnections: func() {
+			called = true
+		},
+	}
+	qcd.CloseIdleConnections()
+	if !called {
+		t.Fatal("not called")
 	}
 }
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1591
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

Like before, do not touch the rest of the tree. Rather create
compatibility types declared as legacy.

We will soon be able to close idle connections for an HTTP3
transport using any kind of resolvers more easily.

See https://github.com/ooni/probe/issues/1591