### PR TITLE
fix(webconnectivity): gather longer HTML titles

### DIFF
--- a/internal/engine/experiment/webconnectivity/httpanalysis.go
+++ b/internal/engine/experiment/webconnectivity/httpanalysis.go
@@ -186,7 +186,9 @@ func HTTPHeadersMatch(tk urlgetter.TestKeys, ctrl ControlResponse) *bool {
 
 // GetTitle returns the title or an empty string.
 func GetTitle(measurementBody string) string {
-	re := regexp.MustCompile(`(?i)<title>([^<]{1,128})</title>`) // like MK
+	// MK used {1,128} but we're making it larger here to get longer titles
+	// e.g. <http://www.isa.gov.il/Pages/default.aspx>'s one
+	re := regexp.MustCompile(`(?i)<title>([^<]{1,512})</title>`)
 	v := re.FindStringSubmatch(measurementBody)
 	if len(v) < 2 {
 		return ""


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1707
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

Allows us to get http://www.isa.gov.il/Pages/default.aspx's one.

Discovered when working on https://github.com/ooni/probe/issues/1707.