### PR TITLE
refactor: introduce and use InputOrStaticDefault

### DIFF
--- a/internal/cmd/miniooni/libminiooni.go
+++ b/internal/cmd/miniooni/libminiooni.go
@@ -416,10 +416,11 @@ func MainWithConfiguration(experimentName string, currentOptions Options) {
 			OnWiFi:   true, // meaning: not on 4G
 			Charging: true,
 		},
-		InputPolicy:  builder.InputPolicy(),
-		StaticInputs: currentOptions.Inputs,
-		SourceFiles:  currentOptions.InputFilePaths,
-		Session:      sess,
+		ExperimentName: experimentName,
+		InputPolicy:    builder.InputPolicy(),
+		StaticInputs:   currentOptions.Inputs,
+		SourceFiles:    currentOptions.InputFilePaths,
+		Session:        sess,
 	}
 	inputs, err := inputLoader.Load(context.Background())
 	fatalOnError(err, "cannot load inputs")

--- a/internal/engine/allexperiments.go
+++ b/internal/engine/allexperiments.go
@@ -49,7 +49,7 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 				))
 			},
 			config:      &dnscheck.Config{},
-			inputPolicy: InputStrictlyRequired,
+			inputPolicy: InputOrStaticDefault,
 		}
 	},
 
@@ -198,7 +198,7 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 				))
 			},
 			config:      &stunreachability.Config{},
-			inputPolicy: InputStrictlyRequired,
+			inputPolicy: InputOrStaticDefault,
 		}
 	},
 

--- a/internal/engine/experimentbuilder.go
+++ b/internal/engine/experimentbuilder.go
@@ -36,6 +36,11 @@ const (
 	// InputNone indicates that the experiment does not want any
 	// input and ignores the input if provided with it.
 	InputNone = InputPolicy("none")
+
+	// We gather input from StaticInput and SourceFiles. If there is
+	// input, we return it. Otherwise, we return an internal static
+	// list of inputs to be used with this experiment.
+	InputOrStaticDefault = InputPolicy("or_static_default")
 )
 
 // ExperimentBuilder is an experiment builder.
@@ -183,10 +188,18 @@ func (b *ExperimentBuilder) NewExperiment() *Experiment {
 
 // canonicalizeExperimentName allows code to provide experiment names
 // in a more flexible way, where we have aliases.
+//
+// Because we allow for uppercase experiment names for backwards
+// compatibility with MK, we need to add some exceptions here when
+// mapping (e.g., DNSCheck => dnscheck).
 func canonicalizeExperimentName(name string) string {
 	switch name = strcase.ToSnake(name); name {
 	case "ndt_7":
 		name = "ndt" // since 2020-03-18, we use ndt7 to implement ndt by default
+	case "dns_check":
+		name = "dnscheck"
+	case "stun_reachability":
+		name = "stunreachability"
 	default:
 	}
 	return name


### PR DESCRIPTION
This commit introduces a new `InputLoader` policy by which, if no
input is provided, we use a static default input list.

We also modify the code to use this policy for dnscheck and
stunreachability, with proper input.

We also modify `miniooni` to pass the new `ExperimentName` field to
the `InputLoader` to indicate which default input list to use.

This diff is part of a set of diffs aiming at fixing
https://github.com/ooni/probe/issues/1814 and has been
extracted from https://github.com/ooni/probe-cli/pull/539.

What remains to be done, after this diff has landed is to ensure
things also work for ooniprobe and oonimkall.
