### PR TITLE
refactor(netxlite): allow easy dialer chain customization

### DIFF
--- a/internal/engine/netx/dialer/dialer_test.go
+++ b/internal/engine/netx/dialer/dialer_test.go
@@ -24,34 +24,12 @@ func TestNewCreatesTheExpectedChain(t *testing.T) {
 	if !ok {
 		t.Fatal("not a byteCounterDialer")
 	}
-	pd, ok := bcd.Dialer.(*netxlite.MaybeProxyDialer)
+	_, ok = bcd.Dialer.(*netxlite.MaybeProxyDialer)
 	if !ok {
 		t.Fatal("not a proxyDialer")
 	}
-	dnsd, ok := pd.Dialer.(*netxlite.DialerResolver)
-	if !ok {
-		t.Fatal("not a dnsDialer")
-	}
-	scd, ok := dnsd.Dialer.(*saverConnDialer)
-	if !ok {
-		t.Fatal("not a saverConnDialer")
-	}
-	sd, ok := scd.Dialer.(*saverDialer)
-	if !ok {
-		t.Fatal("not a saverDialer")
-	}
-	ld, ok := sd.Dialer.(*netxlite.DialerLogger)
-	if !ok {
-		t.Fatal("not a loggingDialer")
-	}
-	ewd, ok := ld.Dialer.(*netxlite.ErrorWrapperDialer)
-	if !ok {
-		t.Fatal("not an errorWrappingDialer")
-	}
-	_, ok = ewd.Dialer.(*netxlite.DialerSystem)
-	if !ok {
-		t.Fatal("not a DialerSystem")
-	}
+	// We can safely stop here: the rest is tested by
+	// the internal/netxlite package
 }
 
 func TestDialerNewSuccess(t *testing.T) {

--- a/internal/netxlite/legacy.go
+++ b/internal/netxlite/legacy.go
@@ -8,7 +8,7 @@ package netxlite
 //
 // Deprecated: do not use these names in new code.
 var (
-	DefaultDialer        = &dialerSystem{}
+	DefaultDialer        = &DialerSystem{}
 	DefaultTLSHandshaker = defaultTLSHandshaker
 	NewConnUTLS          = newConnUTLS
 	DefaultResolver      = &resolverSystem{}
@@ -36,7 +36,6 @@ type (
 	ResolverIDNA              = resolverIDNA
 	TLSHandshakerConfigurable = tlsHandshakerConfigurable
 	TLSHandshakerLogger       = tlsHandshakerLogger
-	DialerSystem              = dialerSystem
 	TLSDialerLegacy           = tlsDialer
 	AddressResolver           = resolverShortCircuitIPAddr
 )

--- a/internal/netxlite/quic.go
+++ b/internal/netxlite/quic.go
@@ -79,7 +79,7 @@ func NewQUICDialerWithResolver(listener model.QUICListener,
 // an address containing a domain name, the dial will fail with
 // the ErrNoResolver failure.
 func NewQUICDialerWithoutResolver(listener model.QUICListener, logger model.DebugLogger) model.QUICDialer {
-	return NewQUICDialerWithResolver(listener, logger, &nullResolver{})
+	return NewQUICDialerWithResolver(listener, logger, &NullResolver{})
 }
 
 // quicDialerQUICGo dials using the lucas-clemente/quic-go library.

--- a/internal/netxlite/quic_test.go
+++ b/internal/netxlite/quic_test.go
@@ -30,7 +30,7 @@ func TestNewQUICDialer(t *testing.T) {
 		t.Fatal("invalid logger")
 	}
 	resolver := logger.Dialer.(*quicDialerResolver)
-	if _, okay := resolver.Resolver.(*nullResolver); !okay {
+	if _, okay := resolver.Resolver.(*NullResolver); !okay {
 		t.Fatal("invalid resolver type")
 	}
 	logger = resolver.Dialer.(*quicDialerLogger)

--- a/internal/netxlite/resolver.go
+++ b/internal/netxlite/resolver.go
@@ -334,32 +334,32 @@ func isIPv6(candidate string) bool {
 // since they can only dial for endpoints containing IP addresses.
 var ErrNoResolver = errors.New("no configured resolver")
 
-// nullResolver is a resolver that is not capable of resolving
+// NullResolver is a resolver that is not capable of resolving
 // domain names to IP addresses and always returns ErrNoResolver.
-type nullResolver struct{}
+type NullResolver struct{}
 
-func (r *nullResolver) LookupHost(ctx context.Context, hostname string) (addrs []string, err error) {
+func (r *NullResolver) LookupHost(ctx context.Context, hostname string) (addrs []string, err error) {
 	return nil, ErrNoResolver
 }
 
-func (r *nullResolver) Network() string {
+func (r *NullResolver) Network() string {
 	return "null"
 }
 
-func (r *nullResolver) Address() string {
+func (r *NullResolver) Address() string {
 	return ""
 }
 
-func (r *nullResolver) CloseIdleConnections() {
+func (r *NullResolver) CloseIdleConnections() {
 	// nothing to do
 }
 
-func (r *nullResolver) LookupHTTPS(
+func (r *NullResolver) LookupHTTPS(
 	ctx context.Context, domain string) (*model.HTTPSSvc, error) {
 	return nil, ErrNoResolver
 }
 
-func (r *nullResolver) LookupNS(
+func (r *NullResolver) LookupNS(
 	ctx context.Context, domain string) ([]*net.NS, error) {
 	return nil, ErrNoResolver
 }

--- a/internal/netxlite/resolver_test.go
+++ b/internal/netxlite/resolver_test.go
@@ -807,7 +807,7 @@ func TestIsIPv6(t *testing.T) {
 
 func TestNullResolver(t *testing.T) {
 	t.Run("LookupHost", func(t *testing.T) {
-		r := &nullResolver{}
+		r := &NullResolver{}
 		ctx := context.Background()
 		addrs, err := r.LookupHost(ctx, "dns.google")
 		if !errors.Is(err, ErrNoResolver) {
@@ -826,7 +826,7 @@ func TestNullResolver(t *testing.T) {
 	})
 
 	t.Run("LookupHTTPS", func(t *testing.T) {
-		r := &nullResolver{}
+		r := &NullResolver{}
 		ctx := context.Background()
 		addrs, err := r.LookupHTTPS(ctx, "dns.google")
 		if !errors.Is(err, ErrNoResolver) {
@@ -845,7 +845,7 @@ func TestNullResolver(t *testing.T) {
 	})
 
 	t.Run("LookupNS", func(t *testing.T) {
-		r := &nullResolver{}
+		r := &NullResolver{}
 		ctx := context.Background()
 		ns, err := r.LookupNS(ctx, "dns.google")
 		if !errors.Is(err, ErrNoResolver) {

--- a/internal/netxlite/tls_test.go
+++ b/internal/netxlite/tls_test.go
@@ -392,7 +392,7 @@ func TestTLSDialer(t *testing.T) {
 		t.Run("failure dialing", func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel() // immediately fail
-			dialer := tlsDialer{Dialer: &dialerSystem{}}
+			dialer := tlsDialer{Dialer: &DialerSystem{}}
 			conn, err := dialer.DialTLSContext(ctx, "tcp", "www.google.com:443")
 			if err == nil || !strings.HasSuffix(err.Error(), "operation was canceled") {
 				t.Fatal("not the error we expected", err)


### PR DESCRIPTION
This diff modifies the construction of a dialer to allow one
to insert custom dialer wrappers into the dialers chain.

The point of the chain in which we allow custom wrappers is the
optimal one for connect, read, and write measurements.

This new design is better than the previous netx design since
we don't need to construct the whole chain manually now.

The work in this diff is part of the effort to make engine/netx
just a tiny wrapper around netxlite.

See https://github.com/ooni/probe/issues/2121.
