### PR TITLE
feat(ooniprobe): add torsf to experimental group

### DIFF
--- a/cmd/ooniprobe/internal/nettests/groups.go
+++ b/cmd/ooniprobe/internal/nettests/groups.go
@@ -55,6 +55,7 @@ var All = map[string]Group{
 		Nettests: []Nettest{
 			DNSCheck{},
 			STUNReachability{},
+			TorSf{},
 		},
 	},
 }

--- a/cmd/ooniprobe/internal/nettests/torsf.go
+++ b/cmd/ooniprobe/internal/nettests/torsf.go
@@ -1,0 +1,14 @@
+package nettests
+
+// TorSf test implementation
+type TorSf struct {
+}
+
+// Run starts the test
+func (h TorSf) Run(ctl *Controller) error {
+	builder, err := ctl.Session.NewExperimentBuilder("torsf")
+	if err != nil {
+		return err
+	}
+	return ctl.Run(builder, []string{""})
+}

--- a/internal/engine/experiment/torsf/torsf.go
+++ b/internal/engine/experiment/torsf/torsf.go
@@ -173,5 +173,5 @@ type SummaryKeys struct {
 
 // GetSummaryKeys implements model.ExperimentMeasurer.GetSummaryKeys.
 func (m *Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
-	return &SummaryKeys{IsAnomaly: false}, nil
+	return SummaryKeys{IsAnomaly: false}, nil
 }

--- a/internal/engine/experiment/torsf/torsf_test.go
+++ b/internal/engine/experiment/torsf/torsf_test.go
@@ -160,7 +160,7 @@ func TestGetSummaryKeys(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rsk := sk.(*SummaryKeys)
+	rsk := sk.(SummaryKeys)
 	if rsk.IsAnomaly {
 		t.Fatal("expected no anomaly here")
 	}


### PR DESCRIPTION
Reference issue: https://github.com/ooni/probe/issues/1917.

I needed to change the summary key type returned by `torsf` to be a value. It seems the DB layer assumes that. If we pass it a pointer, it panics because it's experiment a value rather than a pointer 🤷.