### PR TITLE
cleanup(quic): wait for handshake completion in netxlite

### DIFF
--- a/internal/archival/quic.go
+++ b/internal/archival/quic.go
@@ -64,12 +64,8 @@ func (s *Saver) QUICDialContext(ctx context.Context, dialer model.QUICDialer,
 	var state tls.ConnectionState
 	sess, err := dialer.DialContext(ctx, network, address, tlsConfig, quicConfig)
 	if err == nil {
-		select {
-		case <-sess.HandshakeComplete().Done():
-			state = sess.ConnectionState().TLS.ConnectionState
-		case <-ctx.Done():
-			sess, err = nil, ctx.Err()
-		}
+		<-sess.HandshakeComplete().Done() // robustness (the dialer already does that)
+		state = sess.ConnectionState().TLS.ConnectionState
 	}
 	s.appendQUICHandshake(&QUICTLSHandshakeEvent{
 		ALPN:            tlsConfig.NextProtos,

--- a/internal/measurex/quic.go
+++ b/internal/measurex/quic.go
@@ -118,12 +118,8 @@ func (qh *quicDialerDB) DialContext(ctx context.Context, network, address string
 	defer dialer.CloseIdleConnections()
 	sess, err := dialer.DialContext(ctx, network, address, tlsConfig, quicConfig)
 	if err == nil {
-		select {
-		case <-sess.HandshakeComplete().Done():
-			state = sess.ConnectionState().TLS.ConnectionState
-		case <-ctx.Done():
-			sess, err = nil, ctx.Err()
-		}
+		<-sess.HandshakeComplete().Done() // robustness (the dialer already does that)
+		state = sess.ConnectionState().TLS.ConnectionState
 	}
 	finished := time.Since(qh.begin).Seconds()
 	qh.db.InsertIntoQUICHandshake(&QUICTLSHandshakeEvent{


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2097
- [x] if you changed anything related how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A

## Description

This diff moves the handshake completion logic inside netxlite. So every user of netxlite now can trust the fact that the handshake is complete when they receive a quic conn.