### PR TITLE
[forwardport] fix(oonimkall): don't close channel to signal end of task (#619)

### DIFF
--- a/pkg/oonimkall/task_integration_test.go
+++ b/pkg/oonimkall/task_integration_test.go
@@ -511,13 +511,13 @@ func TestNonblock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !task.IsRunning() {
+	if !task.isRunning() {
 		t.Fatal("The runner should be running at this point")
 	}
 	// If the task blocks because it emits too much events, this test
 	// will run forever and will be killed. Because we have room for up
 	// to 128 events in the buffer, we should hopefully be fine.
-	for task.IsRunning() {
+	for task.isRunning() {
 		time.Sleep(time.Second)
 	}
 	for !task.IsDone() {

--- a/pkg/oonimkall/task_internal_test.go
+++ b/pkg/oonimkall/task_internal_test.go
@@ -1,5 +1,0 @@
-package oonimkall
-
-func (t *Task) IsRunning() bool {
-	return t.isstopped.Load() == 0
-}


### PR DESCRIPTION
This diff forward ports 90bf0629b957c912a5a6f3bb6c98ad3abb5a2ff6 to `master`.

If we close the channel to signal the end of a task we may panic
when some background goroutine tries to post on the channel.

This bug is rare but may happen.

See for example https://github.com/ooni/probe/issues/1438.

How can we improve?

First, let us add a timeout when sending to the channel. Given that
the channel is buffered and we have a generous timeout (1/4 of a
second), it's unlikely we will really block. But, in the event in
which a late message appears, we'll eventually _unblock_ when
sending with a timeout. So, now we don't have to worry anymore
about leaking forever a goroutine.

Then, let us change the protocol with which we signal that a task
is done. We used to close the channel. Now, instead we just
synchronously post a nil on the channel when done.

In turn, we interpret this nil to mean that the task is done when
we receive messages.

The _main_ different with respect to before is that now we are
asking the consumer of our API to drain the channel. Because
before we had a blocking channel, it seems to me we were already
requiring the consumer of the API to do that. Which means, I think
in practical terms it did not change much.

Finally, acknowledge that we don't need a specific state variable
to tell us we're done and simplify a little bit the API by
just making isRunning private and using the "we're done" signal
to determine whether we've stopped running the task.

All these changes should be enough to close https://github.com/ooni/probe/issues/1438.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1438
- [x] related ooni/spec pull request: N/A