### PR TITLE
fix(netxlite/errorsx): serialize directly to JSON

### DIFF
--- a/internal/netxlite/errorsx/errwrapper.go
+++ b/internal/netxlite/errorsx/errwrapper.go
@@ -1,5 +1,7 @@
 package errorsx
 
+import "encoding/json"
+
 // ErrWrapper is our error wrapper for Go errors. The key objective of
 // this structure is to properly set Failure, which is also returned by
 // the Error() method, to be one of the OONI failure strings.
@@ -59,4 +61,9 @@ func (e *ErrWrapper) Error() string {
 // Unwrap allows to access the underlying error
 func (e *ErrWrapper) Unwrap() error {
 	return e.WrappedErr
+}
+
+// MarshalJSON converts an ErrWrapper to a JSON value.
+func (e *ErrWrapper) MarshalJSON() ([]byte, error) {
+	return json.Marshal(e.Failure)
 }

--- a/internal/netxlite/errorsx/errwrapper_test.go
+++ b/internal/netxlite/errorsx/errwrapper_test.go
@@ -1,6 +1,7 @@
 package errorsx
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
 	"testing"
@@ -21,6 +22,21 @@ func TestErrWrapper(t *testing.T) {
 		}
 		if !errors.Is(err, io.EOF) {
 			t.Fatal("cannot unwrap error")
+		}
+	})
+
+	t.Run("MarshalJSON", func(t *testing.T) {
+		wrappedErr := &ErrWrapper{
+			Failure:    FailureEOFError,
+			WrappedErr: io.EOF,
+		}
+		data, err := json.Marshal(wrappedErr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := string(data)
+		if s != "\""+FailureEOFError+"\"" {
+			t.Fatal("invalid serialization", s)
 		}
 	})
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1591
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

This simplifies serializing errors to `*string`. It did not
occur to me before. It seems quite a nice improvement.