### PR TITLE
doc: clarify semantic versioning policy

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,6 +22,15 @@ while most others are top-level. This is part of a long-standing refactoring sta
 when we merged https://github.com/ooni/probe-engine into this repository. We'll slowly
 ensure that all packages inside `engine` are moved out of it and inside `internal`.
 
+## Semantic versioning policy
+
+The mobile library is a public package for technical reasons. Go mobile tools require
+a public package to build from. Yet, we don't consider API breakages happening in
+such a package to be sufficient to bump our major version number. For us, the mobile
+library is just a mean to implement OONI Probe Android and OONI Probe iOS. We'll
+only bump the major version number if we implement any set of breaking changes of
+the `./cmd/ooniprobe`'s CLI.
+
 ## License
 
 ```

--- a/pkg/oonimkall/task.go
+++ b/pkg/oonimkall/task.go
@@ -9,6 +9,14 @@
 // reimplementation of the mkall API implemented by Measurement Kit
 // in, e.g., https://github.com/measurement-kit/mkall-ios.
 //
+// Semantic versioning policy
+//
+// This package is public for technical reasons. We cannot use `go
+// mobile` on a private package. Yet, we are not going to bump this
+// repository's major number in case we change oonimkall's API. We
+// consider this package our private API for interfacing with our
+// mobile applications for Android and iOS.
+//
 // Task API
 //
 // The basic tenet of the task API is that you define an experiment


### PR DESCRIPTION
The oonimkall package is only public for technical reasons. We
cannot use `go mobile` on a private package. We consider oonimkall
our private interface to our mobile apps, thus we reserve the
right to change its API without bumping the major number.

We'll bump the major number in case of breaking changes in the
cmd/ooniprobe CLI interface, or in case of other major improvements
that significantly modify cmd/ooniprobe.
