### PR TITLE
fix(netxlite): add error wrappers

### DIFF
--- a/internal/netxlite/utls.go
+++ b/internal/netxlite/utls.go
@@ -13,8 +13,10 @@ import (
 // gitlab.com/yawning/utls library to create TLS conns.
 func NewTLSHandshakerUTLS(logger Logger, id *utls.ClientHelloID) TLSHandshaker {
 	return &tlsHandshakerLogger{
-		TLSHandshaker: &tlsHandshakerConfigurable{
-			NewConn: newConnUTLS(id),
+		TLSHandshaker: &tlsHandshakerErrWrapper{
+			TLSHandshaker: &tlsHandshakerConfigurable{
+				NewConn: newConnUTLS(id),
+			},
 		},
 		Logger: logger,
 	}

--- a/internal/netxlite/utls_test.go
+++ b/internal/netxlite/utls_test.go
@@ -40,7 +40,11 @@ func TestNewTLSHandshakerUTLSTypes(t *testing.T) {
 	if thl.Logger != log.Log {
 		t.Fatal("invalid logger")
 	}
-	thc, okay := thl.TLSHandshaker.(*tlsHandshakerConfigurable)
+	ew, okay := thl.TLSHandshaker.(*tlsHandshakerErrWrapper)
+	if !okay {
+		t.Fatal("invalid type")
+	}
+	thc, okay := ew.TLSHandshaker.(*tlsHandshakerConfigurable)
 	if !okay {
 		t.Fatal("invalid type")
 	}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1591
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

Copied and adapted code from legacy/errorsx without using the SafeErrWrapperBuilder