### PR TITLE
fix(websteps, webconnectivity): send the correct user agent

### DIFF
--- a/internal/engine/experiment/webconnectivity/control.go
+++ b/internal/engine/experiment/webconnectivity/control.go
@@ -57,6 +57,7 @@ func Control(
 		BaseURL:    thAddr,
 		HTTPClient: sess.DefaultHTTPClient(),
 		Logger:     sess.Logger(),
+		UserAgent:  sess.UserAgent(),
 	}
 	sess.Logger().Infof("control for %s...", creq.HTTPRequest)
 	// make sure error is wrapped

--- a/internal/engine/experiment/webstepsx/measurer.go
+++ b/internal/engine/experiment/webstepsx/measurer.go
@@ -113,9 +113,10 @@ func (mx *Measurer) runAsync(ctx context.Context, sess model.ExperimentSession,
 	URL string, th *model.Service, out chan<- *model.ExperimentAsyncTestKeys) {
 	defer close(out)
 	helper := &measurerMeasureURLHelper{
-		Clnt:   sess.DefaultHTTPClient(),
-		Logger: sess.Logger(),
-		THURL:  th.Address,
+		Clnt:      sess.DefaultHTTPClient(),
+		Logger:    sess.Logger(),
+		THURL:     th.Address,
+		UserAgent: sess.UserAgent(),
 	}
 	mmx := &measurex.Measurer{
 		Begin:            time.Now(),
@@ -158,6 +159,9 @@ type measurerMeasureURLHelper struct {
 
 	// THURL is the MANDATORY TH URL.
 	THURL string
+
+	// UserAgent is the OPTIONAL user-agent to use.
+	UserAgent string
 }
 
 func (mth *measurerMeasureURLHelper) LookupExtraHTTPEndpoints(
@@ -170,6 +174,7 @@ func (mth *measurerMeasureURLHelper) LookupExtraHTTPEndpoints(
 		Header:     headers,
 		THURL:      mth.THURL,
 		TargetURL:  URL.String(),
+		UserAgent:  mth.UserAgent,
 	}
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()

--- a/internal/engine/experiment/webstepsx/th.go
+++ b/internal/engine/experiment/webstepsx/th.go
@@ -122,6 +122,9 @@ type THClientCall struct {
 
 	// TargetURL is the MANDATORY URL to measure.
 	TargetURL string
+
+	// UserAgent is the OPTIONAL user-agent to use.
+	UserAgent string
 }
 
 // Call performs the specified TH call and returns either a response or an error.
@@ -140,7 +143,7 @@ func (c *THClientCall) Call(ctx context.Context) (*THServerResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", fmt.Sprintf("ooniprobe-cli/%s", version.Version))
+	req.Header.Set("User-Agent", c.UserAgent)
 	return c.httpClientDo(req)
 }
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1902
- [x] related ooni/spec pull request: N/A

(This diff includes a forwardport of b8c530388e66b2cc86abad26d077202782e4a823 from release/3.11)