### PR TITLE
fix: experimental should be unattended

### DIFF
--- a/cmd/ooniprobe/internal/nettests/groups.go
+++ b/cmd/ooniprobe/internal/nettests/groups.go
@@ -22,6 +22,7 @@ var All = map[string]Group{
 			Dash{},
 			NDT{},
 		},
+		// unattendedOK is explicitly set to false, since there is no need for consumption of excessive amounts of data with background tests
 		UnattendedOK: false,
 	},
 	"middlebox": {


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2056

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This PR ensures that CLI runs the experimental nettests group in unattended mode, and manually verified that the experimental group runs in this case.
