### PR TITLE
fix(ooniprobe show): correctly handle % in the JSON

### DIFF
--- a/cmd/ooniprobe/internal/log/handlers/cli/measurements.go
+++ b/cmd/ooniprobe/internal/log/handlers/cli/measurements.go
@@ -137,6 +137,6 @@ func logMeasurementJSON(w io.Writer, f log.Fields) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(w, string(json))
+	fmt.Fprintf(w, "%s", string(json))
 	return nil
 }


### PR DESCRIPTION
This diff fixes the way in which we print JSON results inside
`ooniprobe show <ID>` by using the "%s" fmt specifier rather than
using the JSON string itself as the format string.

See https://github.com/ooni/probe/issues/2082

FWIW, `ooniprobe show --batch <ID>` was already WAI.
