### PR TITLE
fix(measurex): make sure we don't redirect loop forever

### DIFF
--- a/internal/measurex/measurer.go
+++ b/internal/measurex/measurer.go
@@ -885,6 +885,7 @@ type redirectionQueue struct {
 
 func (r *redirectionQueue) append(URL ...string) {
 	r.q = append(r.q, URL...)
+	r.cnt++
 }
 
 func (r *redirectionQueue) popleft() (URL string) {


### PR DESCRIPTION

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1792
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

This is the most immediate fix to the issue described by
https://github.com/ooni/probe/issues/1792.

So, the logic was actually miss the increment, which
would have been noticed with proper unit testing.

Anyway, I am not sure why the loop ensues in the first
time. By looking at the headers, it seems we're passing
the headers correctly.

So, even though this fix interrupts the loop, it still
remains the question of whether the loop is legit or
whether we're missing extra logic to properly redirect.
