### PR TITLE
refactor(oohelper): remove unnecessary dep from netx

### DIFF
--- a/internal/cmd/oohelper/internal/client.go
+++ b/internal/cmd/oohelper/internal/client.go
@@ -13,7 +13,6 @@ import (
 	"github.com/apex/log"
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/webconnectivity"
 	"github.com/ooni/probe-cli/v3/internal/engine/httpheader"
-	"github.com/ooni/probe-cli/v3/internal/engine/netx"
 	"github.com/ooni/probe-cli/v3/internal/netxlite/iox"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 	"github.com/ooni/probe-cli/v3/internal/version"
@@ -38,13 +37,18 @@ var (
 	ErrCannotParseJSONReply    = errors.New("oohelper: cannot parse JSON reply")
 )
 
+// Resolver resolves domain names.
+type Resolver interface {
+	LookupHost(ctx context.Context, hostname string) ([]string, error)
+}
+
 // OOClient is a client for the OONI Web Connectivity test helper.
 type OOClient struct {
 	// HTTPClient is the HTTP client to use.
 	HTTPClient *http.Client
 
 	// Resolver is the resolver to user.
-	Resolver netx.Resolver
+	Resolver Resolver
 }
 
 // OOConfig contains configuration for the client.


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1591
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

There are a bunch of packages where we don't really need to depend
on netx but we can use local definitions that describe what we are
expecting from data structures we receive in input. This diff
addresses one of such cases.