### PR TITLE
fix(mk): do nothing if we already have psiphon config 

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,7 @@ on:
       - "mobile-staging"
       - "release/**"
       - "stable"
+      - "issue/1878"
 jobs:
   test:
     runs-on: ubuntu-20.04
@@ -14,4 +15,9 @@ jobs:
         with:
           go-version: "1.17.3"
       - uses: actions/checkout@v2
-      - run: ./mk OONI_PSIPHON_TAGS="" ./MOBILE/android/oonimkall.aar
+
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+
+      - run: ./mk ./MOBILE/android/oonimkall.aar

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           go-version: "1.17.3"
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - run: |
           echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,7 +6,6 @@ on:
       - "mobile-staging"
       - "release/**"
       - "stable"
-      - "issue/1878"
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,5 +19,8 @@ jobs:
       - run: |
           echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
           echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
 
       - run: ./mk ./MOBILE/android/oonimkall.aar

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           go-version: "1.17.3"
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - run: |
           echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -6,6 +6,7 @@ on:
       - "mobile-staging"
       - "release/**"
       - "stable"
+      - "issue/1878"
 jobs:
   test:
     runs-on: macos-10.15
@@ -14,4 +15,9 @@ jobs:
         with:
           go-version: "1.17.3"
       - uses: actions/checkout@v2
-      - run: ./mk OONI_PSIPHON_TAGS="" XCODE_VERSION=12.4 ./MOBILE/ios/oonimkall.xcframework.zip
+
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+
+      - run: ./mk XCODE_VERSION=12.4 ./MOBILE/ios/oonimkall.xcframework.zip

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -19,5 +19,8 @@ jobs:
       - run: |
           echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
           echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
 
       - run: ./mk XCODE_VERSION=12.4 ./MOBILE/ios/oonimkall.xcframework.zip

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -6,7 +6,6 @@ on:
       - "mobile-staging"
       - "release/**"
       - "stable"
-      - "issue/1878"
 jobs:
   test:
     runs-on: macos-10.15

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,13 +5,17 @@ on:
     branches:
       - "release/**"
       - "ooniprobe-staging"
+      - issue/1878
 
 jobs:
   build_386:
     runs-on: "ubuntu-20.04"
     steps:
       - uses: actions/checkout@v2
-      - run: ./mk OONI_PSIPHON_TAGS="" DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/386
+      - run: ./mk DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/386
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
       - run: ./E2E/ooniprobe.sh ./CLI/linux/386/ooniprobe
       - run: ./CLI/linux/pubdebian
         if: github.ref == 'refs/heads/ooniprobe-staging'
@@ -24,7 +28,10 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - uses: actions/checkout@v2
-      - run: ./mk OONI_PSIPHON_TAGS="" DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/amd64
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+      - run: ./mk DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/amd64
       - run: ./E2E/ooniprobe.sh ./CLI/linux/amd64/ooniprobe
       - run: ./CLI/linux/pubdebian
         if: github.ref == 'refs/heads/ooniprobe-staging'
@@ -39,7 +46,10 @@ jobs:
       - uses: actions/checkout@v2
       - run: sudo apt-get update -q
       - run: sudo apt-get install -y qemu-user-static
-      - run: ./mk OONI_PSIPHON_TAGS="" DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/arm
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+      - run: ./mk DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/arm
       - run: ./E2E/ooniprobe.sh ./CLI/linux/arm/ooniprobe
       - run: ./CLI/linux/pubdebian
         if: github.ref == 'refs/heads/ooniprobe-staging'
@@ -54,7 +64,10 @@ jobs:
       - uses: actions/checkout@v2
       - run: sudo apt-get update -q
       - run: sudo apt-get install -y qemu-user-static
-      - run: ./mk OONI_PSIPHON_TAGS="" DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/arm64
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+      - run: ./mk DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/arm64
       - run: ./E2E/ooniprobe.sh ./CLI/linux/arm64/ooniprobe
       - run: ./CLI/linux/pubdebian
         if: github.ref == 'refs/heads/ooniprobe-staging'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - uses: actions/checkout@v2
-      - run: ./mk DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/386
       - run: |
           echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
           echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
         env:
           PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
           PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+      - run: ./mk DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/386
       - run: ./E2E/ooniprobe.sh ./CLI/linux/386/ooniprobe
       - run: ./CLI/linux/pubdebian
         if: github.ref == 'refs/heads/ooniprobe-staging'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - run: |
           echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
           echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
@@ -31,6 +33,8 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - run: |
           echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
           echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
@@ -50,6 +54,8 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - run: sudo apt-get update -q
       - run: sudo apt-get install -y qemu-user-static
       - run: |
@@ -71,6 +77,8 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - run: sudo apt-get update -q
       - run: sudo apt-get install -y qemu-user-static
       - run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "release/**"
       - "ooniprobe-staging"
-      - issue/1878
 
 jobs:
   build_386:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,6 +16,9 @@ jobs:
       - run: |
           echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
           echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
       - run: ./E2E/ooniprobe.sh ./CLI/linux/386/ooniprobe
       - run: ./CLI/linux/pubdebian
         if: github.ref == 'refs/heads/ooniprobe-staging'
@@ -31,6 +34,9 @@ jobs:
       - run: |
           echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
           echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
       - run: ./mk DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/amd64
       - run: ./E2E/ooniprobe.sh ./CLI/linux/amd64/ooniprobe
       - run: ./CLI/linux/pubdebian
@@ -49,6 +55,9 @@ jobs:
       - run: |
           echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
           echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
       - run: ./mk DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/arm
       - run: ./E2E/ooniprobe.sh ./CLI/linux/arm/ooniprobe
       - run: ./CLI/linux/pubdebian
@@ -67,6 +76,9 @@ jobs:
       - run: |
           echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
           echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
       - run: ./mk DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/arm64
       - run: ./E2E/ooniprobe.sh ./CLI/linux/arm64/ooniprobe
       - run: ./CLI/linux/pubdebian

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "release/**"
       - "stable"
+      - issue/1878
 jobs:
   build:
     runs-on: "macos-10.15"
@@ -13,5 +14,8 @@ jobs:
         with:
           go-version: "1.17.3"
       - uses: actions/checkout@v2
-      - run: ./mk OONI_PSIPHON_TAGS="" ./CLI/darwin/amd64/ooniprobe
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+      - run: ./mk ./CLI/darwin/amd64/ooniprobe
       - run: ./E2E/ooniprobe.sh ./CLI/darwin/amd64/ooniprobe

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           go-version: "1.17.3"
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - run: |
           echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
           echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,5 +17,8 @@ jobs:
       - run: |
           echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
           echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
       - run: ./mk ./CLI/darwin/amd64/ooniprobe
       - run: ./E2E/ooniprobe.sh ./CLI/darwin/amd64/ooniprobe

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "release/**"
       - "stable"
-      - issue/1878
 jobs:
   build:
     runs-on: "macos-10.15"

--- a/.github/workflows/miniooni.yml
+++ b/.github/workflows/miniooni.yml
@@ -8,6 +8,7 @@ on:
       - "master"
       - "release/**"
       - "stable"
+      - "issue/1878"
 jobs:
   test:
     runs-on: ubuntu-20.04
@@ -16,7 +17,12 @@ jobs:
         with:
           go-version: "1.17.3"
       - uses: actions/checkout@v2
-      - run: ./mk OONI_PSIPHON_TAGS="" ./CLI/miniooni
+
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+
+      - run: ./mk ./CLI/miniooni
 
       - run: ./E2E/miniooni.bash ./CLI/linux/amd64/miniooni
 

--- a/.github/workflows/miniooni.yml
+++ b/.github/workflows/miniooni.yml
@@ -8,7 +8,6 @@ on:
       - "master"
       - "release/**"
       - "stable"
-      - "issue/1878"
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/miniooni.yml
+++ b/.github/workflows/miniooni.yml
@@ -21,6 +21,9 @@ jobs:
       - run: |
           echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
           echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
 
       - run: ./mk ./CLI/miniooni
 

--- a/.github/workflows/miniooni.yml
+++ b/.github/workflows/miniooni.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           go-version: "1.17.3"
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - run: |
           echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,13 @@ jobs:
           go-version: "1.17.3"
       - uses: actions/checkout@v2
       - run: sudo apt install mingw-w64
-      - run: ./mk OONI_PSIPHON_TAGS="" MINGW_W64_VERSION="9.3-win32" ./CLI/windows/amd64/ooniprobe.exe
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+      - run: ./mk MINGW_W64_VERSION="9.3-win32" ./CLI/windows/amd64/ooniprobe.exe
       - uses: actions/upload-artifact@v2
         with:
           name: ooniprobe.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "release/**"
       - "stable"
-      - "issue/1878"
 jobs:
   build:
     runs-on: "ubuntu-20.04"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,6 +13,8 @@ jobs:
         with:
           go-version: "1.17.3"
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - run: sudo apt install mingw-w64
       - run: |
           echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "release/**"
       - "stable"
+      - "issue/1878"
 jobs:
   build:
     runs-on: "ubuntu-20.04"

--- a/internal/cmd/miniooni/libminiooni.go
+++ b/internal/cmd/miniooni/libminiooni.go
@@ -151,6 +151,7 @@ func Main() {
 		os.Exit(0)
 	}
 	fatalIfFalse(len(getopt.Args()) == 1, "Missing experiment name")
+	fatalOnError(engine.CheckEmbeddedPsiphonConfig(), "Invalid embedded psiphon config")
 	MainWithConfiguration(getopt.Arg(0), globalOptions)
 }
 

--- a/internal/engine/session_nopsiphon.go
+++ b/internal/engine/session_nopsiphon.go
@@ -29,3 +29,8 @@ var errPsiphonNoEmbeddedConfig = errors.New("no embedded configuration file")
 func (s *sessionTunnelEarlySession) FetchPsiphonConfig(ctx context.Context) ([]byte, error) {
 	return nil, errPsiphonNoEmbeddedConfig
 }
+
+// CheckEmbeddedPsiphonConfig checks whether we can load psiphon's config
+func CheckEmbeddedPsiphonConfig() error {
+	return nil
+}

--- a/internal/engine/session_nopsiphon_test.go
+++ b/internal/engine/session_nopsiphon_test.go
@@ -19,3 +19,9 @@ func TestEarlySessionNoPsiphonFetchPsiphonConfig(t *testing.T) {
 		t.Fatal("expected nil here")
 	}
 }
+
+func TestCheckEmbeddedPsiphonConfig(t *testing.T) {
+	if err := CheckEmbeddedPsiphonConfig(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/engine/session_psiphon.go
+++ b/internal/engine/session_psiphon.go
@@ -44,3 +44,10 @@ func (s *Session) FetchPsiphonConfig(ctx context.Context) ([]byte, error) {
 	child := &sessionTunnelEarlySession{}
 	return child.FetchPsiphonConfig(ctx)
 }
+
+// CheckEmbeddedPsiphonConfig checks whether we can load psiphon's config
+func CheckEmbeddedPsiphonConfig() error {
+	child := &sessionTunnelEarlySession{}
+	_, err := child.FetchPsiphonConfig(context.Background())
+	return err
+}

--- a/internal/engine/session_psiphon_test.go
+++ b/internal/engine/session_psiphon_test.go
@@ -18,3 +18,9 @@ func TestSessionEmbeddedPsiphonConfig(t *testing.T) {
 		t.Fatal("expected non-nil data here")
 	}
 }
+
+func TestCheckEmbeddedPsiphonConfig(t *testing.T) {
+	if err := CheckEmbeddedPsiphonConfig(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/mk
+++ b/mk
@@ -500,7 +500,7 @@ __android_build_with_ooni_go: search/for/go
 
 # important: OONIMKALL_V and OONIMKALL_R MUST be expanded just once so we use `:=`
 OONIMKALL_V := $(shell date -u +%Y.%m.%d-%H%M%S)
-OONIMKALL_R := $(shell git describe --tags || echo '0.0.0-dev')
+OONIMKALL_R := $(shell git describe --tags)
 
 #help: The `debian/publish` target publishes all the debian packages
 #help: present in the toplevel directory using debopos-ci.

--- a/mk
+++ b/mk
@@ -500,7 +500,7 @@ __android_build_with_ooni_go: search/for/go
 
 # important: OONIMKALL_V and OONIMKALL_R MUST be expanded just once so we use `:=`
 OONIMKALL_V := $(shell date -u +%Y.%m.%d-%H%M%S)
-OONIMKALL_R := $(shell git describe --tags)
+OONIMKALL_R := $(shell git describe --tags || echo '0.0.0-dev')
 
 #help: The `debian/publish` target publishes all the debian packages
 #help: present in the toplevel directory using debopos-ci.


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1878
- [x] related ooni/spec pull request: N/A

## Description

This change allows for producing cloud builds using the psiphon
config files. We will add those files as build secrets. Only people
in the organization and collaborators with at least "write"
access could trigger builds containing such secrets.

Before this change, `./mk` unconditionally attempted to clone
github.com/ooni/probe-private. Now, it only checks whether
we need to clone _if_ files are not already there.

This allows us to use GitHub actions and secrets to copy the
files in there _without_ needing to clone a private repo.

Cloning a private repo would require us to include as repository
secret an access token with full `repo` scope, which is a very
broad scope. Instead, by using secrets to include psiphon config,
we are narrowing down the secrets required to make a release build.

See https://github.com/ooni/probe/issues/1878

This diff WILL require forward porting to the master branch.