### PR TITLE
netxlite: do not call netgo the CGO_ENABLED=0 resolver

### DIFF
--- a/internal/model/netx.go
+++ b/internal/model/netx.go
@@ -201,10 +201,11 @@ type SimpleResolver interface {
 
 	// Network returns the resolver type. It should be one of:
 	//
-	// - netgo: means we're using golang's "netgo" UDP resolver, which
-	// reads /etc/resolv.conf and only works on Unix systems;
+	// - go: means we're using whatever resolver the Go stdlib uses
+	// depending on the current build configuration;
 	//
-	// - system: means we're calling getaddrinfo;
+	// - system: means we've been compiled with `CGO_ENABLED=1`
+	// so we can bypass the go resolver and call getaddrinfo directly;
 	//
 	// - udp: is a custom DNS-over-UDP resolver;
 	//
@@ -215,6 +216,10 @@ type SimpleResolver interface {
 	// - doh: is a custom DNS-over-HTTPS resolver;
 	//
 	// - doh3: is a custom DNS-over-HTTP3 resolver.
+	//
+	// See https://github.com/ooni/probe/issues/2029#issuecomment-1140805266
+	// for an explanation of why it would not be proper to call "netgo" the
+	// resolver we get by default from the standard library.
 	Network() string
 }
 

--- a/internal/netxlite/getaddrinfo_otherwise.go
+++ b/internal/netxlite/getaddrinfo_otherwise.go
@@ -11,10 +11,13 @@ import (
 // been used to implement the getaddrinfo resolver.
 //
 // This is the CGO_ENABLED=0 implementation of this function, which
-// always returns the string "netgo", because in this scenario we
-// are actually using the netgo implementation of net.Resolver.
+// always returns the string "go", because in this scenario we are actually
+// using whatever resolver is used under the hood by the stdlib.
+//
+// See https://github.com/ooni/probe/issues/2029#issuecomment-1140805266
+// for an explanation of why calling this resolver "netgo" is wrong.
 func getaddrinfoResolverNetwork() string {
-	return "netgo"
+	return "go"
 }
 
 // getaddrinfoLookupANY attempts to perform an ANY lookup using getaddrinfo.


### PR DESCRIPTION
In https://github.com/ooni/probe/issues/2029#issuecomment-1140805266, we
explained why calling it "netgo" would be incorrect.

In other words, we can get the platform's `getaddrinfo` as long as
we're not cross compiling. We do cross compile `ooniprobe`, actually
it's not even possible to cross compile it.

For increased accuracy, we should stop cross compiling `miniooni`
as well, so it would also directly use `getaddrinfo`.

This diff fixes at the same time ooni/probe-cli and ooni/spec
and we'll open two pull requests in parallel.

