### PR TITLE
Refactor the list measurements function to make use of nested queries

### DIFF
--- a/cmd/ooniprobe/internal/cli/list/list.go
+++ b/cmd/ooniprobe/internal/cli/list/list.go
@@ -98,7 +98,13 @@ func init() {
 
 				// We only care to expose in the testKeys the value of the ndt test result
 				if result.TestGroupName == "performance" {
+					// The test_keys column are concanetated with the "|" character as a separator.
+					// We consider this to be safe since we only really care about values of the
+					// performance test_keys where the values are all numbers and none of the keys
+					// contain the "|" character.
 					for _, e := range strings.Split(result.TestKeys, "|") {
+						// We use the presence of the "download" key to indicate we have found the
+						// ndt test_keys, since the dash result does not contain it.
 						if strings.Contains(e, "download") {
 							testKeys = e
 						}

--- a/cmd/ooniprobe/internal/database/actions.go
+++ b/cmd/ooniprobe/internal/database/actions.go
@@ -128,6 +128,10 @@ func ListResults(sess sqlbuilder.Database) ([]ResultNetwork, []ResultNetwork, er
 
 		db.Raw("COUNT(CASE WHEN measurements.is_anomaly = TRUE THEN 1 END) as anomaly_count"),
 		db.Raw("COUNT() as total_count"),
+		// The test_keys column are concanetated with the "|" character as a separator.
+		// We consider this to be safe since we only really care about values of the
+		// performance test_keys where the values are all numbers and none of the keys
+		// contain the "|" character.
 		db.Raw("group_concat(test_keys, '|') as test_keys"),
 	).From("results").
 		Join("networks").On("results.network_id = networks.network_id").

--- a/cmd/ooniprobe/internal/database/actions_test.go
+++ b/cmd/ooniprobe/internal/database/actions_test.go
@@ -87,6 +87,7 @@ func TestMeasurementWorkflow(t *testing.T) {
 		t.Fatal(err)
 	}
 	m1.IsUploaded = true
+	m1.IsAnomaly = sql.NullBool{Valid: true, Bool: false}
 	err = sess.Collection("measurements").Find("measurement_id", m1.ID).Update(m1)
 	if err != nil {
 		t.Fatal(err)
@@ -97,6 +98,7 @@ func TestMeasurementWorkflow(t *testing.T) {
 		t.Fatal(err)
 	}
 	m2.IsUploaded = false
+	m2.IsAnomaly = sql.NullBool{Valid: true, Bool: true}
 	err = sess.Collection("measurements").Find("measurement_id", m2.ID).Update(m2)
 	if err != nil {
 		t.Fatal(err)
@@ -134,6 +136,9 @@ func TestMeasurementWorkflow(t *testing.T) {
 
 	if done[0].TotalCount != 2 {
 		t.Error("there should be a total of 2 measurements in the result")
+	}
+	if done[0].AnomalyCount != 1 {
+		t.Error("there should be a total of 1 anomalies in the result")
 	}
 
 	msmts, err := ListMeasurements(sess, resultID)

--- a/cmd/ooniprobe/internal/database/actions_test.go
+++ b/cmd/ooniprobe/internal/database/actions_test.go
@@ -92,8 +92,7 @@ func TestMeasurementWorkflow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var m2 Measurement
-	err = sess.Collection("measurements").Find("measurement_id", m1.ID).One(&m2)
+	m2, err := CreateMeasurement(sess, reportID, testName, msmtFilePath, 0, resultID, urlID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,6 +109,7 @@ func TestMeasurementWorkflow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	result.Finished(sess)
 
 	var r Result
 	err = sess.Collection("measurements").Find("result_id", result.ID).One(&r)
@@ -125,11 +125,15 @@ func TestMeasurementWorkflow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(incomplete) != 1 {
-		t.Error("there should be 1 incomplete measurement")
+	if len(incomplete) != 0 {
+		t.Error("there should be 0 incomplete result")
 	}
-	if len(done) != 0 {
-		t.Error("there should be 0 done measurements")
+	if len(done) != 1 {
+		t.Error("there should be 1 done result")
+	}
+
+	if done[0].TotalCount != 2 {
+		t.Error("there should be a total of 2 measurements in the result")
 	}
 
 	msmts, err := ListMeasurements(sess, resultID)

--- a/cmd/ooniprobe/internal/database/models.go
+++ b/cmd/ooniprobe/internal/database/models.go
@@ -11,8 +11,11 @@ import (
 // ResultNetwork is used to represent the structure made from the JOIN
 // between the results and networks tables.
 type ResultNetwork struct {
-	Result  `db:",inline"`
-	Network `db:",inline"`
+	Result       `db:",inline"`
+	Network      `db:",inline"`
+	AnomalyCount uint64 `db:"anomaly_count"`
+	TotalCount   uint64 `db:"total_count"`
+	TestKeys     string `db:"test_keys"`
 }
 
 // UploadedTotalCount is the count of the measurements which have been uploaded vs the total measurements in a given result set


### PR DESCRIPTION
With a dataset of 1489 test, the ooniprobe list command went from
taking 17.27s to run, to requiring 0.17s or a 100x speed boost

This fixes: https://github.com/ooni/probe/issues/1966