### PR TITLE
fix(netxlite): prefer composition over embedding

### DIFF
--- a/internal/netxlite/bogon.go
+++ b/internal/netxlite/bogon.go
@@ -18,7 +18,7 @@ import (
 // function a non-IP address causes it to return true.
 func IsBogon(address string) bool {
 	ip := net.ParseIP(address)
-	return ip == nil || isPrivate(address, ip)
+	return ip == nil || isBogon(address, ip)
 }
 
 // IsLoopback returns whether an IP address is loopback. Passing to this
@@ -33,7 +33,7 @@ var (
 	bogons6 []*net.IPNet
 )
 
-func expandbogons(cidrs []string) (out []*net.IPNet) {
+func expandBogons(cidrs []string) (out []*net.IPNet) {
 	for _, cidr := range cidrs {
 		_, block, err := net.ParseCIDR(cidr)
 		runtimex.PanicOnError(err, "net.ParseCIDR failed")
@@ -43,7 +43,7 @@ func expandbogons(cidrs []string) (out []*net.IPNet) {
 }
 
 func init() {
-	bogons4 = append(bogons4, expandbogons([]string{
+	bogons4 = append(bogons4, expandBogons([]string{
 		//
 		// List extracted from https://ipinfo.io/bogon
 		//
@@ -64,7 +64,7 @@ func init() {
 		"240.0.0.0/4",        // Reserved for future use
 		"255.255.255.255/32", // Limited broadcast
 	})...)
-	bogons6 = append(bogons6, expandbogons([]string{
+	bogons6 = append(bogons6, expandBogons([]string{
 		//
 		// List extracted from https://ipinfo.io/bogon
 		//
@@ -110,7 +110,10 @@ func init() {
 	})...)
 }
 
-func isPrivate(address string, ip net.IP) bool {
+// isBogon implements IsBogon
+func isBogon(address string, ip net.IP) bool {
+	// TODO(bassosimone): the following check is probably redundant given that these
+	// three checks are already included into the list of bogons.
 	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
 		return true
 	}

--- a/internal/netxlite/classify.go
+++ b/internal/netxlite/classify.go
@@ -1,5 +1,9 @@
 package netxlite
 
+//
+// Mapping Go errors to OONI errors
+//
+
 import (
 	"context"
 	"crypto/x509"
@@ -38,8 +42,7 @@ func classifyGenericError(err error) string {
 	// The list returned here matches the values used by MK unless
 	// explicitly noted otherwise with a comment.
 
-	// QUIRK: we cannot remove this check as long as this function
-	// is exported and used independently from NewErrWrapper.
+	// Robustness: handle the case where we're passed a wrapped error.
 	var errwrapper *ErrWrapper
 	if errors.As(err, &errwrapper) {
 		return errwrapper.Error() // we've already wrapped it
@@ -146,8 +149,7 @@ const (
 // and returns to the caller its return value.
 func classifyQUICHandshakeError(err error) string {
 
-	// QUIRK: we cannot remove this check as long as this function
-	// is exported and used independently from NewErrWrapper.
+	// Robustness: handle the case where we're passed a wrapped error.
 	var errwrapper *ErrWrapper
 	if errors.As(err, &errwrapper) {
 		return errwrapper.Error() // we've already wrapped it
@@ -269,8 +271,7 @@ var (
 // returns to the caller its return value.
 func classifyResolverError(err error) string {
 
-	// QUIRK: we cannot remove this check as long as this function
-	// is exported and used independently from NewErrWrapper.
+	// Robustness: handle the case where we're passed a wrapped error.
 	var errwrapper *ErrWrapper
 	if errors.As(err, &errwrapper) {
 		return errwrapper.Error() // we've already wrapped it
@@ -303,8 +304,7 @@ func classifyResolverError(err error) string {
 // returns to the caller its return value.
 func classifyTLSHandshakeError(err error) string {
 
-	// QUIRK: we cannot remove this check as long as this function
-	// is exported and used independently from NewErrWrapper.
+	// Robustness: handle the case where we're passed a wrapped error.
 	var errwrapper *ErrWrapper
 	if errors.As(err, &errwrapper) {
 		return errwrapper.Error() // we've already wrapped it

--- a/internal/netxlite/dialer_test.go
+++ b/internal/netxlite/dialer_test.go
@@ -253,7 +253,7 @@ func TestDialerResolver(t *testing.T) {
 			mu := &sync.Mutex{}
 			errorsList := []error{
 				errors.New("a mocked error"),
-				NewErrWrapper(
+				newErrWrapper(
 					classifyGenericError,
 					CloseOperation,
 					io.EOF,
@@ -295,7 +295,7 @@ func TestDialerResolver(t *testing.T) {
 			mu := &sync.Mutex{}
 			errorsList := []error{
 				errors.New("a mocked error"),
-				NewErrWrapper(
+				newErrWrapper(
 					classifyGenericError,
 					CloseOperation,
 					errors.New("antani"),

--- a/internal/netxlite/dnsdecoder.go
+++ b/internal/netxlite/dnsdecoder.go
@@ -1,5 +1,9 @@
 package netxlite
 
+//
+// Decode byte arrays to DNS messages
+//
+
 import (
 	"errors"
 

--- a/internal/netxlite/dnsencoder.go
+++ b/internal/netxlite/dnsencoder.go
@@ -1,5 +1,9 @@
 package netxlite
 
+//
+// Encode DNS queries to byte arrays
+//
+
 import (
 	"github.com/miekg/dns"
 	"github.com/ooni/probe-cli/v3/internal/model"

--- a/internal/netxlite/dnsoverhttps.go
+++ b/internal/netxlite/dnsoverhttps.go
@@ -1,5 +1,9 @@
 package netxlite
 
+//
+// DNS-over-HTTPS transport
+//
+
 import (
 	"bytes"
 	"context"

--- a/internal/netxlite/dnsovertcp.go
+++ b/internal/netxlite/dnsovertcp.go
@@ -1,5 +1,9 @@
 package netxlite
 
+//
+// DNS-over-{TCP,TLS} transport
+//
+
 import (
 	"context"
 	"errors"

--- a/internal/netxlite/dnsoverudp.go
+++ b/internal/netxlite/dnsoverudp.go
@@ -1,5 +1,9 @@
 package netxlite
 
+//
+// DNS-over-UDP transport
+//
+
 import (
 	"context"
 	"time"

--- a/internal/netxlite/dnstransport.go
+++ b/internal/netxlite/dnstransport.go
@@ -1,1 +1,0 @@
-package netxlite

--- a/internal/netxlite/doc.go
+++ b/internal/netxlite/doc.go
@@ -3,7 +3,7 @@
 // This package is the basic networking building block that you
 // should be using every time you need networking.
 //
-// It implements interfaces defined in the internal/model package.
+// It implements interfaces defined in internal/model/netx.go.
 //
 // You should consider checking the tutorial explaining how to use this package
 // for network measurements: https://github.com/ooni/probe-cli/tree/master/internal/tutorial/netxlite.

--- a/internal/netxlite/errwrapper.go
+++ b/internal/netxlite/errwrapper.go
@@ -66,12 +66,12 @@ func (e *ErrWrapper) MarshalJSON() ([]byte, error) {
 	return json.Marshal(e.Failure)
 }
 
-// Classifier is the type of the function that maps a Go error
+// classifier is the type of the function that maps a Go error
 // to a OONI failure string defined at
 // https://github.com/ooni/spec/blob/master/data-formats/df-007-errors.md.
-type Classifier func(err error) string
+type classifier func(err error) string
 
-// NewErrWrapper creates a new ErrWrapper using the given
+// newErrWrapper creates a new ErrWrapper using the given
 // classifier, operation name, and underlying error.
 //
 // This function panics if classifier is nil, or operation
@@ -81,7 +81,7 @@ type Classifier func(err error) string
 // error wrapper will use the same classification string and
 // will determine whether to keep the major operation as documented
 // in the ErrWrapper.Operation documentation.
-func NewErrWrapper(c Classifier, op string, err error) *ErrWrapper {
+func newErrWrapper(c classifier, op string, err error) *ErrWrapper {
 	var wrapper *ErrWrapper
 	if errors.As(err, &wrapper) {
 		return &ErrWrapper{
@@ -107,13 +107,15 @@ func NewErrWrapper(c Classifier, op string, err error) *ErrWrapper {
 }
 
 // NewTopLevelGenericErrWrapper wraps an error occurring at top
-// level using ClassifyGenericError as classifier.
+// level using a generic classifier as classifier. This is the
+// function you should call when you suspect a given error hasn't
+// already been wrapped. This function panics if err is nil.
 //
 // If the err argument has already been classified, the returned
 // error wrapper will use the same classification string and
 // failed operation of the original error.
 func NewTopLevelGenericErrWrapper(err error) *ErrWrapper {
-	return NewErrWrapper(classifyGenericError, TopLevelOperation, err)
+	return newErrWrapper(classifyGenericError, TopLevelOperation, err)
 }
 
 func classifyOperation(ew *ErrWrapper, operation string) string {

--- a/internal/netxlite/errwrapper_test.go
+++ b/internal/netxlite/errwrapper_test.go
@@ -53,7 +53,7 @@ func TestNewErrWrapper(t *testing.T) {
 					recovered.Add(1)
 				}
 			}()
-			NewErrWrapper(nil, CloseOperation, io.EOF)
+			newErrWrapper(nil, CloseOperation, io.EOF)
 		}()
 		if recovered.Load() != 1 {
 			t.Fatal("did not panic")
@@ -68,7 +68,7 @@ func TestNewErrWrapper(t *testing.T) {
 					recovered.Add(1)
 				}
 			}()
-			NewErrWrapper(classifyGenericError, "", io.EOF)
+			newErrWrapper(classifyGenericError, "", io.EOF)
 		}()
 		if recovered.Load() != 1 {
 			t.Fatal("did not panic")
@@ -83,7 +83,7 @@ func TestNewErrWrapper(t *testing.T) {
 					recovered.Add(1)
 				}
 			}()
-			NewErrWrapper(classifyGenericError, CloseOperation, nil)
+			newErrWrapper(classifyGenericError, CloseOperation, nil)
 		}()
 		if recovered.Load() != 1 {
 			t.Fatal("did not panic")
@@ -91,7 +91,7 @@ func TestNewErrWrapper(t *testing.T) {
 	})
 
 	t.Run("otherwise, works as intended", func(t *testing.T) {
-		ew := NewErrWrapper(classifyGenericError, CloseOperation, io.EOF)
+		ew := newErrWrapper(classifyGenericError, CloseOperation, io.EOF)
 		if ew.Failure != FailureEOFError {
 			t.Fatal("unexpected failure")
 		}
@@ -104,10 +104,10 @@ func TestNewErrWrapper(t *testing.T) {
 	})
 
 	t.Run("when the underlying error is already a wrapped error", func(t *testing.T) {
-		ew := NewErrWrapper(classifySyscallError, ReadOperation, ECONNRESET)
+		ew := newErrWrapper(classifySyscallError, ReadOperation, ECONNRESET)
 		var err1 error = ew
 		err2 := fmt.Errorf("cannot read: %w", err1)
-		ew2 := NewErrWrapper(classifyGenericError, HTTPRoundTripOperation, err2)
+		ew2 := newErrWrapper(classifyGenericError, HTTPRoundTripOperation, err2)
 		if ew2.Failure != ew.Failure {
 			t.Fatal("not the same failure")
 		}

--- a/internal/netxlite/http3.go
+++ b/internal/netxlite/http3.go
@@ -1,5 +1,9 @@
 package netxlite
 
+//
+// HTTP3 code
+//
+
 import (
 	"crypto/tls"
 	"io"

--- a/internal/netxlite/http_test.go
+++ b/internal/netxlite/http_test.go
@@ -252,19 +252,19 @@ func TestNewHTTPTransport(t *testing.T) {
 			t.Fatal("invalid tls dialer")
 		}
 		stdlib := connectionsCloser.HTTPTransport.(*stdlibTransport)
-		if !stdlib.Transport.ForceAttemptHTTP2 {
+		if !stdlib.StdlibTransport.ForceAttemptHTTP2 {
 			t.Fatal("invalid ForceAttemptHTTP2")
 		}
-		if !stdlib.Transport.DisableCompression {
+		if !stdlib.StdlibTransport.DisableCompression {
 			t.Fatal("invalid DisableCompression")
 		}
-		if stdlib.Transport.MaxConnsPerHost != 1 {
+		if stdlib.StdlibTransport.MaxConnsPerHost != 1 {
 			t.Fatal("invalid MaxConnPerHost")
 		}
-		if stdlib.Transport.DialTLSContext == nil {
+		if stdlib.StdlibTransport.DialTLSContext == nil {
 			t.Fatal("invalid DialTLSContext")
 		}
-		if stdlib.Transport.DialContext == nil {
+		if stdlib.StdlibTransport.DialContext == nil {
 			t.Fatal("invalid DialContext")
 		}
 	})
@@ -499,6 +499,20 @@ func TestHTTPClientErrWrapper(t *testing.T) {
 				t.Fatal("not the expected response")
 			}
 		})
+	})
+
+	t.Run("CloseIdleConnections", func(t *testing.T) {
+		var called bool
+		child := &mocks.HTTPClient{
+			MockCloseIdleConnections: func() {
+				called = true
+			},
+		}
+		clnt := &httpClientErrWrapper{child}
+		clnt.CloseIdleConnections()
+		if !called {
+			t.Fatal("not called")
+		}
 	})
 }
 

--- a/internal/netxlite/iox.go
+++ b/internal/netxlite/iox.go
@@ -1,5 +1,9 @@
 package netxlite
 
+//
+// I/O extensions
+//
+
 import (
 	"context"
 	"errors"

--- a/internal/netxlite/iox_test.go
+++ b/internal/netxlite/iox_test.go
@@ -41,7 +41,7 @@ func TestReadAllContext(t *testing.T) {
 				//
 				// Note: Returning a wrapped error to ensure we address
 				// https://github.com/ooni/probe/issues/1965
-				return len(b), NewErrWrapper(classifyGenericError,
+				return len(b), newErrWrapper(classifyGenericError,
 					ReadOperation, io.EOF)
 			},
 		}
@@ -171,7 +171,7 @@ func TestCopyContext(t *testing.T) {
 				//
 				// Note: Returning a wrapped error to ensure we address
 				// https://github.com/ooni/probe/issues/1965
-				return len(b), NewErrWrapper(classifyGenericError,
+				return len(b), newErrWrapper(classifyGenericError,
 					ReadOperation, io.EOF)
 			},
 		}

--- a/internal/netxlite/legacy.go
+++ b/internal/netxlite/legacy.go
@@ -1,5 +1,9 @@
 package netxlite
 
+//
+// Legacy code
+//
+
 // These vars export internal names to legacy ooni/probe-cli code.
 //
 // Deprecated: do not use these names in new code.

--- a/internal/netxlite/operations.go
+++ b/internal/netxlite/operations.go
@@ -1,5 +1,9 @@
 package netxlite
 
+//
+// Names of operations
+//
+
 // Operations that we measure. They are the possible values of
 // the ErrWrapper.Operation field.
 const (

--- a/internal/netxlite/parallelresolver.go
+++ b/internal/netxlite/parallelresolver.go
@@ -1,7 +1,7 @@
 package netxlite
 
 //
-// Parallel resolver implementation
+// Parallel DNS resolver implementation
 //
 
 import (

--- a/internal/netxlite/quirks.go
+++ b/internal/netxlite/quirks.go
@@ -1,14 +1,16 @@
 package netxlite
 
+//
+// This file contains weird stuff that we carried over from
+// the original netx implementation and that we cannot remove
+// or change without thinking about the consequences.
+//
+
 import (
 	"errors"
 	"net"
 	"strings"
 )
-
-// This file contains weird stuff that we carried over from
-// the original netx implementation and that we cannot remove
-// or change without thinking about the consequences.
 
 // See https://github.com/ooni/probe/issues/1985
 var errReduceErrorsEmptyList = errors.New("bug: reduceErrors given an empty list")

--- a/internal/netxlite/quirks_test.go
+++ b/internal/netxlite/quirks_test.go
@@ -34,12 +34,12 @@ func TestQuirkReduceErrors(t *testing.T) {
 
 	t.Run("multiple errors with meaningful ones", func(t *testing.T) {
 		err1 := errors.New("mocked error #1")
-		err2 := NewErrWrapper(
+		err2 := newErrWrapper(
 			classifyGenericError,
 			CloseOperation,
 			errors.New("antani"),
 		)
-		err3 := NewErrWrapper(
+		err3 := newErrWrapper(
 			classifyGenericError,
 			CloseOperation,
 			ECONNREFUSED,

--- a/internal/netxlite/resolver_test.go
+++ b/internal/netxlite/resolver_test.go
@@ -400,6 +400,30 @@ func TestResolverIDNA(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("Network", func(t *testing.T) {
+		child := &mocks.Resolver{
+			MockNetwork: func() string {
+				return "x"
+			},
+		}
+		r := &resolverIDNA{child}
+		if r.Network() != "x" {
+			t.Fatal("invalid network")
+		}
+	})
+
+	t.Run("Address", func(t *testing.T) {
+		child := &mocks.Resolver{
+			MockAddress: func() string {
+				return "x"
+			},
+		}
+		r := &resolverIDNA{child}
+		if r.Address() != "x" {
+			t.Fatal("invalid address")
+		}
+	})
 }
 
 func TestResolverShortCircuitIPAddr(t *testing.T) {

--- a/internal/netxlite/tls_test.go
+++ b/internal/netxlite/tls_test.go
@@ -487,6 +487,7 @@ func TestTLSDialer(t *testing.T) {
 func TestNewSingleUseTLSDialer(t *testing.T) {
 	conn := &mocks.TLSConn{}
 	d := NewSingleUseTLSDialer(conn)
+	defer d.CloseIdleConnections()
 	outconn, err := d.DialTLSContext(context.Background(), "", "")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/netxlite/tproxy.go
+++ b/internal/netxlite/tproxy.go
@@ -1,5 +1,9 @@
 package netxlite
 
+//
+// Transparent proxy (for integration testing)
+//
+
 import (
 	"context"
 	"net"

--- a/internal/netxlite/utls.go
+++ b/internal/netxlite/utls.go
@@ -1,5 +1,9 @@
 package netxlite
 
+//
+// Code to use yawning/utls or refraction-networking/utls
+//
+
 import (
 	"context"
 	"crypto/tls"


### PR DESCRIPTION
This diff has been extracted and adapted from https://github.com/bassosimone/websteps-illustrated/commit/8848c8c516a40663c2718b1aff271884a116a147

The reason to prefer composition over embedding is that we want the
build to break if we add new methods to interfaces we define. If the build
does not break, we may forget about wrapping methods we should
actually be wrapping. I noticed this issue inside netxlite when I was working
on websteps-illustrated and I added support for NS and PTR queries.

See https://github.com/ooni/probe/issues/2096

While there, perform comprehensive netxlite code review
and apply minor changes and improve the docs.
