### PR TITLE
fix: build ooniprobe for linux using debian/amd64

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "release/**"
       - "stable"
+      - "linux"
 
 jobs:
   build_386:

--- a/CLI/linux/pkgdebian
+++ b/CLI/linux/pkgdebian
@@ -7,8 +7,9 @@
 # 1. the `ooniprobe` we are packaging is available at
 # this path `./CLI/linux/$GOARCH/ooniprobe`;
 #
-# 2. we are running on a debian system that has the same
-# architecture of the `ooniprobe` we are packaging.
+# 2. we are running on a debian system that is capable
+# of running binaries for the architecture that we wanna
+# package, either natively or via qemu-user-static.
 
 if [ $# -ne 1 ] && [ $# -ne 2 ]; then
 	echo "usage: $0 {arch} [run_number]" 1>&2
@@ -31,26 +32,6 @@ if [ -n "$run_number" ]; then
 	version="${version}~${run_number}"
 fi
 
-# The OONI_DEB_DRY_RUN is a semi-undocumented feature allowing
-# us to see the commands that would be run by this script.
-
-# install the dependencies required by the build process
-$OONI_DEB_DRY_RUN apt-get update -q
-$OONI_DEB_DRY_RUN apt-get build-dep -y --no-install-recommends .
-
-# keep the original changelog file safe
-$OONI_DEB_DRY_RUN cp ./debian/changelog ./debian/changelog.oocopy
-
-$OONI_DEB_DRY_RUN dch -v "$version" "New version ${version}"
-$OONI_DEB_DRY_RUN dpkg-buildpackage -us -uc -b
-
-# restore the original changelog file
-$OONI_DEB_DRY_RUN mv ./debian/changelog.oocopy ./debian/changelog
-
-# move the package so that we don't loose track
-# of it when using a build container
-$OONI_DEB_DRY_RUN mv ../*.deb .
-
 darch=""
 case $goarch in
 386)
@@ -66,6 +47,29 @@ arm64)
 	darch="arm64"
 	;;
 esac
+echo "Building for GOARCH=$goarch / DEBARCH=$darch"
+
+# The OONI_DEB_DRY_RUN is a semi-undocumented feature allowing
+# us to see the commands that would be run by this script.
+
+$OONI_DEB_DRY_RUN dpkg --add-architecture $darch
+
+# install the dependencies required by the build process
+$OONI_DEB_DRY_RUN apt-get update -q
+$OONI_DEB_DRY_RUN apt-get build-dep -y --no-install-recommends .
+
+# keep the original changelog file safe
+$OONI_DEB_DRY_RUN cp ./debian/changelog ./debian/changelog.oocopy
+
+$OONI_DEB_DRY_RUN dch -v "$version" "New version ${version}"
+$OONI_DEB_DRY_RUN dpkg-buildpackage -a $darch -us -uc -b
+
+# restore the original changelog file
+$OONI_DEB_DRY_RUN mv ./debian/changelog.oocopy ./debian/changelog
+
+# move the package so that we don't loose track
+# of it when using a build container
+$OONI_DEB_DRY_RUN mv ../*.deb .
 
 # install the package on the container as a smoke test to
 # ensure that it is installable.

--- a/debian/rules
+++ b/debian/rules
@@ -14,5 +14,17 @@ override_dh_auto_build:
 override_dh_dwz:
 	true
 
+override_dh_strip:
+	# We cross compile and build packages for any arch from
+	# linux/amd64 so we need to avoid this step. BTW this step
+	# is not needed because we already strip when building.
+	true
+
+override_dh_makeshlibs:
+	# We cross compile and build packages for any arch from
+	# linux/amd64 so we need to avoid this step. BTW this step
+	# is not needed because we don't have any shlib.
+	true
+
 override_dh_auto_install:
 	dh_auto_install -- --no-source

--- a/mk
+++ b/mk
@@ -278,8 +278,8 @@ GOLANG_DOCKER_IMAGE = golang:$(GOLANG_VERSION_NUMBER)-alpine
 # This extra .PHONY for linux/386 is to help printing targets 🤷.
 .PHONY:     ./CLI/linux/386/ooniprobe
 ./debian/386: search/for/docker ./CLI/linux/386/ooniprobe
-	docker pull --platform linux/386 debian:stable
-	docker run --platform linux/386 -v $(shell pwd):/ooni -w /ooni debian:stable ./CLI/linux/pkgdebian 386 "$(DEBIAN_TILDE_VERSION)"
+	docker pull debian:stable
+	docker run -v $(shell pwd):/ooni -w /ooni debian:stable ./CLI/linux/pkgdebian 386 "$(DEBIAN_TILDE_VERSION)"
 
 #help:
 #help: * `./mk ./debian/amd64`: debian/amd64
@@ -287,8 +287,8 @@ GOLANG_DOCKER_IMAGE = golang:$(GOLANG_VERSION_NUMBER)-alpine
 # This extra .PHONY for linux/amd64 is to help printing targets 🤷.
 .PHONY:     ./CLI/linux/amd64/ooniprobe
 ./debian/amd64: search/for/docker ./CLI/linux/amd64/ooniprobe
-	docker pull --platform linux/amd64 debian:stable
-	docker run --platform linux/amd64 -v $(shell pwd):/ooni -w /ooni debian:stable ./CLI/linux/pkgdebian amd64 "$(DEBIAN_TILDE_VERSION)"
+	docker pull debian:stable
+	docker run -v $(shell pwd):/ooni -w /ooni debian:stable ./CLI/linux/pkgdebian amd64 "$(DEBIAN_TILDE_VERSION)"
 
 # Note that we're building for armv7 here
 #help:
@@ -297,8 +297,8 @@ GOLANG_DOCKER_IMAGE = golang:$(GOLANG_VERSION_NUMBER)-alpine
 # This extra .PHONY for linux/arm is to help printing targets 🤷.
 .PHONY:     ./CLI/linux/arm/ooniprobe
 ./debian/arm: search/for/docker ./CLI/linux/arm/ooniprobe
-	docker pull --platform linux/arm/v7 debian:stable
-	docker run --platform linux/arm/v7 -v $(shell pwd):/ooni -w /ooni debian:stable ./CLI/linux/pkgdebian arm "$(DEBIAN_TILDE_VERSION)"
+	docker pull debian:stable
+	docker run -v $(shell pwd):/ooni -w /ooni debian:stable ./CLI/linux/pkgdebian arm "$(DEBIAN_TILDE_VERSION)"
 
 #help:
 #help: * `./mk ./debian/arm64`: debian/arm64
@@ -306,8 +306,8 @@ GOLANG_DOCKER_IMAGE = golang:$(GOLANG_VERSION_NUMBER)-alpine
 # This extra .PHONY for linux/arm64 is to help printing targets 🤷.
 .PHONY:     ./CLI/linux/arm64/ooniprobe
 ./debian/arm64: search/for/docker ./CLI/linux/arm64/ooniprobe
-	docker pull --platform linux/arm64 debian:stable
-	docker run --platform linux/arm64 -v $(shell pwd):/ooni -w /ooni debian:stable ./CLI/linux/pkgdebian arm64 "$(DEBIAN_TILDE_VERSION)"
+	docker pull debian:stable
+	docker run -v $(shell pwd):/ooni -w /ooni debian:stable ./CLI/linux/pkgdebian arm64 "$(DEBIAN_TILDE_VERSION)"
 
 #help:
 #help: The `./mk ./CLI/ooniprobe/linux` command builds the ooniprobe official command


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1741
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

In https://github.com/ooni/probe/issues/1741, we observed that
every attempt to use `docker --platform` along with `debian` for
packaging ooniprobe fails with `SEGFAULT`, except when using
the `debian:oldstable` container.

To fix this issue, in this diff we fix Debian packaging to run on
any debian system (`debian:stable` in our case) provided that we
have `qemu-user-static` installed on the system and the system is
a Debian (or Debian-derived) system.

The trick here is to use `dpkg-buildpackage -a $deb_arch`. We
also need to disable a few `debian/rules` that we don't actually
need anyway.

Closes https://github.com/ooni/probe/issues/1741.