### PR TITLE
[forwardport] fix(qa): adapt to new wcth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,13 @@
 /apitool
 /apitool.exe
 /*.asc
+/badproxy.pem
 /coverage.cov
 /*.deb
 /DEBIAN_INSTALLED_PACKAGE.txt
 /debops-ci
 .DS_Store
+/jafar
 /*.jsonl
 /miniooni
 /miniooni.exe


### PR DESCRIPTION
This diff forward ports 36ba3630c9002db0bd79e3a7e49641ce6b665471,
whose original commit message follows:

- - -

This diff contains minimal changes to make webconnectivity QA
WAI with the new Web Connectivity test helper.

It seems we're currently doing round robin between the old and
the new implementation, so I needed to locally pin my probes
to use the new implementation by changing the code. But, obviously,
I don't want to commit this code.

Likewise, in my working environment, I need to build the docker
container using `docker buildx build --platform linux/amd64`, but
I am not sure whether to commit this code.

While there, I noticed there was a missing QA test for the case
in which we're passing through a transparent HTTP proxy. I noticed
as well that the test that said it was passing through such a
proxy was actually using a transparent TLS proxy. I remediated
this by ensuring we have a test for both cases.

The other major change in the suite is that, when using the new TH,
there's uncommon headers intersection in some tests, so we have
had a flip from headers not matching to headers matching.

Finally, some formatting changes because I did re-run black.

These changes should be enough to call it a day with respect to
QA (see https://github.com/ooni/probe/issues/2016#issuecomment-1033813344).

This diff WILL need to be forward ported to master.

(I don't know whether the GitHub QA will converge after these changes
and I suspect it won't because of the test helper round robin.)
