### PR TITLE
[backport] fix(oonimkall): improve channel management pattern (#621)

### DIFF
--- a/pkg/oonimkall/runner.go
+++ b/pkg/oonimkall/runner.go
@@ -38,7 +38,9 @@ const (
 // run runs the task specified by settings.Name until completion. This is the
 // top-level API that should be called by oonimkall.
 func run(ctx context.Context, settings *settings, out chan<- *event) {
-	r := newRunner(settings, out)
+	eof := make(chan interface{})
+	defer close(eof) // tell the emitter to not emit anymore.
+	r := newRunner(settings, out, eof)
 	r.Run(ctx)
 }
 
@@ -51,9 +53,9 @@ type runner struct {
 }
 
 // newRunner creates a new task runner
-func newRunner(settings *settings, out chan<- *event) *runner {
+func newRunner(settings *settings, out chan<- *event, eof <-chan interface{}) *runner {
 	return &runner{
-		emitter:  newEventEmitter(settings.DisabledEvents, out),
+		emitter:  newEventEmitter(settings.DisabledEvents, out, eof),
 		out:      out,
 		settings: settings,
 	}

--- a/pkg/oonimkall/runner_internal_test.go
+++ b/pkg/oonimkall/runner_internal_test.go
@@ -44,32 +44,39 @@ func TestRunnerMaybeLookupLocationFailure(t *testing.T) {
 		Version:  1,
 	}
 	seench := make(chan int64)
+	eof := make(chan interface{})
 	go func() {
 		var seen int64
-		for ev := range out {
-			switch ev.Key {
-			case "failure.ip_lookup", "failure.asn_lookup",
-				"failure.cc_lookup", "failure.resolver_lookup":
-				seen++
-			case "status.progress":
-				evv := ev.Value.(eventStatusProgress)
-				if evv.Percentage >= 0.2 {
-					panic(fmt.Sprintf("too much progress: %+v", ev))
+	Loop:
+		for {
+			select {
+			case ev := <-out:
+				switch ev.Key {
+				case "failure.ip_lookup", "failure.asn_lookup",
+					"failure.cc_lookup", "failure.resolver_lookup":
+					seen++
+				case "status.progress":
+					evv := ev.Value.(eventStatusProgress)
+					if evv.Percentage >= 0.2 {
+						panic(fmt.Sprintf("too much progress: %+v", ev))
+					}
+				case "status.queued", "status.started", "status.end":
+				default:
+					panic(fmt.Sprintf("unexpected key: %s - %+v", ev.Key, ev.Value))
 				}
-			case "status.queued", "status.started", "status.end":
-			default:
-				panic(fmt.Sprintf("unexpected key: %s - %+v", ev.Key, ev.Value))
+			case <-eof:
+				break Loop
 			}
 		}
 		seench <- seen
 	}()
 	expected := errors.New("mocked error")
-	r := newRunner(settings, out)
+	r := newRunner(settings, out, eof)
 	r.maybeLookupLocation = func(*engine.Session) error {
 		return expected
 	}
 	r.Run(context.Background())
-	close(out)
+	close(eof)
 	if n := <-seench; n != 4 {
 		t.Fatal("unexpected number of events")
 	}


### PR DESCRIPTION
This diff backports 120f2b9fbfa663fb70643a2d82291247fece0504.

1. add eof channel to event emitter and use this channel as signal
that we shouldn't be sending anymore instead of using a pattern where
we use a timer to decide sending has timed out (because we're using
a buffered channel, it is still possible for some evetns to end up
in the channel if there is space, but this is not a concern, because
the events will be deleted when the channel itself is gone);

2. refactor all tests where we assumed the output channel was closed
to actually use a parallel "eof" channel and use it as signal we
should not be sending anymore (not strictly required but still the
right thing to do in terms of using consistent patterns);

3. modify how we construct a runner so that it passes to the
event emitter an "eof" channel and closes this channel when the
main goroutine running the task is terminating;

4. modify the task to signal events such as "task goroutine started"
and "task goroutine stopped" using channels, which helps to write
much more correct tests;

5. take advantage of the previous change to improve the test that
ensures we're not blocking for a small number of events and also
improve the name of such a test to reflect what it's testing.

The related issue in term of fixing the channel usage pattern is
https://github.com/ooni/probe/issues/1438.

Regarding improving testability, instead, the correct reference
issue is https://github.com/ooni/probe/issues/1903.

There are possibly more changes to apply here to improve this package
and its testability, but let's land this diff first and then see
how much time is left for further improvements.

I've run unit and integration tests with `-race` locally.

This diff will need to be backported to `release/3.11`.
