### PR TITLE
refactor(jafar): remove unnecessary dep on netx

### DIFF
--- a/internal/cmd/jafar/httpproxy/httpproxy.go
+++ b/internal/cmd/jafar/httpproxy/httpproxy.go
@@ -9,8 +9,6 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strings"
-
-	"github.com/ooni/probe-cli/v3/internal/engine/netx"
 )
 
 const product = "jafar/0.1.0"
@@ -27,7 +25,7 @@ type CensoringProxy struct {
 // the Host header of a request. dnsNetwork and dnsAddress are
 // settings to configure the upstream, non censored DNS.
 func NewCensoringProxy(
-	keywords []string, uncensored netx.HTTPRoundTripper,
+	keywords []string, uncensored http.RoundTripper,
 ) *CensoringProxy {
 	return &CensoringProxy{keywords: keywords, transport: uncensored}
 }

--- a/internal/cmd/jafar/resolver/resolver.go
+++ b/internal/cmd/jafar/resolver/resolver.go
@@ -9,8 +9,12 @@ import (
 	"strings"
 
 	"github.com/miekg/dns"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx"
 )
+
+// Resolver resolves domain names.
+type Resolver interface {
+	LookupHost(ctx context.Context, hostname string) ([]string, error)
+}
 
 // CensoringResolver is a censoring resolver.
 type CensoringResolver struct {
@@ -27,7 +31,7 @@ type CensoringResolver struct {
 // and TLS proxies will pick them up. dnsNetwork and dnsAddress are the
 // settings to configure the upstream, non censored DNS.
 func NewCensoringResolver(
-	blocked, hijacked, ignored []string, uncensored netx.Resolver,
+	blocked, hijacked, ignored []string, uncensored Resolver,
 ) *CensoringResolver {
 	return &CensoringResolver{
 		blocked:    blocked,

--- a/internal/cmd/jafar/tlsproxy/tlsproxy.go
+++ b/internal/cmd/jafar/tlsproxy/tlsproxy.go
@@ -12,8 +12,12 @@ import (
 	"sync"
 
 	"github.com/apex/log"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx"
 )
+
+// Dialer establishes network connections
+type Dialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
 
 // CensoringProxy is a censoring TLS proxy
 type CensoringProxy struct {
@@ -27,7 +31,7 @@ type CensoringProxy struct {
 // the SNII record of a ClientHello. dnsNetwork and dnsAddress are
 // settings to configure the upstream, non censored DNS.
 func NewCensoringProxy(
-	keywords []string, uncensored netx.Dialer,
+	keywords []string, uncensored Dialer,
 ) *CensoringProxy {
 	return &CensoringProxy{
 		keywords: keywords,

--- a/internal/cmd/jafar/tlsproxy/tlsproxy_test.go
+++ b/internal/cmd/jafar/tlsproxy/tlsproxy_test.go
@@ -174,8 +174,6 @@ func TestForwardWriteError(t *testing.T) {
 
 type mockedConnReadOkay struct {
 	net.Conn
-	localIP  net.IP
-	remoteIP net.IP
 }
 
 func (c *mockedConnReadOkay) Read(b []byte) (int, error) {


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1591
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

There are a bunch of packages where we don't really need to depend on `netx` but we can use local definitions that describe what we are expecting from data structures we receive in input. This diff addresses one of such cases.

Part of https://github.com/ooni/probe/issues/1591