### PR TITLE
fix(netxlite): HTTPSSvc: better no_answer checks

### DIFF
--- a/internal/netxlite/dnsdecoder.go
+++ b/internal/netxlite/dnsdecoder.go
@@ -32,7 +32,11 @@ func (d *DNSDecoderMiekg) DecodeHTTPS(data []byte) (*model.HTTPSSvc, error) {
 	if err != nil {
 		return nil, err
 	}
-	out := &model.HTTPSSvc{}
+	out := &model.HTTPSSvc{
+		ALPN: []string{}, // ensure it's not nil
+		IPv4: []string{}, // ensure it's not nil
+		IPv6: []string{}, // ensure it's not nil
+	}
 	for _, answer := range reply.Answer {
 		switch avalue := answer.(type) {
 		case *dns.HTTPS:
@@ -52,7 +56,7 @@ func (d *DNSDecoderMiekg) DecodeHTTPS(data []byte) (*model.HTTPSSvc, error) {
 			}
 		}
 	}
-	if len(out.ALPN) <= 0 {
+	if len(out.IPv4) <= 0 && len(out.IPv6) <= 0 {
 		return nil, ErrOODNSNoAnswer
 	}
 	return out, nil


### PR DESCRIPTION
I've seen some measurements returning some IP addresses for HTTPSSvc
queries but not returning any ALPN value.

For example:

```JSON
% d4
decoding DNS round trip 0:

;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 57768
;; flags: rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0
;; QUESTION SECTION:
;psiphon.ca.                    IN      HTTPS

;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 57768
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
;; QUESTION SECTION:
;psiphon.ca.                    IN      HTTPS
;; ANSWER SECTION:
psiphon.ca.             121     IN      A       31.13.85.53
```

Now, the response is clearly bogus. At the time of this writing that
IP address belongs to Facebook. This measurement has been collected in
China, so it's expected for the GFW to behave like this.

Yet, I don't feel like it's accurate to report this measurement as a
"no answer" response. Rather, this response is a valid one containing
a clearly invalid IP address and should be flagged as such.

Originally: https://github.com/bassosimone/websteps-illustrated/commit/57a023bcf4ebb1dd9dbdac83c18dc53a165011f8

See https://github.com/ooni/probe/issues/2096

