### PR TITLE
[backport] fix(geolocate): use powerdns.org whoami service (#592)

### DIFF
--- a/internal/engine/geolocate/resolverlookup.go
+++ b/internal/engine/geolocate/resolverlookup.go
@@ -20,7 +20,7 @@ type resolverLookupClient struct{}
 
 func (rlc resolverLookupClient) do(ctx context.Context, r dnsResolver) (string, error) {
 	var ips []string
-	ips, err := r.LookupHost(ctx, "whoami.akamai.net")
+	ips, err := r.LookupHost(ctx, "whoami.v4.powerdns.org")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This diff backports 5a481b395aa06f5d1f542562920c0208b2f79fb1.

Original commit message:

- - -

This diff needs to be backported to the release/3.11 branch.

Reference issue https://github.com/ooni/probe/issues/1865.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1865
- [x] related ooni/spec pull request: N/A