### PR TITLE
fix(oohelperd): do not follow bogons for webconnectivity

### DIFF
--- a/internal/cmd/oohelper/internal/client.go
+++ b/internal/cmd/oohelper/internal/client.go
@@ -94,6 +94,9 @@ func (oo OOClient) Do(ctx context.Context, config OOConfig) (*CtrlResponse, erro
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrInvalidURL, err.Error())
 	}
+	if net.ParseIP(targetURL.Hostname()) != nil && netxlite.IsBogon(targetURL.Hostname()) {
+		return nil, ErrHTTPStatusCode
+	}
 	addrs, err := oo.Resolver.LookupHost(ctx, targetURL.Hostname())
 	endpoints := []string{}
 	if err == nil {

--- a/internal/cmd/oohelper/internal/client.go
+++ b/internal/cmd/oohelper/internal/client.go
@@ -94,9 +94,6 @@ func (oo OOClient) Do(ctx context.Context, config OOConfig) (*CtrlResponse, erro
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrInvalidURL, err.Error())
 	}
-	if net.ParseIP(targetURL.Hostname()) != nil && netxlite.IsBogon(targetURL.Hostname()) {
-		return nil, ErrHTTPStatusCode
-	}
 	addrs, err := oo.Resolver.LookupHost(ctx, targetURL.Hostname())
 	endpoints := []string{}
 	if err == nil {

--- a/internal/cmd/oohelperd/internal/webconnectivity/webconnectivity.go
+++ b/internal/cmd/oohelperd/internal/webconnectivity/webconnectivity.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 
 	"github.com/ooni/probe-cli/v3/internal/model"
@@ -21,6 +22,11 @@ type Handler struct {
 }
 
 func (h Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	// Check whether the given URL is bogon.
+	if net.ParseIP(req.URL.Hostname()) != nil && netxlite.IsBogon(req.URL.Hostname()) {
+		w.WriteHeader(400)
+		return
+	}
 	w.Header().Add("Server", fmt.Sprintf(
 		"oohelperd/%s ooniprobe-engine/%s", version.Version, version.Version,
 	))


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2064

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

I have added a conditional in the `Do()` of oohelperd, which obtains URL's Hostname and checks whether the given targetURL is bogon. This PR ensures webconnectivity do not follow bogons.