### PR TITLE
fix(wcth): emit empty Addrs when input URL contains addr

### DIFF
--- a/internal/cmd/oohelperd/internal/webconnectivity/measure.go
+++ b/internal/cmd/oohelperd/internal/webconnectivity/measure.go
@@ -76,7 +76,12 @@ func Measure(ctx context.Context, config MeasureConfig, creq *CtrlRequest) (*Ctr
 	select {
 	case cresp.DNS = <-dnsch:
 	default:
-		// we land here when there's no domain name
+		// we need to emit a non-nil Addrs to match exactly
+		// the behavior of the legacy TH
+		cresp.DNS = CtrlDNSResult{
+			Failure: nil,
+			Addrs:   []string{},
+		}
 	}
 	cresp.HTTPRequest = <-httpch
 	cresp.TCPConnect = make(map[string]CtrlTCPResult)


### PR DESCRIPTION

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1707
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

Matches the behavior that the legacy TH implements in this
situation and reduces slightly the differences.

See https://github.com/ooni/probe/issues/1707#issuecomment-944143329
