### PR TITLE
fix(netxlite): http3 transport needs logging by default

### DIFF
--- a/internal/cmd/oohelperd/internal/websteps/explore.go
+++ b/internal/cmd/oohelperd/internal/websteps/explore.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/apex/log"
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/websteps"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
@@ -135,7 +136,9 @@ func (e *DefaultExplorer) getH3(h3URL *h3URL, headers map[string][]string) (*htt
 	tlsConf := &tls.Config{
 		NextProtos: []string{h3URL.proto},
 	}
-	transport := netxlite.NewHTTP3Transport(
+	// Rationale for using log.Log here: we're already using log.Log
+	// in this package, so it seems fair to use it also here
+	transport := netxlite.NewHTTP3Transport(log.Log,
 		netxlite.NewQUICDialerFromContextDialerAdapter(dialer), tlsConf)
 	// TODO(bassosimone): here we should use runtimex.PanicOnError
 	jarjar, _ := cookiejar.New(nil)

--- a/internal/engine/netx/httptransport/http3transport.go
+++ b/internal/engine/netx/httptransport/http3transport.go
@@ -10,7 +10,15 @@ import (
 //
 // New code should use netxlite.NewHTTP3Transport instead.
 func NewHTTP3Transport(config Config) RoundTripper {
-	return netxlite.NewHTTP3Transport(
+	// Rationale for using NoLogger here: previously this code did
+	// not use a logger as well, so it's fine to keep it as is.
+	return netxlite.NewHTTP3Transport(&NoLogger{},
 		netxlite.NewQUICDialerFromContextDialerAdapter(config.QUICDialer),
 		config.TLSConfig)
 }
+
+type NoLogger struct{}
+
+func (*NoLogger) Debug(message string) {}
+
+func (*NoLogger) Debugf(format string, v ...interface{}) {}

--- a/internal/netxlite/http3.go
+++ b/internal/netxlite/http3.go
@@ -53,17 +53,20 @@ func (txp *http3Transport) CloseIdleConnections() {
 // dialer argument MUST NOT be nil. If the tlsConfig argument is nil,
 // then the code will use the default TLS configuration.
 func NewHTTP3Transport(
-	dialer QUICDialer, tlsConfig *tls.Config) HTTPTransport {
-	return &http3Transport{
-		child: &http3.RoundTripper{
-			Dial: (&http3Dialer{dialer}).dial,
-			// The following (1) reduces the number of headers that Go will
-			// automatically send for us and (2) ensures that we always receive
-			// back the true headers, such as Content-Length. This change is
-			// functional to OONI's goal of observing the network.
-			DisableCompression: true,
-			TLSClientConfig:    tlsConfig,
+	logger Logger, dialer QUICDialer, tlsConfig *tls.Config) HTTPTransport {
+	return &httpTransportLogger{
+		HTTPTransport: &http3Transport{
+			child: &http3.RoundTripper{
+				Dial: (&http3Dialer{dialer}).dial,
+				// The following (1) reduces the number of headers that Go will
+				// automatically send for us and (2) ensures that we always receive
+				// back the true headers, such as Content-Length. This change is
+				// functional to OONI's goal of observing the network.
+				DisableCompression: true,
+				TLSClientConfig:    tlsConfig,
+			},
+			dialer: dialer,
 		},
-		dialer: dialer,
+		Logger: logger,
 	}
 }

--- a/internal/netxlite/http3_test.go
+++ b/internal/netxlite/http3_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/apex/log"
 	"github.com/lucas-clemente/quic-go"
 	"github.com/lucas-clemente/quic-go/http3"
 	"github.com/ooni/probe-cli/v3/internal/netxlite/mocks"
@@ -80,8 +81,12 @@ func TestNewHTTP3Transport(t *testing.T) {
 	t.Run("creates the correct type chain", func(t *testing.T) {
 		qd := &mocks.QUICDialer{}
 		config := &tls.Config{}
-		txp := NewHTTP3Transport(qd, config)
-		h3txp := txp.(*http3Transport)
+		txp := NewHTTP3Transport(log.Log, qd, config)
+		logger := txp.(*httpTransportLogger)
+		if logger.Logger != log.Log {
+			t.Fatal("invalid logger")
+		}
+		h3txp := logger.HTTPTransport.(*http3Transport)
 		if h3txp.dialer != qd {
 			t.Fatal("invalid dialer")
 		}

--- a/internal/netxlite/integration_test.go
+++ b/internal/netxlite/integration_test.go
@@ -42,7 +42,7 @@ func TestHTTP3Transport(t *testing.T) {
 			log.Log,
 			netxlite.NewResolverSystem(log.Log),
 		)
-		txp := netxlite.NewHTTP3Transport(d, &tls.Config{})
+		txp := netxlite.NewHTTP3Transport(log.Log, d, &tls.Config{})
 		client := &http.Client{Transport: txp}
 		resp, err := client.Get("https://www.google.com/robots.txt")
 		if err != nil {


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1591
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

Adapt other places where it was not using a logger to either choose
a reasonable logger or disable logging for backwards compat.