### PR TITLE
cleanup: use ErrorToStringOrOK func in other tests that returns nil

### DIFF
--- a/internal/engine/experiment/hirl/hirl.go
+++ b/internal/engine/experiment/hirl/hirl.go
@@ -131,7 +131,7 @@ func (m Measurer) Run(
 		tk.Tampering = (tk.Tampering || result.Tampering)
 		completed++
 		percentage := (float64(completed)/float64(len(m.Methods)))*0.5 + 0.5
-		callbacks.OnProgress(percentage, fmt.Sprintf("%s... %+v", result.Name, result.Err))
+		callbacks.OnProgress(percentage, fmt.Sprintf("%s... %+v", result.Name, model.ErrorToStringOrOK(result.Err)))
 		if completed >= len(m.Methods) {
 			break
 		}

--- a/internal/engine/experiment/urlgetter/multi.go
+++ b/internal/engine/experiment/urlgetter/multi.go
@@ -106,7 +106,7 @@ func (m Multi) collect(expect int, overallStartIndex int, overallCount int, pref
 		count++
 		percentage := float64(count) / float64(overallCount)
 		callbacks.OnProgress(percentage, fmt.Sprintf(
-			"%s: measure %s: %+v", prefix, entry.Input.Target, entry.Err,
+			"%s: measure %s: %+v", prefix, entry.Input.Target, model.ErrorToStringOrOK(entry.Err),
 		))
 		outputch <- entry
 	}

--- a/internal/engine/experiment/webconnectivity/control.go
+++ b/internal/engine/experiment/webconnectivity/control.go
@@ -64,7 +64,7 @@ func Control(
 	if err != nil {
 		err = netxlite.NewTopLevelGenericErrWrapper(err)
 	}
-	sess.Logger().Infof("control for %s... %+v", creq.HTTPRequest, err)
+	sess.Logger().Infof("control for %s... %+v", creq.HTTPRequest, model.ErrorToStringOrOK(err))
 	(&out.DNS).FillASNs(sess)
 	return
 }

--- a/internal/engine/experiment/webconnectivity/dnslookup.go
+++ b/internal/engine/experiment/webconnectivity/dnslookup.go
@@ -44,7 +44,7 @@ func DNSLookup(ctx context.Context, config DNSLookupConfig) (out DNSLookupResult
 			}
 		}
 	}
-	config.Session.Logger().Infof("%s... %+v", target, err)
+	config.Session.Logger().Infof("%s... %+v", target, model.ErrorToStringOrOK(err))
 	out.Failure = result.Failure
 	out.TestKeys = result
 	return

--- a/internal/engine/experiment/webconnectivity/httpget.go
+++ b/internal/engine/experiment/webconnectivity/httpget.go
@@ -63,7 +63,7 @@ func HTTPGet(ctx context.Context, config HTTPGetConfig) (out HTTPGetResult) {
 		Session: config.Session,
 		Target:  target,
 	}.Get(ctx)
-	config.Session.Logger().Infof("GET %s... %+v", target, err)
+	config.Session.Logger().Infof("GET %s... %+v", target, model.ErrorToStringOrOK(err))
 	out.Failure = result.Failure
 	out.TestKeys = result
 	return

--- a/internal/engine/internal/sessionresolver/sessionresolver.go
+++ b/internal/engine/internal/sessionresolver/sessionresolver.go
@@ -163,7 +163,7 @@ func (r *Resolver) lookupHost(ctx context.Context, ri *resolverinfo, hostname st
 	}
 	addrs, err := r.timeLimitedLookup(ctx, re, hostname)
 	if err == nil {
-		r.logger().Infof("sessionresolver: %s... %v", ri.URL, nil)
+		r.logger().Infof("sessionresolver: %s... %v", ri.URL, model.ErrorToStringOrOK(nil))
 		ri.Score = ewma*1.0 + (1-ewma)*ri.Score // increase score
 		return addrs, nil
 	}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2040

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This PR aims to refactor and ensure "ok" is returned on success of an experiment rather than `<nil>` value.