### PR TITLE
cleanup: remove redundant HTTPClient definition

### DIFF
--- a/internal/engine/experiment/webstepsx/measurer.go
+++ b/internal/engine/experiment/webstepsx/measurer.go
@@ -152,7 +152,7 @@ func (mx *Measurer) runAsync(ctx context.Context, sess model.ExperimentSession,
 // URL measurement flow implemented by measurex.
 type measurerMeasureURLHelper struct {
 	// Clnt is the MANDATORY client to use
-	Clnt measurex.HTTPClient
+	Clnt model.HTTPClient
 
 	// Logger is the MANDATORY Logger to use
 	Logger model.Logger

--- a/internal/engine/experiment/webstepsx/th.go
+++ b/internal/engine/experiment/webstepsx/th.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/ooni/probe-cli/v3/internal/measurex"
+	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 	"github.com/ooni/probe-cli/v3/internal/version"
@@ -59,7 +60,7 @@ type THClient struct {
 
 	// HTTPClient is the MANDATORY HTTP client to
 	// use for contacting the TH.
-	HTTPClient measurex.HTTPClient
+	HTTPClient model.HTTPClient
 
 	// ServerURL is the MANDATORY URL of the TH HTTP endpoint.
 	ServerURL string
@@ -112,7 +113,7 @@ type THClientCall struct {
 
 	// HTTPClient is the MANDATORY HTTP client to
 	// use for contacting the TH.
-	HTTPClient measurex.HTTPClient
+	HTTPClient model.HTTPClient
 
 	// Header contains the MANDATORY request headers.
 	Header http.Header

--- a/internal/measurex/http.go
+++ b/internal/measurex/http.go
@@ -193,25 +193,17 @@ type httpTransportBody struct {
 	io.Closer
 }
 
-// HTTPClient is the HTTP client type we use. This interface is
-// compatible with http.Client. What changes in this kind of clients
-// is that we'll insert redirection events into the WritableDB.
-type HTTPClient interface {
-	Do(req *http.Request) (*http.Response, error)
-	CloseIdleConnections()
-}
-
 // NewHTTPClient creates a new HTTPClient instance that
 // does not automatically perform redirects.
 func NewHTTPClientWithoutRedirects(
-	db WritableDB, jar http.CookieJar, txp model.HTTPTransport) HTTPClient {
+	db WritableDB, jar http.CookieJar, txp model.HTTPTransport) model.HTTPClient {
 	return newHTTPClient(db, jar, txp, http.ErrUseLastResponse)
 }
 
 // NewHTTPClientWithRedirects creates a new HTTPClient
 // instance that automatically perform redirects.
 func NewHTTPClientWithRedirects(
-	db WritableDB, jar http.CookieJar, txp model.HTTPTransport) HTTPClient {
+	db WritableDB, jar http.CookieJar, txp model.HTTPTransport) model.HTTPClient {
 	return newHTTPClient(db, jar, txp, nil)
 }
 
@@ -241,7 +233,7 @@ type HTTPRedirectEvent struct {
 var ErrHTTPTooManyRedirects = errors.New("stopped after 10 redirects")
 
 func newHTTPClient(db WritableDB, cookiejar http.CookieJar,
-	txp model.HTTPTransport, defaultErr error) HTTPClient {
+	txp model.HTTPTransport, defaultErr error) model.HTTPClient {
 	return netxlite.WrapHTTPClient(&http.Client{
 		Transport: txp,
 		Jar:       cookiejar,

--- a/internal/measurex/measurer.go
+++ b/internal/measurex/measurer.go
@@ -32,7 +32,7 @@ type Measurer struct {
 	Begin time.Time
 
 	// HTTPClient is the MANDATORY HTTP client for the WCTH.
-	HTTPClient HTTPClient
+	HTTPClient model.HTTPClient
 
 	// Logger is the MANDATORY logger to use.
 	Logger model.Logger
@@ -496,7 +496,7 @@ func (mx *Measurer) httpEndpointGetQUIC(ctx context.Context,
 }
 
 func (mx *Measurer) HTTPClientGET(
-	ctx context.Context, clnt HTTPClient, URL *url.URL) (*http.Response, error) {
+	ctx context.Context, clnt model.HTTPClient, URL *url.URL) (*http.Response, error) {
 	return mx.httpClientDo(ctx, clnt, &HTTPEndpoint{
 		Domain:  URL.Hostname(),
 		Network: "tcp",
@@ -509,7 +509,7 @@ func (mx *Measurer) HTTPClientGET(
 }
 
 func (mx *Measurer) httpClientDo(ctx context.Context,
-	clnt HTTPClient, epnt *HTTPEndpoint) (*http.Response, error) {
+	clnt model.HTTPClient, epnt *HTTPEndpoint) (*http.Response, error) {
 	req, err := NewHTTPGetRequest(ctx, epnt.URL.String())
 	if err != nil {
 		return nil, err

--- a/internal/mlablocate/mlablocate.go
+++ b/internal/mlablocate/mlablocate.go
@@ -16,18 +16,12 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
-// HTTPClient is anything that looks like an http.Client.
-type HTTPClient interface {
-	// Do behaves like http.Client.Do.
-	Do(req *http.Request) (*http.Response, error)
-}
-
 // Client is a locate.measurementlab.net client. Please use the
 // NewClient factory to construct a new instance of client, otherwise
 // you MUST fill all the fields marked as MANDATORY.
 type Client struct {
 	// HTTPClient is the MANDATORY http client to use.
-	HTTPClient HTTPClient
+	HTTPClient model.HTTPClient
 
 	// Hostname is the MANDATORY hostname of the mlablocate API.
 	Hostname string
@@ -43,7 +37,7 @@ type Client struct {
 }
 
 // NewClient creates a new locate.measurementlab.net client.
-func NewClient(httpClient HTTPClient, logger model.DebugLogger, userAgent string) *Client {
+func NewClient(httpClient model.HTTPClient, logger model.DebugLogger, userAgent string) *Client {
 	return &Client{
 		HTTPClient: httpClient,
 		Hostname:   "locate.measurementlab.net",

--- a/internal/mlablocatev2/mlablocatev2.go
+++ b/internal/mlablocatev2/mlablocatev2.go
@@ -29,18 +29,12 @@ var (
 	ErrEmptyResponse = errors.New("mlablocatev2: empty response")
 )
 
-// HTTPClient is anything that looks like an http.Client.
-type HTTPClient interface {
-	// Do behaves like http.Client.Do.
-	Do(req *http.Request) (*http.Response, error)
-}
-
 // Client is a client for v2 of the locate services. Please use the
 // NewClient factory to construct a new instance of client, otherwise
 // you MUST fill all the fields marked as MANDATORY.
 type Client struct {
 	// HTTPClient is the MANDATORY http client to use
-	HTTPClient HTTPClient
+	HTTPClient model.HTTPClient
 
 	// Hostname is the MANDATORY hostname of the mlablocate API.
 	Hostname string
@@ -56,7 +50,7 @@ type Client struct {
 }
 
 // NewClient creates a client for v2 of the locate services.
-func NewClient(httpClient HTTPClient, logger model.DebugLogger, userAgent string) Client {
+func NewClient(httpClient model.HTTPClient, logger model.DebugLogger, userAgent string) Client {
 	return Client{
 		HTTPClient: httpClient,
 		Hostname:   "locate.measurementlab.net",

--- a/internal/ooapi/dependencies.go
+++ b/internal/ooapi/dependencies.go
@@ -40,10 +40,7 @@ type templateExecutor interface {
 // http.DefaultClient as the default HTTPClient used by Client.
 // Consumers of this package typically provide a custom HTTPClient
 // with additional functionality (e.g., DoH, circumvention).
-type HTTPClient interface {
-	// Do should work like http.Client.Do.
-	Do(req *http.Request) (*http.Response, error)
-}
+type HTTPClient = model.HTTPClient
 
 // GobCodec is a Gob encoder and decoder. Generally, we use a
 // default GobCodec in Client. This is the interface to implement

--- a/internal/ooapi/fake_test.go
+++ b/internal/ooapi/fake_test.go
@@ -41,6 +41,8 @@ func (c *FakeHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	return c.Resp, nil
 }
 
+func (c *FakeHTTPClient) CloseIdleConnections() {}
+
 type FakeBody struct {
 	Data []byte
 	Err  error

--- a/internal/ooapi/httpclient_test.go
+++ b/internal/ooapi/httpclient_test.go
@@ -19,3 +19,5 @@ func (c *VerboseHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	c.T.Logf("< %d", resp.StatusCode)
 	return resp, nil
 }
+
+func (c *VerboseHTTPClient) CloseIdleConnections() {}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1885
- [x] related ooni/spec pull request: N/A

Location of the issue tracker: https://github.com/ooni/probe

## Description

This counts as a follow-up cleanup as part of doing
https://github.com/ooni/probe/issues/1885.
