### PR TITLE
fix(cli/geoip): correct typos in tests

### DIFF
--- a/cmd/ooniprobe/internal/cli/geoip/geoip_test.go
+++ b/cmd/ooniprobe/internal/cli/geoip/geoip_test.go
@@ -117,18 +117,18 @@ func TestMaybeLookupLocationSuccess(t *testing.T) {
 		t.Fatal("invalid log level")
 	}
 	if entry.Message != "Looked up your location" {
-		t.Fatal("invalid .Message")
+		t.Fatal("invalid Message")
 	}
 	if entry.Fields["asn"].(string) != "AS30722" {
 		t.Fatal("invalid asn")
 	}
 	if entry.Fields["country_code"].(string) != "IT" {
-		t.Fatal("invalid asn")
+		t.Fatal("invalid country code")
 	}
 	if entry.Fields["network_name"].(string) != "Vodafone Italia S.p.A." {
-		t.Fatal("invalid asn")
+		t.Fatal("invalid network name")
 	}
 	if entry.Fields["ip"].(string) != "130.25.90.216" {
-		t.Fatal("invalid asn")
+		t.Fatal("invalid ip")
 	}
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [ ] reference issue for this pull request: <!-- add URL here -->
- [ ] if you changed anything related how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This is just a typo fix in the `TestMaybeLookupLocationSuccess` in `cmd/ooniprobe/internal/cli/geoip/geoip_test.go`. As a result it does not refer to any existing issues in `ooni/probe`