### PR TITLE
feat(filtering): introduce DNS cache

### DIFF
--- a/internal/netxlite/filtering/testdata/valid.json
+++ b/internal/netxlite/filtering/testdata/valid.json
@@ -1,4 +1,7 @@
 {
+    "DNSCache": {
+        "dns.google": ["8.8.8.8", "8.8.4.4"]
+    },
     "Domains": {
         "x.org": "pass"
     }


### PR DESCRIPTION


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1803#issuecomment-957323297
- [x] related ooni/spec pull request: N/A

## Description

When we're testing multiple endpoints, it's quite important to control
the order with which they are returned to the code.

This feature is especially relevant to Web Connectivity, which will
check the endpoints to connect to in order.

Therefore, we need to force deterministic results to ensure that we can
have deterministic tests when doing Web Connectivity QA.

This diff gives us the guarantee that we can have determinism.

Part of https://github.com/ooni/probe/issues/1803#issuecomment-957323297.