### PR TITLE
refactor(netxlite): adapt single-use-quic-dialer from websteps

### DIFF
--- a/internal/netxlite/dialer.go
+++ b/internal/netxlite/dialer.go
@@ -164,7 +164,7 @@ func NewSingleUseDialer(conn net.Conn) Dialer {
 	return &dialerSingleUse{conn: conn}
 }
 
-// dialerSingleUse is the type of Dialer returned by NewSingleDialer.
+// dialerSingleUse is the Dialer returned by NewSingleDialer.
 type dialerSingleUse struct {
 	sync.Mutex
 	conn net.Conn


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1591
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

This is the last bit of functionality we need before rewriting a
chunk of websteps to use netxlite.

To rewrite most of it, we still need to move over:

1. dnstransport code

2. errorsx code

With both done, netxlite is a good library for websteps as well
as for most other operations we perform outside of the experiments.

Part of https://github.com/ooni/probe/issues/1591