### PR TITLE
refactor(netxlite/filtering): use strings for blocking policies

### DIFF
--- a/internal/netxlite/filtering/dns.go
+++ b/internal/netxlite/filtering/dns.go
@@ -17,7 +17,7 @@ import (
 type DNSAction string
 
 const (
-	// DNSActionPass pass the traffic to the upstream server.
+	// DNSActionPass passes the traffic to the upstream server.
 	DNSActionPass = DNSAction("pass")
 
 	// DNSActionNXDOMAIN replies with NXDOMAIN.

--- a/internal/netxlite/filtering/dns.go
+++ b/internal/netxlite/filtering/dns.go
@@ -13,27 +13,27 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
-// DNSAction is the action that this proxy should take.
-type DNSAction int
+// DNSAction is a DNS filtering action that this proxy should take.
+type DNSAction string
 
 const (
-	// DNSActionProxy proxies the traffic to the upstream server.
-	DNSActionProxy = DNSAction(iota)
+	// DNSActionPass pass the traffic to the upstream server.
+	DNSActionPass = DNSAction("pass")
 
 	// DNSActionNXDOMAIN replies with NXDOMAIN.
-	DNSActionNXDOMAIN
+	DNSActionNXDOMAIN = DNSAction("nxdomain")
 
 	// DNSActionRefused replies with Refused.
-	DNSActionRefused
+	DNSActionRefused = DNSAction("refused")
 
 	// DNSActionLocalHost replies with `127.0.0.1` and `::1`.
-	DNSActionLocalHost
+	DNSActionLocalHost = DNSAction("localhost")
 
-	// DNSActionEmpty returns an empty reply.
-	DNSActionEmpty
+	// DNSActionNoAnswer returns an empty reply.
+	DNSActionNoAnswer = DNSAction("no-answer")
 
 	// DNSActionTimeout never replies to the query.
-	DNSActionTimeout
+	DNSActionTimeout = DNSAction("timeout")
 )
 
 // DNSProxy is a DNS proxy that routes traffic to an upstream
@@ -121,13 +121,13 @@ func (p *DNSProxy) replyDefault(query *dns.Msg) (*dns.Msg, error) {
 	}
 	name := query.Question[0].Name
 	switch p.OnQuery(name) {
-	case DNSActionProxy:
+	case DNSActionPass:
 		return p.proxy(query)
 	case DNSActionNXDOMAIN:
 		return p.nxdomain(query), nil
 	case DNSActionLocalHost:
 		return p.localHost(query), nil
-	case DNSActionEmpty:
+	case DNSActionNoAnswer:
 		return p.empty(query), nil
 	case DNSActionTimeout:
 		return nil, errors.New("let's ignore this query")

--- a/internal/netxlite/filtering/dns_test.go
+++ b/internal/netxlite/filtering/dns_test.go
@@ -31,7 +31,7 @@ func TestDNSProxy(t *testing.T) {
 
 	t.Run("DNSActionProxy with default proxy", func(t *testing.T) {
 		ctx := context.Background()
-		listener, done, err := newproxy(DNSActionProxy)
+		listener, done, err := newproxy(DNSActionPass)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -117,7 +117,7 @@ func TestDNSProxy(t *testing.T) {
 
 	t.Run("DNSActionEmpty", func(t *testing.T) {
 		ctx := context.Background()
-		listener, done, err := newproxy(DNSActionEmpty)
+		listener, done, err := newproxy(DNSActionNoAnswer)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/netxlite/filtering/tls.go
+++ b/internal/netxlite/filtering/tls.go
@@ -9,29 +9,29 @@ import (
 	"sync"
 )
 
-// TLSAction is the action that this proxy should take.
-type TLSAction int
+// TLSAction is a TLS filtering action that this proxy should take.
+type TLSAction string
 
 const (
-	// TLSActionProxy proxies the traffic to the destination.
-	TLSActionProxy = TLSAction(iota)
+	// TLSActionPass passes the traffic to the destination.
+	TLSActionPass = TLSAction("pass")
 
 	// TLSActionReset resets the connection.
-	TLSActionReset
+	TLSActionReset = TLSAction("reset")
 
 	// TLSActionTimeout causes the connection to timeout.
-	TLSActionTimeout
+	TLSActionTimeout = TLSAction("timeout")
 
 	// TLSActionEOF closes the connection.
-	TLSActionEOF
+	TLSActionEOF = TLSAction("eof")
 
 	// TLSActionAlertInternalError sends an internal error
 	// alert message to the TLS client.
-	TLSActionAlertInternalError
+	TLSActionAlertInternalError = TLSAction("internal-error")
 
 	// TLSActionAlertUnrecognizedName tells the client that
 	// it's handshaking with an unknown SNI.
-	TLSActionAlertUnrecognizedName
+	TLSActionAlertUnrecognizedName = TLSAction("alert-unrecognized-name")
 )
 
 // TLSProxy is a TLS proxy that routes the traffic depending
@@ -86,7 +86,7 @@ func (p *TLSProxy) handle(conn net.Conn) {
 		return
 	}
 	switch p.OnIncomingSNI(sni) {
-	case TLSActionProxy:
+	case TLSActionPass:
 		p.proxy(conn, sni, hello)
 	case TLSActionTimeout:
 		p.timeout(conn)

--- a/internal/netxlite/filtering/tls_test.go
+++ b/internal/netxlite/filtering/tls_test.go
@@ -36,7 +36,7 @@ func TestTLSProxy(t *testing.T) {
 
 	t.Run("TLSActionProxy with default proxy", func(t *testing.T) {
 		ctx := context.Background()
-		listener, done, err := newproxy(TLSActionProxy)
+		listener, done, err := newproxy(TLSActionPass)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -135,7 +135,7 @@ func TestTLSProxy(t *testing.T) {
 	})
 
 	t.Run("handle cannot read ClientHello", func(t *testing.T) {
-		listener, done, err := newproxy(TLSActionProxy)
+		listener, done, err := newproxy(TLSActionPass)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -161,7 +161,7 @@ func TestTLSProxy(t *testing.T) {
 
 	t.Run("TLSActionProxy fails because we don't have SNI", func(t *testing.T) {
 		ctx := context.Background()
-		listener, done, err := newproxy(TLSActionProxy)
+		listener, done, err := newproxy(TLSActionPass)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -178,7 +178,7 @@ func TestTLSProxy(t *testing.T) {
 
 	t.Run("TLSActionProxy fails because we can't dial", func(t *testing.T) {
 		ctx := context.Background()
-		listener, done, err := newproxy(TLSActionProxy)
+		listener, done, err := newproxy(TLSActionPass)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1803#issuecomment-957323297
- [x] related ooni/spec pull request: N/A

## Description

This change will simplify follow-up work done as part of
https://github.com/ooni/probe/issues/1803#issuecomment-957323297 to
implement a comprehensive self-censoring solution.

While there, rename the "proxy" action to "pass" because what we
are effectively doing is passing traffic to the network (that's a
minor change but it seems a better analogy).