### PR TITLE
fix(netxlite): http3 propagates CloseIdleConnections to its dialer

### DIFF
--- a/internal/cmd/oohelperd/internal/websteps/explore.go
+++ b/internal/cmd/oohelperd/internal/websteps/explore.go
@@ -135,7 +135,8 @@ func (e *DefaultExplorer) getH3(h3URL *h3URL, headers map[string][]string) (*htt
 	tlsConf := &tls.Config{
 		NextProtos: []string{h3URL.proto},
 	}
-	transport := netxlite.NewHTTP3Transport(dialer, tlsConf)
+	transport := netxlite.NewHTTP3Transport(
+		netxlite.NewQUICDialerFromContextDialerAdapter(dialer), tlsConf)
 	// TODO(bassosimone): here we should use runtimex.PanicOnError
 	jarjar, _ := cookiejar.New(nil)
 	clnt := &http.Client{

--- a/internal/engine/netx/httptransport/http3transport.go
+++ b/internal/engine/netx/httptransport/http3transport.go
@@ -10,5 +10,7 @@ import (
 //
 // New code should use netxlite.NewHTTP3Transport instead.
 func NewHTTP3Transport(config Config) RoundTripper {
-	return netxlite.NewHTTP3Transport(config.QUICDialer, config.TLSConfig)
+	return netxlite.NewHTTP3Transport(
+		netxlite.NewQUICDialerFromContextDialerAdapter(config.QUICDialer),
+		config.TLSConfig)
 }

--- a/internal/netxlite/http3_test.go
+++ b/internal/netxlite/http3_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/netxlite/mocks"
 )
 
 func TestHTTP3TransportWorks(t *testing.T) {
@@ -23,4 +24,19 @@ func TestHTTP3TransportWorks(t *testing.T) {
 	}
 	resp.Body.Close()
 	txp.CloseIdleConnections()
+}
+
+func TestHTTP3TransportClosesIdleConnections(t *testing.T) {
+	var called bool
+	d := &mocks.QUICDialer{
+		MockCloseIdleConnections: func() {
+			called = true
+		},
+	}
+	txp := NewHTTP3Transport(d, &tls.Config{})
+	client := &http.Client{Transport: txp}
+	client.CloseIdleConnections()
+	if !called {
+		t.Fatal("not called")
+	}
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1591
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

With this change, we are now able to change more dependent code to simplify
the way in which we create and manage resolvers.

See https://github.com/ooni/probe/issues/1591