### PR TITLE
tls_handshakes: add endpoint addresses to handshake list

### DIFF
--- a/internal/engine/experiment/urlgetter/getter.go
+++ b/internal/engine/experiment/urlgetter/getter.go
@@ -77,7 +77,7 @@ func (g Getter) Get(ctx context.Context) (TestKeys, error) {
 		tk.TCPConnect, archival.NewTCPConnectList(g.Begin, events)...,
 	)
 	tk.TLSHandshakes = append(
-		tk.TLSHandshakes, archival.NewTLSHandshakesList(g.Begin, events)...,
+		tk.TLSHandshakes, archival.NewTLSHandshakesList(g.Begin, g.Target, events)...,
 	)
 	return tk, err
 }

--- a/internal/engine/experiment/urlgetter/getter.go
+++ b/internal/engine/experiment/urlgetter/getter.go
@@ -77,7 +77,7 @@ func (g Getter) Get(ctx context.Context) (TestKeys, error) {
 		tk.TCPConnect, archival.NewTCPConnectList(g.Begin, events)...,
 	)
 	tk.TLSHandshakes = append(
-		tk.TLSHandshakes, archival.NewTLSHandshakesList(g.Begin, g.Target, events)...,
+		tk.TLSHandshakes, archival.NewTLSHandshakesList(g.Begin, events)...,
 	)
 	return tk, err
 }

--- a/internal/engine/netx/archival/archival.go
+++ b/internal/engine/netx/archival/archival.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"net"
 	"net/http"
-	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -308,27 +307,14 @@ func NewNetworkEventsList(begin time.Time, events []trace.Event) []NetworkEvent 
 }
 
 // NewTLSHandshakesList creates a new TLSHandshakesList
-func NewTLSHandshakesList(begin time.Time, target string, events []trace.Event) []TLSHandshake {
-	// setting a default value if the handshake is performed
-	// without a connect operation
-	// This requires target to be an IP which may not always be the case
-	address := target
-	targetURL, err := url.Parse(target)
-	if err == nil {
-		address = targetURL.Host
-	}
+func NewTLSHandshakesList(begin time.Time, events []trace.Event) []TLSHandshake {
 	var out []TLSHandshake
 	for _, ev := range events {
-		// check for a tcp connect event before the handshake
-		// and extract the IP address here
-		if ev.Name == netxlite.ConnectOperation {
-			address = ev.Address
-		}
 		if !strings.Contains(ev.Name, "_handshake_done") {
 			continue
 		}
 		out = append(out, TLSHandshake{
-			Address:            address,
+			Address:            ev.Address,
 			CipherSuite:        ev.TLSCipherSuite,
 			Failure:            NewFailure(ev.Err),
 			NegotiatedProtocol: ev.TLSNegotiatedProto,

--- a/internal/engine/netx/archival/archival_test.go
+++ b/internal/engine/netx/archival/archival_test.go
@@ -545,7 +545,7 @@ func TestNewTLSHandshakesList(t *testing.T) {
 			}},
 		},
 		want: []archival.TLSHandshake{{
-			Address:            "131.252.210.176",
+			Address:            "131.252.210.176:443",
 			CipherSuite:        "SUITE",
 			Failure:            archival.NewFailure(io.EOF),
 			NegotiatedProtocol: "h2",

--- a/internal/engine/netx/archival/archival_test.go
+++ b/internal/engine/netx/archival/archival_test.go
@@ -504,6 +504,7 @@ func TestNewTLSHandshakesList(t *testing.T) {
 	begin := time.Now()
 	type args struct {
 		begin  time.Time
+		target string
 		events []trace.Event
 	}
 	tests := []struct {
@@ -514,13 +515,15 @@ func TestNewTLSHandshakesList(t *testing.T) {
 		name: "empty run",
 		args: args{
 			begin:  begin,
+			target: "tlshandshake://0.0.0.0:443",
 			events: nil,
 		},
 		want: nil,
 	}, {
 		name: "realistic run",
 		args: args{
-			begin: begin,
+			begin:  begin,
+			target: "tlshandshake://131.252.210.176:443",
 			events: []trace.Event{{
 				Name: netxlite.CloseOperation,
 				Err:  websocket.ErrReadLimit,
@@ -542,6 +545,7 @@ func TestNewTLSHandshakesList(t *testing.T) {
 			}},
 		},
 		want: []archival.TLSHandshake{{
+			Address:            "131.252.210.176",
 			CipherSuite:        "SUITE",
 			Failure:            archival.NewFailure(io.EOF),
 			NegotiatedProtocol: "h2",
@@ -558,7 +562,7 @@ func TestNewTLSHandshakesList(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := archival.NewTLSHandshakesList(tt.args.begin, tt.args.events); !reflect.DeepEqual(got, tt.want) {
+			if got := archival.NewTLSHandshakesList(tt.args.begin, tt.args.target, tt.args.events); !reflect.DeepEqual(got, tt.want) {
 				t.Error(cmp.Diff(got, tt.want))
 			}
 		})

--- a/internal/engine/netx/archival/archival_test.go
+++ b/internal/engine/netx/archival/archival_test.go
@@ -504,7 +504,6 @@ func TestNewTLSHandshakesList(t *testing.T) {
 	begin := time.Now()
 	type args struct {
 		begin  time.Time
-		target string
 		events []trace.Event
 	}
 	tests := []struct {
@@ -515,20 +514,19 @@ func TestNewTLSHandshakesList(t *testing.T) {
 		name: "empty run",
 		args: args{
 			begin:  begin,
-			target: "tlshandshake://0.0.0.0:443",
 			events: nil,
 		},
 		want: nil,
 	}, {
 		name: "realistic run",
 		args: args{
-			begin:  begin,
-			target: "tlshandshake://131.252.210.176:443",
+			begin: begin,
 			events: []trace.Event{{
 				Name: netxlite.CloseOperation,
 				Err:  websocket.ErrReadLimit,
 				Time: begin.Add(17 * time.Millisecond),
 			}, {
+				Address:            "131.252.210.176:443",
 				Name:               "tls_handshake_done",
 				Err:                io.EOF,
 				NoTLSVerify:        false,
@@ -562,7 +560,7 @@ func TestNewTLSHandshakesList(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := archival.NewTLSHandshakesList(tt.args.begin, tt.args.target, tt.args.events); !reflect.DeepEqual(got, tt.want) {
+			if got := archival.NewTLSHandshakesList(tt.args.begin, tt.args.events); !reflect.DeepEqual(got, tt.want) {
 				t.Error(cmp.Diff(got, tt.want))
 			}
 		})

--- a/internal/engine/netx/tlsdialer/saver.go
+++ b/internal/engine/netx/tlsdialer/saver.go
@@ -32,6 +32,7 @@ func (h SaverTLSHandshaker) Handshake(
 	tlsconn, state, err := h.TLSHandshaker.Handshake(ctx, conn, config)
 	stop := time.Now()
 	h.Saver.Write(trace.Event{
+		Address:            conn.RemoteAddr().String(),
 		Duration:           stop.Sub(start),
 		Err:                err,
 		Name:               "tls_handshake_done",

--- a/internal/engine/netx/tlsdialer/saver.go
+++ b/internal/engine/netx/tlsdialer/saver.go
@@ -29,10 +29,11 @@ func (h SaverTLSHandshaker) Handshake(
 		TLSServerName: config.ServerName,
 		Time:          start,
 	})
+	remoteAddr := conn.RemoteAddr().String()
 	tlsconn, state, err := h.TLSHandshaker.Handshake(ctx, conn, config)
 	stop := time.Now()
 	h.Saver.Write(trace.Event{
-		Address:            conn.RemoteAddr().String(),
+		Address:            remoteAddr,
 		Duration:           stop.Sub(start),
 		Err:                err,
 		Name:               "tls_handshake_done",

--- a/internal/model/archival.go
+++ b/internal/model/archival.go
@@ -163,6 +163,7 @@ type ArchivalTCPConnectStatus struct {
 //
 // See https://github.com/ooni/spec/blob/master/data-formats/df-006-tlshandshake.md
 type ArchivalTLSOrQUICHandshakeResult struct {
+	Address            string                    `json:"address"`
 	CipherSuite        string                    `json:"cipher_suite"`
 	Failure            *string                   `json:"failure"`
 	NegotiatedProtocol string                    `json:"negotiated_protocol"`


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: [Issue #2065](https://github.com/ooni/probe/issues/2065)
- [x] if you changed anything related how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: [PR #233](https://github.com/ooni/spec/pull/233)

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description
- Added IP addresses to the tls_handshakes list
- Tested measurement outputs on webconnectivity, IM and riseupvpn experiments. 

We can track the tls_handshakes issue here. Although I have made some changes, we may come up with a better approach to handle this issue.  
