### PR TITLE
[forwardport] chore: use go1.17.3 (#588)

### DIFF
--- a/.github/workflows/alltests.yml
+++ b/.github/workflows/alltests.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.2"
+          go-version: "1.17.3"
       - uses: actions/checkout@v2
       - run: go test -race -tags shaping ./...

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.2"
+          go-version: "1.17.3"
       - uses: actions/checkout@v2
       - run: ./mk OONI_PSIPHON_TAGS="" ./MOBILE/android/oonimkall.aar

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ "1.17.2" ]
+        go: [ "1.17.3" ]
     steps:
       - uses: actions/setup-go@v1
         with:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.2"
+          go-version: "1.17.3"
       - uses: actions/checkout@v2
       - run: go generate ./...

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.2"
+          go-version: "1.17.3"
       - uses: actions/checkout@v2
       - run: ./mk OONI_PSIPHON_TAGS="" XCODE_VERSION=12.4 ./MOBILE/ios/oonimkall.framework.zip

--- a/.github/workflows/jafar.yml
+++ b/.github/workflows/jafar.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.2"
+          go-version: "1.17.3"
       - uses: actions/checkout@v2
       - run: go build -v ./internal/cmd/jafar
       - run: sudo ./testjafar.bash

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.2"
+          go-version: "1.17.3"
       - uses: actions/checkout@v2
       - run: ./mk OONI_PSIPHON_TAGS="" ./CLI/darwin/amd64/ooniprobe
       - run: ./E2E/ooniprobe.sh ./CLI/darwin/amd64/ooniprobe

--- a/.github/workflows/miniooni.yml
+++ b/.github/workflows/miniooni.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.2"
+          go-version: "1.17.3"
       - uses: actions/checkout@v2
       - run: ./mk OONI_PSIPHON_TAGS="" ./CLI/miniooni
 

--- a/.github/workflows/netxlite.yml
+++ b/.github/workflows/netxlite.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        go: [ "1.17.2" ]
+        go: [ "1.17.3" ]
         os: [ "ubuntu-20.04", "windows-2019", "macos-10.15" ]
     steps:
       - uses: actions/setup-go@v1

--- a/.github/workflows/oohelperd.yml
+++ b/.github/workflows/oohelperd.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.2"
+          go-version: "1.17.3"
 
       - name: build oohelperd binary
         run: GOOS=linux GOARCH=amd64 go build -v ./internal/cmd/oohelperd

--- a/.github/workflows/qafbmessenger.yml
+++ b/.github/workflows/qafbmessenger.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.2"
+          go-version: "1.17.3"
       - uses: actions/checkout@v2
       - run: ./QA/rundocker.bash "fbmessenger"

--- a/.github/workflows/qahhfm.yml
+++ b/.github/workflows/qahhfm.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.2"
+          go-version: "1.17.3"
       - uses: actions/checkout@v2
       - run: ./QA/rundocker.bash "hhfm"

--- a/.github/workflows/qahirl.yml
+++ b/.github/workflows/qahirl.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.2"
+          go-version: "1.17.3"
       - uses: actions/checkout@v2
       - run: ./QA/rundocker.bash "hirl"

--- a/.github/workflows/qatelegram.yml
+++ b/.github/workflows/qatelegram.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.2"
+          go-version: "1.17.3"
       - uses: actions/checkout@v2
       - run: ./QA/rundocker.bash "telegram"

--- a/.github/workflows/qawebconnectivity.yml
+++ b/.github/workflows/qawebconnectivity.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.2"
+          go-version: "1.17.3"
       - uses: actions/checkout@v2
       - run: ./QA/rundocker.bash "webconnectivity"

--- a/.github/workflows/qawhatsapp.yml
+++ b/.github/workflows/qawhatsapp.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.2"
+          go-version: "1.17.3"
       - uses: actions/checkout@v2
       - run: ./QA/rundocker.bash "whatsapp"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.2"
+          go-version: "1.17.3"
       - uses: actions/checkout@v2
       - run: sudo apt install mingw-w64
       - run: ./mk OONI_PSIPHON_TAGS="" MINGW_W64_VERSION="9.3-win32" ./CLI/windows/amd64/ooniprobe.exe

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/montanaflynn/stats v0.6.6
 	github.com/onsi/ginkgo v1.16.5 // indirect
-	github.com/ooni/oohttp v0.0.0-20211019141953-f1c2702fbb1e
+	github.com/ooni/oohttp v0.0.0-20211110125146-9fc06c067bd6
 	github.com/ooni/probe-assets v0.5.0
 	github.com/ooni/psiphon v0.9.0
 	github.com/oschwald/geoip2-golang v1.5.0
@@ -49,7 +49,7 @@ require (
 	gitlab.com/yawning/obfs4.git v0.0.0-20210511220700-e330d1b7024b
 	gitlab.com/yawning/utls.git v0.0.12-1
 	golang.org/x/mod v0.5.1 // indirect
-	golang.org/x/net v0.0.0-20211020060615-d418f374d309
+	golang.org/x/net v0.0.0-20211109214657-ef0fda0de508
 	golang.org/x/sys v0.0.0-20211020064051-0ec99a608a1b
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -418,8 +418,8 @@ github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDs
 github.com/onsi/gomega v1.11.0/go.mod h1:azGKhqFUon9Vuj0YmTfLSmx0FUwqXYSTl5re8lQLTUg=
 github.com/onsi/gomega v1.13.0 h1:7lLHu94wT9Ij0o6EWWclhu0aOh32VxhkwEJvzuWPeak=
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
-github.com/ooni/oohttp v0.0.0-20211019141953-f1c2702fbb1e h1:qxMkCUolEF15N0t/z823I4eRwYIih+nglhcWWfeg3WU=
-github.com/ooni/oohttp v0.0.0-20211019141953-f1c2702fbb1e/go.mod h1:kgtoj+Dn4bmx09hEUgbPI7YX0gkWlu+fz2I0S5auyX4=
+github.com/ooni/oohttp v0.0.0-20211110125146-9fc06c067bd6 h1:o1Uwpkw+KfJEhiqhnfcEIkXNVnyV6tVgllATZEWmNGw=
+github.com/ooni/oohttp v0.0.0-20211110125146-9fc06c067bd6/go.mod h1:kgtoj+Dn4bmx09hEUgbPI7YX0gkWlu+fz2I0S5auyX4=
 github.com/ooni/probe-assets v0.5.0 h1:4pfiyYaWfWaK4isokNAEYOwHqOISTOqm2kd/2MquWh8=
 github.com/ooni/probe-assets v0.5.0/go.mod h1:N0PyNM3aadlYDDCFXAPzs54HC54+MZA/4/xnCtd9EAo=
 github.com/ooni/psiphon v0.9.0 h1:THWP09pYSKzoq9RIKZWuz9367ho9bri9lKxkMu8VsM8=
@@ -765,8 +765,8 @@ golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211005001312-d4b1ae081e3b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211020060615-d418f374d309 h1:A0lJIi+hcTR6aajJH4YqKWwohY4aW9RO7oRMcdv+HKI=
-golang.org/x/net v0.0.0-20211020060615-d418f374d309/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211109214657-ef0fda0de508 h1:v3NKo+t/Kc3EASxaKZ82lwK6mCf4ZeObQBduYFZHo7c=
+golang.org/x/net v0.0.0-20211109214657-ef0fda0de508/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=


### PR DESCRIPTION
This diff forward ports adcb0f9ae3b9e074c301d4f7f0e8f2d0ef6466b9.

Original commit message:

- - -

- ensure we use go1.17.3 in workflows

- update to a version of ooni/oohttp that uses go1.17.3

This change WILL need to be forward ported to master.

Closes https://github.com/ooni/probe/issues/1861

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1861
- [x] related ooni/spec pull request: N/A