### PR TITLE
chore: use go1.17.9

### DIFF
--- a/.github/workflows/alltests.yml
+++ b/.github/workflows/alltests.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.8"
+          go-version: "1.17.9"
       - uses: actions/checkout@v2
       - run: go test -race -tags shaping ./...

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.8"
+          go-version: "1.17.9"
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.17.8"
-          - "1.18"
+          - "1.17.9"
+          - "1.18.1"
     steps:
       - uses: actions/setup-go@v1
         with:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.8"
+          go-version: "1.17.9"
       - uses: actions/checkout@v2
       - run: go generate ./...

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.8"
+          go-version: "1.17.9"
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/jafar.yml
+++ b/.github/workflows/jafar.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.8"
+          go-version: "1.17.9"
       - uses: actions/checkout@v2
       - run: go build -v ./internal/cmd/jafar
       - run: sudo ./testjafar.bash

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.8"
+          go-version: "1.17.9"
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/miniooni.yml
+++ b/.github/workflows/miniooni.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.8"
+          go-version: "1.17.9"
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/netxlite.yml
+++ b/.github/workflows/netxlite.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        go: [ "1.17.8" ]
+        go: [ "1.17.9" ]
         os: [ "ubuntu-20.04", "windows-2019", "macos-10.15" ]
     steps:
       - uses: actions/setup-go@v1

--- a/.github/workflows/oohelperd.yml
+++ b/.github/workflows/oohelperd.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.8"
+          go-version: "1.17.9"
 
       - name: build oohelperd binary
         run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ./CLI/oohelperd-linux-amd64 -v -tags netgo -ldflags="-s -w -extldflags -static" ./internal/cmd/oohelperd

--- a/.github/workflows/qafbmessenger.yml
+++ b/.github/workflows/qafbmessenger.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.8"
+          go-version: "1.17.9"
       - uses: actions/checkout@v2
       - run: ./QA/rundocker.bash "fbmessenger"

--- a/.github/workflows/qahhfm.yml
+++ b/.github/workflows/qahhfm.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.8"
+          go-version: "1.17.9"
       - uses: actions/checkout@v2
       - run: ./QA/rundocker.bash "hhfm"

--- a/.github/workflows/qahirl.yml
+++ b/.github/workflows/qahirl.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.8"
+          go-version: "1.17.9"
       - uses: actions/checkout@v2
       - run: ./QA/rundocker.bash "hirl"

--- a/.github/workflows/qatelegram.yml
+++ b/.github/workflows/qatelegram.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.8"
+          go-version: "1.17.9"
       - uses: actions/checkout@v2
       - run: ./QA/rundocker.bash "telegram"

--- a/.github/workflows/qawebconnectivity.yml
+++ b/.github/workflows/qawebconnectivity.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.8"
+          go-version: "1.17.9"
       - uses: actions/checkout@v2
       - run: ./QA/rundocker.bash "webconnectivity"

--- a/.github/workflows/qawhatsapp.yml
+++ b/.github/workflows/qawhatsapp.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.8"
+          go-version: "1.17.9"
       - uses: actions/checkout@v2
       - run: ./QA/rundocker.bash "whatsapp"

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.8
+          go-version: 1.17.9
       - name: Generate release tarball
         run: |
           VERSION=${GITHUB_REF_NAME#v}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.17.8"
+          go-version: "1.17.9"
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/mk
+++ b/mk
@@ -64,7 +64,7 @@ GOLANG_EXTRA_FLAGS =
 
 #help:
 #help: * GOLANG_VERSION_NUMBER : the expected version number for golang.
-GOLANG_VERSION_NUMBER = 1.17.8
+GOLANG_VERSION_NUMBER = 1.17.9
 
 #help:
 #help: * MINGW_W64_VERSION     : the expected mingw-w64 version.
@@ -72,7 +72,7 @@ MINGW_W64_VERSION = 10.3.1
 
 #help:
 #help: * OONIGO_BRANCH         : the github.com/ooni/go branch to use.
-OONIGO_BRANCH = oonigo1.17.8
+OONIGO_BRANCH = oonigo1.17.9
 
 #help:
 #help: * OONI_PSIPHON_TAGS     : build tags for `go build -tags ...` that cause


### PR DESCRIPTION
See https://github.com/ooni/probe/issues/2076

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2076
- [x] if you changed anything related how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A

## Description

They released go1.17.9 in the meanwhile, so upgrade to using it rather than using go1.17.8.