### PR TITLE
[forwardport] fix(ooniprobe): ensure tunnelDir is correctly set

### DIFF
--- a/cmd/ooniprobe/internal/ooni/ooni.go
+++ b/cmd/ooniprobe/internal/ooni/ooni.go
@@ -189,6 +189,7 @@ func (p *Probe) Init(softwareName, softwareVersion string) error {
 		return errors.Wrap(err, "creating TempDir")
 	}
 	p.tempDir = tempDir
+	p.tunnelDir = utils.TunnelDir(p.home)
 
 	p.softwareName = softwareName
 	p.softwareVersion = softwareVersion
@@ -205,7 +206,7 @@ func (p *Probe) NewSession(ctx context.Context) (*engine.Session, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "creating engine's kvstore")
 	}
-	if err := os.MkdirAll(utils.TunnelDir(p.home), 0700); err != nil {
+	if err := os.MkdirAll(p.tunnelDir, 0700); err != nil {
 		return nil, errors.Wrap(err, "creating tunnel dir")
 	}
 	return engine.NewSession(ctx, engine.SessionConfig{


### PR DESCRIPTION
This commit forward ports 59c63ee0b2249c803c40f1eb19c0f6c062838bf1,
whose original log message follows:

- - -

While doing QA in https://github.com/ooni/probe/issues/1845, I
noticed we're not using the correct directory.

Results are written in the current directory inside of the OONI_HOME,
which is quite not what we want to happen.

This diff WILL require forward porting to master.
