### PR TITLE
chore: bump version to 3.12.0-alpha.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,5 +3,5 @@ package version
 
 const (
 	// Version is the software version
-	Version = "3.12.0-alpha"
+	Version = "3.12.0-alpha.1"
 )


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1815
- [x] related ooni/spec pull request: N/A

## Description

This commit just bumps the version number to 3.12.0-alpha.1