### PR TITLE
feat: add an experimental quicping experiment

### DIFF
--- a/internal/engine/allexperiments.go
+++ b/internal/engine/allexperiments.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/httphostheader"
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/ndt7"
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/psiphon"
+	"github.com/ooni/probe-cli/v3/internal/engine/experiment/quicping"
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/riseupvpn"
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/run"
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/signal"
@@ -139,6 +140,18 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 			},
 			config:      &psiphon.Config{},
 			inputPolicy: InputOptional,
+		}
+	},
+
+	"quicping": func(session *Session) *ExperimentBuilder {
+		return &ExperimentBuilder{
+			build: func(config interface{}) *Experiment {
+				return NewExperiment(session, quicping.NewExperimentMeasurer(
+					*config.(*quicping.Config),
+				))
+			},
+			config:      &quicping.Config{},
+			inputPolicy: InputStrictlyRequired,
 		}
 	},
 

--- a/internal/engine/experiment/quicping/crypto.go
+++ b/internal/engine/experiment/quicping/crypto.go
@@ -108,7 +108,7 @@ func encryptHeader(raw, hdr, clientSecret []byte) []byte {
 // https://www.rfc-editor.org/rfc/rfc9001.html#name-packet-protection
 //
 // encryptPayload encrypts the payload of the packet.
-func encryptPayload(payload, destConnID ConnectionID, clientSecret []byte) []byte {
+func encryptPayload(payload, destConnID connectionID, clientSecret []byte) []byte {
 	myKey, myIV := computeInitialKeyAndIV(clientSecret)
 	encrypter := aeadAESGCMTLS13(myKey, myIV)
 

--- a/internal/engine/experiment/quicping/crypto.go
+++ b/internal/engine/experiment/quicping/crypto.go
@@ -1,0 +1,167 @@
+package quicping
+
+import (
+	"crypto"
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/binary"
+	"fmt"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+// https://github.com/marten-seemann/qtls-go1-15/blob/0d137e9e3594d8e9c864519eff97b323321e5e74/cipher_suites.go#L281
+type aead interface {
+	cipher.AEAD
+
+	// explicitNonceLen returns the number of bytes of explicit nonce
+	// included in each record. This is eight for older AEADs and
+	// zero for modern ones.
+	explicitNonceLen() int
+}
+
+const (
+	aeadNonceLength   = 12
+	noncePrefixLength = 4
+)
+
+// https://github.com/marten-seemann/qtls-go1-15/blob/0d137e9e3594d8e9c864519eff97b323321e5e74/cipher_suites.go#L375
+func aeadAESGCMTLS13(key, nonceMask []byte) aead {
+	if len(nonceMask) != aeadNonceLength {
+		panic("tls: internal error: wrong nonce length")
+	}
+	aes, err := aes.NewCipher(key)
+	if err != nil {
+		panic(err)
+	}
+	aead, err := cipher.NewGCM(aes)
+	if err != nil {
+		panic(err)
+	}
+	ret := &xorNonceAEAD{aead: aead}
+	copy(ret.nonceMask[:], nonceMask)
+	return ret
+}
+
+// computeInitialKeyAndIV derives the packet protection key and Initialization Vector (IV)
+// from the initial secret.
+// https://www.rfc-editor.org/rfc/rfc9001.html#protection-keys
+func computeInitialKeyAndIV(secret []byte) (key, iv []byte) {
+	key = hkdfExpandLabel(crypto.SHA256, secret, []byte{}, "quic key", 16)
+	iv = hkdfExpandLabel(crypto.SHA256, secret, []byte{}, "quic iv", 12)
+	return
+}
+
+// computeHP derives the header protection key from the initial secret.
+// https://www.rfc-editor.org/rfc/rfc9001.html#protection-keys
+func computeHP(secret []byte) (hp []byte) {
+	hp = hkdfExpandLabel(crypto.SHA256, secret, []byte{}, "quic hp", 16)
+	return
+}
+
+// computeSecrets computes the initial secrets based on the destination connection ID.
+// https://www.rfc-editor.org/rfc/rfc9001.html#name-initial-secrets
+func computeSecrets(destConnID []byte) (clientSecret, serverSecret []byte) {
+	initialSalt := []byte{0x38, 0x76, 0x2c, 0xf7, 0xf5, 0x59, 0x34, 0xb3, 0x4d, 0x17, 0x9a, 0xe6, 0xa4, 0xc8, 0x0c, 0xad, 0xcc, 0xbb, 0x7f, 0x0a}
+	// initial_secret = HKDF-Extract(initial_salt,client_dst_connection_id)
+	initialSecret := hkdf.Extract(crypto.SHA256.New, destConnID, initialSalt)
+	// client_initial_secret = HKDF-Expand-Label(initial_secret, "client in", "", 32) = c00cf151ca5be075ed0ebfb5c80323c42d6b7db67881289af4008f1f6c357aea
+	clientSecret = hkdfExpandLabel(crypto.SHA256, initialSecret, []byte{}, "client in", crypto.SHA256.Size())
+	serverSecret = hkdfExpandLabel(crypto.SHA256, initialSecret, []byte{}, "server in", crypto.SHA256.Size())
+	return
+}
+
+// encryptHeader applies header protection to the packet bytes (raw).
+// https://www.rfc-editor.org/rfc/rfc9001.html#name-client-initial
+// https://www.rfc-editor.org/rfc/rfc9001.html#name-header-protection
+func encryptHeader(raw, hdr, clientSecret []byte) []byte {
+	hp := computeHP(clientSecret)
+	block, err := aes.NewCipher(hp)
+	if err != nil {
+		panic(fmt.Sprintf("error creating new AES cipher: %s", err))
+	}
+	hdroffset := 0
+	payloadOffset := len(hdr)
+	sample := raw[payloadOffset : payloadOffset+16]
+
+	mask := make([]byte, block.BlockSize())
+	if len(sample) != len(mask) {
+		panic("invalid sample size")
+	}
+	block.Encrypt(mask, sample)
+
+	pnOffset := len(hdr) - 4
+	pnBytes := raw[pnOffset:payloadOffset]
+	raw[hdroffset] ^= mask[0] & 0xf
+	for i := range pnBytes {
+		pnBytes[i] ^= mask[i+1]
+	}
+	return raw
+}
+
+// encryptPayload encrypts the payload of the packet.
+// https://www.rfc-editor.org/rfc/rfc9001.html#name-packet-protection
+func encryptPayload(payload, destConnID ConnectionID, clientSecret []byte) []byte {
+	myKey, myIV := computeInitialKeyAndIV(clientSecret)
+	encrypter := aeadAESGCMTLS13(myKey, myIV)
+
+	nonceBuf := make([]byte, encrypter.NonceSize())
+	var pn int64 = 2
+	binary.BigEndian.PutUint64(nonceBuf[len(nonceBuf)-8:], uint64(pn))
+
+	encrypted := encrypter.Seal(nil, nonceBuf, payload, nil)
+	return encrypted
+}
+
+// hkdfExpandLabel HKDF expands a label.
+// https://github.com/lucas-clemente/quic-go/blob/master/internal/handshake/hkdf.go
+func hkdfExpandLabel(hash crypto.Hash, secret, context []byte, label string, length int) []byte {
+	b := make([]byte, 3, 3+6+len(label)+1+len(context))
+	binary.BigEndian.PutUint16(b, uint16(length))
+	b[2] = uint8(6 + len(label))
+	b = append(b, []byte("tls13 ")...)
+	b = append(b, []byte(label)...)
+	b = b[:3+6+len(label)+1]
+	b[3+6+len(label)] = uint8(len(context))
+	b = append(b, context...)
+
+	out := make([]byte, length)
+	n, err := hkdf.Expand(hash.New, secret, b).Read(out)
+	if err != nil || n != length {
+		panic("quic: HKDF-Expand-Label invocation failed unexpectedly")
+	}
+	return out
+}
+
+// xoredNonceAEAD wraps an AEAD by XORing in a fixed pattern to the nonce before each call.
+// https://github.com/marten-seemann/qtls-go1-15/blob/0d137e9e3594d8e9c864519eff97b323321e5e74/cipher_suites.go#L319
+type xorNonceAEAD struct {
+	nonceMask [aeadNonceLength]byte
+	aead      cipher.AEAD
+}
+
+func (f *xorNonceAEAD) NonceSize() int        { return 8 } // 64-bit sequence number
+func (f *xorNonceAEAD) Overhead() int         { return f.aead.Overhead() }
+func (f *xorNonceAEAD) explicitNonceLen() int { return 0 }
+
+func (f *xorNonceAEAD) Seal(out, nonce, plaintext, additionalData []byte) []byte {
+	for i, b := range nonce {
+		f.nonceMask[4+i] ^= b
+	}
+	result := f.aead.Seal(out, f.nonceMask[:], plaintext, additionalData)
+	for i, b := range nonce {
+		f.nonceMask[4+i] ^= b
+	}
+	return result
+}
+
+func (f *xorNonceAEAD) Open(out, nonce, ciphertext, additionalData []byte) ([]byte, error) {
+	for i, b := range nonce {
+		f.nonceMask[4+i] ^= b
+	}
+	result, err := f.aead.Open(out, f.nonceMask[:], ciphertext, additionalData)
+	for i, b := range nonce {
+		f.nonceMask[4+i] ^= b
+	}
+	return result, err
+}

--- a/internal/engine/experiment/quicping/crypto.go
+++ b/internal/engine/experiment/quicping/crypto.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
 	"golang.org/x/crypto/hkdf"
 )
 
@@ -31,13 +32,9 @@ func aeadAESGCMTLS13(key, nonceMask []byte) aead {
 		panic("tls: internal error: wrong nonce length")
 	}
 	aes, err := aes.NewCipher(key)
-	if err != nil {
-		panic(err)
-	}
+	runtimex.PanicOnError(err, fmt.Sprintf("aes.NewCipher failed: %s", err))
 	aead, err := cipher.NewGCM(aes)
-	if err != nil {
-		panic(err)
-	}
+	runtimex.PanicOnError(err, fmt.Sprintf("cipher.NewGCM failed: %s", err))
 	ret := &xorNonceAEAD{aead: aead}
 	copy(ret.nonceMask[:], nonceMask)
 	return ret
@@ -77,9 +74,7 @@ func computeSecrets(destConnID []byte) (clientSecret, serverSecret []byte) {
 func encryptHeader(raw, hdr, clientSecret []byte) []byte {
 	hp := computeHP(clientSecret)
 	block, err := aes.NewCipher(hp)
-	if err != nil {
-		panic(fmt.Sprintf("error creating new AES cipher: %s", err))
-	}
+	runtimex.PanicOnError(err, fmt.Sprintf("error creating new AES cipher: %s", err))
 	hdroffset := 0
 	payloadOffset := len(hdr)
 	sample := raw[payloadOffset : payloadOffset+16]

--- a/internal/engine/experiment/quicping/crypto.go
+++ b/internal/engine/experiment/quicping/crypto.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/crypto/hkdf"
 )
 
-// BSD 3-Clause "New" or "Revised" License
+// SPDX-License-Identifier: BSD-3-Clause
 // This code is borrowed from https://github.com/marten-seemann/qtls-go1-15
 // https://github.com/marten-seemann/qtls-go1-15/blob/0d137e9e3594d8e9c864519eff97b323321e5e74/cipher_suites.go#L281
 type aead interface {
@@ -28,7 +28,7 @@ const (
 	noncePrefixLength = 4
 )
 
-// BSD 3-Clause "New" or "Revised" License
+// SPDX-License-Identifier: BSD-3-Clause
 // This code is borrowed from https://github.com/marten-seemann/qtls-go1-15
 // https://github.com/marten-seemann/qtls-go1-15/blob/0d137e9e3594d8e9c864519eff97b323321e5e74/cipher_suites.go#L375
 func aeadAESGCMTLS13(key, nonceMask []byte) aead {
@@ -44,7 +44,7 @@ func aeadAESGCMTLS13(key, nonceMask []byte) aead {
 	return ret
 }
 
-// MIT License
+// SPDX-License-Identifier: MIT
 // This code is borrowed from https://github.com/lucas-clemente/quic-go/
 // https://github.com/lucas-clemente/quic-go/blob/f3b098775e40f96486c0065204145ddc8675eb7c/internal/handshake/initial_aead.go#L60
 // https://www.rfc-editor.org/rfc/rfc9001.html#protection-keys
@@ -64,7 +64,7 @@ func computeHP(secret []byte) (hp []byte) {
 	return
 }
 
-// MIT License
+// SPDX-License-Identifier: MIT
 // This code is borrowed from https://github.com/lucas-clemente/quic-go/
 // https://github.com/lucas-clemente/quic-go/blob/f3b098775e40f96486c0065204145ddc8675eb7c/internal/handshake/initial_aead.go#L53
 // https://www.rfc-editor.org/rfc/rfc9001.html#name-initial-secrets
@@ -120,7 +120,7 @@ func encryptPayload(payload, destConnID ConnectionID, clientSecret []byte) []byt
 	return encrypted
 }
 
-// MIT License
+// SPDX-License-Identifier: MIT
 // This code is borrowed from https://github.com/lucas-clemente/quic-go/
 // https://github.com/lucas-clemente/quic-go/blob/master/internal/handshake/hkdf.go
 //
@@ -143,7 +143,7 @@ func hkdfExpandLabel(hash crypto.Hash, secret, context []byte, label string, len
 	return out
 }
 
-// BSD 3-Clause "New" or "Revised" License
+// SPDX-License-Identifier: BSD-3-Clause
 // This code is borrowed from https://github.com/marten-seemann/qtls-go1-15
 // https://github.com/marten-seemann/qtls-go1-15/blob/0d137e9e3594d8e9c864519eff97b323321e5e74/cipher_suites.go#L319
 //

--- a/internal/engine/experiment/quicping/quic.go
+++ b/internal/engine/experiment/quicping/quic.go
@@ -1,0 +1,132 @@
+package quicping
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
+)
+
+// buildHeader creates the unprotected QUIC header.
+// https://www.rfc-editor.org/rfc/rfc9000.html#name-initial-packet
+func buildHeader(destConnID, srcConnID connectionID, payloadLen int) []byte {
+	hdr := []byte{0xc3} // long header type, fixed
+
+	version := make([]byte, 4)
+	binary.BigEndian.PutUint32(version, uint32(0xbabababa))
+	hdr = append(hdr, version...) // version
+
+	lendID := uint8(len(destConnID))
+	hdr = append(hdr, lendID)        // destination connection ID length
+	hdr = append(hdr, destConnID...) // destination connection ID
+
+	lensID := uint8(len(srcConnID))
+	hdr = append(hdr, lensID)       // source connection ID length
+	hdr = append(hdr, srcConnID...) // source connection ID
+
+	hdr = append(hdr, 0x0) // token length
+
+	remainder := 4 + payloadLen
+	remainder_mask := 0b100000000000000
+	remainder_mask |= remainder
+	remainder_b := make([]byte, 2)
+	binary.BigEndian.PutUint16(remainder_b, uint16(remainder_mask))
+	hdr = append(hdr, remainder_b...) // remainder length: packet number + encrypted payload
+
+	pn := make([]byte, 4)
+	binary.BigEndian.PutUint32(pn, uint32(2))
+	hdr = append(hdr, pn...) // packet number
+
+	return hdr
+}
+
+// buildPacket constructs an Initial QUIC packet
+// and applies Initial protection.
+// https://www.rfc-editor.org/rfc/rfc9001.html#name-client-initial
+func buildPacket() ([]byte, connectionID, connectionID) {
+	destConnID, srcConnID := generateConnectionIDs()
+	// generate random payload
+	minPayloadSize := 1200 - 14 - (len(destConnID) + len(srcConnID))
+	randomPayload := make([]byte, minPayloadSize)
+	rand.Read(randomPayload)
+
+	clientSecret, _ := computeSecrets(destConnID)
+	encrypted := encryptPayload(randomPayload, destConnID, clientSecret)
+	hdr := buildHeader(destConnID, srcConnID, len(encrypted))
+	raw := append(hdr, encrypted...)
+
+	raw = encryptHeader(raw, hdr, clientSecret)
+	return raw, destConnID, srcConnID
+}
+
+// generateConnectionID generates a connection ID using cryptographic random
+func generateConnectionID(len int) connectionID {
+	b := make([]byte, len)
+	_, err := rand.Read(b)
+	runtimex.PanicOnError(err, "rand.Read failed")
+	return connectionID(b)
+}
+
+// generateConnectionIDForInitial generates a connection ID for the Initial packet.
+// It uses a length randomly chosen between 8 and 18 bytes.
+func generateConnectionIDForInitial() connectionID {
+	r := make([]byte, 1)
+	_, err := rand.Read(r)
+	runtimex.PanicOnError(err, "rand.Read failed")
+	len := minConnectionIDLenInitial + int(r[0])%(maxConnectionIDLen-minConnectionIDLenInitial+1)
+	return generateConnectionID(len)
+}
+
+// generateConnectionIDs generates a destination and source connection ID.
+func generateConnectionIDs() ([]byte, []byte) {
+	destConnID := generateConnectionIDForInitial()
+	srcConnID := generateConnectionID(defaultConnectionIDLength)
+	return destConnID, srcConnID
+}
+
+// dissectVersionNegotiation dissects the Version Negotiation response.
+// It returns the supported versions and the destination connection ID of the response,
+// The destination connection ID of the response has to coincide with the source connection ID of the request.
+// https://www.rfc-editor.org/rfc/rfc9000.html#name-version-negotiation-packet
+func (m *Measurer) dissectVersionNegotiation(i []byte) ([]uint32, connectionID, error) {
+	firstByte := uint8(i[0])
+	mask := 0b10000000
+	mask &= int(firstByte)
+	if mask == 0 {
+		return nil, nil, &errUnexpectedResponse{msg: "not a long header packet"}
+	}
+
+	versionBytes := i[1:5]
+	v := binary.BigEndian.Uint32(versionBytes)
+	if v != 0 {
+		return nil, nil, &errUnexpectedResponse{msg: "unexpected Version Negotiation format"}
+	}
+
+	dstLength := i[5]
+	offset := 6 + uint8(dstLength)
+	dst := i[6:offset]
+
+	srcLength := i[offset]
+	offset = offset + 1 + srcLength
+
+	n := uint8(len(i))
+	var supportedVersions []uint32
+	for offset < n {
+		supportedVersions = append(supportedVersions, binary.BigEndian.Uint32(i[offset:offset+4]))
+		offset += 4
+	}
+	return supportedVersions, dst, nil
+}
+
+// errUnexpectedResponse is thrown when the response from the server
+// is not a valid Version Negotiation packet
+type errUnexpectedResponse struct {
+	error
+	msg string
+}
+
+// Error implements error.Error()
+func (e *errUnexpectedResponse) Error() string {
+	return fmt.Sprintf("unexptected response: %s", e.msg)
+}

--- a/internal/engine/experiment/quicping/quicping.go
+++ b/internal/engine/experiment/quicping/quicping.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
 	"strconv"
 	"sync"
 	"time"
@@ -135,6 +136,9 @@ func (m *Measurer) Run(
 	callbacks model.ExperimentCallbacks,
 ) error {
 	host := string(measurement.Input)
+	if u, err := url.ParseRequestURI(host); err == nil {
+		host = u.Host
+	}
 	service := net.JoinHostPort(host, m.config.port())
 	udpAddr, err := net.ResolveUDPAddr("udp4", service)
 	if err != nil {

--- a/internal/engine/experiment/quicping/quicping.go
+++ b/internal/engine/experiment/quicping/quicping.go
@@ -153,8 +153,6 @@ func (m *Measurer) sender(
 			// propagate send information, including errors
 			out <- requestInfo{raw: packet, t: sendTime, dstID: hex.EncodeToString(dstID), srcID: hex.EncodeToString(srcID), err: err}
 			i += 1
-
-		default:
 		}
 	}
 }
@@ -283,8 +281,6 @@ L:
 
 		case <-ctx.Done():
 			break L
-
-		default:
 		}
 	}
 	// store all ping requests that have not been answered with a timeout failure

--- a/internal/engine/experiment/quicping/quicping.go
+++ b/internal/engine/experiment/quicping/quicping.go
@@ -163,8 +163,7 @@ func (m *Measurer) sender(
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
-	i := 0
-	for i < int(m.config.repetitions()) {
+	for i := int64(0); i < m.config.repetitions(); i++ {
 		select {
 		case <-ctx.Done():
 			return // user aborted or timeout expired
@@ -178,7 +177,6 @@ func (m *Measurer) sender(
 
 			// propagate send information, including errors
 			out <- requestInfo{raw: packet, t: sendTime, dstID: hex.EncodeToString(dstID), srcID: hex.EncodeToString(srcID), err: err}
-			i += 1
 		}
 	}
 }

--- a/internal/engine/experiment/quicping/quicping.go
+++ b/internal/engine/experiment/quicping/quicping.go
@@ -230,7 +230,7 @@ func (m *Measurer) Run(
 
 	// set context and read timeouts
 	deadline := time.Duration(rep*5) * time.Second
-	pconn.SetReadDeadline(time.Now().Add(deadline))
+	pconn.SetDeadline(time.Now().Add(deadline))
 	ctx, cancel := context.WithTimeout(ctx, time.Second*time.Duration(5*rep))
 	defer cancel()
 

--- a/internal/engine/experiment/quicping/quicping.go
+++ b/internal/engine/experiment/quicping/quicping.go
@@ -1,0 +1,343 @@
+package quicping
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	random "math/rand"
+	"net"
+	"net/url"
+	"time"
+
+	_ "crypto/sha256"
+
+	"github.com/ooni/probe-cli/v3/internal/engine/netx/archival"
+	"github.com/ooni/probe-cli/v3/internal/model"
+)
+
+// A ConnectionID in QUIC
+type ConnectionID []byte
+
+const maxConnectionIDLen = 18
+const MinConnectionIDLenInitial = 8
+const DefaultConnectionIDLength = 16
+
+const (
+	testName    = "quicping"
+	testVersion = "0.1.0"
+)
+
+// Config contains the experiment configuration.
+type Config struct {
+	// Repetitions is the number of repetitions for each ping.
+	Repetitions int64 `ooni:"number of times to repeat the measurement"`
+
+	// Port is the port to test.
+	Port string `ooni:"port is the port to test"`
+
+	// WaitSeconds is the number of seconds to wait for the ping response
+	WaitSeconds int `ooni:"waitseconds is the number of seconds to wait for the ping response"`
+}
+
+func (c *Config) repetitions() int64 {
+	if c.Repetitions > 0 {
+		return c.Repetitions
+	}
+	return 10
+}
+
+func (c *Config) port() string {
+	if c.Port != "" {
+		return c.Port
+	}
+	return "443"
+}
+
+func (c *Config) waitseconds() int {
+	if c.WaitSeconds != 0 {
+		return c.WaitSeconds
+	}
+	return 5
+}
+
+// TestKeys contains the experiment results.
+type TestKeys struct {
+	Domain      string
+	Pings       []*SinglePing `json:"pings"`
+	Repetitions int64
+}
+
+type SinglePing struct {
+	ConnIdDst         ConnectionID
+	ConnIdSrc         ConnectionID
+	Failure           *string
+	Ping              *model.ArchivalMaybeBinaryData
+	Response          *model.ArchivalMaybeBinaryData
+	SupportedVersions []uint32
+}
+
+// Measurer performs the measurement.
+type Measurer struct {
+	config Config
+}
+
+// ExperimentName implements ExperimentMeasurer.ExperimentName.
+func (m *Measurer) ExperimentName() string {
+	return testName
+}
+
+// ExperimentVersion implements ExperimentMeasurer.ExperimentVersion.
+func (m *Measurer) ExperimentVersion() string {
+	return testVersion
+}
+
+// Run implements ExperimentMeasurer.Run.
+func (m *Measurer) Run(
+	ctx context.Context,
+	sess model.ExperimentSession,
+	measurement *model.Measurement,
+	callbacks model.ExperimentCallbacks,
+) error {
+	url, err := url.Parse(string(measurement.Input))
+	if err != nil {
+		return errors.New("input is not an URL")
+	}
+	tk := new(TestKeys)
+	tk.Domain = url.Host
+	tk.Repetitions = m.config.repetitions()
+	measurement.TestKeys = tk
+
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	service := net.JoinHostPort(url.Host, m.config.port())
+
+	// create UDP socket
+	udpAddr, err := net.ResolveUDPAddr("udp4", service)
+	if err != nil {
+		return err
+	}
+	conn, err := net.DialUDP("udp", nil, udpAddr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	for i := int64(0); i < m.config.repetitions(); i++ {
+		<-ticker.C
+		sess.Logger().Infof("PING %s", service)
+
+		sent, dstID, srcID, err := buildPacket() // build QUIC Initial packet
+		if err != nil {
+			return errors.New(fmt.Sprintf("buildPacket failed: %s", err.Error()))
+		}
+		_, err = conn.Write(sent) // send Initial packet
+		if err != nil {
+			return errors.New(fmt.Sprintf("UDP send failed: %s", err.Error()))
+		}
+		resp, err := m.waitResponse(conn) // wait for server response
+		if err != nil {
+			tk.Pings = append(tk.Pings, &SinglePing{
+				ConnIdDst: dstID,
+				ConnIdSrc: srcID,
+				Failure:   archival.NewFailure(err),
+				Ping:      &model.ArchivalMaybeBinaryData{Value: string(sent)},
+				Response:  nil,
+			})
+			continue
+		}
+		supportedVersions, err := m.dissectVersionNegotiation(resp, dstID, srcID) // dissect server response
+		if err != nil {
+			tk.Pings = append(tk.Pings, &SinglePing{
+				ConnIdDst: dstID,
+				ConnIdSrc: srcID,
+				Failure:   archival.NewFailure(err),
+				Ping:      &model.ArchivalMaybeBinaryData{Value: string(sent)},
+				Response:  &model.ArchivalMaybeBinaryData{Value: string(resp)},
+			})
+			continue
+		}
+		tk.Pings = append(tk.Pings, &SinglePing{
+			ConnIdDst:         dstID,
+			ConnIdSrc:         srcID,
+			Failure:           nil,
+			Ping:              &model.ArchivalMaybeBinaryData{Value: string(sent)},
+			Response:          &model.ArchivalMaybeBinaryData{Value: string(resp)},
+			SupportedVersions: supportedVersions,
+		})
+	}
+
+	return nil
+}
+
+// waitResponse reads the server response. Times out after m.config.waitseconds() seconds (default: 5).
+func (m *Measurer) waitResponse(conn *net.UDPConn) ([]byte, error) {
+	buffer := make([]byte, 1024)
+	conn.SetReadDeadline(time.Now().Add(time.Duration(m.config.waitseconds()) * time.Second))
+	n, _, err := conn.ReadFromUDP(buffer)
+	if err != nil {
+		return nil, err
+	}
+	return buffer[0:n], nil
+}
+
+// dissectVersionNegotiation dissects the Version Negotiation response
+// and prints it to the command line.
+// https://www.rfc-editor.org/rfc/rfc9000.html#name-version-negotiation-packet
+func (m *Measurer) dissectVersionNegotiation(i []byte, dstID, srcID ConnectionID) ([]uint32, error) {
+	firstByte := uint8(i[0])
+	mask := 0b10000000
+	mask &= int(firstByte)
+	if mask == 0 {
+		return nil, &errUnexpectedResponse{msg: "not a long header packet"}
+	}
+
+	versionBytes := i[1:5]
+	v := binary.BigEndian.Uint32(versionBytes)
+	if v != 0 {
+		return nil, &errUnexpectedResponse{msg: "unexpected Version Negotiation format"}
+	}
+
+	dstLength := i[5]
+	offset := 6 + uint8(dstLength)
+	dst := i[6:offset]
+	if hex.EncodeToString(dst) != hex.EncodeToString(srcID) {
+		return nil, &errUnexpectedResponse{msg: fmt.Sprintf("destination connection ID: is %s, was %s", dst, srcID)}
+	}
+	srcLength := i[offset]
+	src := i[offset+1 : offset+1+srcLength]
+	offset = offset + 1 + srcLength
+	if hex.EncodeToString(src) != hex.EncodeToString(dstID) {
+		return nil, &errUnexpectedResponse{msg: fmt.Sprintf("destination connection ID: is %s, was %s", src, dstID)}
+	}
+
+	n := uint8(len(i))
+	var supportedVersions []uint32
+	for offset < n {
+		supportedVersions = append(supportedVersions, binary.BigEndian.Uint32(i[offset:offset+4]))
+		offset += 4
+	}
+	return supportedVersions, nil
+}
+
+// NewExperimentMeasurer creates a new ExperimentMeasurer.
+func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
+	return &Measurer{config: config}
+}
+
+// SummaryKeys contains summary keys for this experiment.
+//
+// Note that this structure is part of the ABI contract with probe-cli
+// therefore we should be careful when changing it.
+type SummaryKeys struct {
+	IsAnomaly bool `json:"-"`
+}
+
+// GetSummaryKeys implements model.ExperimentMeasurer.GetSummaryKeys.
+func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
+	return SummaryKeys{IsAnomaly: false}, nil
+}
+
+// buildHeader creates the unprotected QUIC header.
+// https://www.rfc-editor.org/rfc/rfc9000.html#name-initial-packet
+func buildHeader(destConnID, srcConnID ConnectionID, payloadLen int) []byte {
+	hdr := []byte{0xc3} // long header type, fixed
+
+	version := make([]byte, 4)
+	binary.BigEndian.PutUint32(version, uint32(0xbabababa))
+	hdr = append(hdr, version...) // version
+
+	lendID := uint8(len(destConnID))
+	hdr = append(hdr, lendID)        // destination connection ID length
+	hdr = append(hdr, destConnID...) // destination connection ID
+
+	lensID := uint8(len(srcConnID))
+	hdr = append(hdr, lensID)       // source connection ID length
+	hdr = append(hdr, srcConnID...) // source connection ID
+
+	hdr = append(hdr, 0x0) // token length
+
+	remainder := 4 + payloadLen
+	remainder_mask := 0b100000000000000
+	remainder_mask |= remainder
+	remainder_b := make([]byte, 2)
+	binary.BigEndian.PutUint16(remainder_b, uint16(remainder_mask))
+	hdr = append(hdr, remainder_b...) // remainder length: packet number + encrypted payload
+
+	pn := make([]byte, 4)
+	binary.BigEndian.PutUint32(pn, uint32(2))
+	hdr = append(hdr, pn...) // packet number
+
+	return hdr
+}
+
+// buildPacket constructs an Initial QUIC packet
+// and applies Initial protection.
+// https://www.rfc-editor.org/rfc/rfc9001.html#name-client-initial
+func buildPacket() ([]byte, ConnectionID, ConnectionID, error) {
+	destConnID, srcConnID, err := generateConnectionIDs()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	// generate random payload
+	minPayloadSize := 1200 - 14 - (len(destConnID) + len(srcConnID))
+	randomPayload := make([]byte, minPayloadSize)
+	random.Seed(time.Now().UnixNano())
+	random.Read(randomPayload)
+
+	clientSecret, _ := computeSecrets(destConnID)
+	encrypted := encryptPayload(randomPayload, destConnID, clientSecret)
+	hdr := buildHeader(destConnID, srcConnID, len(encrypted))
+	raw := append(hdr, encrypted...)
+
+	raw = encryptHeader(raw, hdr, clientSecret)
+	return raw, destConnID, srcConnID, nil
+}
+
+// generateConnectionID generates a connection ID using cryptographic random
+func generateConnectionID(len int) (ConnectionID, error) {
+	b := make([]byte, len)
+	if _, err := rand.Read(b); err != nil {
+		return nil, err
+	}
+	return ConnectionID(b), nil
+}
+
+// generateConnectionIDForInitial generates a connection ID for the Initial packet.
+// It uses a length randomly chosen between 8 and 18 bytes.
+func generateConnectionIDForInitial() (ConnectionID, error) {
+	r := make([]byte, 1)
+	if _, err := rand.Read(r); err != nil {
+		return nil, err
+	}
+	len := MinConnectionIDLenInitial + int(r[0])%(maxConnectionIDLen-MinConnectionIDLenInitial+1)
+	return generateConnectionID(len)
+}
+
+// generateConnectionIDs generates a destination and source connection ID.
+func generateConnectionIDs() ([]byte, []byte, error) {
+	destConnID, err := generateConnectionIDForInitial()
+	if err != nil {
+		return nil, nil, err
+	}
+	srcConnID, err := generateConnectionID(DefaultConnectionIDLength)
+	if err != nil {
+		return nil, nil, err
+	}
+	return destConnID, srcConnID, nil
+}
+
+// errUnexpectedResponse is thrown when the response from the server
+// is not a valid Version Negotiation packet
+type errUnexpectedResponse struct {
+	error
+	msg string
+}
+
+// Error implements error.Error()
+func (e *errUnexpectedResponse) Error() string {
+	return fmt.Sprintf("unexptected response: %s", e.msg)
+}

--- a/internal/engine/experiment/quicping/quicping.go
+++ b/internal/engine/experiment/quicping/quicping.go
@@ -311,7 +311,7 @@ L:
 		if ping.request == nil { // this should not happen
 			return errors.New("internal error: ping.request is nil")
 		}
-		if len(ping.responses) == 0 {
+		if len(ping.responses) <= 0 {
 			tk.Pings = append(tk.Pings, &SinglePing{
 				ConnIdDst:   ping.request.dstID,
 				ConnIdSrc:   ping.request.srcID,

--- a/internal/engine/experiment/quicping/quicping.go
+++ b/internal/engine/experiment/quicping/quicping.go
@@ -161,11 +161,10 @@ func (m *Measurer) Run(
 	if err != nil {
 		return err
 	}
-	conn.SetReadDeadline(time.Now().Add(time.Duration(rep*m.config.timeout()) * time.Millisecond))
 	defer conn.Close()
+	conn.SetReadDeadline(time.Now().Add(time.Duration(rep*m.config.timeout()) * time.Millisecond))
 
 	sendInfoMap := make(map[string]*sendInfo)
-
 	var wg sync.WaitGroup
 	wg.Add(1)
 
@@ -225,7 +224,7 @@ func (m *Measurer) Run(
 		})
 		sess.Logger().Infof("PING got response from %s", service)
 
-		if len(tk.Pings) == int(rep) {
+		if len(tk.Pings) >= int(rep) {
 			break // leave loop when we collected all ping responses
 		}
 	}

--- a/internal/engine/experiment/quicping/quicping.go
+++ b/internal/engine/experiment/quicping/quicping.go
@@ -172,6 +172,9 @@ func (m *Measurer) sender(
 			sendTime := stime.Sub(measurement.MeasurementStartTimeSaved).Seconds()
 			packet, dstID, srcID := buildPacket()     // build QUIC Initial packet
 			_, err := pconn.WriteTo(packet, destAddr) // send Initial packet
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
 
 			sess.Logger().Infof("PING %s", destAddr)
 

--- a/internal/engine/experiment/quicping/quicping.go
+++ b/internal/engine/experiment/quicping/quicping.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	random "math/rand"
 	"net"
+	"strconv"
 	"time"
 
 	_ "crypto/sha256"
@@ -35,7 +36,7 @@ type Config struct {
 	Repetitions int64 `ooni:"number of times to repeat the measurement"`
 
 	// Port is the port to test.
-	Port string `ooni:"port is the port to test"`
+	Port int64 `ooni:"port is the port to test"`
 
 	// WaitSeconds is the number of seconds to wait for the ping response
 	WaitSeconds int `ooni:"waitseconds is the number of seconds to wait for the ping response"`
@@ -49,8 +50,8 @@ func (c *Config) repetitions() int64 {
 }
 
 func (c *Config) port() string {
-	if c.Port != "" {
-		return c.Port
+	if c.Port != 0 {
+		return strconv.FormatInt(c.Port, 10)
 	}
 	return "443"
 }

--- a/internal/engine/experiment/quicping/quicping.go
+++ b/internal/engine/experiment/quicping/quicping.go
@@ -255,7 +255,7 @@ func (m *Measurer) Run(
 	defer pconn.Close()
 
 	// set context and read timeouts
-	deadline := time.Duration(rep*5) * time.Second
+	deadline := time.Duration(rep*2) * time.Second
 	pconn.SetDeadline(time.Now().Add(deadline))
 	ctx, cancel := context.WithTimeout(ctx, deadline)
 	defer cancel()

--- a/internal/engine/experiment/quicping/quicping.go
+++ b/internal/engine/experiment/quicping/quicping.go
@@ -323,6 +323,9 @@ func (m *Measurer) DissectVersionNegotiation(i []byte) ([]uint32, ConnectionID, 
 	offset := 6 + uint8(dstLength)
 	dst := i[6:offset]
 
+	srcLength := i[offset]
+	offset = offset + 1 + srcLength
+
 	n := uint8(len(i))
 	var supportedVersions []uint32
 	for offset < n {

--- a/internal/engine/experiment/quicping/quicping.go
+++ b/internal/engine/experiment/quicping/quicping.go
@@ -6,8 +6,6 @@ package quicping
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -22,7 +20,6 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/archival"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
-	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
 // A connectionID in QUIC
@@ -341,40 +338,6 @@ L:
 	return nil
 }
 
-// dissectVersionNegotiation dissects the Version Negotiation response.
-// It returns the supported versions and the destination connection ID of the response,
-// The destination connection ID of the response has to coincide with the source connection ID of the request.
-// https://www.rfc-editor.org/rfc/rfc9000.html#name-version-negotiation-packet
-func (m *Measurer) dissectVersionNegotiation(i []byte) ([]uint32, connectionID, error) {
-	firstByte := uint8(i[0])
-	mask := 0b10000000
-	mask &= int(firstByte)
-	if mask == 0 {
-		return nil, nil, &errUnexpectedResponse{msg: "not a long header packet"}
-	}
-
-	versionBytes := i[1:5]
-	v := binary.BigEndian.Uint32(versionBytes)
-	if v != 0 {
-		return nil, nil, &errUnexpectedResponse{msg: "unexpected Version Negotiation format"}
-	}
-
-	dstLength := i[5]
-	offset := 6 + uint8(dstLength)
-	dst := i[6:offset]
-
-	srcLength := i[offset]
-	offset = offset + 1 + srcLength
-
-	n := uint8(len(i))
-	var supportedVersions []uint32
-	for offset < n {
-		supportedVersions = append(supportedVersions, binary.BigEndian.Uint32(i[offset:offset+4]))
-		offset += 4
-	}
-	return supportedVersions, dst, nil
-}
-
 // NewExperimentMeasurer creates a new ExperimentMeasurer.
 func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
 	return &Measurer{config: config}
@@ -391,93 +354,4 @@ type SummaryKeys struct {
 // GetSummaryKeys implements model.ExperimentMeasurer.GetSummaryKeys.
 func (m *Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
 	return SummaryKeys{IsAnomaly: false}, nil
-}
-
-// buildHeader creates the unprotected QUIC header.
-// https://www.rfc-editor.org/rfc/rfc9000.html#name-initial-packet
-func buildHeader(destConnID, srcConnID connectionID, payloadLen int) []byte {
-	hdr := []byte{0xc3} // long header type, fixed
-
-	version := make([]byte, 4)
-	binary.BigEndian.PutUint32(version, uint32(0xbabababa))
-	hdr = append(hdr, version...) // version
-
-	lendID := uint8(len(destConnID))
-	hdr = append(hdr, lendID)        // destination connection ID length
-	hdr = append(hdr, destConnID...) // destination connection ID
-
-	lensID := uint8(len(srcConnID))
-	hdr = append(hdr, lensID)       // source connection ID length
-	hdr = append(hdr, srcConnID...) // source connection ID
-
-	hdr = append(hdr, 0x0) // token length
-
-	remainder := 4 + payloadLen
-	remainder_mask := 0b100000000000000
-	remainder_mask |= remainder
-	remainder_b := make([]byte, 2)
-	binary.BigEndian.PutUint16(remainder_b, uint16(remainder_mask))
-	hdr = append(hdr, remainder_b...) // remainder length: packet number + encrypted payload
-
-	pn := make([]byte, 4)
-	binary.BigEndian.PutUint32(pn, uint32(2))
-	hdr = append(hdr, pn...) // packet number
-
-	return hdr
-}
-
-// buildPacket constructs an Initial QUIC packet
-// and applies Initial protection.
-// https://www.rfc-editor.org/rfc/rfc9001.html#name-client-initial
-func buildPacket() ([]byte, connectionID, connectionID) {
-	destConnID, srcConnID := generateConnectionIDs()
-	// generate random payload
-	minPayloadSize := 1200 - 14 - (len(destConnID) + len(srcConnID))
-	randomPayload := make([]byte, minPayloadSize)
-	rand.Read(randomPayload)
-
-	clientSecret, _ := computeSecrets(destConnID)
-	encrypted := encryptPayload(randomPayload, destConnID, clientSecret)
-	hdr := buildHeader(destConnID, srcConnID, len(encrypted))
-	raw := append(hdr, encrypted...)
-
-	raw = encryptHeader(raw, hdr, clientSecret)
-	return raw, destConnID, srcConnID
-}
-
-// generateConnectionID generates a connection ID using cryptographic random
-func generateConnectionID(len int) connectionID {
-	b := make([]byte, len)
-	_, err := rand.Read(b)
-	runtimex.PanicOnError(err, "rand.Read failed")
-	return connectionID(b)
-}
-
-// generateConnectionIDForInitial generates a connection ID for the Initial packet.
-// It uses a length randomly chosen between 8 and 18 bytes.
-func generateConnectionIDForInitial() connectionID {
-	r := make([]byte, 1)
-	_, err := rand.Read(r)
-	runtimex.PanicOnError(err, "rand.Read failed")
-	len := minConnectionIDLenInitial + int(r[0])%(maxConnectionIDLen-minConnectionIDLenInitial+1)
-	return generateConnectionID(len)
-}
-
-// generateConnectionIDs generates a destination and source connection ID.
-func generateConnectionIDs() ([]byte, []byte) {
-	destConnID := generateConnectionIDForInitial()
-	srcConnID := generateConnectionID(defaultConnectionIDLength)
-	return destConnID, srcConnID
-}
-
-// errUnexpectedResponse is thrown when the response from the server
-// is not a valid Version Negotiation packet
-type errUnexpectedResponse struct {
-	error
-	msg string
-}
-
-// Error implements error.Error()
-func (e *errUnexpectedResponse) Error() string {
-	return fmt.Sprintf("unexptected response: %s", e.msg)
 }

--- a/internal/engine/experiment/quicping/quicping_test.go
+++ b/internal/engine/experiment/quicping/quicping_test.go
@@ -282,7 +282,7 @@ func TestDissect(t *testing.T) {
 	versionNegotiationResponse, _ := hex.DecodeString("eb0000000010040b9649d3fd4c038ab6c073966f39210b44d064031288e97646451f00000001ff00001dff00001cff00001b")
 	measurer := NewExperimentMeasurer(Config{})
 	destID := "040b9649d3fd4c038ab6c073966f3921"
-	_, dst, err := measurer.(*Measurer).DissectVersionNegotiation(versionNegotiationResponse)
+	_, dst, err := measurer.(*Measurer).dissectVersionNegotiation(versionNegotiationResponse)
 	if err != nil {
 		t.Fatal("unexpected error", err)
 	}
@@ -291,7 +291,7 @@ func TestDissect(t *testing.T) {
 	}
 
 	versionNegotiationResponse[1] = byte(0xff)
-	_, _, err = measurer.(*Measurer).DissectVersionNegotiation(versionNegotiationResponse)
+	_, _, err = measurer.(*Measurer).dissectVersionNegotiation(versionNegotiationResponse)
 	if err == nil {
 		t.Fatal("expected an error here", err)
 	}
@@ -300,7 +300,7 @@ func TestDissect(t *testing.T) {
 	}
 
 	versionNegotiationResponse[0] = byte(0x01)
-	_, _, err = measurer.(*Measurer).DissectVersionNegotiation(versionNegotiationResponse)
+	_, _, err = measurer.(*Measurer).dissectVersionNegotiation(versionNegotiationResponse)
 	if err == nil {
 		t.Fatal("expected an error here", err)
 	}

--- a/internal/engine/experiment/quicping/quicping_test.go
+++ b/internal/engine/experiment/quicping/quicping_test.go
@@ -146,8 +146,13 @@ func TestSuccess(t *testing.T) {
 		if ping.Failure != nil {
 			t.Fatal("ping failed unexpectedly", i, *ping.Failure)
 		}
-		if ping.SupportedVersions == nil || len(ping.SupportedVersions) == 0 {
-			t.Fatal("server did not respond with supported versions")
+		for _, resp := range ping.Responses {
+			if resp.Failure != nil {
+				t.Fatal("unexepcted response failure")
+			}
+			if resp.SupportedVersions == nil || len(resp.SupportedVersions) == 0 {
+				t.Fatal("server did not respond with supported versions")
+			}
 		}
 	}
 	sk, err := measurer.GetSummaryKeys(measurement)

--- a/internal/engine/experiment/quicping/quicping_test.go
+++ b/internal/engine/experiment/quicping/quicping_test.go
@@ -1,0 +1,101 @@
+package quicping_test
+
+import (
+	"context"
+	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/engine/experiment/quicping"
+	"github.com/ooni/probe-cli/v3/internal/engine/mockable"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestNewExperimentMeasurer(t *testing.T) {
+	measurer := quicping.NewExperimentMeasurer(quicping.Config{})
+	if measurer.ExperimentName() != "quicping" {
+		t.Fatal("unexpected name")
+	}
+	if measurer.ExperimentVersion() != "0.1.0" {
+		t.Fatal("unexpected version")
+	}
+}
+
+func TestInvalidHost(t *testing.T) {
+	measurer := quicping.NewExperimentMeasurer(quicping.Config{
+		Port: int64(443),
+	})
+	measurement := new(model.Measurement)
+	measurement.Input = model.MeasurementTarget("a.a.a.a")
+	sess := &mockable.Session{MockableLogger: log.Log}
+	err := measurer.Run(context.Background(), sess, measurement,
+		model.NewPrinterCallbacks(log.Log))
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	if _, ok := err.(*net.DNSError); !ok {
+		t.Fatal("unexpected error type")
+	}
+}
+
+func TestReadTimeout(t *testing.T) {
+	measurer := quicping.NewExperimentMeasurer(quicping.Config{
+		Port:        int64(443),
+		Timeout:     int64(10),
+		Repetitions: int64(2),
+	})
+	measurement := new(model.Measurement)
+	measurement.Input = model.MeasurementTarget("cloudflare.com")
+	sess := &mockable.Session{MockableLogger: log.Log}
+	err := measurer.Run(context.Background(), sess, measurement,
+		model.NewPrinterCallbacks(log.Log))
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
+	tk := measurement.TestKeys.(*quicping.TestKeys)
+	for i, ping := range tk.Pings {
+		if ping.Failure == nil {
+			t.Fatal("ping should have failed", i)
+		}
+		if !strings.Contains(*ping.Failure, "timeout") {
+			t.Fatal("ping: unexpected error type", i, *ping.Failure)
+		}
+	}
+}
+
+func TestSucess(t *testing.T) {
+	measurer := quicping.NewExperimentMeasurer(quicping.Config{})
+	measurement := new(model.Measurement)
+	measurement.Input = model.MeasurementTarget("cloudflare.com")
+	sess := &mockable.Session{MockableLogger: log.Log}
+	err := measurer.Run(context.Background(), sess, measurement,
+		model.NewPrinterCallbacks(log.Log))
+	if err != nil {
+		t.Fatal("did not expect an error here")
+	}
+	tk := measurement.TestKeys.(*quicping.TestKeys)
+	if tk.Domain != "cloudflare.com" {
+		t.Fatal("unexpected domain")
+	}
+	if tk.Repetitions != 10 {
+		t.Fatal("unexpected number of repetitions, default is 10")
+	}
+	if tk.Pings == nil || len(tk.Pings) != 10 {
+		t.Fatal("not enough pings")
+	}
+	for i, ping := range tk.Pings {
+		if ping.Failure != nil {
+			t.Fatal("ping failed unexpectedly", i, *ping.Failure)
+		}
+		if ping.SupportedVersions == nil || len(ping.SupportedVersions) == 0 {
+			t.Fatal("server did not respond with supported versions")
+		}
+	}
+	sk, err := measurer.GetSummaryKeys(measurement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := sk.(quicping.SummaryKeys); !ok {
+		t.Fatal("invalid type for summary keys")
+	}
+}

--- a/internal/engine/experiment/quicping/quicping_test.go
+++ b/internal/engine/experiment/quicping/quicping_test.go
@@ -38,8 +38,8 @@ func (f *FailStdLib) ListenUDP(network string, laddr *net.UDPAddr) (model.UDPLik
 			MockReadFrom: func(p []byte) (int, net.Addr, error) {
 				return f.conn.ReadFrom(p)
 			},
-			MockSetReadDeadline: func(t time.Time) error {
-				return f.conn.SetReadDeadline(t)
+			MockSetDeadline: func(t time.Time) error {
+				return f.conn.SetDeadline(t)
 			},
 			MockClose: func() error {
 				return f.conn.Close()
@@ -54,8 +54,8 @@ func (f *FailStdLib) ListenUDP(network string, laddr *net.UDPAddr) (model.UDPLik
 			MockReadFrom: func(p []byte) (int, net.Addr, error) {
 				return 0, nil, f.readErr
 			},
-			MockSetReadDeadline: func(t time.Time) error {
-				return f.conn.SetReadDeadline(t)
+			MockSetDeadline: func(t time.Time) error {
+				return f.conn.SetDeadline(t)
 			},
 			MockClose: func() error {
 				return f.conn.Close()

--- a/internal/engine/experiment/quicping/quicping_test.go
+++ b/internal/engine/experiment/quicping/quicping_test.go
@@ -18,27 +18,52 @@ import (
 
 // FailStdLib is a failing model.UnderlyingNetworkLibrary.
 type FailStdLib struct {
-	err      error
-	writeErr error
-	readErr  error
+	conn      model.UDPLikeConn
+	err       error
+	writeErr  error
+	readErr   error
 }
 
 // ListenUDP implements UnderlyingNetworkLibrary.ListenUDP.
 func (f *FailStdLib) ListenUDP(network string, laddr *net.UDPAddr) (model.UDPLikeConn, error) {
-	return &mocks.UDPLikeConn{
-		MockWriteTo: func(p []byte, addr net.Addr) (int, error) {
-			return 0, f.writeErr
-		},
-		MockReadFrom: func(p []byte) (int, net.Addr, error) {
-			return 0, nil, f.readErr
-		},
-		MockClose: func() error {
-			return nil
-		},
-		MockSetReadDeadline: func(t time.Time) error {
-			return nil
-		},
-	}, f.err
+	conn, _ := net.ListenUDP(network, laddr)
+	f.conn = model.UDPLikeConn(conn)
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.writeErr != nil {
+		return &mocks.UDPLikeConn{
+			MockWriteTo: func(p []byte, addr net.Addr) (int, error) {
+				return 0, f.writeErr
+			},
+			MockReadFrom: func(p []byte) (int, net.Addr, error) {
+				return f.conn.ReadFrom(p)
+			},
+			MockSetReadDeadline: func(t time.Time) error {
+				return f.conn.SetReadDeadline(t)
+			},
+			MockClose: func() error {
+				return f.conn.Close()
+			},
+		}, nil
+	}
+	if f.readErr != nil {
+		return &mocks.UDPLikeConn{
+			MockWriteTo: func(p []byte, addr net.Addr) (int, error) {
+				return f.conn.WriteTo(p, addr)
+			},
+			MockReadFrom: func(p []byte) (int, net.Addr, error) {
+				return 0, nil, f.readErr
+			},
+			MockSetReadDeadline: func(t time.Time) error {
+				return f.conn.SetReadDeadline(t)
+			},
+			MockClose: func() error {
+				return f.conn.Close()
+			},
+		}, nil 
+	}
+	return &mocks.UDPLikeConn{}, nil
 }
 
 // LookupHost implements UnderlyingNetworkLibrary.LookupHost.
@@ -127,17 +152,27 @@ func TestWriteFails(t *testing.T) {
 	expected := errors.New("expected")
 	measurer := quicping.NewExperimentMeasurer(quicping.Config{
 		NetworkLibrary: &FailStdLib{err: nil, readErr: nil, writeErr: expected},
+		Repetitions:    1,
 	})
 	measurement := new(model.Measurement)
 	measurement.Input = model.MeasurementTarget("google.com")
 	sess := &mockable.Session{MockableLogger: log.Log}
 	err := measurer.Run(context.Background(), sess, measurement,
 		model.NewPrinterCallbacks(log.Log))
-	if err == nil {
-		t.Fatal("expected an error here")
+	if err != nil {
+		t.Fatal("unexpected error")
 	}
-	if !errors.Is(err, expected) {
-		t.Fatal("unexpected error type")
+	tk := measurement.TestKeys.(*quicping.TestKeys)
+	if tk.Pings == nil || len(tk.Pings) != 1 {
+		t.Fatal("not enough pings")
+	}
+	for i, ping := range tk.Pings {
+		if ping.Failure == nil {
+			t.Fatal("expected an error here, ping", i)
+		}
+		if !strings.Contains(*ping.Failure, "expected") {
+			t.Fatal("ping: unexpected error type", i, *ping.Failure)
+		}
 	}
 }
 
@@ -164,7 +199,6 @@ func TestReadFails(t *testing.T) {
 			t.Fatal("expected an error here, ping", i)
 		}
 	}
-
 }
 
 func TestSucess(t *testing.T) {
@@ -208,33 +242,17 @@ func TestDissect(t *testing.T) {
 	//                             destID--srcID: 040b9649d3fd4c038ab6c073966f3921--44d064031288e97646451f
 	versionNegotiationResponse, _ := hex.DecodeString("eb0000000010040b9649d3fd4c038ab6c073966f39210b44d064031288e97646451f00000001ff00001dff00001cff00001b")
 	measurer := quicping.NewExperimentMeasurer(quicping.Config{})
-	destIDOriginal, _ := hex.DecodeString("44d064031288e97646451f")
-	srcIDOriginal, _ := hex.DecodeString("040b9649d3fd4c038ab6c073966f3921")
-	_, err := measurer.(*quicping.Measurer).DissectVersionNegotiation(versionNegotiationResponse, destIDOriginal, srcIDOriginal)
+	destID := "040b9649d3fd4c038ab6c073966f3921"
+	_, dst, err := measurer.(*quicping.Measurer).DissectVersionNegotiation(versionNegotiationResponse)
 	if err != nil {
 		t.Fatal("unexpected error", err)
 	}
-
-	versionNegotiationResponse[23] = byte(0xff)
-	_, err = measurer.(*quicping.Measurer).DissectVersionNegotiation(versionNegotiationResponse, destIDOriginal, srcIDOriginal)
-	if err == nil {
-		t.Fatal("expected an error here", err)
-	}
-	if !strings.Contains(err.Error(), "source connection ID: is") {
-		t.Fatal("unexpected error type", err)
-	}
-
-	versionNegotiationResponse[7] = byte(0xff)
-	_, err = measurer.(*quicping.Measurer).DissectVersionNegotiation(versionNegotiationResponse, destIDOriginal, srcIDOriginal)
-	if err == nil {
-		t.Fatal("expected an error here", err)
-	}
-	if !strings.Contains(err.Error(), "destination connection ID: is") {
-		t.Fatal("unexpected error type", err)
+	if dst != destID {
+		t.Fatal("unexpected destination connection ID")
 	}
 
 	versionNegotiationResponse[1] = byte(0xff)
-	_, err = measurer.(*quicping.Measurer).DissectVersionNegotiation(versionNegotiationResponse, destIDOriginal, srcIDOriginal)
+	_, _, err = measurer.(*quicping.Measurer).DissectVersionNegotiation(versionNegotiationResponse)
 	if err == nil {
 		t.Fatal("expected an error here", err)
 	}
@@ -243,7 +261,7 @@ func TestDissect(t *testing.T) {
 	}
 
 	versionNegotiationResponse[0] = byte(0x01)
-	_, err = measurer.(*quicping.Measurer).DissectVersionNegotiation(versionNegotiationResponse, destIDOriginal, srcIDOriginal)
+	_, _, err = measurer.(*quicping.Measurer).DissectVersionNegotiation(versionNegotiationResponse)
 	if err == nil {
 		t.Fatal("expected an error here", err)
 	}


### PR DESCRIPTION
This experiment pings a QUIC-able host. It can be used to measure QUIC availability independently from TLS.
This is the reference issue: https://github.com/ooni/probe/issues/1994

### A QUIC PING is:
- a QUIC Initial packet with a size of 1200 bytes (minimum datagram size defined in the [RFC 9000](https://www.rfc-editor.org/rfc/rfc9000.html#initial-size)),
- with a random payload (i.e. no TLS ClientHello),
- with the version string 0xbabababa which forces Version Negotiation at the server.

QUIC-able hosts respond to the QUIC PING with a Version Negotiation packet.

The input is a domain name or an IP address. The default port used by quicping is 443, as this is the port used by HTTP/3. The port can be modified with the `-O Port=` option.
The default number of repetitions is 10, it can be changed with `-O Repetitions=`.

### Usage:
```
./miniooni -i google.com quicping
./miniooni -i 142.250.181.206 quicping
./miniooni -i 142.250.181.206 -OPort=443 quicping
./miniooni -i 142.250.181.206 -ORepetitions=2 quicping

```

