### PR TITLE
refactor(sessionresolver): run queries in parallel

### DIFF
--- a/internal/engine/internal/sessionresolver/childresolver.go
+++ b/internal/engine/internal/sessionresolver/childresolver.go
@@ -16,12 +16,39 @@ type childResolver interface {
 }
 
 // timeLimitedLookup performs a time-limited lookup using the given re.
-func (r *Resolver) timeLimitedLookup(ctx context.Context, re childResolver, hostname string) ([]string, error) {
+func (r *Resolver) timeLimitedLookup(
+	ctx context.Context, re childResolver, hostname string) ([]string, error) {
 	// Algorithm similar to Firefox TRR2 mode. See:
 	// https://wiki.mozilla.org/Trusted_Recursive_Resolver#DNS-over-HTTPS_Prefs_in_Firefox
 	// We use a higher timeout than Firefox's timeout (1.5s) to be on the safe side
 	// and therefore see to use DoH more often.
-	ctx, cancel := context.WithTimeout(ctx, 4*time.Second)
+	const timeout = 4 * time.Second
+	return r.timeLimitedLookupx(ctx, timeout, re, hostname)
+}
+
+func (r *Resolver) timeLimitedLookupx(ctx context.Context,
+	timeout time.Duration, re childResolver, hostname string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	return re.LookupHost(ctx, hostname)
+	ach := make(chan []string, 1)
+	errch := make(chan error, 1)
+	go r.doTimeLimitedLookup(ctx, re, hostname, ach, errch)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case addrs := <-ach:
+		return addrs, nil
+	case err := <-errch:
+		return nil, err
+	}
+}
+
+func (r *Resolver) doTimeLimitedLookup(ctx context.Context, re childResolver,
+	hostname string, ach chan<- []string, errch chan<- error) {
+	addrs, err := re.LookupHost(ctx, hostname)
+	if err != nil {
+		errch <- err
+		return
+	}
+	ach <- addrs
 }

--- a/internal/engine/internal/sessionresolver/resolvermaker_test.go
+++ b/internal/engine/internal/sessionresolver/resolvermaker_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/ooni/probe-cli/v3/internal/bytecounter"
+	"github.com/ooni/probe-cli/v3/internal/model/mocks"
 )
 
 func TestDefaultByteCounter(t *testing.T) {
@@ -29,7 +30,12 @@ func TestDefaultLogger(t *testing.T) {
 func TestGetResolverHTTPSStandard(t *testing.T) {
 	bc := bytecounter.New()
 	URL := "https://dns.google"
-	re := &FakeResolver{}
+	var closed bool
+	re := &mocks.Resolver{
+		MockCloseIdleConnections: func() {
+			closed = true
+		},
+	}
 	cmk := &fakeDNSClientMaker{reso: re}
 	reso := &Resolver{dnsClientMaker: cmk, ByteCounter: bc}
 	out, err := reso.getresolver(URL)
@@ -47,7 +53,7 @@ func TestGetResolverHTTPSStandard(t *testing.T) {
 		t.Fatal("not the result we expected")
 	}
 	reso.closeall()
-	if re.Closed != true {
+	if closed != true {
 		t.Fatal("was not closed")
 	}
 	if cmk.savedURL != URL {
@@ -70,7 +76,12 @@ func TestGetResolverHTTPSStandard(t *testing.T) {
 func TestGetResolverHTTP3(t *testing.T) {
 	bc := bytecounter.New()
 	URL := "http3://dns.google"
-	re := &FakeResolver{}
+	var closed bool
+	re := &mocks.Resolver{
+		MockCloseIdleConnections: func() {
+			closed = true
+		},
+	}
 	cmk := &fakeDNSClientMaker{reso: re}
 	reso := &Resolver{dnsClientMaker: cmk, ByteCounter: bc}
 	out, err := reso.getresolver(URL)
@@ -88,7 +99,7 @@ func TestGetResolverHTTP3(t *testing.T) {
 		t.Fatal("not the result we expected")
 	}
 	reso.closeall()
-	if re.Closed != true {
+	if closed != true {
 		t.Fatal("was not closed")
 	}
 	if cmk.savedURL != strings.Replace(URL, "http3://", "https://", 1) {


### PR DESCRIPTION
This PR aims to refactor sessionresolver to run queries in parallel.

Reference issue: https://github.com/ooni/probe/issues/1889.