### PR TITLE
fix(filtering): avoid the if err == nil pattern

### DIFF
--- a/internal/netxlite/filtering/http_test.go
+++ b/internal/netxlite/filtering/http_test.go
@@ -2,6 +2,7 @@ package filtering
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"net/url"
@@ -97,7 +98,7 @@ func TestHTTPProxy(t *testing.T) {
 			t.Fatal(err)
 		}
 		resp, err := httpGET(ctx, listener.Addr(), "nexa.polito.it")
-		if err == nil || !strings.HasSuffix(err.Error(), "context deadline exceeded") {
+		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatal("unexpected err", err)
 		}
 		if resp != nil {
@@ -159,8 +160,8 @@ func TestHTTPProxy(t *testing.T) {
 	t.Run("Start fails on an invalid address", func(t *testing.T) {
 		p := &HTTPProxy{}
 		listener, err := p.Start("127.0.0.1")
-		if err == nil {
-			t.Fatal("expected an error")
+		if err == nil || !strings.HasSuffix(err.Error(), "missing port in address") {
+			t.Fatal("unexpected err", err)
 		}
 		if listener != nil {
 			t.Fatal("expected nil listener")

--- a/internal/netxlite/filtering/tls.go
+++ b/internal/netxlite/filtering/tls.go
@@ -60,16 +60,21 @@ func (p *TLSProxy) start(address string) (net.Listener, <-chan interface{}, erro
 
 func (p *TLSProxy) mainloop(listener net.Listener, done chan<- interface{}) {
 	defer close(done)
-	for {
-		conn, err := listener.Accept()
-		if err == nil {
-			go p.handle(conn)
-			continue
-		}
-		if strings.HasSuffix(err.Error(), "use of closed network connection") {
-			break
-		}
+	for p.oneloop(listener) {
+		// nothing
 	}
+}
+
+func (p *TLSProxy) oneloop(listener net.Listener) bool {
+	conn, err := listener.Accept()
+	if err != nil && strings.HasSuffix(err.Error(), "use of closed network connection") {
+		return false // we need to stop
+	}
+	if err != nil {
+		return true // we can continue running
+	}
+	go p.handle(conn)
+	return true // we can continue running
 }
 
 const (
@@ -143,10 +148,11 @@ type tlsClientHelloReader struct {
 
 func (c *tlsClientHelloReader) Read(b []byte) (int, error) {
 	count, err := c.Conn.Read(b)
-	if err == nil {
-		c.clientHello = append(c.clientHello, b[:count]...)
+	if err != nil {
+		return 0, err
 	}
-	return count, err
+	c.clientHello = append(c.clientHello, b[:count]...)
+	return count, nil
 }
 
 // Write prevents writing on the real connection

--- a/internal/netxlite/filtering/tls_test.go
+++ b/internal/netxlite/filtering/tls_test.go
@@ -134,25 +134,24 @@ func TestTLSProxy(t *testing.T) {
 		<-done // wait for background goroutine to exit
 	})
 
+	dial := func(ctx context.Context, endpoint string) (net.Conn, error) {
+		d := netxlite.NewDialerWithoutResolver(log.Log)
+		return d.DialContext(ctx, "tcp", endpoint)
+	}
+
 	t.Run("handle cannot read ClientHello", func(t *testing.T) {
 		listener, done, err := newproxy(TLSActionPass)
 		if err != nil {
 			t.Fatal(err)
 		}
-		conn, err := net.Dial("tcp", listener.Addr().String())
+		conn, err := dial(context.Background(), listener.Addr().String())
 		if err != nil {
 			t.Fatal(err)
 		}
 		conn.Write([]byte("GET / HTTP/1.0\r\n\r\n"))
 		buff := make([]byte, 1<<17)
 		_, err = conn.Read(buff)
-		// Implementation note: we need to wrap the error because
-		// otherwise the error string on Windows is different from Unix
-		if err == nil {
-			t.Fatal("expected non-nil error")
-		}
-		err = netxlite.NewTopLevelGenericErrWrapper(err)
-		if err.Error() != netxlite.FailureConnectionReset {
+		if err == nil || err.Error() != netxlite.FailureConnectionReset {
 			t.Fatal("unexpected err", err)
 		}
 		listener.Close()
@@ -251,11 +250,45 @@ func TestTLSProxy(t *testing.T) {
 	t.Run("Start fails on an invalid address", func(t *testing.T) {
 		p := &TLSProxy{}
 		listener, err := p.Start("127.0.0.1")
-		if err == nil {
-			t.Fatal("expected an error")
+		if err == nil || !strings.HasSuffix(err.Error(), "missing port in address") {
+			t.Fatal("unexpected err", err)
 		}
 		if listener != nil {
 			t.Fatal("expected nil listener")
+		}
+	})
+
+	t.Run("oneloop correctly handles a listener error", func(t *testing.T) {
+		listener := &mocks.Listener{
+			MockAccept: func() (net.Conn, error) {
+				return nil, errors.New("mocked error")
+			},
+		}
+		p := &TLSProxy{}
+		if !p.oneloop(listener) {
+			t.Fatal("should return true here")
+		}
+	})
+}
+
+func TestTLSClientHelloReader(t *testing.T) {
+	t.Run("on failure", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		chr := &tlsClientHelloReader{
+			Conn: &mocks.Conn{
+				MockRead: func(b []byte) (int, error) {
+					return 0, expected
+				},
+			},
+			clientHello: []byte{},
+		}
+		buf := make([]byte, 128)
+		count, err := chr.Read(buf)
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected err", err)
+		}
+		if count != 0 {
+			t.Fatal("invalid count")
 		}
 	})
 }

--- a/internal/netxlite/mocks/listener.go
+++ b/internal/netxlite/mocks/listener.go
@@ -1,0 +1,32 @@
+package mocks
+
+import "net"
+
+// Listener allows mocking a net.Listener.
+type Listener struct {
+	// Accept allows mocking Accept.
+	MockAccept func() (net.Conn, error)
+
+	// Close allows mocking Close.
+	MockClose func() error
+
+	// Addr allows mocking Addr.
+	MockAddr func() net.Addr
+}
+
+var _ net.Listener = &Listener{}
+
+// Accept implements net.Listener.Accept
+func (li *Listener) Accept() (net.Conn, error) {
+	return li.MockAccept()
+}
+
+// Close implements net.Listener.Closer.
+func (li *Listener) Close() error {
+	return li.MockClose()
+}
+
+// Addr implements net.Listener.Addr
+func (li *Listener) Addr() net.Addr {
+	return li.MockAddr()
+}

--- a/internal/netxlite/mocks/listener_test.go
+++ b/internal/netxlite/mocks/listener_test.go
@@ -1,0 +1,56 @@
+package mocks
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestListener(t *testing.T) {
+	t.Run("Accept", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		li := &Listener{
+			MockAccept: func() (net.Conn, error) {
+				return nil, expected
+			},
+		}
+		conn, err := li.Accept()
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected err", err)
+		}
+		if conn != nil {
+			t.Fatal("expected nil conn")
+		}
+	})
+
+	t.Run("Close", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		li := &Listener{
+			MockClose: func() error {
+				return expected
+			},
+		}
+		err := li.Close()
+		if !errors.Is(err, expected) {
+			t.Fatal("unexpected err", err)
+		}
+	})
+
+	t.Run("Addr", func(t *testing.T) {
+		addr := &net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: 1234,
+		}
+		li := &Listener{
+			MockAddr: func() net.Addr {
+				return addr
+			},
+		}
+		outAddr := li.Addr()
+		if diff := cmp.Diff(addr, outAddr); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+}


### PR DESCRIPTION


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1803#issuecomment-957323297
- [x] related ooni/spec pull request: N/A

## Description

1. in normal code is better to always do if err != nil so that
the ifs only contain error code (this is ~coding policy)

2. in tests we want to ensure we narrow down the error to the
real error that happened, to have greater confidence

Written while working on https://github.com/ooni/probe/issues/1803#issuecomment-957323297