### PR TITLE
fix(i/t/tor.go): show correct command line

### DIFF
--- a/internal/tunnel/config.go
+++ b/internal/tunnel/config.go
@@ -35,7 +35,7 @@ type Config struct {
 
 	// Logger is the optional logger to use. If empty we use a default
 	// implementation that does not emit any output.
-	Logger model.InfoLogger
+	Logger model.Logger
 
 	// TorArgs contains the optional arguments that you want us to pass
 	// to the tor binary when invoking it. By default we do not
@@ -76,7 +76,7 @@ type Config struct {
 }
 
 // logger returns the logger to use.
-func (c *Config) logger() model.InfoLogger {
+func (c *Config) logger() model.Logger {
 	if c.Logger != nil {
 		return c.Logger
 	}

--- a/internal/tunnel/tor.go
+++ b/internal/tunnel/tor.go
@@ -72,7 +72,6 @@ func torStart(ctx context.Context, config *Config) (Tunnel, error) {
 	extraArgs = append(extraArgs, "notice stderr")
 	extraArgs = append(extraArgs, "Log")
 	extraArgs = append(extraArgs, fmt.Sprintf(`notice file %s`, logfile))
-	config.logger().Infof("tunnel: tor: exec params: %s %+v", stateDir, extraArgs)
 	torStartConf, err := getTorStartConf(config, stateDir, extraArgs)
 	if err != nil {
 		return nil, err

--- a/internal/tunnel/tordesktop.go
+++ b/internal/tunnel/tordesktop.go
@@ -4,16 +4,22 @@ package tunnel
 
 // This file implements our strategy for running tor on desktop.
 
-import "github.com/cretz/bine/tor"
+import (
+	"strings"
+
+	"github.com/cretz/bine/tor"
+)
 
 // getTorStartConf in this configuration uses torExePath to get a
 // suitable tor binary and then executes it.
 func getTorStartConf(config *Config, dataDir string, extraArgs []string) (*tor.StartConf, error) {
 	exePath, err := config.torBinary()
 	if err != nil {
+		config.logger().Warnf("cannot find tor binary: %s", err.Error())
 		return nil, err
 	}
-	config.logger().Infof("tunnel: tor: exec binary: %s", exePath)
+	config.logger().Infof("tunnel: tor: exec: %s %s %s", exePath,
+		dataDir, strings.Join(extraArgs, " "))
 	return &tor.StartConf{
 		ExePath:   exePath,
 		DataDir:   dataDir,

--- a/internal/tunnel/tormobile.go
+++ b/internal/tunnel/tormobile.go
@@ -5,13 +5,16 @@ package tunnel
 // This file implements our strategy for running tor on mobile.
 
 import (
+	"strings"
+
 	"github.com/cretz/bine/tor"
 	"github.com/ooni/go-libtor"
 )
 
 // getTorStartConf in this configuration uses github.com/ooni/go-libtor.
 func getTorStartConf(config *Config, dataDir string, extraArgs []string) (*tor.StartConf, error) {
-	config.logger().Info("tunnel: tor: using ooni/go-libtor")
+	config.logger().Infof("tunnel: tor: exec: <ooni/go-libtor> %s %s",
+		dataDir, strings.Join(extraArgs, " "))
 	return &tor.StartConf{
 		ProcessCreator: libtor.Creator,
 		DataDir:        dataDir,


### PR DESCRIPTION
While there, ensure that we print a warning if we cannot find
the correct tor binary.

Work part of https://github.com/ooni/probe/issues/1917.

