### PR TITLE
feat(ooniprobe): add vanilla_tor to experimental

### DIFF
--- a/cmd/ooniprobe/internal/nettests/groups.go
+++ b/cmd/ooniprobe/internal/nettests/groups.go
@@ -57,6 +57,7 @@ var All = map[string]Group{
 			DNSCheck{},
 			STUNReachability{},
 			TorSf{},
+			VanillaTor{},
 		},
 		UnattendedOK: true,
 	},

--- a/cmd/ooniprobe/internal/nettests/run.go
+++ b/cmd/ooniprobe/internal/nettests/run.go
@@ -103,6 +103,12 @@ func RunGroup(config RunGroupConfig) error {
 			log.Debugf("context is terminated, stopping group.Nettests early")
 			break
 		}
+		if config.RunType != model.RunTypeTimed {
+			if _, background := nt.(onlyBackground); background {
+				log.Debug("we only run this nettest in background mode")
+				continue
+			}
+		}
 		log.Debugf("Running test %T", nt)
 		ctl := NewController(nt, config.Probe, result, sess)
 		ctl.InputFiles = config.InputFiles
@@ -130,4 +136,16 @@ func RunGroup(config RunGroupConfig) error {
 		return err
 	}
 	return nil
+}
+
+// onlyBackground is the interface implements by nettests that we don't
+// want to run in manual mode because they take too much runtime
+//
+// See:
+//
+// - https://github.com/ooni/probe/issues/2101
+//
+// - https://github.com/ooni/probe/issues/2057
+type onlyBackground interface {
+	onlyBackground()
 }

--- a/cmd/ooniprobe/internal/nettests/torsf.go
+++ b/cmd/ooniprobe/internal/nettests/torsf.go
@@ -12,3 +12,5 @@ func (h TorSf) Run(ctl *Controller) error {
 	}
 	return ctl.Run(builder, []string{""})
 }
+
+func (h TorSf) onlyBackground() {}

--- a/cmd/ooniprobe/internal/nettests/vanillator.go
+++ b/cmd/ooniprobe/internal/nettests/vanillator.go
@@ -1,0 +1,16 @@
+package nettests
+
+// VanillaTor test implementation
+type VanillaTor struct {
+}
+
+// Run starts the test
+func (h VanillaTor) Run(ctl *Controller) error {
+	builder, err := ctl.Session.NewExperimentBuilder("vanilla_tor")
+	if err != nil {
+		return err
+	}
+	return ctl.Run(builder, []string{""})
+}
+
+func (h VanillaTor) onlyBackground() {}


### PR DESCRIPTION
While there make vanilla_tor only run in unattended mode.

While there also make torsf unattended-mode only.

See https://github.com/ooni/probe/issues/2101

See https://github.com/ooni/probe/issues/2057

