### PR TITLE
doc(CONTRIBUTING.md): add golang resources and links to community channels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,14 @@ general to follow these guidelines when working on ooni/probe-cli. In
 the unlikely care where those guidelines conflict with this document, this
 document will take precedence.
 
+### Golang resources
+
+We use golang as our primary language for the development of OONI Probe CLI and do check out the resources mentioned below, it may help you to level-up.
+
+- [Effective Go](https://go.dev/doc/effective_go)
+- [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
+- [Concurrency](https://go.dev/blog/pipelines) and [Data races](https://go.dev/ref/mem)
+
 ## Opening issues
 
 Please, before opening a new issue, check whether the issue or feature request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,9 @@ general to follow these guidelines when working on ooni/probe-cli. In
 the unlikely care where those guidelines conflict with this document, this
 document will take precedence.
 
-### Golang resources
+## Golang Resources
 
-We use golang as our primary language for the development of OONI Probe CLI and do check out the resources mentioned below, it may help you to level-up.
+We use golang as our primary language for the development of OONI Probe CLI and do check out the resources below, quite useful to read before contributing.
 
 - [Effective Go](https://go.dev/doc/effective_go)
 - [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
@@ -141,3 +141,7 @@ the `alpha` version used by `master`.
 
 We build binary packages for each tagged release. We will use external
 tools for publishing binaries to our Debian repository, Maven Central, etc.
+
+## Community Channels
+
+Stuck somewhere or Have any questions? please join our [Slack Channels](https://slack.ooni.org/) or [IRC](ircs://irc.oftc.net:6697/#ooni). We're here to help and always available to discuss. 


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)

There is no reference issue for this pull request, since this is an improvement for the `CONTRIBUTING.md`

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

Added golang resources, pointers to our Slack and IRC channels  in `CONTRIBUTING.md` which helps new contributors to understand golang better and reach out to us on the platforms mentioned for discussion.