### PR TITLE
fix(httpx): correctly combine paths

### DIFF
--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -144,8 +144,32 @@ func (c *apiClient) newRequestWithJSONBody(
 
 // joinURLPath joins the BaseURL and the URLPath, allows httpx to access the URL
 func (c *apiClient) joinURLPath(URLPath string) string {
-	accessURL := c.BaseURL + URLPath
-	return accessURL
+
+	if c.BaseURL != "" && URLPath != "" {
+		if c.BaseURL[len(c.BaseURL)-1] != '/' && URLPath[0] != '/' {
+			c.BaseURL += "/"
+			return c.BaseURL + URLPath
+		}
+
+		if c.BaseURL[len(c.BaseURL)-1] == '/' && URLPath[0] == '/' {
+			return c.BaseURL + URLPath[1:]
+		}
+
+		if c.BaseURL[len(c.BaseURL)-1] == '/' && URLPath[0] != '/' {
+			return c.BaseURL + URLPath
+		}
+
+		if c.BaseURL[len(c.BaseURL)-1] != '/' && URLPath[0] == '/' {
+			return c.BaseURL + URLPath
+		}
+		return c.BaseURL + URLPath
+	}
+
+	if c.BaseURL != "" && URLPath == "" {
+		return c.BaseURL
+	}
+
+	return ""
 }
 
 // newRequest creates a new request.

--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -74,9 +74,9 @@ const DefaultMaxBodySize = 1 << 22
 // baseURL path is appended with the resourcePath if it is
 // created using APIClientTemplate.
 type APIClient interface {
-	// GetJSON reads the JSON resource at combined path of baseURL with
-	// the resourcePath and unmarshals the results into output.
-	// The request is bounded by the lifetime of the
+	// GetJSON reads the JSON resource whose path is obtained concatenating
+	// the baseURL's path with `resourcePath` and unmarshals the results
+	// into `output`. The request is bounded by the lifetime of the
 	// context passed as argument. Returns the error that occurred.
 	GetJSON(ctx context.Context, resourcePath string, output interface{}) error
 

--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -143,25 +143,20 @@ func (c *apiClient) newRequestWithJSONBody(
 	return request, nil
 }
 
-// joinURLPath joins the BaseURL and the URLPath, allows httpx to access the URL
+// joinURLPath joins the BaseURL and the resource URL Path, allows httpx to access the URL
 func (c *apiClient) joinURLPath(origPath string, newPath string) string {
 
-	if origPath != "" && newPath != "" {
-		if !strings.HasSuffix(origPath, "/") && !strings.HasPrefix(newPath, "/") {
-			origPath += "/"
-		}
-
-		if strings.HasSuffix(origPath, "/") && strings.HasPrefix(newPath, "/") {
-			newPath = newPath[1:]
-		}
-		return origPath + newPath
+	// If the BaseURL path doesn't end with a slash, added one
+	if !strings.HasSuffix(origPath, "/") {
+		origPath += "/"
 	}
 
-	if origPath != "" && newPath == "" {
-		return origPath
+	// If the resourceURL path has a leading slash, it is removed
+	if strings.HasPrefix(newPath, "/") {
+		newPath = newPath[1:]
 	}
 
-	return ""
+	return origPath + newPath
 }
 
 // newRequest creates a new request.
@@ -171,6 +166,7 @@ func (c *apiClient) newRequest(ctx context.Context, method, resourcePath string,
 	if err != nil {
 		return nil, err
 	}
+	// BaseURL and resource URL is joined if they have a path
 	URL.Path = c.joinURLPath(URL.Path, resourcePath)
 	if query != nil {
 		URL.RawQuery = query.Encode()

--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -142,6 +142,12 @@ func (c *apiClient) newRequestWithJSONBody(
 	return request, nil
 }
 
+// joinURLPath joins the BaseURL and the URLPath, allows httpx to access the URL
+func (c *apiClient) joinURLPath(URLPath string) string {
+	accessURL := c.BaseURL + URLPath
+	return accessURL
+}
+
 // newRequest creates a new request.
 func (c *apiClient) newRequest(ctx context.Context, method, resourcePath string,
 	query url.Values, body io.Reader) (*http.Request, error) {

--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -71,8 +71,9 @@ const DefaultMaxBodySize = 1 << 22
 
 // APIClient is a client configured to call a given API identified
 // by a given baseURL and using a given model.HTTPClient.
-// baseURL path is appended with the resourcePath if it is
-// created using APIClientTemplate.
+//
+// The resource path argument passed to APIClient methods is appended
+// to the base URL's path for determining the full URL's path.
 type APIClient interface {
 	// GetJSON reads the JSON resource whose path is obtained concatenating
 	// the baseURL's path with `resourcePath` and unmarshals the results
@@ -84,9 +85,9 @@ type APIClient interface {
 	GetJSONWithQuery(ctx context.Context, resourcePath string,
 		query url.Values, output interface{}) error
 
-	// PostJSON creates a JSON subresource of the resource at
-	// combined path of baseURL with the resourcePath using the JSON
-	// document at input and returning the result into the
+	// PostJSON creates a JSON subresource of the resource whose
+	// path is obtained concatenating the baseURL'spath with `resourcePath` using
+	// the JSON document at `input` as value and returning the result into the
 	// JSON document at output. The request is bounded by the context's
 	// lifetime. Returns the error that occurred.
 	PostJSON(ctx context.Context, resourcePath string, input, output interface{}) error
@@ -147,8 +148,8 @@ func (c *apiClient) newRequestWithJSONBody(
 	return request, nil
 }
 
-// joinURLPath combines the path of resource URL with the baseURL,
-// and allows httpx to access the URL when it creates a new request.
+// joinURLPath appends the path of resource URL to the baseURL taking
+// care of multiple forward slashes gracefully.
 func (c *apiClient) joinURLPath(origPath string, newPath string) string {
 
 	// If the BaseURL path doesn't end with a slash, added one

--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -151,11 +151,10 @@ func (c *apiClient) joinURLPath(URLPath string) string {
 // newRequest creates a new request.
 func (c *apiClient) newRequest(ctx context.Context, method, resourcePath string,
 	query url.Values, body io.Reader) (*http.Request, error) {
-	URL, err := url.Parse(c.BaseURL)
+	URL, err := url.Parse(c.joinURLPath(resourcePath))
 	if err != nil {
 		return nil, err
 	}
-	URL.Path = resourcePath
 	if query != nil {
 		URL.RawQuery = query.Encode()
 	}

--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -71,9 +71,12 @@ const DefaultMaxBodySize = 1 << 22
 
 // APIClient is a client configured to call a given API identified
 // by a given baseURL and using a given model.HTTPClient.
+// baseURL path is appended with the resourcePath if it is
+// created using APIClientTemplate.
 type APIClient interface {
-	// GetJSON reads the JSON resource at resourcePath and unmarshals the
-	// results into output. The request is bounded by the lifetime of the
+	// GetJSON reads the JSON resource at combined path of baseURL with
+	// the resourcePath and unmarshals the results into output.
+	// The request is bounded by the lifetime of the
 	// context passed as argument. Returns the error that occurred.
 	GetJSON(ctx context.Context, resourcePath string, output interface{}) error
 
@@ -81,8 +84,9 @@ type APIClient interface {
 	GetJSONWithQuery(ctx context.Context, resourcePath string,
 		query url.Values, output interface{}) error
 
-	// PostJSON creates a JSON subresource of the resource at resourcePath
-	// using the JSON document at input and returning the result into the
+	// PostJSON creates a JSON subresource of the resource at
+	// combined path of baseURL with the resourcePath using the JSON
+	// document at input and returning the result into the
 	// JSON document at output. The request is bounded by the context's
 	// lifetime. Returns the error that occurred.
 	PostJSON(ctx context.Context, resourcePath string, input, output interface{}) error
@@ -143,7 +147,8 @@ func (c *apiClient) newRequestWithJSONBody(
 	return request, nil
 }
 
-// joinURLPath joins the BaseURL and the resource URL Path, allows httpx to access the URL
+// joinURLPath combines the path of resource URL with the baseURL,
+// and allows httpx to access the URL when it creates a new request.
 func (c *apiClient) joinURLPath(origPath string, newPath string) string {
 
 	// If the BaseURL path doesn't end with a slash, added one

--- a/internal/httpx/httpx_test.go
+++ b/internal/httpx/httpx_test.go
@@ -94,15 +94,16 @@ func newAPIClient() *apiClient {
 }
 
 func TestJoinURLPath(t *testing.T) {
-	t.Run("BaseURL and URLpath", func(t *testing.T) {
+	t.Run("empty baseURL path and slash-prefixed resource path", func(t *testing.T) {
 		ac := newAPIClient()
+		ac.BaseURL = "https://example.com"
 		req, err := ac.newRequest(context.Background(), "GET", "/foo", nil, nil)
 		if req.URL.String() != "https://example.com/foo" {
 			t.Fatal("unexpected result", err)
 		}
 	})
 
-	t.Run("BaseURL and URLpath contains /", func(t *testing.T) {
+	t.Run("root baseURL path and slash-prefixed resource path", func(t *testing.T) {
 		ac := newAPIClient()
 		ac.BaseURL = "https://example.com/"
 		req, err := ac.newRequest(context.Background(), "GET", "/foo", nil, nil)
@@ -111,15 +112,16 @@ func TestJoinURLPath(t *testing.T) {
 		}
 	})
 
-	t.Run("empty URLpath", func(t *testing.T) {
+	t.Run("empty baseURL path and empty resource path", func(t *testing.T) {
 		ac := newAPIClient()
+		ac.BaseURL = "https://example.com"
 		req, err := ac.newRequest(context.Background(), "GET", "", nil, nil)
 		if req.URL.String() != "https://example.com/" {
 			t.Fatal("unexpected result", err)
 		}
 	})
 
-	t.Run("path with the BaseURL", func(t *testing.T) {
+	t.Run("non-slash-terminated baseURL path and slash-prefixed resource path", func(t *testing.T) {
 		ac := newAPIClient()
 		ac.BaseURL = "http://example.com/foo"
 		req, err := ac.newRequest(context.Background(), "GET", "/bar", nil, nil)
@@ -128,7 +130,7 @@ func TestJoinURLPath(t *testing.T) {
 		}
 	})
 
-	t.Run("BaseURL with path and URLpath, both contains slash", func(t *testing.T) {
+	t.Run("slash-terminated baseURL path and slash-prefixed resource path", func(t *testing.T) {
 		ac := newAPIClient()
 		ac.BaseURL = "http://example.com/foo/"
 		req, err := ac.newRequest(context.Background(), "GET", "/bar", nil, nil)
@@ -137,7 +139,7 @@ func TestJoinURLPath(t *testing.T) {
 		}
 	})
 
-	t.Run("BaseURL ends with slash and no slash in URLpath", func(t *testing.T) {
+	t.Run("slash-terminated baseURL path and non-slash-prefixed resource path", func(t *testing.T) {
 		ac := newAPIClient()
 		ac.BaseURL = "http://example.com/foo/"
 		req, err := ac.newRequest(context.Background(), "GET", "bar", nil, nil)

--- a/internal/httpx/httpx_test.go
+++ b/internal/httpx/httpx_test.go
@@ -93,6 +93,40 @@ func newAPIClient() *apiClient {
 	}
 }
 
+func TestJoinURLPath(t *testing.T) {
+	t.Run("with Base URL and path", func(t *testing.T) {
+		ac := newAPIClient()
+		ac.BaseURL = "http://example.com"
+		if got, want := ac.joinURLPath("/foo"), ""; got == want {
+			t.Fatal("expected result")
+		}
+	})
+
+	t.Run("both Base URL and URL path contains /", func(t *testing.T) {
+		ac := newAPIClient()
+		ac.BaseURL = "http://example.com/"
+		if got, want := ac.joinURLPath("/foo"), "http://example.com/foo"; got != want {
+			t.Fatal("unexpected result")
+		}
+	})
+
+	t.Run("with empty URL path", func(t *testing.T) {
+		ac := newAPIClient()
+		ac.BaseURL = "http://example.com"
+		if got, want := ac.joinURLPath(""), "http://example.com"; got != want {
+			t.Fatal("unexpected result")
+		}
+	})
+
+	t.Run("with no BaseURL", func(t *testing.T) {
+		ac := newAPIClient()
+		ac.BaseURL = ""
+		if got, want := ac.joinURLPath("/foo"), ""; got != want {
+			t.Fatal("unexpected result")
+		}
+	})
+}
+
 // fakeRequest is a fake request we serialize.
 type fakeRequest struct {
 	Name       string

--- a/internal/httpx/httpx_test.go
+++ b/internal/httpx/httpx_test.go
@@ -96,57 +96,53 @@ func newAPIClient() *apiClient {
 func TestJoinURLPath(t *testing.T) {
 	t.Run("BaseURL and URLpath", func(t *testing.T) {
 		ac := newAPIClient()
-		ac.BaseURL = "https://example.com"
-		if got, want := ac.joinURLPath(ac.BaseURL, "/foo"), "https://example.com/foo"; got != want {
-			t.Fatal("unexpected result")
+		req, err := ac.newRequest(context.Background(), "GET", "/foo", nil, nil)
+		if req.URL.String() != "https://example.com/foo" {
+			t.Fatal("unexpected result", err)
 		}
 	})
 
 	t.Run("BaseURL and URLpath contains /", func(t *testing.T) {
 		ac := newAPIClient()
 		ac.BaseURL = "https://example.com/"
-		if got, want := ac.joinURLPath(ac.BaseURL, "/foo"), "https://example.com/foo"; got != want {
-			t.Fatal("unexpected result")
+		req, err := ac.newRequest(context.Background(), "GET", "/foo", nil, nil)
+		if req.URL.String() != "https://example.com/foo" {
+			t.Fatal("unexpected result", err)
 		}
 	})
 
 	t.Run("empty URLpath", func(t *testing.T) {
 		ac := newAPIClient()
-		ac.BaseURL = "http://example.com"
-		if got, want := ac.joinURLPath(ac.BaseURL, ""), "http://example.com"; got != want {
-			t.Fatal("unexpected result")
-		}
-	})
-
-	t.Run("empty BaseURL", func(t *testing.T) {
-		ac := newAPIClient()
-		ac.BaseURL = ""
-		if got, want := ac.joinURLPath(ac.BaseURL, "/foo"), ""; got != want {
-			t.Fatal("unexpected result")
+		req, err := ac.newRequest(context.Background(), "GET", "", nil, nil)
+		if req.URL.String() != "https://example.com/" {
+			t.Fatal("unexpected result", err)
 		}
 	})
 
 	t.Run("path with the BaseURL", func(t *testing.T) {
 		ac := newAPIClient()
 		ac.BaseURL = "http://example.com/foo"
-		if got, want := ac.joinURLPath(ac.BaseURL, "/bar"), "http://example.com/foo/bar"; got != want {
-			t.Fatal("unexpected result")
+		req, err := ac.newRequest(context.Background(), "GET", "/bar", nil, nil)
+		if req.URL.String() != "http://example.com/foo/bar" {
+			t.Fatal("unexpected result", err)
 		}
 	})
 
 	t.Run("BaseURL with path and URLpath, both contains slash", func(t *testing.T) {
 		ac := newAPIClient()
 		ac.BaseURL = "http://example.com/foo/"
-		if got, want := ac.joinURLPath(ac.BaseURL, "/bar"), "http://example.com/foo/bar"; got != want {
-			t.Fatal("unexpected result")
+		req, err := ac.newRequest(context.Background(), "GET", "/bar", nil, nil)
+		if req.URL.String() != "http://example.com/foo/bar" {
+			t.Fatal("unexpected result", err)
 		}
 	})
 
 	t.Run("BaseURL ends with slash and no slash in URLpath", func(t *testing.T) {
 		ac := newAPIClient()
 		ac.BaseURL = "http://example.com/foo/"
-		if got, want := ac.joinURLPath(ac.BaseURL, "bar"), "http://example.com/foo/bar"; got != want {
-			t.Fatal("unexpected result")
+		req, err := ac.newRequest(context.Background(), "GET", "bar", nil, nil)
+		if req.URL.String() != "http://example.com/foo/bar" {
+			t.Fatal("unexpected result", err)
 		}
 	})
 }

--- a/internal/httpx/httpx_test.go
+++ b/internal/httpx/httpx_test.go
@@ -125,6 +125,30 @@ func TestJoinURLPath(t *testing.T) {
 			t.Fatal("unexpected result")
 		}
 	})
+
+	t.Run("URL path with the BaseURL", func(t *testing.T) {
+		ac := newAPIClient()
+		ac.BaseURL = "http://example.com/foo"
+		if got, want := ac.joinURLPath("/bar"), "http://example.com/foo/bar"; got != want {
+			t.Fatal("unexpected result")
+		}
+	})
+
+	t.Run("URL path with the BaseURL and slash", func(t *testing.T) {
+		ac := newAPIClient()
+		ac.BaseURL = "http://example.com/foo/"
+		if got, want := ac.joinURLPath("/bar"), "http://example.com/foo/bar"; got != want {
+			t.Fatal("unexpected result")
+		}
+	})
+
+	t.Run("with the BaseURL slash and no slash in URL path", func(t *testing.T) {
+		ac := newAPIClient()
+		ac.BaseURL = "http://example.com/foo/"
+		if got, want := ac.joinURLPath("bar"), "http://example.com/foo/bar"; got != want {
+			t.Fatal("unexpected result")
+		}
+	})
 }
 
 // fakeRequest is a fake request we serialize.

--- a/internal/httpx/httpx_test.go
+++ b/internal/httpx/httpx_test.go
@@ -94,58 +94,58 @@ func newAPIClient() *apiClient {
 }
 
 func TestJoinURLPath(t *testing.T) {
-	t.Run("with Base URL and path", func(t *testing.T) {
+	t.Run("BaseURL and URLpath", func(t *testing.T) {
 		ac := newAPIClient()
-		ac.BaseURL = "http://example.com"
-		if got, want := ac.joinURLPath("/foo"), ""; got == want {
-			t.Fatal("expected result")
-		}
-	})
-
-	t.Run("both Base URL and URL path contains /", func(t *testing.T) {
-		ac := newAPIClient()
-		ac.BaseURL = "http://example.com/"
-		if got, want := ac.joinURLPath("/foo"), "http://example.com/foo"; got != want {
+		ac.BaseURL = "https://example.com"
+		if got, want := ac.joinURLPath(ac.BaseURL, "/foo"), "https://example.com/foo"; got != want {
 			t.Fatal("unexpected result")
 		}
 	})
 
-	t.Run("with empty URL path", func(t *testing.T) {
+	t.Run("BaseURL and URLpath contains /", func(t *testing.T) {
 		ac := newAPIClient()
-		ac.BaseURL = "http://example.com"
-		if got, want := ac.joinURLPath(""), "http://example.com"; got != want {
+		ac.BaseURL = "https://example.com/"
+		if got, want := ac.joinURLPath(ac.BaseURL, "/foo"), "https://example.com/foo"; got != want {
 			t.Fatal("unexpected result")
 		}
 	})
 
-	t.Run("with no BaseURL", func(t *testing.T) {
+	t.Run("empty URLpath", func(t *testing.T) {
+		ac := newAPIClient()
+		ac.BaseURL = "http://example.com"
+		if got, want := ac.joinURLPath(ac.BaseURL, ""), "http://example.com"; got != want {
+			t.Fatal("unexpected result")
+		}
+	})
+
+	t.Run("empty BaseURL", func(t *testing.T) {
 		ac := newAPIClient()
 		ac.BaseURL = ""
-		if got, want := ac.joinURLPath("/foo"), ""; got != want {
+		if got, want := ac.joinURLPath(ac.BaseURL, "/foo"), ""; got != want {
 			t.Fatal("unexpected result")
 		}
 	})
 
-	t.Run("URL path with the BaseURL", func(t *testing.T) {
+	t.Run("path with the BaseURL", func(t *testing.T) {
 		ac := newAPIClient()
 		ac.BaseURL = "http://example.com/foo"
-		if got, want := ac.joinURLPath("/bar"), "http://example.com/foo/bar"; got != want {
+		if got, want := ac.joinURLPath(ac.BaseURL, "/bar"), "http://example.com/foo/bar"; got != want {
 			t.Fatal("unexpected result")
 		}
 	})
 
-	t.Run("URL path with the BaseURL and slash", func(t *testing.T) {
+	t.Run("BaseURL with path and URLpath, both contains slash", func(t *testing.T) {
 		ac := newAPIClient()
 		ac.BaseURL = "http://example.com/foo/"
-		if got, want := ac.joinURLPath("/bar"), "http://example.com/foo/bar"; got != want {
+		if got, want := ac.joinURLPath(ac.BaseURL, "/bar"), "http://example.com/foo/bar"; got != want {
 			t.Fatal("unexpected result")
 		}
 	})
 
-	t.Run("with the BaseURL slash and no slash in URL path", func(t *testing.T) {
+	t.Run("BaseURL ends with slash and no slash in URLpath", func(t *testing.T) {
 		ac := newAPIClient()
 		ac.BaseURL = "http://example.com/foo/"
-		if got, want := ac.joinURLPath("bar"), "http://example.com/foo/bar"; got != want {
+		if got, want := ac.joinURLPath(ac.BaseURL, "bar"), "http://example.com/foo/bar"; got != want {
 			t.Fatal("unexpected result")
 		}
 	})


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2010

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This PR ensures that given a BaseURL `https://example.com/example` and an URLPath of `/foo/bar`, the code in httpx should access `https://example.com/example/foo/bar`. Also, the documentation for the same.