### PR TITLE
🐛 template.podspec: the suffix is xcframework

### DIFF
--- a/MOBILE/ios/template.podspec
+++ b/MOBILE/ios/template.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage = "https://github.com/ooni/probe-cli"
   s.license = { :type => "BSD" }
   s.source = {
-    :http => "https://github.com/ooni/probe-cli/releases/download/@RELEASE@/oonimkall.framework.zip"
+    :http => "https://github.com/ooni/probe-cli/releases/download/@RELEASE@/oonimkall.xcframework.zip"
   }
   s.platform = :ios, "9.0"
   s.ios.vendored_frameworks = "oonimkall.framework"


### PR DESCRIPTION
The template was still wrong and was referencing a .framework
while now we generate a .xcframework.

See, e.g., this failed build: https://github.com/ooni/probe-ios/runs/4444313406?check_suite_focus=true

Part of https://github.com/ooni/probe/issues/1843
