### PR TITLE
fix(oohelperd): return HTTP headers as empty map on error

### DIFF
--- a/internal/cmd/oohelperd/internal/webconnectivity/http.go
+++ b/internal/cmd/oohelperd/internal/webconnectivity/http.go
@@ -34,6 +34,7 @@ func HTTPDo(ctx context.Context, config *HTTPConfig) {
 			BodyLength: -1,
 			Failure:    newfailure(err),
 			StatusCode: -1,
+			Headers:    map[string]string{},
 		}
 		return
 	}
@@ -53,6 +54,7 @@ func HTTPDo(ctx context.Context, config *HTTPConfig) {
 			BodyLength: -1,
 			Failure:    newfailure(err),
 			StatusCode: -1,
+			Headers:    map[string]string{},
 		}
 		return
 	}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1707
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

Part of https://github.com/ooni/probe/issues/1707

