### PR TITLE
cleanup: move bogon checking code in netxlite

### DIFF
--- a/internal/engine/netx/resolver/bogon.go
+++ b/internal/engine/netx/resolver/bogon.go
@@ -2,52 +2,9 @@ package resolver
 
 import (
 	"context"
-	"net"
 
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
-	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
-
-var privateIPBlocks []*net.IPNet
-
-func init() {
-	for _, cidr := range []string{
-		"0.0.0.0/8",      // "This" network (however, Linux...)
-		"10.0.0.0/8",     // RFC1918
-		"100.64.0.0/10",  // Carrier grade NAT
-		"127.0.0.0/8",    // IPv4 loopback
-		"169.254.0.0/16", // RFC3927 link-local
-		"172.16.0.0/12",  // RFC1918
-		"192.168.0.0/16", // RFC1918
-		"224.0.0.0/4",    // Multicast
-		"::1/128",        // IPv6 loopback
-		"fe80::/10",      // IPv6 link-local
-		"fc00::/7",       // IPv6 unique local addr
-	} {
-		_, block, err := net.ParseCIDR(cidr)
-		runtimex.PanicOnError(err, "net.ParseCIDR failed")
-		privateIPBlocks = append(privateIPBlocks, block)
-	}
-}
-
-func isPrivate(ip net.IP) bool {
-	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
-		return true
-	}
-	for _, block := range privateIPBlocks {
-		if block.Contains(ip) {
-			return true
-		}
-	}
-	return false
-}
-
-// IsBogon returns whether if an IP address is bogon. Passing to this
-// function a non-IP address causes it to return bogon.
-func IsBogon(address string) bool {
-	ip := net.ParseIP(address)
-	return ip == nil || isPrivate(ip)
-}
 
 // BogonResolver is a bogon aware resolver. When a bogon is encountered in
 // a reply, this resolver will return an error.
@@ -64,7 +21,7 @@ type BogonResolver struct {
 func (r BogonResolver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
 	addrs, err := r.Resolver.LookupHost(ctx, hostname)
 	for _, addr := range addrs {
-		if IsBogon(addr) {
+		if netxlite.IsBogon(addr) {
 			return nil, netxlite.ErrDNSBogon
 		}
 	}

--- a/internal/engine/netx/resolver/bogon_test.go
+++ b/internal/engine/netx/resolver/bogon_test.go
@@ -9,21 +9,6 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
-func TestResolverIsBogon(t *testing.T) {
-	if resolver.IsBogon("antani") != true {
-		t.Fatal("unexpected result")
-	}
-	if resolver.IsBogon("127.0.0.1") != true {
-		t.Fatal("unexpected result")
-	}
-	if resolver.IsBogon("1.1.1.1") != false {
-		t.Fatal("unexpected result")
-	}
-	if resolver.IsBogon("10.0.1.1") != true {
-		t.Fatal("unexpected result")
-	}
-}
-
 func TestBogonAwareResolverWithBogon(t *testing.T) {
 	r := resolver.BogonResolver{
 		Resolver: resolver.NewFakeResolverWithResult([]string{"127.0.0.1"}),

--- a/internal/measurex/resolver.go
+++ b/internal/measurex/resolver.go
@@ -175,7 +175,7 @@ func (r *resolverDB) computeOddityLookupHost(addrs []string, err error) Oddity {
 		}
 	}
 	for _, addr := range addrs {
-		if isBogon(addr) {
+		if netxlite.IsBogon(addr) {
 			return OddityDNSLookupBogon
 		}
 	}

--- a/internal/netxlite/bogon.go
+++ b/internal/netxlite/bogon.go
@@ -1,4 +1,4 @@
-package measurex
+package netxlite
 
 //
 // Bogon
@@ -14,9 +14,9 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
-// isBogon returns whether if an IP address is bogon. Passing to this
+// IsBogon returns whether if an IP address is bogon. Passing to this
 // function a non-IP address causes it to return true.
-func isBogon(address string) bool {
+func IsBogon(address string) bool {
 	ip := net.ParseIP(address)
 	return ip == nil || isPrivate(ip)
 }

--- a/internal/netxlite/bogon_test.go
+++ b/internal/netxlite/bogon_test.go
@@ -1,0 +1,18 @@
+package netxlite
+
+import "testing"
+
+func TestIsBogon(t *testing.T) {
+	if IsBogon("antani") != true {
+		t.Fatal("unexpected result")
+	}
+	if IsBogon("127.0.0.1") != true {
+		t.Fatal("unexpected result")
+	}
+	if IsBogon("1.1.1.1") != false {
+		t.Fatal("unexpected result")
+	}
+	if IsBogon("10.0.1.1") != true {
+		t.Fatal("unexpected result")
+	}
+}


### PR DESCRIPTION

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1803#issuecomment-957323297
- [x] related ooni/spec pull request: N/A

## Description

I develop this diff while working on https://github.com/ooni/probe/issues/1803#issuecomment-957323297.

While there, make sure we don't have duplicate bogon code
and always use the code inside netxlite.
