### PR TITLE
fix(ooniprobe): Measure returns EITHER measurement OR error now

### DIFF
--- a/cmd/ooniprobe/internal/nettests/nettests.go
+++ b/cmd/ooniprobe/internal/nettests/nettests.go
@@ -165,10 +165,14 @@ func (c *Controller) Run(builder *engine.ExperimentBuilder, inputs []string) err
 			if err := c.msmts[idx64].Failed(c.Probe.DB(), err.Error()); err != nil {
 				return errors.Wrap(err, "failed to mark measurement as failed")
 			}
-			// Even with a failed measurement, we want to continue. We want to
-			// record and submit the information we have. Saving the information
-			// is useful for local inspection. Submitting it is useful to us to
-			// understand what went wrong (censorship? bug? anomaly?).
+			// Since https://github.com/ooni/probe-cli/pull/527, the Measure
+			// function returns EITHER a valid measurement OR an error. Before
+			// that, instead, the measurement was valid EVEN in case of an
+			// error, which is quite not the <value> OR <error> semantics that
+			// is so typical and widespread in the Go ecosystem. So, we must
+			// jump to the next iteration of the loop here rather than falling
+			// through and attempting to do something with the measurement.
+			continue
 		}
 
 		saveToDisk := true


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1816
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

This diff addresses the most immediate issue but there is probably
extra work to do, including testing and making sure experiments
do not return an error when they should not.