### PR TITLE
[forwardport] fix(signal): use the correct string to score a measurement (#602)

### DIFF
--- a/internal/engine/experiment/signal/signal.go
+++ b/internal/engine/experiment/signal/signal.go
@@ -189,6 +189,6 @@ func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, e
 	}
 	sk.SignalBackendStatus = tk.SignalBackendStatus
 	sk.SignalBackendFailure = tk.SignalBackendFailure
-	sk.IsAnomaly = tk.SignalBackendStatus == "blocking"
+	sk.IsAnomaly = tk.SignalBackendStatus == "blocked"
 	return sk, nil
 }


### PR DESCRIPTION
This diff forwardports 3b1cc1b6afbc29fbc9ff8221d2cd84f34032df60.

Original commit message:

- - -

See https://github.com/ooni/probe/issues/1858#issuecomment-970322363

This diff will need forward porting to master.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1858#issuecomment-970322363
- [x] related ooni/spec pull request: N/A