### PR TITLE
feat(httpx): implement optional body logging also on http error

### DIFF
--- a/internal/engine/experiment/webconnectivity/control.go
+++ b/internal/engine/experiment/webconnectivity/control.go
@@ -62,7 +62,7 @@ func Control(
 	sess.Logger().Infof("control for %s...", creq.HTTPRequest)
 	// make sure error is wrapped
 	err = legacyerrorsx.SafeErrWrapperBuilder{
-		Error:     clnt.Build().PostJSON(ctx, "/", creq, &out),
+		Error:     clnt.WithBodyLogging().Build().PostJSON(ctx, "/", creq, &out),
 		Operation: netxlite.TopLevelOperation,
 	}.MaybeBuild()
 	sess.Logger().Infof("control for %s... %+v", creq.HTTPRequest, err)

--- a/internal/engine/experiment/websteps/control.go
+++ b/internal/engine/experiment/websteps/control.go
@@ -20,7 +20,7 @@ func Control(
 	}
 	// make sure error is wrapped
 	err = errorsxlegacy.SafeErrWrapperBuilder{
-		Error:     clnt.Build().PostJSON(ctx, resourcePath, creq, &out),
+		Error:     clnt.WithBodyLogging().Build().PostJSON(ctx, resourcePath, creq, &out),
 		Operation: netxlite.TopLevelOperation,
 	}.MaybeBuild()
 	return

--- a/internal/engine/geolocate/avast.go
+++ b/internal/engine/geolocate/avast.go
@@ -24,7 +24,7 @@ func avastIPLookup(
 		HTTPClient: httpClient,
 		Logger:     logger,
 		UserAgent:  userAgent,
-	}).Build().GetJSON(ctx, "/v1/info", &v)
+	}).WithBodyLogging().Build().GetJSON(ctx, "/v1/info", &v)
 	if err != nil {
 		return DefaultProbeIP, err
 	}

--- a/internal/engine/geolocate/ipconfig.go
+++ b/internal/engine/geolocate/ipconfig.go
@@ -21,7 +21,7 @@ func ipConfigIPLookup(
 		HTTPClient: httpClient,
 		Logger:     logger,
 		UserAgent:  httpheader.CLIUserAgent(),
-	}).Build().FetchResource(ctx, "/")
+	}).WithBodyLogging().Build().FetchResource(ctx, "/")
 	if err != nil {
 		return DefaultProbeIP, err
 	}

--- a/internal/engine/geolocate/ipinfo.go
+++ b/internal/engine/geolocate/ipinfo.go
@@ -26,7 +26,7 @@ func ipInfoIPLookup(
 		HTTPClient: httpClient,
 		Logger:     logger,
 		UserAgent:  httpheader.CLIUserAgent(), // we must be a CLI client
-	}).Build().GetJSON(ctx, "/", &v)
+	}).WithBodyLogging().Build().GetJSON(ctx, "/", &v)
 	if err != nil {
 		return DefaultProbeIP, err
 	}

--- a/internal/engine/geolocate/ubuntu.go
+++ b/internal/engine/geolocate/ubuntu.go
@@ -25,7 +25,7 @@ func ubuntuIPLookup(
 		HTTPClient: httpClient,
 		Logger:     logger,
 		UserAgent:  userAgent,
-	}).Build().FetchResource(ctx, "/lookup")
+	}).WithBodyLogging().Build().FetchResource(ctx, "/lookup")
 	if err != nil {
 		return DefaultProbeIP, err
 	}

--- a/internal/engine/probeservices/bouncer.go
+++ b/internal/engine/probeservices/bouncer.go
@@ -9,6 +9,6 @@ import (
 // GetTestHelpers is like GetCollectors but for test helpers.
 func (c Client) GetTestHelpers(
 	ctx context.Context) (output map[string][]model.OOAPIService, err error) {
-	err = c.APIClientTemplate.Build().GetJSON(ctx, "/api/v1/test-helpers", &output)
+	err = c.APIClientTemplate.WithBodyLogging().Build().GetJSON(ctx, "/api/v1/test-helpers", &output)
 	return
 }

--- a/internal/engine/probeservices/checkreportid.go
+++ b/internal/engine/probeservices/checkreportid.go
@@ -21,7 +21,7 @@ func (c Client) CheckReportID(ctx context.Context, reportID string) (bool, error
 		HTTPClient: c.HTTPClient,
 		Logger:     c.Logger,
 		UserAgent:  c.UserAgent,
-	}).Build().GetJSONWithQuery(ctx, "/api/_/check_report_id", query, &response)
+	}).WithBodyLogging().Build().GetJSONWithQuery(ctx, "/api/_/check_report_id", query, &response)
 	if err != nil {
 		return false, err
 	}

--- a/internal/engine/probeservices/collector.go
+++ b/internal/engine/probeservices/collector.go
@@ -105,7 +105,7 @@ func (c Client) OpenReport(ctx context.Context, rt ReportTemplate) (ReportChanne
 		return nil, ErrUnsupportedFormat
 	}
 	var cor collectorOpenResponse
-	if err := c.APIClientTemplate.Build().PostJSON(ctx, "/report", rt, &cor); err != nil {
+	if err := c.APIClientTemplate.WithBodyLogging().Build().PostJSON(ctx, "/report", rt, &cor); err != nil {
 		return nil, err
 	}
 	for _, format := range cor.SupportedFormats {
@@ -144,7 +144,7 @@ func (r reportChan) CanSubmit(m *model.Measurement) bool {
 func (r reportChan) SubmitMeasurement(ctx context.Context, m *model.Measurement) error {
 	var updateResponse collectorUpdateResponse
 	m.ReportID = r.ID
-	err := r.client.APIClientTemplate.Build().PostJSON(
+	err := r.client.APIClientTemplate.WithBodyLogging().Build().PostJSON(
 		ctx, fmt.Sprintf("/report/%s", r.ID), collectorUpdateRequest{
 			Format:  "json",
 			Content: m,

--- a/internal/engine/probeservices/measurementmeta.go
+++ b/internal/engine/probeservices/measurementmeta.go
@@ -59,7 +59,7 @@ func (c Client) GetMeasurementMeta(
 		HTTPClient: c.HTTPClient,
 		Logger:     c.Logger,
 		UserAgent:  c.UserAgent,
-	}).Build().GetJSONWithQuery(ctx, "/api/v1/measurement_meta", query, &response)
+	}).WithBodyLogging().Build().GetJSONWithQuery(ctx, "/api/v1/measurement_meta", query, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/probeservices/urls.go
+++ b/internal/engine/probeservices/urls.go
@@ -28,7 +28,7 @@ func (c Client) FetchURLList(ctx context.Context, config model.OOAPIURLListConfi
 		query.Set("category_codes", strings.Join(config.Categories, ","))
 	}
 	var response urlListResult
-	err := c.APIClientTemplate.Build().GetJSONWithQuery(ctx,
+	err := c.APIClientTemplate.WithBodyLogging().Build().GetJSONWithQuery(ctx,
 		"/api/v1/test-list/urls", query, &response)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
1. we want optionally to log the body (we don't want to log the body
when we're fetching psiphon secrets or tor targets)

2. we want body logging to _also_ happen on error since this is quite
useful to debug possible errors when accessing the API

This diff adds the above functionality, which were previously
described in https://github.com/ooni/probe/issues/1951.

This diff also adds comprehensive testing.
