### PR TITLE
refactor: create common package for holding STUN input

### DIFF
--- a/internal/ptx/snowflake.go
+++ b/internal/ptx/snowflake.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	sflib "git.torproject.org/pluggable-transports/snowflake.git/client/lib"
+	"github.com/ooni/probe-cli/v3/internal/stuninput"
 )
 
 // SnowflakeDialer is a dialer for snowflake. When optional fields are
@@ -115,20 +116,7 @@ func (d *SnowflakeDialer) iceAddresses() []string {
 	if len(d.ICEAddresses) > 0 {
 		return d.ICEAddresses
 	}
-	return []string{
-		"stun:stun.voip.blackberry.com:3478",
-		"stun:stun.altar.com.pl:3478",
-		"stun:stun.antisip.com:3478",
-		"stun:stun.bluesip.net:3478",
-		"stun:stun.dus.net:3478",
-		"stun:stun.epygi.com:3478",
-		"stun:stun.sonetel.com:3478",
-		"stun:stun.sonetel.net:3478",
-		"stun:stun.stunprotocol.org:3478",
-		"stun:stun.uls.co.za:3478",
-		"stun:stun.voipgate.com:3478",
-		"stun:stun.voys.nl:3478",
-	}
+	return stuninput.AsSnowflakeInput()
 }
 
 // maxSnowflakes returns the number of snowflakes to collect.

--- a/internal/stuninput/stuninput.go
+++ b/internal/stuninput/stuninput.go
@@ -1,0 +1,44 @@
+// Package stuninput contains stun targets as well as
+// code to format such targets according to various conventions.
+package stuninput
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// TODO(bassosimone): we need to keep this list in sync with
+// the list internally used by TPO's snowflake.
+var inputs = []string{
+	"stun.voip.blackberry.com:3478",
+	"stun.altar.com.pl:3478",
+	"stun.antisip.com:3478",
+	"stun.bluesip.net:3478",
+	"stun.dus.net:3478",
+	"stun.epygi.com:3478",
+	"stun.sonetel.com:3478",
+	"stun.sonetel.net:3478",
+	"stun.stunprotocol.org:3478",
+	"stun.uls.co.za:3478",
+	"stun.voipgate.com:3478",
+	"stun.voys.nl:3478",
+}
+
+// AsSnowflakeInput formats the input in the format
+// that is expected by snowflake.
+func AsSnowflakeInput() (output []string) {
+	for _, input := range inputs {
+		output = append(output, fmt.Sprintf("stun:%s", input))
+	}
+	return
+}
+
+// AsnStunReachabilityInput formats the input in
+// the format that is expected by stunreachability.
+func AsnStunReachabilityInput() (output []string) {
+	for _, input := range inputs {
+		serio := (&url.URL{Scheme: "stun", Host: input})
+		output = append(output, serio.String())
+	}
+	return
+}

--- a/internal/stuninput/stuninput_test.go
+++ b/internal/stuninput/stuninput_test.go
@@ -1,0 +1,31 @@
+package stuninput
+
+import "testing"
+
+func TestAsSnowflakeInput(t *testing.T) {
+	outputs := AsSnowflakeInput()
+	if len(outputs) != len(inputs) {
+		t.Fatal("unexpected number of entries")
+	}
+	for idx := 0; idx < len(inputs); idx++ {
+		output := outputs[idx]
+		input := "stun:" + inputs[idx]
+		if input != output {
+			t.Fatal("mismatch")
+		}
+	}
+}
+
+func TestAsStunReachabilityInput(t *testing.T) {
+	outputs := AsnStunReachabilityInput()
+	if len(outputs) != len(inputs) {
+		t.Fatal("unexpected number of entries")
+	}
+	for idx := 0; idx < len(inputs); idx++ {
+		output := outputs[idx]
+		input := "stun://" + inputs[idx]
+		if input != output {
+			t.Fatal("mismatch")
+		}
+	}
+}


### PR DESCRIPTION
We want stunreachability to use the same STUN servers used by
snowflake, so let's start by making a common package holding the
servers. Let's also use this new package in Snowflake.

We're currently not using this package in stunreachability, but
I am going to apply this as a subsequent diff.

Reference issue: https://github.com/ooni/probe/issues/1814. This
issue is a bit complex to address in a single PR, so we are going
to proceed incremntally.

This diff was extracted from https://github.com/ooni/probe-cli/pull/539.

