### PR TITLE
fix(http): do not mutate outgoing requests

### DIFF
--- a/internal/engine/legacy/netx/oldhttptransport/httptransport.go
+++ b/internal/engine/legacy/netx/oldhttptransport/httptransport.go
@@ -22,11 +22,6 @@ func New(roundTripper http.RoundTripper) *Transport {
 // RoundTrip executes a single HTTP transaction, returning
 // a Response for the provided Request.
 func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
-	// Make sure we're not sending Go's default User-Agent
-	// if the user has configured no user agent
-	if req.Header.Get("User-Agent") == "" {
-		req.Header["User-Agent"] = nil
-	}
 	return t.roundTripper.RoundTrip(req)
 }
 

--- a/internal/engine/netx/httptransport/saver.go
+++ b/internal/engine/netx/httptransport/saver.go
@@ -52,7 +52,7 @@ type SaverMetadataHTTPTransport struct {
 // RoundTrip implements RoundTripper.RoundTrip
 func (txp SaverMetadataHTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	txp.Saver.Write(trace.Event{
-		HTTPHeaders: req.Header,
+		HTTPHeaders: txp.CloneHeaders(req),
 		HTTPMethod:  req.Method,
 		HTTPURL:     req.URL.String(),
 		Transport:   txp.Transport,
@@ -70,6 +70,19 @@ func (txp SaverMetadataHTTPTransport) RoundTrip(req *http.Request) (*http.Respon
 		Time:           time.Now(),
 	})
 	return resp, err
+}
+
+// CloneHeaders returns a clone of the headers where we have
+// also set the host header, which normally is not set by
+// golang until it serializes the request itself.
+func (txp SaverMetadataHTTPTransport) CloneHeaders(req *http.Request) http.Header {
+	header := req.Header.Clone()
+	if req.Host != "" {
+		header.Set("Host", req.Host)
+	} else {
+		header.Set("Host", req.URL.Host)
+	}
+	return header
 }
 
 // SaverTransactionHTTPTransport is a RoundTripper that saves

--- a/internal/engine/netx/httptransport/saver_test.go
+++ b/internal/engine/netx/httptransport/saver_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -428,4 +429,36 @@ func TestSaverBodyResponseReadError(t *testing.T) {
 	if ev[0].Time.After(time.Now()) {
 		t.Fatal("invalid Time")
 	}
+}
+
+func TestCloneHeaders(t *testing.T) {
+	t.Run("with req.Host set", func(t *testing.T) {
+		req := &http.Request{
+			Host: "www.example.com",
+			URL: &url.URL{
+				Host: "www.kernel.org",
+			},
+			Header: http.Header{},
+		}
+		txp := httptransport.SaverMetadataHTTPTransport{}
+		header := txp.CloneHeaders(req)
+		if header.Get("Host") != "www.example.com" {
+			t.Fatal("did not set Host header correctly")
+		}
+	})
+
+	t.Run("with only req.URL.Host set", func(t *testing.T) {
+		req := &http.Request{
+			Host: "",
+			URL: &url.URL{
+				Host: "www.kernel.org",
+			},
+			Header: http.Header{},
+		}
+		txp := httptransport.SaverMetadataHTTPTransport{}
+		header := txp.CloneHeaders(req)
+		if header.Get("Host") != "www.kernel.org" {
+			t.Fatal("did not set Host header correctly")
+		}
+	})
 }

--- a/internal/engine/netx/httptransport/useragent.go
+++ b/internal/engine/netx/httptransport/useragent.go
@@ -1,9 +1,0 @@
-package httptransport
-
-import (
-	"github.com/ooni/probe-cli/v3/internal/netxlite"
-)
-
-// UserAgentTransport is a transport that ensures that we always
-// set an OONI specific default User-Agent header.
-type UserAgentTransport = netxlite.UserAgentTransport

--- a/internal/engine/netx/netx.go
+++ b/internal/engine/netx/netx.go
@@ -252,7 +252,6 @@ func NewHTTPTransport(config Config) HTTPRoundTripper {
 		txp = httptransport.SaverTransactionHTTPTransport{
 			RoundTripper: txp, Saver: config.HTTPSaver}
 	}
-	txp = &httptransport.UserAgentTransport{HTTPTransport: txp}
 	return txp
 }
 

--- a/internal/engine/netx/netx_test.go
+++ b/internal/engine/netx/netx_test.go
@@ -489,11 +489,7 @@ func TestNewTLSDialerWithNoTLSVerifyAndNoConfig(t *testing.T) {
 
 func TestNewVanilla(t *testing.T) {
 	txp := netx.NewHTTPTransport(netx.Config{})
-	uatxp, ok := txp.(*httptransport.UserAgentTransport)
-	if !ok {
-		t.Fatal("not the transport we expected")
-	}
-	if _, ok := uatxp.HTTPTransport.(*http.Transport); !ok {
+	if _, ok := txp.(*http.Transport); !ok {
 		t.Fatal("not the transport we expected")
 	}
 }
@@ -546,11 +542,7 @@ func TestNewWithByteCounter(t *testing.T) {
 	txp := netx.NewHTTPTransport(netx.Config{
 		ByteCounter: counter,
 	})
-	uatxp, ok := txp.(*httptransport.UserAgentTransport)
-	if !ok {
-		t.Fatal("not the transport we expected")
-	}
-	bctxp, ok := uatxp.HTTPTransport.(httptransport.ByteCountingTransport)
+	bctxp, ok := txp.(httptransport.ByteCountingTransport)
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}
@@ -566,11 +558,7 @@ func TestNewWithLogger(t *testing.T) {
 	txp := netx.NewHTTPTransport(netx.Config{
 		Logger: log.Log,
 	})
-	uatxp, ok := txp.(*httptransport.UserAgentTransport)
-	if !ok {
-		t.Fatal("not the transport we expected")
-	}
-	ltxp, ok := uatxp.HTTPTransport.(*netxlite.HTTPTransportLogger)
+	ltxp, ok := txp.(*netxlite.HTTPTransportLogger)
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}
@@ -587,11 +575,7 @@ func TestNewWithSaver(t *testing.T) {
 	txp := netx.NewHTTPTransport(netx.Config{
 		HTTPSaver: saver,
 	})
-	uatxp, ok := txp.(*httptransport.UserAgentTransport)
-	if !ok {
-		t.Fatal("not the transport we expected")
-	}
-	stxptxp, ok := uatxp.HTTPTransport.(httptransport.SaverTransactionHTTPTransport)
+	stxptxp, ok := txp.(httptransport.SaverTransactionHTTPTransport)
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}

--- a/internal/netxlite/legacy.go
+++ b/internal/netxlite/legacy.go
@@ -32,7 +32,6 @@ type (
 	TLSHandshakerLogger       = tlsHandshakerLogger
 	DialerSystem              = dialerSystem
 	TLSDialerLegacy           = tlsDialer
-	UserAgentTransport        = httpUserAgentTransport
 	AddressResolver           = resolverShortCircuitIPAddr
 )
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1733
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

I have recently seen a data race related our way of
mutating the outgoing request to set the host header.

Unfortunately, I've lost track of the race output,
because I rebooted my Linux box before saving it.

Though, after inspecting why and and where we're mutating
outgoing requets, I've found that:

1. we add the host header when logging to have it logged,
which is not a big deal since we already emit the URL
rather than just the URL path when logging a request, and
so we can safely zap this piece of code;

2. as a result, in measurements we may omit the host header
but again this is pretty much obvious from the URL itself
and so it should not be very important (nonetheless,
avoid surprises and keep the existing behavior);

3. when the User-Agent header is not set, we default to
a `miniooni/0.1.0-dev` user agent, which is probably not
very useful anyway, so we can actually remove it.

Part of https://github.com/ooni/probe/issues/1733 (this diff
has been extracted from https://github.com/ooni/probe-cli/pull/506).
