### PR TITLE
refactor(netxlite): add Transport suffix to DNS transports

### DIFF
--- a/internal/engine/experiment/urlgetter/configurer_test.go
+++ b/internal/engine/experiment/urlgetter/configurer_test.go
@@ -124,7 +124,7 @@ func TestConfigurerNewConfigurationResolverDNSOverHTTPSPowerdns(t *testing.T) {
 	if !ok {
 		t.Fatal("not the DNS transport we expected")
 	}
-	dohtxp, ok := stxp.DNSTransport.(*netxlite.DNSOverHTTPS)
+	dohtxp, ok := stxp.DNSTransport.(*netxlite.DNSOverHTTPSTransport)
 	if !ok {
 		t.Fatal("not the DNS transport we expected")
 	}
@@ -200,7 +200,7 @@ func TestConfigurerNewConfigurationResolverDNSOverHTTPSGoogle(t *testing.T) {
 	if !ok {
 		t.Fatal("not the DNS transport we expected")
 	}
-	dohtxp, ok := stxp.DNSTransport.(*netxlite.DNSOverHTTPS)
+	dohtxp, ok := stxp.DNSTransport.(*netxlite.DNSOverHTTPSTransport)
 	if !ok {
 		t.Fatal("not the DNS transport we expected")
 	}
@@ -276,7 +276,7 @@ func TestConfigurerNewConfigurationResolverDNSOverHTTPSCloudflare(t *testing.T) 
 	if !ok {
 		t.Fatal("not the DNS transport we expected")
 	}
-	dohtxp, ok := stxp.DNSTransport.(*netxlite.DNSOverHTTPS)
+	dohtxp, ok := stxp.DNSTransport.(*netxlite.DNSOverHTTPSTransport)
 	if !ok {
 		t.Fatal("not the DNS transport we expected")
 	}
@@ -352,7 +352,7 @@ func TestConfigurerNewConfigurationResolverUDP(t *testing.T) {
 	if !ok {
 		t.Fatal("not the DNS transport we expected")
 	}
-	udptxp, ok := stxp.DNSTransport.(*netxlite.DNSOverUDP)
+	udptxp, ok := stxp.DNSTransport.(*netxlite.DNSOverUDPTransport)
 	if !ok {
 		t.Fatal("not the DNS transport we expected")
 	}

--- a/internal/engine/experiment/webstepsx/th.go
+++ b/internal/engine/experiment/webstepsx/th.go
@@ -368,5 +368,5 @@ const thResolverURL = "https://dns.google/dns-query"
 // Here we're using github.com/apex/log as the logger, which
 // is fine because this is backend only code.
 var thResolver = netxlite.WrapResolver(log.Log, netxlite.NewSerialResolver(
-	netxlite.NewDNSOverHTTPS(http.DefaultClient, thResolverURL),
+	netxlite.NewDNSOverHTTPSTransport(http.DefaultClient, thResolverURL),
 ))

--- a/internal/engine/netx/netx.go
+++ b/internal/engine/netx/netx.go
@@ -286,7 +286,7 @@ func NewDNSClientWithOverrides(config Config, URL, hostOverride, SNIOverride,
 	case "https":
 		config.TLSConfig.NextProtos = []string{"h2", "http/1.1"}
 		httpClient := &http.Client{Transport: NewHTTPTransport(config)}
-		var txp model.DNSTransport = netxlite.NewDNSOverHTTPSWithHostOverride(
+		var txp model.DNSTransport = netxlite.NewDNSOverHTTPSTransportWithHostOverride(
 			httpClient, URL, hostOverride)
 		if config.ResolveSaver != nil {
 			txp = resolver.SaverDNSTransport{
@@ -301,7 +301,7 @@ func NewDNSClientWithOverrides(config Config, URL, hostOverride, SNIOverride,
 		if err != nil {
 			return nil, err
 		}
-		var txp model.DNSTransport = netxlite.NewDNSOverUDP(
+		var txp model.DNSTransport = netxlite.NewDNSOverUDPTransport(
 			dialer, endpoint)
 		if config.ResolveSaver != nil {
 			txp = resolver.SaverDNSTransport{
@@ -332,7 +332,7 @@ func NewDNSClientWithOverrides(config Config, URL, hostOverride, SNIOverride,
 		if err != nil {
 			return nil, err
 		}
-		var txp model.DNSTransport = netxlite.NewDNSOverTCP(
+		var txp model.DNSTransport = netxlite.NewDNSOverTCPTransport(
 			dialer.DialContext, endpoint)
 		if config.ResolveSaver != nil {
 			txp = resolver.SaverDNSTransport{

--- a/internal/engine/netx/netx_test.go
+++ b/internal/engine/netx/netx_test.go
@@ -586,7 +586,7 @@ func TestNewDNSClientPowerdnsDoH(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	if _, ok := r.Transport().(*netxlite.DNSOverHTTPS); !ok {
+	if _, ok := r.Transport().(*netxlite.DNSOverHTTPSTransport); !ok {
 		t.Fatal("not the transport we expected")
 	}
 	dnsclient.CloseIdleConnections()
@@ -602,7 +602,7 @@ func TestNewDNSClientGoogleDoH(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	if _, ok := r.Transport().(*netxlite.DNSOverHTTPS); !ok {
+	if _, ok := r.Transport().(*netxlite.DNSOverHTTPSTransport); !ok {
 		t.Fatal("not the transport we expected")
 	}
 	dnsclient.CloseIdleConnections()
@@ -618,7 +618,7 @@ func TestNewDNSClientCloudflareDoH(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	if _, ok := r.Transport().(*netxlite.DNSOverHTTPS); !ok {
+	if _, ok := r.Transport().(*netxlite.DNSOverHTTPSTransport); !ok {
 		t.Fatal("not the transport we expected")
 	}
 	dnsclient.CloseIdleConnections()
@@ -639,7 +639,7 @@ func TestNewDNSClientCloudflareDoHSaver(t *testing.T) {
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}
-	if _, ok := txp.DNSTransport.(*netxlite.DNSOverHTTPS); !ok {
+	if _, ok := txp.DNSTransport.(*netxlite.DNSOverHTTPSTransport); !ok {
 		t.Fatal("not the transport we expected")
 	}
 	dnsclient.CloseIdleConnections()
@@ -655,7 +655,7 @@ func TestNewDNSClientUDP(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	if _, ok := r.Transport().(*netxlite.DNSOverUDP); !ok {
+	if _, ok := r.Transport().(*netxlite.DNSOverUDPTransport); !ok {
 		t.Fatal("not the transport we expected")
 	}
 	dnsclient.CloseIdleConnections()
@@ -676,7 +676,7 @@ func TestNewDNSClientUDPDNSSaver(t *testing.T) {
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}
-	if _, ok := txp.DNSTransport.(*netxlite.DNSOverUDP); !ok {
+	if _, ok := txp.DNSTransport.(*netxlite.DNSOverUDPTransport); !ok {
 		t.Fatal("not the transport we expected")
 	}
 	dnsclient.CloseIdleConnections()
@@ -692,7 +692,7 @@ func TestNewDNSClientTCP(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	txp, ok := r.Transport().(*netxlite.DNSOverTCP)
+	txp, ok := r.Transport().(*netxlite.DNSOverTCPTransport)
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}
@@ -717,7 +717,7 @@ func TestNewDNSClientTCPDNSSaver(t *testing.T) {
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}
-	dotcp, ok := txp.DNSTransport.(*netxlite.DNSOverTCP)
+	dotcp, ok := txp.DNSTransport.(*netxlite.DNSOverTCPTransport)
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}
@@ -737,7 +737,7 @@ func TestNewDNSClientDoT(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	txp, ok := r.Transport().(*netxlite.DNSOverTCP)
+	txp, ok := r.Transport().(*netxlite.DNSOverTCPTransport)
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}
@@ -762,7 +762,7 @@ func TestNewDNSClientDoTDNSSaver(t *testing.T) {
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}
-	dotls, ok := txp.DNSTransport.(*netxlite.DNSOverTCP)
+	dotls, ok := txp.DNSTransport.(*netxlite.DNSOverTCPTransport)
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}

--- a/internal/engine/netx/resolver/integration_test.go
+++ b/internal/engine/netx/resolver/integration_test.go
@@ -71,28 +71,28 @@ func TestNewResolverSystem(t *testing.T) {
 
 func TestNewResolverUDPAddress(t *testing.T) {
 	reso := netxlite.NewSerialResolver(
-		netxlite.NewDNSOverUDP(netxlite.DefaultDialer, "8.8.8.8:53"))
+		netxlite.NewDNSOverUDPTransport(netxlite.DefaultDialer, "8.8.8.8:53"))
 	testresolverquick(t, reso)
 	testresolverquickidna(t, reso)
 }
 
 func TestNewResolverUDPDomain(t *testing.T) {
 	reso := netxlite.NewSerialResolver(
-		netxlite.NewDNSOverUDP(netxlite.DefaultDialer, "dns.google.com:53"))
+		netxlite.NewDNSOverUDPTransport(netxlite.DefaultDialer, "dns.google.com:53"))
 	testresolverquick(t, reso)
 	testresolverquickidna(t, reso)
 }
 
 func TestNewResolverTCPAddress(t *testing.T) {
 	reso := netxlite.NewSerialResolver(
-		netxlite.NewDNSOverTCP(new(net.Dialer).DialContext, "8.8.8.8:53"))
+		netxlite.NewDNSOverTCPTransport(new(net.Dialer).DialContext, "8.8.8.8:53"))
 	testresolverquick(t, reso)
 	testresolverquickidna(t, reso)
 }
 
 func TestNewResolverTCPDomain(t *testing.T) {
 	reso := netxlite.NewSerialResolver(
-		netxlite.NewDNSOverTCP(new(net.Dialer).DialContext, "dns.google.com:53"))
+		netxlite.NewDNSOverTCPTransport(new(net.Dialer).DialContext, "dns.google.com:53"))
 	testresolverquick(t, reso)
 	testresolverquickidna(t, reso)
 }
@@ -113,7 +113,7 @@ func TestNewResolverDoTDomain(t *testing.T) {
 
 func TestNewResolverDoH(t *testing.T) {
 	reso := netxlite.NewSerialResolver(
-		netxlite.NewDNSOverHTTPS(http.DefaultClient, "https://cloudflare-dns.com/dns-query"))
+		netxlite.NewDNSOverHTTPSTransport(http.DefaultClient, "https://cloudflare-dns.com/dns-query"))
 	testresolverquick(t, reso)
 	testresolverquickidna(t, reso)
 }

--- a/internal/measurex/resolver.go
+++ b/internal/measurex/resolver.go
@@ -44,7 +44,7 @@ func (mx *Measurer) NewResolverSystem(db WritableDB, logger model.Logger) model.
 func (mx *Measurer) NewResolverUDP(db WritableDB, logger model.Logger, address string) model.Resolver {
 	return mx.WrapResolver(db, netxlite.WrapResolver(
 		logger, netxlite.NewSerialResolver(
-			mx.WrapDNSXRoundTripper(db, netxlite.NewDNSOverUDP(
+			mx.WrapDNSXRoundTripper(db, netxlite.NewDNSOverUDPTransport(
 				mx.NewDialerWithSystemResolver(db, logger),
 				address,
 			)))),

--- a/internal/netxlite/classify.go
+++ b/internal/netxlite/classify.go
@@ -244,7 +244,7 @@ const (
 )
 
 // These errors are returned by custom DNSTransport instances (e.g.,
-// DNSOverHTTPS and DNSOverUDP). Their suffix matches the equivalent
+// DNSOverHTTPSTransport and DNSOverUDPTransport). Their suffix matches the equivalent
 // unexported errors used by the Go standard library.
 var (
 	ErrOODNSNoSuchHost  = fmt.Errorf("ooniresolver: %s", DNSNoSuchHostSuffix)

--- a/internal/netxlite/dnsoverhttps.go
+++ b/internal/netxlite/dnsoverhttps.go
@@ -11,8 +11,8 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
 
-// DNSOverHTTPS is a DNS-over-HTTPS DNSTransport.
-type DNSOverHTTPS struct {
+// DNSOverHTTPSTransport is a DNS-over-HTTPS DNSTransport.
+type DNSOverHTTPSTransport struct {
 	// Client is the MANDATORY http client to use.
 	Client model.HTTPClient
 
@@ -24,26 +24,26 @@ type DNSOverHTTPS struct {
 	HostOverride string
 }
 
-// NewDNSOverHTTPS creates a new DNSOverHTTPS instance.
+// NewDNSOverHTTPSTransport creates a new DNSOverHTTPSTransport instance.
 //
 // Arguments:
 //
 // - client in http.Client-like type (e.g., http.DefaultClient);
 //
 // - URL is the DoH resolver URL (e.g., https://1.1.1.1/dns-query).
-func NewDNSOverHTTPS(client model.HTTPClient, URL string) *DNSOverHTTPS {
-	return NewDNSOverHTTPSWithHostOverride(client, URL, "")
+func NewDNSOverHTTPSTransport(client model.HTTPClient, URL string) *DNSOverHTTPSTransport {
+	return NewDNSOverHTTPSTransportWithHostOverride(client, URL, "")
 }
 
-// NewDNSOverHTTPSWithHostOverride creates a new DNSOverHTTPS
+// NewDNSOverHTTPSTransportWithHostOverride creates a new DNSOverHTTPSTransport
 // with the given Host header override.
-func NewDNSOverHTTPSWithHostOverride(
-	client model.HTTPClient, URL, hostOverride string) *DNSOverHTTPS {
-	return &DNSOverHTTPS{Client: client, URL: URL, HostOverride: hostOverride}
+func NewDNSOverHTTPSTransportWithHostOverride(
+	client model.HTTPClient, URL, hostOverride string) *DNSOverHTTPSTransport {
+	return &DNSOverHTTPSTransport{Client: client, URL: URL, HostOverride: hostOverride}
 }
 
 // RoundTrip sends a query and receives a reply.
-func (t *DNSOverHTTPS) RoundTrip(ctx context.Context, query []byte) ([]byte, error) {
+func (t *DNSOverHTTPSTransport) RoundTrip(ctx context.Context, query []byte) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, 45*time.Second)
 	defer cancel()
 	req, err := http.NewRequest("POST", t.URL, bytes.NewReader(query))
@@ -71,23 +71,23 @@ func (t *DNSOverHTTPS) RoundTrip(ctx context.Context, query []byte) ([]byte, err
 }
 
 // RequiresPadding returns true for DoH according to RFC8467.
-func (t *DNSOverHTTPS) RequiresPadding() bool {
+func (t *DNSOverHTTPSTransport) RequiresPadding() bool {
 	return true
 }
 
 // Network returns the transport network, i.e., "doh".
-func (t *DNSOverHTTPS) Network() string {
+func (t *DNSOverHTTPSTransport) Network() string {
 	return "doh"
 }
 
 // Address returns the URL we're using for the DoH server.
-func (t *DNSOverHTTPS) Address() string {
+func (t *DNSOverHTTPSTransport) Address() string {
 	return t.URL
 }
 
 // CloseIdleConnections closes idle connections, if any.
-func (t *DNSOverHTTPS) CloseIdleConnections() {
+func (t *DNSOverHTTPSTransport) CloseIdleConnections() {
 	t.Client.CloseIdleConnections()
 }
 
-var _ model.DNSTransport = &DNSOverHTTPS{}
+var _ model.DNSTransport = &DNSOverHTTPSTransport{}

--- a/internal/netxlite/dnsoverhttps_test.go
+++ b/internal/netxlite/dnsoverhttps_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/model/mocks"
 )
 
-func TestDNSOverHTTPS(t *testing.T) {
+func TestDNSOverHTTPSTransport(t *testing.T) {
 	t.Run("RoundTrip", func(t *testing.T) {
 		t.Run("NewRequestFailure", func(t *testing.T) {
 			const invalidURL = "\t"
-			txp := NewDNSOverHTTPS(http.DefaultClient, invalidURL)
+			txp := NewDNSOverHTTPSTransport(http.DefaultClient, invalidURL)
 			data, err := txp.RoundTrip(context.Background(), nil)
 			if err == nil || !strings.HasSuffix(err.Error(), "invalid control character in URL") {
 				t.Fatal("expected an error here")
@@ -29,7 +29,7 @@ func TestDNSOverHTTPS(t *testing.T) {
 
 		t.Run("client.Do failure", func(t *testing.T) {
 			expected := errors.New("mocked error")
-			txp := &DNSOverHTTPS{
+			txp := &DNSOverHTTPSTransport{
 				Client: &mocks.HTTPClient{
 					MockDo: func(*http.Request) (*http.Response, error) {
 						return nil, expected
@@ -47,7 +47,7 @@ func TestDNSOverHTTPS(t *testing.T) {
 		})
 
 		t.Run("server returns 500", func(t *testing.T) {
-			txp := &DNSOverHTTPS{
+			txp := &DNSOverHTTPSTransport{
 				Client: &mocks.HTTPClient{
 					MockDo: func(*http.Request) (*http.Response, error) {
 						return &http.Response{
@@ -68,7 +68,7 @@ func TestDNSOverHTTPS(t *testing.T) {
 		})
 
 		t.Run("missing content type", func(t *testing.T) {
-			txp := &DNSOverHTTPS{
+			txp := &DNSOverHTTPSTransport{
 				Client: &mocks.HTTPClient{
 					MockDo: func(*http.Request) (*http.Response, error) {
 						return &http.Response{
@@ -90,7 +90,7 @@ func TestDNSOverHTTPS(t *testing.T) {
 
 		t.Run("success", func(t *testing.T) {
 			body := []byte("AAA")
-			txp := &DNSOverHTTPS{
+			txp := &DNSOverHTTPSTransport{
 				Client: &mocks.HTTPClient{
 					MockDo: func(*http.Request) (*http.Response, error) {
 						return &http.Response{
@@ -116,7 +116,7 @@ func TestDNSOverHTTPS(t *testing.T) {
 		t.Run("sets the correct user-agent", func(t *testing.T) {
 			expected := errors.New("mocked error")
 			var correct bool
-			txp := &DNSOverHTTPS{
+			txp := &DNSOverHTTPSTransport{
 				Client: &mocks.HTTPClient{
 					MockDo: func(req *http.Request) (*http.Response, error) {
 						correct = req.Header.Get("User-Agent") == httpheader.UserAgent()
@@ -141,7 +141,7 @@ func TestDNSOverHTTPS(t *testing.T) {
 			var correct bool
 			expected := errors.New("mocked error")
 			hostOverride := "test.com"
-			txp := &DNSOverHTTPS{
+			txp := &DNSOverHTTPSTransport{
 				Client: &mocks.HTTPClient{
 					MockDo: func(req *http.Request) (*http.Response, error) {
 						correct = req.Host == hostOverride
@@ -167,7 +167,7 @@ func TestDNSOverHTTPS(t *testing.T) {
 
 	t.Run("other functions behave correctly", func(t *testing.T) {
 		const queryURL = "https://cloudflare-dns.com/dns-query"
-		txp := NewDNSOverHTTPS(http.DefaultClient, queryURL)
+		txp := NewDNSOverHTTPSTransport(http.DefaultClient, queryURL)
 		if txp.Network() != "doh" {
 			t.Fatal("invalid network")
 		}
@@ -181,7 +181,7 @@ func TestDNSOverHTTPS(t *testing.T) {
 
 	t.Run("CloseIdleConnections", func(t *testing.T) {
 		var called bool
-		doh := &DNSOverHTTPS{
+		doh := &DNSOverHTTPSTransport{
 			Client: &mocks.HTTPClient{
 				MockCloseIdleConnections: func() {
 					called = true

--- a/internal/netxlite/dnsovertcp.go
+++ b/internal/netxlite/dnsovertcp.go
@@ -14,25 +14,25 @@ import (
 // DialContextFunc is the type of net.Dialer.DialContext.
 type DialContextFunc func(context.Context, string, string) (net.Conn, error)
 
-// DNSOverTCP is a DNS-over-{TCP,TLS} DNSTransport.
+// DNSOverTCPTransport is a DNS-over-{TCP,TLS} DNSTransport.
 //
 // Bug: this implementation always creates a new connection for each query.
-type DNSOverTCP struct {
+type DNSOverTCPTransport struct {
 	dial            DialContextFunc
 	address         string
 	network         string
 	requiresPadding bool
 }
 
-// NewDNSOverTCP creates a new DNSOverTCP transport.
+// NewDNSOverTCPTransport creates a new DNSOverTCPTransport.
 //
 // Arguments:
 //
 // - dial is a function with the net.Dialer.DialContext's signature;
 //
 // - address is the endpoint address (e.g., 8.8.8.8:53).
-func NewDNSOverTCP(dial DialContextFunc, address string) *DNSOverTCP {
-	return &DNSOverTCP{
+func NewDNSOverTCPTransport(dial DialContextFunc, address string) *DNSOverTCPTransport {
+	return &DNSOverTCPTransport{
 		dial:            dial,
 		address:         address,
 		network:         "tcp",
@@ -47,8 +47,8 @@ func NewDNSOverTCP(dial DialContextFunc, address string) *DNSOverTCP {
 // - dial is a function with the net.Dialer.DialContext's signature;
 //
 // - address is the endpoint address (e.g., 8.8.8.8:853).
-func NewDNSOverTLS(dial DialContextFunc, address string) *DNSOverTCP {
-	return &DNSOverTCP{
+func NewDNSOverTLS(dial DialContextFunc, address string) *DNSOverTCPTransport {
+	return &DNSOverTCPTransport{
 		dial:            dial,
 		address:         address,
 		network:         "dot",
@@ -57,7 +57,7 @@ func NewDNSOverTLS(dial DialContextFunc, address string) *DNSOverTCP {
 }
 
 // RoundTrip sends a query and receives a reply.
-func (t *DNSOverTCP) RoundTrip(ctx context.Context, query []byte) ([]byte, error) {
+func (t *DNSOverTCPTransport) RoundTrip(ctx context.Context, query []byte) ([]byte, error) {
 	if len(query) > math.MaxUint16 {
 		return nil, errors.New("query too long")
 	}
@@ -91,23 +91,23 @@ func (t *DNSOverTCP) RoundTrip(ctx context.Context, query []byte) ([]byte, error
 
 // RequiresPadding returns true for DoT and false for TCP
 // according to RFC8467.
-func (t *DNSOverTCP) RequiresPadding() bool {
+func (t *DNSOverTCPTransport) RequiresPadding() bool {
 	return t.requiresPadding
 }
 
 // Network returns the transport network, i.e., "dot" or "tcp".
-func (t *DNSOverTCP) Network() string {
+func (t *DNSOverTCPTransport) Network() string {
 	return t.network
 }
 
 // Address returns the upstream server endpoint (e.g., "1.1.1.1:853").
-func (t *DNSOverTCP) Address() string {
+func (t *DNSOverTCPTransport) Address() string {
 	return t.address
 }
 
 // CloseIdleConnections closes idle connections, if any.
-func (t *DNSOverTCP) CloseIdleConnections() {
+func (t *DNSOverTCPTransport) CloseIdleConnections() {
 	// nothing to do
 }
 
-var _ model.DNSTransport = &DNSOverTCP{}
+var _ model.DNSTransport = &DNSOverTCPTransport{}

--- a/internal/netxlite/dnsovertcp_test.go
+++ b/internal/netxlite/dnsovertcp_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/model/mocks"
 )
 
-func TestDNSOverTCP(t *testing.T) {
+func TestDNSOverTCPTransport(t *testing.T) {
 	t.Run("RoundTrip", func(t *testing.T) {
 		t.Run("query too large", func(t *testing.T) {
 			const address = "9.9.9.9:53"
-			txp := NewDNSOverTCP(new(net.Dialer).DialContext, address)
+			txp := NewDNSOverTCPTransport(new(net.Dialer).DialContext, address)
 			reply, err := txp.RoundTrip(context.Background(), make([]byte, 1<<18))
 			if err == nil {
 				t.Fatal("expected an error here")
@@ -35,7 +35,7 @@ func TestDNSOverTCP(t *testing.T) {
 					return nil, mocked
 				},
 			}
-			txp := NewDNSOverTCP(fakedialer.DialContext, address)
+			txp := NewDNSOverTCPTransport(fakedialer.DialContext, address)
 			reply, err := txp.RoundTrip(context.Background(), make([]byte, 1<<11))
 			if !errors.Is(err, mocked) {
 				t.Fatal("not the error we expected")
@@ -60,7 +60,7 @@ func TestDNSOverTCP(t *testing.T) {
 					}, nil
 				},
 			}
-			txp := NewDNSOverTCP(fakedialer.DialContext, address)
+			txp := NewDNSOverTCPTransport(fakedialer.DialContext, address)
 			reply, err := txp.RoundTrip(context.Background(), make([]byte, 1<<11))
 			if !errors.Is(err, mocked) {
 				t.Fatal("not the error we expected")
@@ -88,7 +88,7 @@ func TestDNSOverTCP(t *testing.T) {
 					}, nil
 				},
 			}
-			txp := NewDNSOverTCP(fakedialer.DialContext, address)
+			txp := NewDNSOverTCPTransport(fakedialer.DialContext, address)
 			reply, err := txp.RoundTrip(context.Background(), make([]byte, 1<<11))
 			if !errors.Is(err, mocked) {
 				t.Fatal("not the error we expected")
@@ -119,7 +119,7 @@ func TestDNSOverTCP(t *testing.T) {
 					}, nil
 				},
 			}
-			txp := NewDNSOverTCP(fakedialer.DialContext, address)
+			txp := NewDNSOverTCPTransport(fakedialer.DialContext, address)
 			reply, err := txp.RoundTrip(context.Background(), make([]byte, 1<<11))
 			if !errors.Is(err, mocked) {
 				t.Fatal("not the error we expected")
@@ -156,7 +156,7 @@ func TestDNSOverTCP(t *testing.T) {
 					}, nil
 				},
 			}
-			txp := NewDNSOverTCP(fakedialer.DialContext, address)
+			txp := NewDNSOverTCPTransport(fakedialer.DialContext, address)
 			reply, err := txp.RoundTrip(context.Background(), make([]byte, 1<<11))
 			if !errors.Is(err, mocked) {
 				t.Fatal("not the error we expected")
@@ -185,7 +185,7 @@ func TestDNSOverTCP(t *testing.T) {
 					}, nil
 				},
 			}
-			txp := NewDNSOverTCP(fakedialer.DialContext, address)
+			txp := NewDNSOverTCPTransport(fakedialer.DialContext, address)
 			reply, err := txp.RoundTrip(context.Background(), make([]byte, 1<<11))
 			if err != nil {
 				t.Fatal(err)
@@ -198,7 +198,7 @@ func TestDNSOverTCP(t *testing.T) {
 
 	t.Run("other functions okay with TCP", func(t *testing.T) {
 		const address = "9.9.9.9:53"
-		txp := NewDNSOverTCP(new(net.Dialer).DialContext, address)
+		txp := NewDNSOverTCPTransport(new(net.Dialer).DialContext, address)
 		if txp.RequiresPadding() != false {
 			t.Fatal("invalid RequiresPadding")
 		}

--- a/internal/netxlite/dnsoverudp.go
+++ b/internal/netxlite/dnsoverudp.go
@@ -7,25 +7,25 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
 
-// DNSOverUDP is a DNS-over-UDP DNSTransport.
-type DNSOverUDP struct {
+// DNSOverUDPTransport is a DNS-over-UDP DNSTransport.
+type DNSOverUDPTransport struct {
 	dialer  model.Dialer
 	address string
 }
 
-// NewDNSOverUDP creates a DNSOverUDP instance.
+// NewDNSOverUDPTransport creates a DNSOverUDPTransport instance.
 //
 // Arguments:
 //
 // - dialer is any type that implements the Dialer interface;
 //
 // - address is the endpoint address (e.g., 8.8.8.8:53).
-func NewDNSOverUDP(dialer model.Dialer, address string) *DNSOverUDP {
-	return &DNSOverUDP{dialer: dialer, address: address}
+func NewDNSOverUDPTransport(dialer model.Dialer, address string) *DNSOverUDPTransport {
+	return &DNSOverUDPTransport{dialer: dialer, address: address}
 }
 
 // RoundTrip sends a query and receives a reply.
-func (t *DNSOverUDP) RoundTrip(ctx context.Context, query []byte) ([]byte, error) {
+func (t *DNSOverUDPTransport) RoundTrip(ctx context.Context, query []byte) ([]byte, error) {
 	conn, err := t.dialer.DialContext(ctx, "udp", t.address)
 	if err != nil {
 		return nil, err
@@ -49,23 +49,23 @@ func (t *DNSOverUDP) RoundTrip(ctx context.Context, query []byte) ([]byte, error
 }
 
 // RequiresPadding returns false for UDP according to RFC8467.
-func (t *DNSOverUDP) RequiresPadding() bool {
+func (t *DNSOverUDPTransport) RequiresPadding() bool {
 	return false
 }
 
 // Network returns the transport network, i.e., "udp".
-func (t *DNSOverUDP) Network() string {
+func (t *DNSOverUDPTransport) Network() string {
 	return "udp"
 }
 
 // Address returns the upstream server address.
-func (t *DNSOverUDP) Address() string {
+func (t *DNSOverUDPTransport) Address() string {
 	return t.address
 }
 
 // CloseIdleConnections closes idle connections, if any.
-func (t *DNSOverUDP) CloseIdleConnections() {
+func (t *DNSOverUDPTransport) CloseIdleConnections() {
 	// nothing to do
 }
 
-var _ model.DNSTransport = &DNSOverUDP{}
+var _ model.DNSTransport = &DNSOverUDPTransport{}

--- a/internal/netxlite/dnsoverudp_test.go
+++ b/internal/netxlite/dnsoverudp_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/model/mocks"
 )
 
-func TestDNSOverUDP(t *testing.T) {
+func TestDNSOverUDPTransport(t *testing.T) {
 	t.Run("RoundTrip", func(t *testing.T) {
 		t.Run("dial failure", func(t *testing.T) {
 			mocked := errors.New("mocked error")
 			const address = "9.9.9.9:53"
-			txp := NewDNSOverUDP(&mocks.Dialer{
+			txp := NewDNSOverUDPTransport(&mocks.Dialer{
 				MockDialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
 					return nil, mocked
 				},
@@ -33,7 +33,7 @@ func TestDNSOverUDP(t *testing.T) {
 
 		t.Run("SetDeadline failure", func(t *testing.T) {
 			mocked := errors.New("mocked error")
-			txp := NewDNSOverUDP(
+			txp := NewDNSOverUDPTransport(
 				&mocks.Dialer{
 					MockDialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
 						return &mocks.Conn{
@@ -58,7 +58,7 @@ func TestDNSOverUDP(t *testing.T) {
 
 		t.Run("Write failure", func(t *testing.T) {
 			mocked := errors.New("mocked error")
-			txp := NewDNSOverUDP(
+			txp := NewDNSOverUDPTransport(
 				&mocks.Dialer{
 					MockDialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
 						return &mocks.Conn{
@@ -86,7 +86,7 @@ func TestDNSOverUDP(t *testing.T) {
 
 		t.Run("Read failure", func(t *testing.T) {
 			mocked := errors.New("mocked error")
-			txp := NewDNSOverUDP(
+			txp := NewDNSOverUDPTransport(
 				&mocks.Dialer{
 					MockDialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
 						return &mocks.Conn{
@@ -118,7 +118,7 @@ func TestDNSOverUDP(t *testing.T) {
 		t.Run("read success", func(t *testing.T) {
 			const expected = 17
 			input := bytes.NewReader(make([]byte, expected))
-			txp := NewDNSOverUDP(
+			txp := NewDNSOverUDPTransport(
 				&mocks.Dialer{
 					MockDialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
 						return &mocks.Conn{
@@ -148,7 +148,7 @@ func TestDNSOverUDP(t *testing.T) {
 
 	t.Run("other functions okay", func(t *testing.T) {
 		const address = "9.9.9.9:53"
-		txp := NewDNSOverUDP(NewDialerWithoutResolver(log.Log), address)
+		txp := NewDNSOverUDPTransport(NewDialerWithoutResolver(log.Log), address)
 		if txp.RequiresPadding() != false {
 			t.Fatal("invalid RequiresPadding")
 		}

--- a/internal/netxlite/filtering/dns.go
+++ b/internal/netxlite/filtering/dns.go
@@ -242,5 +242,5 @@ func (p *DNSProxy) dnstransport() DNSTransport {
 		return p.Upstream
 	}
 	const URL = "https://1.1.1.1/dns-query"
-	return netxlite.NewDNSOverHTTPS(http.DefaultClient, URL)
+	return netxlite.NewDNSOverHTTPSTransport(http.DefaultClient, URL)
 }

--- a/internal/netxlite/resolver.go
+++ b/internal/netxlite/resolver.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ErrNoDNSTransport is the error returned when you attempt to perform
-// a DNS operation that requires a custom DNSTransport (e.g., DNSOverHTTPS)
+// a DNS operation that requires a custom DNSTransport (e.g., DNSOverHTTPSTransport)
 // but you are using the "system" resolver instead.
 var ErrNoDNSTransport = errors.New("operation requires a DNS transport")
 
@@ -34,7 +34,7 @@ func NewResolverStdlib(logger model.DebugLogger) model.Resolver {
 // - address is the server address (e.g., 1.1.1.1:53)
 func NewResolverUDP(logger model.DebugLogger, dialer model.Dialer, address string) model.Resolver {
 	return WrapResolver(logger, NewSerialResolver(
-		NewDNSOverUDP(dialer, address),
+		NewDNSOverUDPTransport(dialer, address),
 	))
 }
 

--- a/internal/netxlite/resolver_test.go
+++ b/internal/netxlite/resolver_test.go
@@ -38,7 +38,7 @@ func TestNewResolverUDP(t *testing.T) {
 	shortCircuit := logger.Resolver.(*resolverShortCircuitIPAddr)
 	errWrapper := shortCircuit.Resolver.(*resolverErrWrapper)
 	serio := errWrapper.Resolver.(*SerialResolver)
-	txp := serio.Transport().(*DNSOverUDP)
+	txp := serio.Transport().(*DNSOverUDPTransport)
 	if txp.Address() != "1.1.1.1:53" {
 		t.Fatal("invalid address")
 	}


### PR DESCRIPTION
This diff has been extracted from https://github.com/bassosimone/websteps-illustrated/commit/c2f7ccab0ec971d5c084ea4c571b76f7530b28ee

See https://github.com/ooni/probe/issues/2096

