### PR TITLE
refactor(netx): move dns transports in netxlite/dnsx

### DIFF
--- a/internal/engine/netx/resolver/legacy.go
+++ b/internal/engine/netx/resolver/legacy.go
@@ -1,0 +1,28 @@
+package resolver
+
+import "github.com/ooni/probe-cli/v3/internal/netxlite/dnsx"
+
+// Variables that other packages expect to find here but have been
+// moved into the internal/netxlite/dnsx package.
+var (
+	NewSerialResolver               = dnsx.NewSerialResolver
+	NewDNSOverUDP                   = dnsx.NewDNSOverUDP
+	NewDNSOverTCP                   = dnsx.NewDNSOverTCP
+	NewDNSOverTLS                   = dnsx.NewDNSOverTLS
+	NewDNSOverHTTPS                 = dnsx.NewDNSOverHTTPS
+	NewDNSOverHTTPSWithHostOverride = dnsx.NewDNSOverHTTPSWithHostOverride
+)
+
+// Types that other packages expect to find here but have been
+// moved into the internal/netxlite/dnsx package.
+type (
+	DNSOverHTTPS    = dnsx.DNSOverHTTPS
+	DNSOverTCP      = dnsx.DNSOverTCP
+	DNSOverUDP      = dnsx.DNSOverUDP
+	MiekgEncoder    = dnsx.MiekgEncoder
+	MiekgDecoder    = dnsx.MiekgDecoder
+	RoundTripper    = dnsx.RoundTripper
+	SerialResolver  = dnsx.SerialResolver
+	Dialer          = dnsx.Dialer
+	DialContextFunc = dnsx.DialContextFunc
+)

--- a/internal/netxlite/dnsx/decoder.go
+++ b/internal/netxlite/dnsx/decoder.go
@@ -1,4 +1,4 @@
-package resolver
+package dnsx
 
 import (
 	"errors"

--- a/internal/netxlite/dnsx/dnsoverhttps.go
+++ b/internal/netxlite/dnsx/dnsoverhttps.go
@@ -1,4 +1,4 @@
-package resolver
+package dnsx
 
 import (
 	"bytes"

--- a/internal/netxlite/dnsx/dnsoverhttps_test.go
+++ b/internal/netxlite/dnsx/dnsoverhttps_test.go
@@ -1,4 +1,4 @@
-package resolver
+package dnsx
 
 import (
 	"bytes"

--- a/internal/netxlite/dnsx/dnsovertcp.go
+++ b/internal/netxlite/dnsx/dnsovertcp.go
@@ -1,4 +1,4 @@
-package resolver
+package dnsx
 
 import (
 	"context"

--- a/internal/netxlite/dnsx/dnsoverudp.go
+++ b/internal/netxlite/dnsx/dnsoverudp.go
@@ -1,4 +1,4 @@
-package resolver
+package dnsx
 
 import (
 	"context"

--- a/internal/netxlite/dnsx/encoder.go
+++ b/internal/netxlite/dnsx/encoder.go
@@ -1,4 +1,4 @@
-package resolver
+package dnsx
 
 import "github.com/miekg/dns"
 

--- a/internal/netxlite/dnsx/encoder_test.go
+++ b/internal/netxlite/dnsx/encoder_test.go
@@ -1,4 +1,4 @@
-package resolver
+package dnsx
 
 import (
 	"strings"

--- a/internal/netxlite/dnsx/mocks/decoder.go
+++ b/internal/netxlite/dnsx/mocks/decoder.go
@@ -1,0 +1,11 @@
+package mocks
+
+// Decoder allows mocking dnsx.Decoder.
+type Decoder struct {
+	MockDecode func(qtype uint16, reply []byte) ([]string, error)
+}
+
+// Decode calls MockDecode.
+func (e *Decoder) Decode(qtype uint16, reply []byte) ([]string, error) {
+	return e.MockDecode(qtype, reply)
+}

--- a/internal/netxlite/dnsx/mocks/decoder_test.go
+++ b/internal/netxlite/dnsx/mocks/decoder_test.go
@@ -1,0 +1,26 @@
+package mocks
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestDecoder(t *testing.T) {
+	t.Run("Decode", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		e := &Decoder{
+			MockDecode: func(qtype uint16, reply []byte) ([]string, error) {
+				return nil, expected
+			},
+		}
+		out, err := e.Decode(dns.TypeA, make([]byte, 17))
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected err", err)
+		}
+		if out != nil {
+			t.Fatal("unexpected out")
+		}
+	})
+}

--- a/internal/netxlite/dnsx/mocks/doc.go
+++ b/internal/netxlite/dnsx/mocks/doc.go
@@ -1,0 +1,2 @@
+// Package mocks contains mocks for dnsx.
+package mocks

--- a/internal/netxlite/dnsx/mocks/encoder.go
+++ b/internal/netxlite/dnsx/mocks/encoder.go
@@ -1,0 +1,11 @@
+package mocks
+
+// Encoder allows mocking dnsx.Encoder.
+type Encoder struct {
+	MockEncode func(domain string, qtype uint16, padding bool) ([]byte, error)
+}
+
+// Encode calls MockEncode.
+func (e *Encoder) Encode(domain string, qtype uint16, padding bool) ([]byte, error) {
+	return e.MockEncode(domain, qtype, padding)
+}

--- a/internal/netxlite/dnsx/mocks/encoder_test.go
+++ b/internal/netxlite/dnsx/mocks/encoder_test.go
@@ -1,0 +1,26 @@
+package mocks
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestEncoder(t *testing.T) {
+	t.Run("Encode", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		e := &Encoder{
+			MockEncode: func(domain string, qtype uint16, padding bool) ([]byte, error) {
+				return nil, expected
+			},
+		}
+		out, err := e.Encode("dns.google", dns.TypeA, true)
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected err", err)
+		}
+		if out != nil {
+			t.Fatal("unexpected out")
+		}
+	})
+}

--- a/internal/netxlite/dnsx/mocks/roundtripper.go
+++ b/internal/netxlite/dnsx/mocks/roundtripper.go
@@ -1,0 +1,41 @@
+package mocks
+
+import "context"
+
+// RoundTripper allows mocking dnsx.RoundTripper.
+type RoundTripper struct {
+	MockRoundTrip func(ctx context.Context, query []byte) (reply []byte, err error)
+
+	MockRequiresPadding func() bool
+
+	MockNetwork func() string
+
+	MockAddress func() string
+
+	MockCloseIdleConnections func()
+}
+
+// RoundTrip calls MockRoundTrip.
+func (txp *RoundTripper) RoundTrip(ctx context.Context, query []byte) (reply []byte, err error) {
+	return txp.MockRoundTrip(ctx, query)
+}
+
+// RequiresPadding calls MockRequiresPadding.
+func (txp *RoundTripper) RequiresPadding() bool {
+	return txp.MockRequiresPadding()
+}
+
+// Network calls MockNetwork.
+func (txp *RoundTripper) Network() string {
+	return txp.MockNetwork()
+}
+
+// Address calls MockAddress.
+func (txp *RoundTripper) Address() string {
+	return txp.MockAddress()
+}
+
+// CloseIdleConnections calls MockCloseIdleConnections.
+func (txp *RoundTripper) CloseIdleConnections() {
+	txp.MockCloseIdleConnections()
+}

--- a/internal/netxlite/dnsx/mocks/roundtripper_test.go
+++ b/internal/netxlite/dnsx/mocks/roundtripper_test.go
@@ -1,0 +1,73 @@
+package mocks
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ooni/probe-cli/v3/internal/atomicx"
+)
+
+func TestRoundTripper(t *testing.T) {
+	t.Run("RoundTrip", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		txp := &RoundTripper{
+			MockRoundTrip: func(ctx context.Context, query []byte) ([]byte, error) {
+				return nil, expected
+			},
+		}
+		resp, err := txp.RoundTrip(context.Background(), make([]byte, 16))
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected", err)
+		}
+		if resp != nil {
+			t.Fatal("expected nil response here")
+		}
+	})
+
+	t.Run("RequiresPadding", func(t *testing.T) {
+		txp := &RoundTripper{
+			MockRequiresPadding: func() bool {
+				return true
+			},
+		}
+		if txp.RequiresPadding() != true {
+			t.Fatal("unexpected result")
+		}
+	})
+
+	t.Run("Network", func(t *testing.T) {
+		txp := &RoundTripper{
+			MockNetwork: func() string {
+				return "antani"
+			},
+		}
+		if txp.Network() != "antani" {
+			t.Fatal("unexpected result")
+		}
+	})
+
+	t.Run("Address", func(t *testing.T) {
+		txp := &RoundTripper{
+			MockAddress: func() string {
+				return "mascetti"
+			},
+		}
+		if txp.Address() != "mascetti" {
+			t.Fatal("unexpected result")
+		}
+	})
+
+	t.Run("CloseIdleConnections", func(t *testing.T) {
+		called := &atomicx.Int64{}
+		txp := &RoundTripper{
+			MockCloseIdleConnections: func() {
+				called.Add(1)
+			},
+		}
+		txp.CloseIdleConnections()
+		if called.Load() != 1 {
+			t.Fatal("not called")
+		}
+	})
+}

--- a/internal/netxlite/dnsx/roundtripper.go
+++ b/internal/netxlite/dnsx/roundtripper.go
@@ -1,0 +1,21 @@
+package dnsx
+
+import "context"
+
+// RoundTripper represents an abstract DNS transport.
+type RoundTripper interface {
+	// RoundTrip sends a DNS query and receives the reply.
+	RoundTrip(ctx context.Context, query []byte) (reply []byte, err error)
+
+	// RequiresPadding return true for DoH and DoT according to RFC8467
+	RequiresPadding() bool
+
+	// Network is the network of the round tripper (e.g. "dot")
+	Network() string
+
+	// Address is the address of the round tripper (e.g. "1.1.1.1:853")
+	Address() string
+
+	// CloseIdleConnections closes idle connections.
+	CloseIdleConnections()
+}

--- a/internal/netxlite/dnsx/serial.go
+++ b/internal/netxlite/dnsx/serial.go
@@ -1,4 +1,4 @@
-package resolver
+package dnsx
 
 import (
 	"context"
@@ -8,24 +8,6 @@ import (
 	"github.com/miekg/dns"
 	"github.com/ooni/probe-cli/v3/internal/atomicx"
 )
-
-// RoundTripper represents an abstract DNS transport.
-type RoundTripper interface {
-	// RoundTrip sends a DNS query and receives the reply.
-	RoundTrip(ctx context.Context, query []byte) (reply []byte, err error)
-
-	// RequiresPadding return true for DoH and DoT according to RFC8467
-	RequiresPadding() bool
-
-	// Network is the network of the round tripper (e.g. "dot")
-	Network() string
-
-	// Address is the address of the round tripper (e.g. "1.1.1.1:853")
-	Address() string
-
-	// CloseIdleConnections closes idle connections.
-	CloseIdleConnections()
-}
 
 // SerialResolver is a resolver that first issues an A query and then
 // issues an AAAA query for the requested domain.
@@ -117,5 +99,3 @@ func (r *SerialResolver) roundTrip(
 	}
 	return r.Decoder.Decode(qtype, replydata)
 }
-
-var _ Resolver = &SerialResolver{}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1591
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

While there, modernize the way in which we run tests to avoid
depending on the fake files scattered around the tree and to
use some well defined mock structures instead.