### PR TITLE
fix(jafar): re-enable previously broken integration test

### DIFF
--- a/internal/cmd/jafar/uncensored/uncensored_test.go
+++ b/internal/cmd/jafar/uncensored/uncensored_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestGood(t *testing.T) {
-	t.Skip("TODO(https://github.com/ooni/probe/issues/1913)")
 	client, err := NewClient("dot://1.1.1.1:853")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
I have tested this integration test locally and it's now WAI.

It may be that it will fail again when run on GitHub Actions, which will
indicate we cannot fully trust Actions for running _some_ tests.

Closes https://github.com/ooni/probe/issues/1913.
