### PR TITLE
fix(torsf): ensure tor-logs-filtering regexp is correct

### DIFF
--- a/internal/engine/experiment/torsf/torsf.go
+++ b/internal/engine/experiment/torsf/torsf.go
@@ -196,7 +196,7 @@ func (m *Measurer) bootstrap(ctx context.Context, sess model.ExperimentSession,
 
 // torProgressRegexp helps to extract progress info from logs.
 //
-// See https://regex101.com/r/3YfIed/1.
+// See https://regex101.com/r/cer3lm/1.
 var torProgressRegexp = regexp.MustCompile(
 	`^[A-Za-z0-9.: ]+ \[notice\] Bootstrapped [0-9]+% \([A-Za-z_]+\): [A-Za-z0-9 ]+$`)
 

--- a/internal/engine/experiment/torsf/torsf.go
+++ b/internal/engine/experiment/torsf/torsf.go
@@ -198,7 +198,7 @@ func (m *Measurer) bootstrap(ctx context.Context, sess model.ExperimentSession,
 //
 // See https://regex101.com/r/3YfIed/1.
 var torProgressRegexp = regexp.MustCompile(
-	`^[A-Za-z0-9.: ]+ \[notice\] Bootstrapped [0-9]+% \([a-zA-z]+\): [A-Za-z0-9 ]+$`)
+	`^[A-Za-z0-9.: ]+ \[notice\] Bootstrapped [0-9]+% \([A-Za-z_]+\): [A-Za-z0-9 ]+$`)
 
 // readTorLogs attempts to read and include the tor logs into
 // the test keys if this operation is possible.


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: [2060] (https://github.com/ooni/probe/issues/2060)
- [ ] if you changed anything related how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: 

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description
https://github.com/ooni/probe-cli/blob/85664f1e31de0844f444af7c690a57628ff79ff7/internal/engine/experiment/torsf/torsf.go#L200-L201

The regex fragment [a-zA-z]+ was matching strings with an underscore, like conn_pt and onehop_create. Look closely: the second z, which you would expect to be uppercase, is actually lowercase. The underscore character _ (ASCII 95) lies between A (ASCII 65) and z (ASCII 122), which is why the regex works for its intended purpose, despite containing an evident typo.

A small fix in regex to increase its readabliity and thus avoid extra characters like `[\]^_\``.

