### PR TITLE
[backport] fix(netxlite): ensure HTTP errors are always wrapped (#584)

### DIFF
--- a/internal/netxlite/classify.go
+++ b/internal/netxlite/classify.go
@@ -38,6 +38,8 @@ func ClassifyGenericError(err error) string {
 	// The list returned here matches the values used by MK unless
 	// explicitly noted otherwise with a comment.
 
+	// QUIRK: we cannot remove this check as long as this function
+	// is exported and used independently from NewErrWrapper.
 	var errwrapper *ErrWrapper
 	if errors.As(err, &errwrapper) {
 		return errwrapper.Error() // we've already wrapped it
@@ -143,6 +145,9 @@ const (
 // If this classifier fails, it calls ClassifyGenericError
 // and returns to the caller its return value.
 func ClassifyQUICHandshakeError(err error) string {
+
+	// QUIRK: we cannot remove this check as long as this function
+	// is exported and used independently from NewErrWrapper.
 	var errwrapper *ErrWrapper
 	if errors.As(err, &errwrapper) {
 		return errwrapper.Error() // we've already wrapped it
@@ -257,10 +262,14 @@ var (
 // If this classifier fails, it calls ClassifyGenericError and
 // returns to the caller its return value.
 func ClassifyResolverError(err error) string {
+
+	// QUIRK: we cannot remove this check as long as this function
+	// is exported and used independently from NewErrWrapper.
 	var errwrapper *ErrWrapper
 	if errors.As(err, &errwrapper) {
 		return errwrapper.Error() // we've already wrapped it
 	}
+
 	if errors.Is(err, ErrDNSBogon) {
 		return FailureDNSBogonError // not in MK
 	}
@@ -281,10 +290,14 @@ func ClassifyResolverError(err error) string {
 // If this classifier fails, it calls ClassifyGenericError and
 // returns to the caller its return value.
 func ClassifyTLSHandshakeError(err error) string {
+
+	// QUIRK: we cannot remove this check as long as this function
+	// is exported and used independently from NewErrWrapper.
 	var errwrapper *ErrWrapper
 	if errors.As(err, &errwrapper) {
 		return errwrapper.Error() // we've already wrapped it
 	}
+
 	var x509HostnameError x509.HostnameError
 	if errors.As(err, &x509HostnameError) {
 		// Test case: https://wrong.host.badssl.com/

--- a/internal/netxlite/dnsoverhttps.go
+++ b/internal/netxlite/dnsoverhttps.go
@@ -10,12 +10,6 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/engine/httpheader"
 )
 
-// HTTPClient is an http.Client-like interface.
-type HTTPClient interface {
-	Do(req *http.Request) (*http.Response, error)
-	CloseIdleConnections()
-}
-
 // DNSOverHTTPS is a DNS-over-HTTPS DNSTransport.
 type DNSOverHTTPS struct {
 	// Client is the MANDATORY http client to use.

--- a/internal/netxlite/errwrapper_test.go
+++ b/internal/netxlite/errwrapper_test.go
@@ -3,6 +3,7 @@ package netxlite
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -99,6 +100,22 @@ func TestNewErrWrapper(t *testing.T) {
 		}
 		if ew.WrappedErr != io.EOF {
 			t.Fatal("unexpected WrappedErr")
+		}
+	})
+
+	t.Run("when the underlying error is already a wrapped error", func(t *testing.T) {
+		ew := NewErrWrapper(classifySyscallError, ReadOperation, ECONNRESET)
+		var err1 error = ew
+		err2 := fmt.Errorf("cannot read: %w", err1)
+		ew2 := NewErrWrapper(ClassifyGenericError, TopLevelOperation, err2)
+		if ew2.Failure != ew.Failure {
+			t.Fatal("not the same failure")
+		}
+		if ew2.Operation != ew.Operation {
+			t.Fatal("not the same operation")
+		}
+		if ew2.WrappedErr != err2 {
+			t.Fatal("invalid underlying error")
 		}
 	})
 }

--- a/internal/netxlite/iox.go
+++ b/internal/netxlite/iox.go
@@ -27,9 +27,9 @@ func ReadAllContext(ctx context.Context, r io.Reader) ([]byte, error) {
 	case data := <-datach:
 		return data, nil
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, NewTopLevelGenericErrWrapper(ctx.Err())
 	case err := <-errch:
-		return nil, err
+		return nil, NewTopLevelGenericErrWrapper(err)
 	}
 }
 
@@ -51,8 +51,8 @@ func CopyContext(ctx context.Context, dst io.Writer, src io.Reader) (int64, erro
 	case count := <-countch:
 		return count, nil
 	case <-ctx.Done():
-		return 0, ctx.Err()
+		return 0, NewTopLevelGenericErrWrapper(ctx.Err())
 	case err := <-errch:
-		return 0, err
+		return 0, NewTopLevelGenericErrWrapper(err)
 	}
 }

--- a/internal/netxlite/iox_test.go
+++ b/internal/netxlite/iox_test.go
@@ -36,6 +36,10 @@ func TestReadAllContext(t *testing.T) {
 		if !errors.Is(err, expected) {
 			t.Fatal("not the error we expected", err)
 		}
+		var errWrapper *ErrWrapper
+		if !errors.As(err, &errWrapper) {
+			t.Fatal("the returned error is not wrapped")
+		}
 		if len(out) != 0 {
 			t.Fatal("not the expected number of bytes")
 		}
@@ -65,6 +69,10 @@ func TestReadAllContext(t *testing.T) {
 		if !errors.Is(err, context.Canceled) {
 			t.Fatal("not the error we expected", err)
 		}
+		var errWrapper *ErrWrapper
+		if !errors.As(err, &errWrapper) {
+			t.Fatal("the returned error is not wrapped")
+		}
 		if len(out) != 0 {
 			t.Fatal("not the expected number of bytes")
 		}
@@ -89,6 +97,10 @@ func TestReadAllContext(t *testing.T) {
 		out, err := ReadAllContext(ctx, r)
 		if !errors.Is(err, context.Canceled) {
 			t.Fatal("not the error we expected", err)
+		}
+		var errWrapper *ErrWrapper
+		if !errors.As(err, &errWrapper) {
+			t.Fatal("the returned error is not wrapped")
 		}
 		if len(out) != 0 {
 			t.Fatal("not the expected number of bytes")
@@ -123,6 +135,10 @@ func TestCopyContext(t *testing.T) {
 		if !errors.Is(err, expected) {
 			t.Fatal("not the error we expected", err)
 		}
+		var errWrapper *ErrWrapper
+		if !errors.As(err, &errWrapper) {
+			t.Fatal("the returned error is not wrapped")
+		}
 		if out != 0 {
 			t.Fatal("not the expected number of bytes")
 		}
@@ -152,6 +168,10 @@ func TestCopyContext(t *testing.T) {
 		if !errors.Is(err, context.Canceled) {
 			t.Fatal("not the error we expected", err)
 		}
+		var errWrapper *ErrWrapper
+		if !errors.As(err, &errWrapper) {
+			t.Fatal("the returned error is not wrapped")
+		}
 		if out != 0 {
 			t.Fatal("not the expected number of bytes")
 		}
@@ -176,6 +196,10 @@ func TestCopyContext(t *testing.T) {
 		out, err := CopyContext(ctx, io.Discard, r)
 		if !errors.Is(err, context.Canceled) {
 			t.Fatal("not the error we expected", err)
+		}
+		var errWrapper *ErrWrapper
+		if !errors.As(err, &errWrapper) {
+			t.Fatal("the returned error is not wrapped")
 		}
 		if out != 0 {
 			t.Fatal("not the expected number of bytes")


### PR DESCRIPTION
1. introduce implementations of HTTPTransport and HTTPClient
that apply an error wrapping policy using the constructor
for a generic top-level error wrapper

2. make sure we use the implementations in point 1 when we
are constructing HTTPTransport and HTTPClient

3. make sure we apply error wrapping using the constructor for
a generic top-level error wrapper when reading bodies

4. acknowledge that error wrapping would be broken if we do
not return the same classification _and_ operation when we wrap
an already wrapped error, so fix the to code to do that

5. acknowledge that the classifiers already deal with preserving
the error string and explain why this is a quirk and why we
cannot remove it right now and what needs to happen to safely
remove this quirk from the codebase

Closes https://github.com/ooni/probe/issues/1860

This backports 6a935d5407fa05e0e2d73cc01492ebb888d10a29 from master.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1860
- [x] related ooni/spec pull request: N/A