### PR TITLE
[forwardport] fix(mk): do nothing if we already have psiphon config (#605)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,4 +13,14 @@ jobs:
         with:
           go-version: "1.17.3"
       - uses: actions/checkout@v2
-      - run: ./mk OONI_PSIPHON_TAGS="" ./MOBILE/android/oonimkall.aar
+        with:
+          fetch-depth: 0
+
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+
+      - run: ./mk ./MOBILE/android/oonimkall.aar

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -13,4 +13,14 @@ jobs:
         with:
           go-version: "1.17.3"
       - uses: actions/checkout@v2
-      - run: ./mk OONI_PSIPHON_TAGS="" XCODE_VERSION=12.4 ./MOBILE/ios/oonimkall.xcframework.zip
+        with:
+          fetch-depth: 0
+
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+
+      - run: ./mk XCODE_VERSION=12.4 ./MOBILE/ios/oonimkall.xcframework.zip

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,7 +11,15 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - uses: actions/checkout@v2
-      - run: ./mk OONI_PSIPHON_TAGS="" DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/386
+        with:
+          fetch-depth: 0
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+      - run: ./mk DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/386
       - run: ./E2E/ooniprobe.sh ./CLI/linux/386/ooniprobe
       - run: ./CLI/linux/pubdebian
         if: github.ref == 'refs/heads/ooniprobe-staging'
@@ -24,7 +32,15 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - uses: actions/checkout@v2
-      - run: ./mk OONI_PSIPHON_TAGS="" DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/amd64
+        with:
+          fetch-depth: 0
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+      - run: ./mk DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/amd64
       - run: ./E2E/ooniprobe.sh ./CLI/linux/amd64/ooniprobe
       - run: ./CLI/linux/pubdebian
         if: github.ref == 'refs/heads/ooniprobe-staging'
@@ -37,9 +53,17 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - run: sudo apt-get update -q
       - run: sudo apt-get install -y qemu-user-static
-      - run: ./mk OONI_PSIPHON_TAGS="" DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/arm
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+      - run: ./mk DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/arm
       - run: ./E2E/ooniprobe.sh ./CLI/linux/arm/ooniprobe
       - run: ./CLI/linux/pubdebian
         if: github.ref == 'refs/heads/ooniprobe-staging'
@@ -52,9 +76,17 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - run: sudo apt-get update -q
       - run: sudo apt-get install -y qemu-user-static
-      - run: ./mk OONI_PSIPHON_TAGS="" DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/arm64
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+      - run: ./mk DEBIAN_TILDE_VERSION=$GITHUB_RUN_NUMBER ./debian/arm64
       - run: ./E2E/ooniprobe.sh ./CLI/linux/arm64/ooniprobe
       - run: ./CLI/linux/pubdebian
         if: github.ref == 'refs/heads/ooniprobe-staging'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,5 +12,13 @@ jobs:
         with:
           go-version: "1.17.3"
       - uses: actions/checkout@v2
-      - run: ./mk OONI_PSIPHON_TAGS="" ./CLI/darwin/amd64/ooniprobe
+        with:
+          fetch-depth: 0
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+      - run: ./mk ./CLI/darwin/amd64/ooniprobe
       - run: ./E2E/ooniprobe.sh ./CLI/darwin/amd64/ooniprobe

--- a/.github/workflows/miniooni.yml
+++ b/.github/workflows/miniooni.yml
@@ -15,7 +15,17 @@ jobs:
         with:
           go-version: "1.17.3"
       - uses: actions/checkout@v2
-      - run: ./mk OONI_PSIPHON_TAGS="" ./CLI/miniooni
+        with:
+          fetch-depth: 0
+
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+
+      - run: ./mk ./CLI/miniooni
 
       - run: ./E2E/miniooni.bash ./CLI/linux/amd64/miniooni
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,8 +12,16 @@ jobs:
         with:
           go-version: "1.17.3"
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - run: sudo apt install mingw-w64
-      - run: ./mk OONI_PSIPHON_TAGS="" MINGW_W64_VERSION="9.3-win32" ./CLI/windows/amd64/ooniprobe.exe
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+      - run: ./mk MINGW_W64_VERSION="9.3-win32" ./CLI/windows/amd64/ooniprobe.exe
       - uses: actions/upload-artifact@v2
         with:
           name: ooniprobe.exe

--- a/internal/cmd/miniooni/libminiooni.go
+++ b/internal/cmd/miniooni/libminiooni.go
@@ -159,6 +159,7 @@ func Main() {
 		os.Exit(0)
 	}
 	fatalIfFalse(len(getopt.Args()) == 1, "Missing experiment name")
+	fatalOnError(engine.CheckEmbeddedPsiphonConfig(), "Invalid embedded psiphon config")
 	MainWithConfiguration(getopt.Arg(0), globalOptions)
 }
 

--- a/internal/engine/session_nopsiphon.go
+++ b/internal/engine/session_nopsiphon.go
@@ -29,3 +29,8 @@ var errPsiphonNoEmbeddedConfig = errors.New("no embedded configuration file")
 func (s *sessionTunnelEarlySession) FetchPsiphonConfig(ctx context.Context) ([]byte, error) {
 	return nil, errPsiphonNoEmbeddedConfig
 }
+
+// CheckEmbeddedPsiphonConfig checks whether we can load psiphon's config
+func CheckEmbeddedPsiphonConfig() error {
+	return nil
+}

--- a/internal/engine/session_nopsiphon_test.go
+++ b/internal/engine/session_nopsiphon_test.go
@@ -19,3 +19,9 @@ func TestEarlySessionNoPsiphonFetchPsiphonConfig(t *testing.T) {
 		t.Fatal("expected nil here")
 	}
 }
+
+func TestCheckEmbeddedPsiphonConfig(t *testing.T) {
+	if err := CheckEmbeddedPsiphonConfig(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/engine/session_psiphon.go
+++ b/internal/engine/session_psiphon.go
@@ -44,3 +44,10 @@ func (s *Session) FetchPsiphonConfig(ctx context.Context) ([]byte, error) {
 	child := &sessionTunnelEarlySession{}
 	return child.FetchPsiphonConfig(ctx)
 }
+
+// CheckEmbeddedPsiphonConfig checks whether we can load psiphon's config
+func CheckEmbeddedPsiphonConfig() error {
+	child := &sessionTunnelEarlySession{}
+	_, err := child.FetchPsiphonConfig(context.Background())
+	return err
+}

--- a/internal/engine/session_psiphon_test.go
+++ b/internal/engine/session_psiphon_test.go
@@ -18,3 +18,9 @@ func TestSessionEmbeddedPsiphonConfig(t *testing.T) {
 		t.Fatal("expected non-nil data here")
 	}
 }
+
+func TestCheckEmbeddedPsiphonConfig(t *testing.T) {
+	if err := CheckEmbeddedPsiphonConfig(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This diff forward ports ea44e99451f345474738b9010ff791759a1f1367.

Original commit message:

- - -

This change allows for producing cloud builds using the psiphon
config files. We will add those files as build secrets. Only people
in the organization and collaborators with at least "write"
access could trigger builds containing such secrets.

Before this change, `./mk` unconditionally attempted to clone
github.com/ooni/probe-private. Now, it only checks whether
we need to clone _if_ files are not already there.

This allows us to use GitHub actions and secrets to copy the
files in there _without_ needing to clone a private repo.

Cloning a private repo would require us to include as repository
secret an access token with full `repo` scope, which is a very
broad scope. Instead, by using secrets to include psiphon config,
we are narrowing down the secrets required to make a release build.

See https://github.com/ooni/probe/issues/1878

This diff WILL require forward porting to the master branch.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1878
- [x] related ooni/spec pull request: N/A