### PR TITLE
feat(snowflake): upgrade to v2 (+ small tweaks)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	filippo.io/age v1.0.0
 	git.torproject.org/pluggable-transports/goptlib.git v1.2.0
-	git.torproject.org/pluggable-transports/snowflake.git v1.1.0
+	git.torproject.org/pluggable-transports/snowflake.git/v2 v2.0.1
 	github.com/alecthomas/kingpin v2.2.6+incompatible
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/apex/log v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ git.torproject.org/pluggable-transports/goptlib.git v1.0.0/go.mod h1:YT4XMSkuEXb
 git.torproject.org/pluggable-transports/goptlib.git v1.1.0/go.mod h1:YT4XMSkuEXbtqlydr9+OxqFAyspUv0Gr9qhM3B++o/Q=
 git.torproject.org/pluggable-transports/goptlib.git v1.2.0 h1:0qRF7Dw5qXd0FtZkjWUiAh5GTutRtDGL4GXUDJ4qMHs=
 git.torproject.org/pluggable-transports/goptlib.git v1.2.0/go.mod h1:4PBMl1dg7/3vMWSoWb46eGWlrxkUyn/CAJmxhDLAlDs=
-git.torproject.org/pluggable-transports/snowflake.git v1.1.0 h1:rl/LloEeBG1sqdZdVxdW1Gmb/c3ZjdvT5o3RV8iaDg4=
-git.torproject.org/pluggable-transports/snowflake.git v1.1.0/go.mod h1:+a2yI6dfEjwEnqPgXTtKobeHDEdgJa3ANZN4bjSQk+M=
+git.torproject.org/pluggable-transports/snowflake.git/v2 v2.0.1 h1:0hivepCHxfUr+GBypo9G2hJvKuYnOxNnm7/yPHoKuo4=
+git.torproject.org/pluggable-transports/snowflake.git/v2 v2.0.1/go.mod h1:Ja4gwzbs3jyXCx6PQMM6Vigj09gOl9ox7A3lHi1s+2I=
 github.com/AlecAivazis/survey/v2 v2.0.5/go.mod h1:WYBhg6f0y/fNYUuesWQc0PKbJcEliGcYHB9sNT3Bg74=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -679,6 +679,7 @@ gitlab.com/yawning/obfs4.git v0.0.0-20220102012252-cbf3f3cfa09c/go.mod h1:M/ySGu
 gitlab.com/yawning/utls.git v0.0.11-1/go.mod h1:eYdrOOCoedNc3xw50kJ/s8JquyxeS5kr3vkFZFPTI9w=
 gitlab.com/yawning/utls.git v0.0.12-1 h1:RL6O0MP2YI0KghuEU/uGN6+8b4183eqNWoYgx7CXD0U=
 gitlab.com/yawning/utls.git v0.0.12-1/go.mod h1:3ONKiSFR9Im/c3t5RKmMJTVdmZN496FNyk3mjrY1dyo=
+gitlab.torproject.org/tpo/anti-censorship/geoip v0.0.0-20210928150955-7ce4b3d98d01/go.mod h1:K3LOI4H8fa6j+7E10ViHeGEQV10304FG4j94ypmKLjY=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=

--- a/internal/engine/experiment/torsf/torsf.go
+++ b/internal/engine/experiment/torsf/torsf.go
@@ -89,11 +89,10 @@ func (m *Measurer) Run(
 			callbacks.OnProgress(1.0, "torsf experiment is finished")
 			return err
 		case <-ticker.C:
-			if m.config.DisableProgress {
-				continue
+			if !m.config.DisableProgress {
+				progress := time.Since(start).Seconds() / maxRuntime.Seconds()
+				callbacks.OnProgress(progress, "torsf experiment is running")
 			}
-			progress := time.Since(start).Seconds() / maxRuntime.Seconds()
-			callbacks.OnProgress(progress, "torsf experiment is running")
 		}
 	}
 }

--- a/internal/engine/experiment/torsf/torsf.go
+++ b/internal/engine/experiment/torsf/torsf.go
@@ -16,10 +16,12 @@ import (
 )
 
 // testVersion is the tor experiment version.
-const testVersion = "0.1.0"
+const testVersion = "0.1.1"
 
 // Config contains the experiment config.
-type Config struct{}
+type Config struct {
+	DisableProgress bool `ooni:"Disable printing progress messages"`
+}
 
 // TestKeys contains the experiment's result.
 type TestKeys struct {
@@ -74,7 +76,7 @@ func (m *Measurer) Run(
 	testkeys := &TestKeys{}
 	measurement.TestKeys = testkeys
 	start := time.Now()
-	const maxRuntime = 300 * time.Second
+	const maxRuntime = 600 * time.Second
 	ctx, cancel := context.WithTimeout(ctx, maxRuntime)
 	defer cancel()
 	errch := make(chan error)
@@ -87,6 +89,9 @@ func (m *Measurer) Run(
 			callbacks.OnProgress(1.0, "torsf experiment is finished")
 			return err
 		case <-ticker.C:
+			if m.config.DisableProgress {
+				continue
+			}
 			progress := time.Since(start).Seconds() / maxRuntime.Seconds()
 			callbacks.OnProgress(progress, "torsf experiment is running")
 		}

--- a/internal/engine/experiment/torsf/torsf_test.go
+++ b/internal/engine/experiment/torsf/torsf_test.go
@@ -18,7 +18,7 @@ func TestExperimentNameAndVersion(t *testing.T) {
 	if m.ExperimentName() != "torsf" {
 		t.Fatal("invalid experiment name")
 	}
-	if m.ExperimentVersion() != "0.1.0" {
+	if m.ExperimentVersion() != "0.1.1" {
 		t.Fatal("invalid experiment version")
 	}
 }

--- a/internal/ptx/ptx.go
+++ b/internal/ptx/ptx.go
@@ -39,6 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -184,7 +185,9 @@ func (lst *Listener) acceptLoop(ctx context.Context, ln ptxSocksListener) {
 			if err, ok := err.(net.Error); ok && err.Temporary() {
 				continue
 			}
-			lst.logger().Warnf("ptx: socks accept error: %s", err)
+			if !errors.Is(err, net.ErrClosed) {
+				lst.logger().Warnf("ptx: socks accept error: %s", err)
+			}
 			return
 		}
 		go lst.handleSocksConn(ctx, conn)

--- a/internal/ptx/snowflake.go
+++ b/internal/ptx/snowflake.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net"
 
-	sflib "git.torproject.org/pluggable-transports/snowflake.git/client/lib"
+	sflib "git.torproject.org/pluggable-transports/snowflake.git/v2/client/lib"
 	"github.com/ooni/probe-cli/v3/internal/stuninput"
 )
 
@@ -90,9 +90,15 @@ func (d *SnowflakeDialer) newSnowflakeClient(brokerURL string, frontDomain strin
 		return d.newClientTransport(brokerURL, frontDomain, iceAddresses,
 			keepLocalAddresses, maxSnowflakes)
 	}
-	return sflib.NewSnowflakeClient(
-		brokerURL, frontDomain, iceAddresses,
-		keepLocalAddresses, maxSnowflakes)
+	// XXX: should we set the AMP cache URL here?
+	return sflib.NewSnowflakeClient(sflib.ClientConfig{
+		BrokerURL:          brokerURL,
+		AmpCacheURL:        "",
+		FrontDomain:        frontDomain,
+		ICEAddresses:       iceAddresses,
+		KeepLocalAddresses: keepLocalAddresses,
+		Max:                maxSnowflakes,
+	})
 }
 
 // brokerURL returns a suitable broker URL.


### PR DESCRIPTION
This diff contains the following changes and enhancements:

1. upgrade snowflake to v2

2. observe that we were not changing defaults from outside of snowflake.go, so remove code allowing to do that;

3. bump the timeout to 600 seconds (it seems 300 was not always enough based on my testing);

4. add useful knob to disable `torsf` progress (it's really annoying on console, we should do something about this);

5. ptx.go: avoid printing an error when the connection has just been closed;

6. snowflake: test AMP cache, see that it's not working currently, so leave it disabled.

Related issues: https://github.com/ooni/probe/issues/1845, https://github.com/ooni/probe/issues/1894, and https://github.com/ooni/probe/issues/1917.