### PR TITLE
fix(webconnectivity): Add TH to measurement

### DIFF
--- a/internal/engine/experiment.go
+++ b/internal/engine/experiment.go
@@ -131,6 +131,7 @@ func (eaw *experimentAsyncWrapper) RunAsync(
 			Input:              measurement.Input,
 			MeasurementRuntime: stop.Sub(start).Seconds(),
 			TestKeys:           measurement.TestKeys,
+			TestHelpers:        measurement.TestHelpers,
 		}
 	}()
 	return out, nil
@@ -180,6 +181,7 @@ func (e *Experiment) MeasureAsync(
 			measurement.Extensions = tk.Extensions
 			measurement.Input = tk.Input
 			measurement.MeasurementRuntime = tk.MeasurementRuntime
+			measurement.TestHelpers = tk.TestHelpers
 			measurement.TestKeys = tk.TestKeys
 			if err := measurement.Scrub(e.session.ProbeIP()); err != nil {
 				// If we fail to scrub the measurement then we are not going to

--- a/internal/model/experiment.go
+++ b/internal/model/experiment.go
@@ -39,6 +39,9 @@ type ExperimentAsyncTestKeys struct {
 	// MeasurementRuntime is the total measurement runtime.
 	MeasurementRuntime float64
 
+	// TestHelpers contains the test helpers used in the experiment
+	TestHelpers map[string]interface{}
+
 	// TestKeys contains the actual test keys.
 	TestKeys interface{}
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: [Issue #2073](https://github.com/ooni/probe/issues/2073)
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

- Passed the `TestHelpers` field to `RunAsyc` and `MeasureAsync`. This reflects the `test_helpers` in the measurement.
- Spec already contains the correct output.