### PR TITLE
fix(ndt7): force our bundled CA pool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/ziutek/mymysql v1.5.4 // indirect
 	gitlab.com/yawning/obfs4.git v0.0.0-20220102012252-cbf3f3cfa09c
 	gitlab.com/yawning/utls.git v0.0.12-1
-	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce // indirect
+	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce
 	golang.org/x/net v0.0.0-20220114011407-0dd24b26b47d
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect

--- a/internal/engine/experiment/ndt7/dial.go
+++ b/internal/engine/experiment/ndt7/dial.go
@@ -17,7 +17,6 @@ type dialManager struct {
 	logger          model.Logger
 	proxyURL        *url.URL
 	readBufferSize  int
-	tlsConfig       *tls.Config
 	userAgent       string
 	writeBufferSize int
 }
@@ -43,10 +42,15 @@ func (mgr dialManager) dialWithTestName(ctx context.Context, testName string) (*
 		Logger:              mgr.logger,
 		ProxyURL:            mgr.proxyURL,
 	}, reso)
+	// We force using our bundled CA pool, which should fix
+	// https://github.com/ooni/probe/issues/2031
+	tlsConfig := &tls.Config{
+		RootCAs: netxlite.NewDefaultCertPool(),
+	}
 	dialer := websocket.Dialer{
 		NetDialContext:  dlr.DialContext,
 		ReadBufferSize:  mgr.readBufferSize,
-		TLSClientConfig: mgr.tlsConfig,
+		TLSClientConfig: tlsConfig,
 		WriteBufferSize: mgr.writeBufferSize,
 	}
 	headers := http.Header{}


### PR DESCRIPTION
This change should prevent old clients (e.g., Android 6) from
failing to perform a ndt7 experiment because their internal CA
bundle is now too old.

Reference issue: https://github.com/ooni/probe/issues/2031

While there, run `go mod tidy` to fix a minor inconsistence in
the current `go.mod` file.

This diff WILL require a backport to release/3.14.
