### PR TITLE
fix: avoid http3 for dns.google and www.google.com

### DIFF
--- a/internal/cmd/oohelperd/internal/websteps/explore_test.go
+++ b/internal/cmd/oohelperd/internal/websteps/explore_test.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/ooni/probe-cli/v3/internal/netxlite/quictesting"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
@@ -84,12 +85,11 @@ func TestGetFailure(t *testing.T) {
 }
 
 func TestGetH3Success(t *testing.T) {
-	u, err := url.Parse("https://www.google.com")
-	runtimex.PanicOnError(err, "url.Parse failed for clearly good URL")
+	u := &url.URL{Scheme: "https", Host: quictesting.Domain, Path: "/"}
 	h3u := &h3URL{URL: u, proto: "h3"}
 	resp, err := explorer.getH3(h3u, nil)
 	if err != nil {
-		t.Fatal("unexpected error")
+		t.Fatal("unexpected error", err)
 	}
 	if resp == nil {
 		t.Fatal("unexpected nil response")

--- a/internal/cmd/oohelperd/internal/websteps/generate_test.go
+++ b/internal/cmd/oohelperd/internal/websteps/generate_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/lucas-clemente/quic-go"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
+	"github.com/ooni/probe-cli/v3/internal/netxlite/quictesting"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
@@ -297,8 +298,7 @@ func TestGenerateHTTPSTLSFailure(t *testing.T) {
 }
 
 func TestGenerateH3(t *testing.T) {
-	u, err := url.Parse("https://www.google.com")
-	runtimex.PanicOnError(err, "url.Parse failed")
+	u := &url.URL{Scheme: "https", Host: quictesting.Domain, Path: "/"}
 	rt := &RoundTrip{
 		Proto: "h3",
 		Request: &http.Request{
@@ -309,10 +309,7 @@ func TestGenerateH3(t *testing.T) {
 		},
 		SortIndex: 0,
 	}
-	endpointMeasurement := generator.GenerateH3Endpoint(context.Background(), rt, "173.194.76.103:443")
-	if err != nil {
-		t.Fatal("unexpected err")
-	}
+	endpointMeasurement := generator.GenerateH3Endpoint(context.Background(), rt, quictesting.Endpoint("443"))
 	if endpointMeasurement == nil {
 		t.Fatal("unexpected nil urlMeasurement")
 	}

--- a/internal/engine/internal/sessionresolver/resolvermaker.go
+++ b/internal/engine/internal/sessionresolver/resolvermaker.go
@@ -29,8 +29,6 @@ var allmakers = []*resolvermaker{{
 }, {
 	url: "https://dns.google/dns-query",
 }, {
-	url: "http3://dns.google/dns-query",
-}, {
 	url: "https://dns.quad9.net/dns-query",
 }, {
 	url: "https://doh.powerdns.org/",

--- a/internal/engine/netx/quicdialer/system_test.go
+++ b/internal/engine/netx/quicdialer/system_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/trace"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/netxlite/mocks"
+	"github.com/ooni/probe-cli/v3/internal/netxlite/quictesting"
 	"github.com/ooni/probe-cli/v3/internal/netxlite/quicx"
 )
 
@@ -42,7 +43,7 @@ func TestSystemDialerSuccessWithReadWrite(t *testing.T) {
 	// This is the most common use case for collecting reads, writes
 	tlsConf := &tls.Config{
 		NextProtos: []string{"h3"},
-		ServerName: "www.google.com",
+		ServerName: quictesting.Domain,
 	}
 	saver := &trace.Saver{}
 	systemdialer := &netxlite.QUICDialerQUICGo{
@@ -52,7 +53,7 @@ func TestSystemDialerSuccessWithReadWrite(t *testing.T) {
 		},
 	}
 	_, err := systemdialer.DialContext(context.Background(), "udp",
-		"216.58.212.164:443", tlsConf, &quic.Config{})
+		quictesting.Endpoint("443"), tlsConf, &quic.Config{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/netxlite/integration_test.go
+++ b/internal/netxlite/integration_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -503,8 +504,8 @@ func TestHTTP3Transport(t *testing.T) {
 		)
 		txp := netxlite.NewHTTP3Transport(log.Log, d, &tls.Config{})
 		client := &http.Client{Transport: txp}
-		url := fmt.Sprintf("https://%s/robots.txt", quictesting.Domain)
-		resp, err := client.Get(url)
+		URL := (&url.URL{Scheme: "https", Host: quictesting.Domain, Path: "/"}).String()
+		resp, err := client.Get(URL)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/netxlite/quictesting/quictesting.go
+++ b/internal/netxlite/quictesting/quictesting.go
@@ -1,0 +1,38 @@
+// Package quictesting contains code useful to test QUIC.
+package quictesting
+
+import (
+	"context"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
+)
+
+// Domain is the the domain we should be testing using QUIC.
+const Domain = "www.cloudflare.com"
+
+// Address is the address we should be testing using QUIC.
+var Address string
+
+// Endpoint returns the endpoint to test using QUIC by combining
+// the Address variable with the given port.
+func Endpoint(port string) string {
+	return net.JoinHostPort(Address, port)
+}
+
+func init() {
+	const timeout = 10 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	reso := &net.Resolver{}
+	addrs, err := reso.LookupHost(ctx, Domain)
+	runtimex.PanicOnError(err, "reso.LookupHost failed")
+	for _, addr := range addrs {
+		if !strings.Contains(addr, ":") {
+			Address = addr
+			break
+		}
+	}
+}

--- a/internal/netxlite/quictesting/quictesting_test.go
+++ b/internal/netxlite/quictesting/quictesting_test.go
@@ -1,0 +1,20 @@
+package quictesting
+
+import (
+	"net"
+	"testing"
+)
+
+func TestWorksAsIntended(t *testing.T) {
+	epnt := Endpoint("443")
+	addr, port, err := net.SplitHostPort(epnt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if addr != Address {
+		t.Fatal("invalid addr")
+	}
+	if port != "443" {
+		t.Fatal("invalid port")
+	}
+}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1873
- [x] related ooni/spec pull request: N/A

## Description

This diff changes code the release/3.11 branch to ensure we're not using dns.google and www.google.com over HTTP3. As documented in https://github.com/ooni/probe/issues/1873, since this morning (approx) these services do not support HTTP3 anymore. (I didn't bother with checking whether this issue affects _other_ Google services; I just limited my analysis to the services that we were using as part of testing.)

This patch WILL require forward porting to the master branch.