### PR TITLE
fix(psiphon): increase the maximum runtime to 300s

### DIFF
--- a/internal/engine/experiment/psiphon/psiphon.go
+++ b/internal/engine/experiment/psiphon/psiphon.go
@@ -70,7 +70,7 @@ func (m *Measurer) Run(
 	ctx context.Context, sess model.ExperimentSession,
 	measurement *model.Measurement, callbacks model.ExperimentCallbacks,
 ) error {
-	const maxruntime = 60
+	const maxruntime = 300
 	ctx, cancel := context.WithTimeout(ctx, maxruntime*time.Second)
 	var (
 		wg     sync.WaitGroup

--- a/internal/engine/experiment/psiphon/psiphon.go
+++ b/internal/engine/experiment/psiphon/psiphon.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	testName    = "psiphon"
-	testVersion = "0.5.0"
+	testVersion = "0.5.1"
 )
 
 // Config contains the experiment's configuration.

--- a/internal/engine/experiment/psiphon/psiphon_test.go
+++ b/internal/engine/experiment/psiphon/psiphon_test.go
@@ -23,7 +23,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "psiphon" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.5.0" {
+	if measurer.ExperimentVersion() != "0.5.1" {
 		t.Fatal("unexpected version")
 	}
 }


### PR DESCRIPTION
See: https://github.com/ooni/probe/issues/1856.

This diff will need to be backported to release/3.11.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request:  https://github.com/ooni/probe/issues/1856.
- [x] related ooni/spec pull request: N/A