### PR TITLE
fix(netxlite): ensure we only accept DNS responses

### DIFF
--- a/internal/model/netx.go
+++ b/internal/model/netx.go
@@ -60,6 +60,9 @@ type DNSDecoder interface {
 	//
 	// - data is the raw reply
 	//
+	// This function fails if we cannot parse data as a DNS
+	// message or the message is not a reply.
+	//
 	// If you use this function, remember that:
 	//
 	// 1. the Rcode MAY be nonzero;


### PR DESCRIPTION
Previously, the DNS decoder did not check whether it was parsing
a DNS query or a DNS response, which was wrong.

As a side note, it seems I am using "reply" in the codebase instead
of "response". The latter seems correct DNS terminology.

This diff has been extracted from https://github.com/bassosimone/websteps-illustrated/commit/9249d14f80b4c685234da8e344b36c8904ee69e9

See https://github.com/ooni/probe/issues/2096.
