### PR TITLE
refactor(tracex): start applying recent code conventions

### DIFF
--- a/internal/engine/experiment/urlgetter/configurer_test.go
+++ b/internal/engine/experiment/urlgetter/configurer_test.go
@@ -119,7 +119,7 @@ func TestConfigurerNewConfigurationResolverDNSOverHTTPSPowerdns(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	stxp, ok := sr.Txp.(tracex.SaverDNSTransport)
+	stxp, ok := sr.Txp.(*tracex.SaverDNSTransport)
 	if !ok {
 		t.Fatal("not the DNS transport we expected")
 	}
@@ -195,7 +195,7 @@ func TestConfigurerNewConfigurationResolverDNSOverHTTPSGoogle(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	stxp, ok := sr.Txp.(tracex.SaverDNSTransport)
+	stxp, ok := sr.Txp.(*tracex.SaverDNSTransport)
 	if !ok {
 		t.Fatal("not the DNS transport we expected")
 	}
@@ -271,7 +271,7 @@ func TestConfigurerNewConfigurationResolverDNSOverHTTPSCloudflare(t *testing.T) 
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	stxp, ok := sr.Txp.(tracex.SaverDNSTransport)
+	stxp, ok := sr.Txp.(*tracex.SaverDNSTransport)
 	if !ok {
 		t.Fatal("not the DNS transport we expected")
 	}
@@ -347,7 +347,7 @@ func TestConfigurerNewConfigurationResolverUDP(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	stxp, ok := sr.Txp.(tracex.SaverDNSTransport)
+	stxp, ok := sr.Txp.(*tracex.SaverDNSTransport)
 	if !ok {
 		t.Fatal("not the DNS transport we expected")
 	}

--- a/internal/engine/netx/netx_test.go
+++ b/internal/engine/netx/netx_test.go
@@ -126,7 +126,7 @@ func TestNewResolverWithSaver(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	sr, ok := ir.Resolver.(tracex.SaverResolver)
+	sr, ok := ir.Resolver.(*tracex.SaverResolver)
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
@@ -332,7 +332,7 @@ func TestNewTLSDialerWithSaver(t *testing.T) {
 	if rtd.TLSHandshaker == nil {
 		t.Fatal("invalid TLSHandshaker")
 	}
-	sth, ok := rtd.TLSHandshaker.(tracex.SaverTLSHandshaker)
+	sth, ok := rtd.TLSHandshaker.(*tracex.SaverTLSHandshaker)
 	if !ok {
 		t.Fatal("not the TLSHandshaker we expected")
 	}
@@ -633,7 +633,7 @@ func TestNewDNSClientCloudflareDoHSaver(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	txp, ok := r.Transport().(tracex.SaverDNSTransport)
+	txp, ok := r.Transport().(*tracex.SaverDNSTransport)
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}
@@ -670,7 +670,7 @@ func TestNewDNSClientUDPDNSSaver(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	txp, ok := r.Transport().(tracex.SaverDNSTransport)
+	txp, ok := r.Transport().(*tracex.SaverDNSTransport)
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}
@@ -711,7 +711,7 @@ func TestNewDNSClientTCPDNSSaver(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	txp, ok := r.Transport().(tracex.SaverDNSTransport)
+	txp, ok := r.Transport().(*tracex.SaverDNSTransport)
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}
@@ -756,7 +756,7 @@ func TestNewDNSClientDoTDNSSaver(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	txp, ok := r.Transport().(tracex.SaverDNSTransport)
+	txp, ok := r.Transport().(*tracex.SaverDNSTransport)
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}

--- a/internal/engine/netx/tracex/archival_test.go
+++ b/internal/engine/netx/tracex/archival_test.go
@@ -47,7 +47,7 @@ func TestDNSQueryIPOfType(t *testing.T) {
 		output: false,
 	}}
 	for _, exp := range expectations {
-		if exp.qtype.ipoftype(exp.ip) != exp.output {
+		if exp.qtype.ipOfType(exp.ip) != exp.output {
 			t.Fatalf("failure for %+v", exp)
 		}
 	}

--- a/internal/engine/netx/tracex/dialer.go
+++ b/internal/engine/netx/tracex/dialer.go
@@ -1,5 +1,9 @@
 package tracex
 
+//
+// TCP and connected UDP sockets
+//
+
 import (
 	"context"
 	"net"
@@ -11,7 +15,10 @@ import (
 
 // SaverDialer saves events occurring during the dial
 type SaverDialer struct {
-	model.Dialer
+	// Dialer is the underlying dialer,
+	Dialer model.Dialer
+
+	// Saver saves events.
 	Saver *Saver
 }
 
@@ -31,10 +38,17 @@ func (d *SaverDialer) DialContext(ctx context.Context, network, address string) 
 	return conn, err
 }
 
+func (d *SaverDialer) CloseIdleConnections() {
+	d.Dialer.CloseIdleConnections()
+}
+
 // SaverConnDialer wraps the returned connection such that we
 // collect all the read/write events that occur.
 type SaverConnDialer struct {
-	model.Dialer
+	// Dialer is the underlying dialer
+	Dialer model.Dialer
+
+	// Saver saves events
 	Saver *Saver
 }
 
@@ -45,6 +59,10 @@ func (d *SaverConnDialer) DialContext(ctx context.Context, network, address stri
 		return nil, err
 	}
 	return &saverConn{saver: d.Saver, Conn: conn}, nil
+}
+
+func (d *SaverConnDialer) CloseIdleConnections() {
+	d.Dialer.CloseIdleConnections()
 }
 
 type saverConn struct {

--- a/internal/engine/netx/tracex/doc.go
+++ b/internal/engine/netx/tracex/doc.go
@@ -1,2 +1,8 @@
-// Package tracex contains code to perform measurements using tracing.
+// Package tracex performs measurements using tracing. To use tracing means
+// that we'll wrap netx data types (e.g., a Dialer) with equivalent data types
+// saving events into a Saver data struture. Then we will use the data types
+// normally (e.g., call the Dialer's DialContet method and then use the
+// resulting connection). When done, we will extract the trace containing
+// all the events that occurred from the saver and process it to determine
+// what happened during the measurement itself.
 package tracex

--- a/internal/engine/netx/tracex/event.go
+++ b/internal/engine/netx/tracex/event.go
@@ -1,9 +1,7 @@
 package tracex
 
 import (
-	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"net/http"
 	"time"
 )
@@ -35,26 +33,4 @@ type Event struct {
 	TLSVersion         string              `json:",omitempty"`
 	Time               time.Time           `json:",omitempty"`
 	Transport          string              `json:",omitempty"`
-}
-
-// PeerCerts returns the certificates presented by the peer regardless
-// of whether the TLS handshake was successful
-func PeerCerts(state tls.ConnectionState, err error) []*x509.Certificate {
-	var x509HostnameError x509.HostnameError
-	if errors.As(err, &x509HostnameError) {
-		// Test case: https://wrong.host.badssl.com/
-		return []*x509.Certificate{x509HostnameError.Certificate}
-	}
-	var x509UnknownAuthorityError x509.UnknownAuthorityError
-	if errors.As(err, &x509UnknownAuthorityError) {
-		// Test case: https://self-signed.badssl.com/. This error has
-		// never been among the ones returned by MK.
-		return []*x509.Certificate{x509UnknownAuthorityError.Cert}
-	}
-	var x509CertificateInvalidError x509.CertificateInvalidError
-	if errors.As(err, &x509CertificateInvalidError) {
-		// Test case: https://expired.badssl.com/
-		return []*x509.Certificate{x509CertificateInvalidError.Cert}
-	}
-	return state.PeerCertificates
 }

--- a/internal/engine/netx/tracex/http_test.go
+++ b/internal/engine/netx/tracex/http_test.go
@@ -394,8 +394,7 @@ func TestCloneHeaders(t *testing.T) {
 			},
 			Header: http.Header{},
 		}
-		txp := SaverMetadataHTTPTransport{}
-		header := txp.CloneHeaders(req)
+		header := httpCloneHeaders(req)
 		if header.Get("Host") != "www.example.com" {
 			t.Fatal("did not set Host header correctly")
 		}
@@ -409,8 +408,7 @@ func TestCloneHeaders(t *testing.T) {
 			},
 			Header: http.Header{},
 		}
-		txp := SaverMetadataHTTPTransport{}
-		header := txp.CloneHeaders(req)
+		header := httpCloneHeaders(req)
 		if header.Get("Host") != "www.kernel.org" {
 			t.Fatal("did not set Host header correctly")
 		}

--- a/internal/engine/netx/tracex/resolver.go
+++ b/internal/engine/netx/tracex/resolver.go
@@ -1,20 +1,43 @@
 package tracex
 
+//
+// DNS lookup and round trip
+//
+
 import (
 	"context"
+	"net"
 	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
 
-// SaverResolver is a resolver that saves events
+// SaverResolver is a resolver that saves events.
 type SaverResolver struct {
-	model.Resolver
+	// Resolver is the underlying resolver.
+	Resolver model.Resolver
+
+	// Saver saves events.
 	Saver *Saver
 }
 
+// WrapResolver wraps a model.Resolver with a SaverResolver that will save
+// the DNS lookup results into this Saver.
+//
+// When this function is invoked on a nil Saver, it will directly return
+// the original Resolver without any wrapping.
+func (s *Saver) WrapResolver(r model.Resolver) model.Resolver {
+	if s == nil {
+		return r
+	}
+	return &SaverResolver{
+		Resolver: r,
+		Saver:    s,
+	}
+}
+
 // LookupHost implements Resolver.LookupHost
-func (r SaverResolver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
+func (r *SaverResolver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
 	start := time.Now()
 	r.Saver.Write(Event{
 		Address:  r.Resolver.Address(),
@@ -38,49 +61,105 @@ func (r SaverResolver) LookupHost(ctx context.Context, hostname string) ([]strin
 	return addrs, err
 }
 
-// SaverDNSTransport is a DNS transport that saves events
+func (r *SaverResolver) Network() string {
+	return r.Resolver.Network()
+}
+
+func (r *SaverResolver) Address() string {
+	return r.Resolver.Address()
+}
+
+func (r *SaverResolver) CloseIdleConnections() {
+	r.Resolver.CloseIdleConnections()
+}
+
+func (r *SaverResolver) LookupHTTPS(ctx context.Context, domain string) (*model.HTTPSSvc, error) {
+	// TODO(bassosimone): we should probably implement this method
+	return r.Resolver.LookupHTTPS(ctx, domain)
+}
+
+func (r *SaverResolver) LookupNS(ctx context.Context, domain string) ([]*net.NS, error) {
+	// TODO(bassosimone): we should probably implement this method
+	return r.Resolver.LookupNS(ctx, domain)
+}
+
+// SaverDNSTransport is a DNS transport that saves events.
 type SaverDNSTransport struct {
-	model.DNSTransport
+	// DNSTransport is the underlying DNS transport.
+	DNSTransport model.DNSTransport
+
+	// Saver saves events.
 	Saver *Saver
 }
 
+// WrapDNSTransport wraps a model.DNSTransport with a SaverDNSTransport that
+// will save the DNS round trip results into this Saver.
+//
+// When this function is invoked on a nil Saver, it will directly return
+// the original DNSTransport without any wrapping.
+func (s *Saver) WrapDNSTransport(txp model.DNSTransport) model.DNSTransport {
+	if s == nil {
+		return txp
+	}
+	return &SaverDNSTransport{
+		DNSTransport: txp,
+		Saver:        s,
+	}
+}
+
 // RoundTrip implements RoundTripper.RoundTrip
-func (txp SaverDNSTransport) RoundTrip(
+func (txp *SaverDNSTransport) RoundTrip(
 	ctx context.Context, query model.DNSQuery) (model.DNSResponse, error) {
 	start := time.Now()
 	txp.Saver.Write(Event{
-		Address:  txp.Address(),
-		DNSQuery: txp.maybeQueryBytes(query),
+		Address:  txp.DNSTransport.Address(),
+		DNSQuery: dnsMaybeQueryBytes(query),
 		Name:     "dns_round_trip_start",
-		Proto:    txp.Network(),
+		Proto:    txp.DNSTransport.Network(),
 		Time:     start,
 	})
 	response, err := txp.DNSTransport.RoundTrip(ctx, query)
 	stop := time.Now()
 	txp.Saver.Write(Event{
-		Address:  txp.Address(),
-		DNSQuery: txp.maybeQueryBytes(query),
-		DNSReply: txp.maybeResponseBytes(response),
+		Address:  txp.DNSTransport.Address(),
+		DNSQuery: dnsMaybeQueryBytes(query),
+		DNSReply: dnsMaybeResponseBytes(response),
 		Duration: stop.Sub(start),
 		Err:      err,
 		Name:     "dns_round_trip_done",
-		Proto:    txp.Network(),
+		Proto:    txp.DNSTransport.Network(),
 		Time:     stop,
 	})
 	return response, err
 }
 
-func (txp SaverDNSTransport) maybeQueryBytes(query model.DNSQuery) []byte {
+func (txp *SaverDNSTransport) Network() string {
+	return txp.DNSTransport.Network()
+}
+
+func (txp *SaverDNSTransport) Address() string {
+	return txp.DNSTransport.Address()
+}
+
+func (txp *SaverDNSTransport) CloseIdleConnections() {
+	txp.DNSTransport.CloseIdleConnections()
+}
+
+func (txp *SaverDNSTransport) RequiresPadding() bool {
+	return txp.DNSTransport.RequiresPadding()
+}
+
+func dnsMaybeQueryBytes(query model.DNSQuery) []byte {
 	data, _ := query.Bytes()
 	return data
 }
 
-func (txp SaverDNSTransport) maybeResponseBytes(response model.DNSResponse) []byte {
+func dnsMaybeResponseBytes(response model.DNSResponse) []byte {
 	if response == nil {
 		return nil
 	}
 	return response.Bytes()
 }
 
-var _ model.Resolver = SaverResolver{}
-var _ model.DNSTransport = SaverDNSTransport{}
+var _ model.Resolver = &SaverResolver{}
+var _ model.DNSTransport = &SaverDNSTransport{}

--- a/internal/engine/netx/tracex/saver.go
+++ b/internal/engine/netx/tracex/saver.go
@@ -1,11 +1,19 @@
 package tracex
 
+//
+// Saver implementation
+//
+
 import "sync"
 
-// The Saver saves a trace
+// The Saver saves a trace. The zero value of this type
+// is valid and can be used without initializtion.
 type Saver struct {
+	// ops contains the saved events.
 	ops []Event
-	mu  sync.Mutex
+
+	// mu provides mutual exclusion.
+	mu sync.Mutex
 }
 
 // Read reads and returns events inside the trace. It advances

--- a/internal/engine/netx/tracex/saver_test.go
+++ b/internal/engine/netx/tracex/saver_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestGood(t *testing.T) {
+func TestSaver(t *testing.T) {
 	saver := Saver{}
 	var wg sync.WaitGroup
 	const parallel = 10

--- a/internal/engine/netx/tracex/tls_test.go
+++ b/internal/engine/netx/tracex/tls_test.go
@@ -30,10 +30,7 @@ func TestSaverTLSHandshakerSuccessWithReadWrite(t *testing.T) {
 				}
 			},
 		),
-		TLSHandshaker: SaverTLSHandshaker{
-			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
-			Saver:         saver,
-		},
+		TLSHandshaker: saver.WrapTLSHandshaker(&netxlite.TLSHandshakerConfigurable{}),
 	}
 	// Implementation note: we don't close the connection here because it is
 	// very handy to have the last event being the end of the handshake
@@ -121,12 +118,9 @@ func TestSaverTLSHandshakerSuccess(t *testing.T) {
 	nextprotos := []string{"h2"}
 	saver := &Saver{}
 	tlsdlr := &netxlite.TLSDialerLegacy{
-		Config: &tls.Config{NextProtos: nextprotos},
-		Dialer: netxlite.DefaultDialer,
-		TLSHandshaker: SaverTLSHandshaker{
-			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
-			Saver:         saver,
-		},
+		Config:        &tls.Config{NextProtos: nextprotos},
+		Dialer:        &netxlite.DialerSystem{},
+		TLSHandshaker: saver.WrapTLSHandshaker(&netxlite.TLSHandshakerConfigurable{}),
 	}
 	conn, err := tlsdlr.DialTLSContext(context.Background(), "tcp", "www.google.com:443")
 	if err != nil {
@@ -187,11 +181,8 @@ func TestSaverTLSHandshakerHostnameError(t *testing.T) {
 	}
 	saver := &Saver{}
 	tlsdlr := &netxlite.TLSDialerLegacy{
-		Dialer: netxlite.DefaultDialer,
-		TLSHandshaker: SaverTLSHandshaker{
-			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
-			Saver:         saver,
-		},
+		Dialer:        &netxlite.DialerSystem{},
+		TLSHandshaker: saver.WrapTLSHandshaker(&netxlite.TLSHandshakerConfigurable{}),
 	}
 	conn, err := tlsdlr.DialTLSContext(
 		context.Background(), "tcp", "wrong.host.badssl.com:443")
@@ -220,11 +211,8 @@ func TestSaverTLSHandshakerInvalidCertError(t *testing.T) {
 	}
 	saver := &Saver{}
 	tlsdlr := &netxlite.TLSDialerLegacy{
-		Dialer: netxlite.DefaultDialer,
-		TLSHandshaker: SaverTLSHandshaker{
-			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
-			Saver:         saver,
-		},
+		Dialer:        &netxlite.DialerSystem{},
+		TLSHandshaker: saver.WrapTLSHandshaker(&netxlite.TLSHandshakerConfigurable{}),
 	}
 	conn, err := tlsdlr.DialTLSContext(
 		context.Background(), "tcp", "expired.badssl.com:443")
@@ -253,11 +241,8 @@ func TestSaverTLSHandshakerAuthorityError(t *testing.T) {
 	}
 	saver := &Saver{}
 	tlsdlr := &netxlite.TLSDialerLegacy{
-		Dialer: netxlite.DefaultDialer,
-		TLSHandshaker: SaverTLSHandshaker{
-			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
-			Saver:         saver,
-		},
+		Dialer:        &netxlite.DialerSystem{},
+		TLSHandshaker: saver.WrapTLSHandshaker(&netxlite.TLSHandshakerConfigurable{}),
 	}
 	conn, err := tlsdlr.DialTLSContext(
 		context.Background(), "tcp", "self-signed.badssl.com:443")
@@ -286,12 +271,9 @@ func TestSaverTLSHandshakerNoTLSVerify(t *testing.T) {
 	}
 	saver := &Saver{}
 	tlsdlr := &netxlite.TLSDialerLegacy{
-		Config: &tls.Config{InsecureSkipVerify: true},
-		Dialer: netxlite.DefaultDialer,
-		TLSHandshaker: SaverTLSHandshaker{
-			TLSHandshaker: &netxlite.TLSHandshakerConfigurable{},
-			Saver:         saver,
-		},
+		Config:        &tls.Config{InsecureSkipVerify: true},
+		Dialer:        &netxlite.DialerSystem{},
+		TLSHandshaker: saver.WrapTLSHandshaker(&netxlite.TLSHandshakerConfigurable{}),
 	}
 	conn, err := tlsdlr.DialTLSContext(
 		context.Background(), "tcp", "self-signed.badssl.com:443")


### PR DESCRIPTION
The code that is now into the tracex package was written a long
time ago, so let's start to make it more in line with the coding
style of packages that were written more recently.

I didn't apply all the changes I'd like to apply in a single diff
and for now I am committing just this diff.

Broadly, what we need to do is:

1. improve documentation

2. ~always use pointer receivers (object receives have the issue
that they are not mutable by accident meaning that you can mutate
them but their state do not change after the call returns, which
is potentially a source of bugs in case you later refactor to use
a pointer receiver, so always use pointer receivers)

3. ~always avoid embedding (let's say we want to avoid embedding
for types we define and it's instead fine to embed types that are
defined in the stdlib: if later we add a new method, we will not
see a broken build and we'll probably forget to add the new method
to all wrappers -- conversely, if we're wrapping rather than
embedding, we'll see a broken build and act accordingly)

4. prefer unit tests and group tests by type being tested rather
than using a flat structure for tests

Reference issue: https://github.com/ooni/probe/issues/2121

