### PR TITLE
chore: bump version to 3.11.0-beta.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,5 +3,5 @@ package version
 
 const (
 	// Version is the software version
-	Version = "3.11.0-beta"
+	Version = "3.11.0-beta.1"
 )


### PR DESCRIPTION

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1815
- [x] related ooni/spec pull request: N/A

## Description

This diff just bumps the version to 3.11.0-beta.1 since we have just
tagged 3.11.0-beta to put a milestone towards making 3.11.0.

The reference issue is https://github.com/ooni/probe/issues/1815.