### PR TITLE
fix(ooniprobe-cli.timer): run every 12h

### DIFF
--- a/debian/ooniprobe-cli.timer
+++ b/debian/ooniprobe-cli.timer
@@ -5,7 +5,7 @@ Requires=ooniprobe-cli.service
 [Timer]
 Unit=ooniprobe-cli.service
 OnCalendar=daily
-RandomizedDelaySec=24h
+RandomizedDelaySec=12h
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
## Checklist

- [ ] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [ ] reference issue for this pull request: https://github.com/ooni/probe/issues/1786
- [ ] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

N/A