### PR TITLE
[forwardport] fix(jafar/iptables/test): force using pure Go resolver

### DIFF
--- a/internal/cmd/jafar/iptables/iptables_integration_test.go
+++ b/internal/cmd/jafar/iptables/iptables_integration_test.go
@@ -137,11 +137,10 @@ func TestDropKeywordHex(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	req, err := http.NewRequest("GET", "http://www.ooni.io", nil)
-	if err != nil {
-		t.Fatal(err)
+	reso := &net.Resolver{
+		PreferGo: true,
 	}
-	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
+	addrs, err := reso.LookupHost(ctx, "www.ooni.io")
 	if err == nil {
 		t.Fatal("expected an error here")
 	}
@@ -152,7 +151,7 @@ func TestDropKeywordHex(t *testing.T) {
 		!strings.HasSuffix(err.Error(), "no such host") {
 		t.Fatalf("unexpected error occurred: %+v", err)
 	}
-	if resp != nil {
+	if addrs != nil {
 		t.Fatal("expected nil response here")
 	}
 }
@@ -254,7 +253,10 @@ func TestHijackDNS(t *testing.T) {
 	if err := policy.Apply(); err != nil {
 		t.Fatal(err)
 	}
-	addrs, err := net.LookupHost("www.ooni.io")
+	reso := &net.Resolver{
+		PreferGo: true,
+	}
+	addrs, err := reso.LookupHost(context.Background(), "www.ooni.io")
 	if err == nil {
 		t.Fatal("expected an error here")
 	}


### PR DESCRIPTION
This commit forward ports 8f2d7945f806579af4d0495f4b8f5a6a01eefb0c, whose
commit message is as follows:

- - -

The discrepancy I was seeing between my local tests and tests run
in the CI is that my systemd is configured to use DoT.

Hence, it was bypassing iptables rules because the query was sent
over an encrypted tunnel. Using a pure Go resolver fixes since
that always uses UDP, so the filter works.

Also, reason that we want as minimal as possible tests, so refactor
a test so that we use just a resolver rather than an HTTP client, and,
while there, also enforce this resolver to be a pure Go resolver.

Reference issue: https://github.com/ooni/probe/issues/2016

This diff WILL need to be forward ported to master.
