### PR TITLE
feat: start adding torsf to desktop and mobile

### DIFF
--- a/internal/engine/experiment/torsf/torsf.go
+++ b/internal/engine/experiment/torsf/torsf.go
@@ -6,6 +6,7 @@ package torsf
 
 import (
 	"context"
+	"fmt"
 	"path"
 	"time"
 
@@ -80,7 +81,7 @@ func (m *Measurer) Run(
 	ctx, cancel := context.WithTimeout(ctx, maxRuntime)
 	defer cancel()
 	errch := make(chan error)
-	ticker := time.NewTicker(250 * time.Millisecond)
+	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
 	go m.run(ctx, sess, testkeys, errch)
 	for {
@@ -90,8 +91,11 @@ func (m *Measurer) Run(
 			return err
 		case <-ticker.C:
 			if !m.config.DisableProgress {
-				progress := time.Since(start).Seconds() / maxRuntime.Seconds()
-				callbacks.OnProgress(progress, "torsf experiment is running")
+				elapsedTime := time.Since(start)
+				progress := elapsedTime.Seconds() / maxRuntime.Seconds()
+				callbacks.OnProgress(progress, fmt.Sprintf(
+					"torsf: elapsedTime: %.0f s; maxRuntime: %.0f s",
+					elapsedTime.Seconds(), maxRuntime.Seconds()))
 			}
 		}
 	}


### PR DESCRIPTION
This commit message is the same across probe-cli, probe-desktop,
and probe-android. With the changes contained in the enclosed
diff, I'm starting to add support for torsf for android and for
desktop.

When smoke testing that torsf was WAI, I also noticed that its
progress messages in output are too frequent. We may want to do
better in a future version when we'll be able to read `tor`'s
output. In the meanwhile, make the progress messages less
frequent and indicated the maximum runtime inside of the messages
themselves. This improved message, albeit not so nice from the
UX PoV, should at least provide a clue that we're not stuck.

Reference issue: https://github.com/ooni/probe/issues/1917

