### PR TITLE
fix: ensure we bind oohelperd with the repo's version number

### DIFF
--- a/.github/workflows/oohelperd.yml
+++ b/.github/workflows/oohelperd.yml
@@ -26,6 +26,12 @@ jobs:
           sudo apt-get install -yq --no-install-recommends curl devscripts \
             dpkg-dev debhelper git python3 python3-requests python3-gnupg s3cmd
 
+      - name: update the debian changelog
+        run: |
+          version="$(go run ./internal/cmd/printversion)~$GITHUB_RUN_NUMBER"
+          cd ./internal/cmd/oohelperd
+          dch -v "$version" "New version ${version}"
+
       - name: build deb package
         run: |
           cd ./internal/cmd/oohelperd

--- a/internal/cmd/printversion/main.go
+++ b/internal/cmd/printversion/main.go
@@ -1,0 +1,12 @@
+// Command printversion prints the current version of this repository.
+package main
+
+import (
+	"fmt"
+
+	"github.com/ooni/probe-cli/v3/internal/version"
+)
+
+func main() {
+	fmt.Println(version.Version)
+}


### PR DESCRIPTION


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1506#issuecomment-949715707
- [x] related ooni/spec pull request: N/A

## Description

Work related to https://github.com/ooni/probe/issues/1506#issuecomment-949715707.

This diff cherry-picks from the release/3.11 branch.