### PR TITLE
fix(resolvermake): re-enable dns.google DoH HTTP3 resolutions

### DIFF
--- a/internal/engine/internal/sessionresolver/resolvermaker.go
+++ b/internal/engine/internal/sessionresolver/resolvermaker.go
@@ -30,6 +30,8 @@ var allmakers = []*resolvermaker{{
 }, {
 	url: "https://dns.google/dns-query",
 }, {
+	url: "http3://dns.google/dns-query",
+}, {
 	url: "https://dns.quad9.net/dns-query",
 }, {
 	url: "https://doh.powerdns.org/",


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] Closes ooni/probe#1883

Location of the issue tracker: https://github.com/ooni/probe

## Description

I have re-added to session resolver the lines of code that were telling it to speak DNS-over-HTTPS using QUIC and HTTP3 with dns.google. Inspected the resulting measurement and it works perfectly.

Also, the test coverage is 99.3% (same as before adding those lines)

