### PR TITLE
cleanup(ooniprobe): remove unused send_crash_report option

### DIFF
--- a/cmd/ooniprobe/internal/cli/onboard/onboard.go
+++ b/cmd/ooniprobe/internal/cli/onboard/onboard.go
@@ -122,7 +122,6 @@ func Onboarding(config *config.Config) error {
 
 	config.Lock()
 	config.InformedConsent = true
-	config.Advanced.SendCrashReports = settings.SendCrashReports
 	config.Sharing.UploadResults = settings.UploadResults
 	config.Unlock()
 

--- a/cmd/ooniprobe/internal/config/settings.go
+++ b/cmd/ooniprobe/internal/config/settings.go
@@ -6,9 +6,7 @@ type Sharing struct {
 }
 
 // Advanced settings
-type Advanced struct {
-	SendCrashReports bool `json:"send_crash_reports"`
-}
+type Advanced struct{}
 
 // Nettests related settings
 type Nettests struct {

--- a/cmd/ooniprobe/internal/config/testdata/valid-config.json
+++ b/cmd/ooniprobe/internal/config/testdata/valid-config.json
@@ -8,6 +8,5 @@
     "websites_max_runtime": 0
   },
   "advanced": {
-    "send_crash_reports": true
   }
 }

--- a/cmd/ooniprobe/internal/ooni/default-config.json
+++ b/cmd/ooniprobe/internal/ooni/default-config.json
@@ -7,7 +7,5 @@
   "nettests": {
     "websites_max_runtime": 0
   },
-  "advanced": {
-    "send_crash_reports": true
-  }
+  "advanced": {}
 }

--- a/cmd/ooniprobe/testdata/testing-config.json
+++ b/cmd/ooniprobe/testdata/testing-config.json
@@ -7,7 +7,5 @@
   "nettests": {
     "websites_max_runtime": 15
   },
-  "advanced": {
-    "send_crash_reports": true
-  }
+  "advanced": {}
 }

--- a/debian/ooniprobe.conf.disabled
+++ b/debian/ooniprobe.conf.disabled
@@ -9,7 +9,5 @@
     "websites_max_runtime": 0,
     "websites_enabled_category_codes": null
   },
-  "advanced": {
-    "send_crash_reports": true
-  }
+  "advanced": {}
 }


### PR DESCRIPTION
Closes https://github.com/ooni/probe/issues/1766

