### PR TITLE
fix(netxlite): LookupHTTPS: short circuit IP addr

### DIFF
--- a/internal/netxlite/resolver.go
+++ b/internal/netxlite/resolver.go
@@ -209,6 +209,19 @@ func (r *resolverShortCircuitIPAddr) LookupHost(ctx context.Context, hostname st
 	return r.Resolver.LookupHost(ctx, hostname)
 }
 
+func (r *resolverShortCircuitIPAddr) LookupHTTPS(ctx context.Context, hostname string) (*model.HTTPSSvc, error) {
+	if net.ParseIP(hostname) != nil {
+		https := &model.HTTPSSvc{}
+		if isIPv6(hostname) {
+			https.IPv6 = append(https.IPv6, hostname)
+		} else {
+			https.IPv4 = append(https.IPv4, hostname)
+		}
+		return https, nil
+	}
+	return r.Resolver.LookupHTTPS(ctx, hostname)
+}
+
 // IsIPv6 returns true if the given candidate is a valid IP address
 // representation and such representation is IPv6.
 func IsIPv6(candidate string) (bool, error) {


### PR DESCRIPTION
This diff fixes the short-circuit-IP-addr resolver to
correctly handle IP addrs during LookupHTTPS.

The original diff was: https://github.com/bassosimone/websteps-illustrated/commit/2b51d144bf642f10237102bdc79a0defc30c1579

See https://github.com/ooni/probe/issues/2096

While there, add unit tests for IPv6.

