### PR TITLE
refactor(netxlite): better integration with tracex

### DIFF
--- a/internal/engine/netx/dialer/dialer.go
+++ b/internal/engine/netx/dialer/dialer.go
@@ -54,21 +54,10 @@ func New(config *Config, resolver model.Resolver) model.Dialer {
 	if config.Logger != nil {
 		logger = config.Logger
 	}
-	modifiers := []netxlite.DialerWrapper{
-		func(dialer model.Dialer) model.Dialer {
-			if config.DialSaver != nil {
-				dialer = &tracex.SaverDialer{Dialer: dialer, Saver: config.DialSaver}
-			}
-			return dialer
-		},
-		func(dialer model.Dialer) model.Dialer {
-			if config.ReadWriteSaver != nil {
-				dialer = &tracex.SaverConnDialer{Dialer: dialer, Saver: config.ReadWriteSaver}
-			}
-			return dialer
-		},
-	}
-	d := netxlite.NewDialerWithResolver(logger, resolver, modifiers...)
+	d := netxlite.NewDialerWithResolver(
+		logger, resolver, config.DialSaver.NewConnectObserver(),
+		config.ReadWriteSaver.NewReadWriteObserver(),
+	)
 	d = &netxlite.MaybeProxyDialer{ProxyURL: config.ProxyURL, Dialer: d}
 	if config.ContextByteCounting {
 		d = &bytecounter.ContextAwareDialer{Dialer: d}

--- a/internal/engine/netx/netx.go
+++ b/internal/engine/netx/netx.go
@@ -132,12 +132,7 @@ func NewQUICDialer(config Config) model.QUICDialer {
 	if config.Logger != nil {
 		logger = config.Logger
 	}
-	extensions := []netxlite.QUICDialerWrapper{
-		func(dialer model.QUICDialer) model.QUICDialer {
-			return config.TLSSaver.WrapQUICDialer(dialer) // robust to nil TLSSaver
-		},
-	}
-	return netxlite.NewQUICDialerWithResolver(ql, logger, config.FullResolver, extensions...)
+	return netxlite.NewQUICDialerWithResolver(ql, logger, config.FullResolver, config.TLSSaver)
 }
 
 // NewTLSDialer creates a new TLSDialer from the specified config

--- a/internal/engine/netx/tracex/dialer.go
+++ b/internal/engine/netx/tracex/dialer.go
@@ -22,6 +22,31 @@ type SaverDialer struct {
 	Saver *Saver
 }
 
+// NewConnectObserver returns a DialerWrapper that observes the
+// connect event. This function will return nil, which is a valid
+// DialerWrapper for netxlite.WrapDialer, if Saver is nil.
+func (s *Saver) NewConnectObserver() model.DialerWrapper {
+	if s == nil {
+		return nil // valid DialerWrapper according to netxlite's docs
+	}
+	return &saverDialerWrapper{
+		saver: s,
+	}
+}
+
+type saverDialerWrapper struct {
+	saver *Saver
+}
+
+var _ model.DialerWrapper = &saverDialerWrapper{}
+
+func (w *saverDialerWrapper) WrapDialer(d model.Dialer) model.Dialer {
+	return &SaverDialer{
+		Dialer: d,
+		Saver:  w.saver,
+	}
+}
+
 // DialContext implements Dialer.DialContext
 func (d *SaverDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
 	start := time.Now()
@@ -50,6 +75,31 @@ type SaverConnDialer struct {
 
 	// Saver saves events
 	Saver *Saver
+}
+
+// NewReadWriteObserver returns a DialerWrapper that observes the
+// I/O events. This function will return nil, which is a valid
+// DialerWrapper for netxlite.WrapDialer, if Saver is nil.
+func (s *Saver) NewReadWriteObserver() model.DialerWrapper {
+	if s == nil {
+		return nil // valid DialerWrapper according to netxlite's docs
+	}
+	return &saverReadWriteWrapper{
+		saver: s,
+	}
+}
+
+type saverReadWriteWrapper struct {
+	saver *Saver
+}
+
+var _ model.DialerWrapper = &saverReadWriteWrapper{}
+
+func (w *saverReadWriteWrapper) WrapDialer(d model.Dialer) model.Dialer {
+	return &SaverConnDialer{
+		Dialer: d,
+		Saver:  w.saver,
+	}
 }
 
 // DialContext implements Dialer.DialContext

--- a/internal/engine/netx/tracex/saver.go
+++ b/internal/engine/netx/tracex/saver.go
@@ -7,7 +7,7 @@ package tracex
 import "sync"
 
 // The Saver saves a trace. The zero value of this type
-// is valid and can be used without initializtion.
+// is valid and can be used without initialization.
 type Saver struct {
 	// ops contains the saved events.
 	ops []Event

--- a/internal/engine/netx/tracex/tls_test.go
+++ b/internal/engine/netx/tracex/tls_test.go
@@ -23,12 +23,7 @@ func TestSaverTLSHandshakerSuccessWithReadWrite(t *testing.T) {
 		Dialer: netxlite.NewDialerWithResolver(
 			model.DiscardLogger,
 			netxlite.NewResolverStdlib(model.DiscardLogger),
-			func(dialer model.Dialer) model.Dialer {
-				return &SaverConnDialer{
-					Dialer: dialer,
-					Saver:  saver,
-				}
-			},
+			saver.NewReadWriteObserver(),
 		),
 		TLSHandshaker: saver.WrapTLSHandshaker(&netxlite.TLSHandshakerConfigurable{}),
 	}

--- a/internal/model/netx.go
+++ b/internal/model/netx.go
@@ -119,6 +119,12 @@ type DNSTransport interface {
 	CloseIdleConnections()
 }
 
+// DialerWrapper is a type that takes in input a Dialer
+// and returns in output a wrapped Dialer.
+type DialerWrapper interface {
+	WrapDialer(d Dialer) Dialer
+}
+
 // SimpleDialer establishes network connections.
 type SimpleDialer interface {
 	// DialContext behaves like net.Dialer.DialContext.
@@ -169,6 +175,12 @@ type HTTPSSvc struct {
 type QUICListener interface {
 	// Listen creates a new listening UDPLikeConn.
 	Listen(addr *net.UDPAddr) (UDPLikeConn, error)
+}
+
+// QUICDialerWrapper is a type that takes in input a QUICDialer
+// and returns in output a wrapped QUICDialer.
+type QUICDialerWrapper interface {
+	WrapQUICDialer(qd QUICDialer) QUICDialer
 }
 
 // QUICDialer dials QUIC sessions.

--- a/internal/netxlite/dialer_test.go
+++ b/internal/netxlite/dialer_test.go
@@ -19,19 +19,27 @@ type extensionDialerFirst struct {
 	model.Dialer
 }
 
+type dialerWrapperFirst struct{}
+
+func (*dialerWrapperFirst) WrapDialer(d model.Dialer) model.Dialer {
+	return &extensionDialerFirst{d}
+}
+
 type extensionDialerSecond struct {
 	model.Dialer
 }
 
+type dialerWrapperSecond struct{}
+
+func (*dialerWrapperSecond) WrapDialer(d model.Dialer) model.Dialer {
+	return &extensionDialerSecond{d}
+}
 func TestNewDialer(t *testing.T) {
 	t.Run("produces a chain with the expected types", func(t *testing.T) {
-		modifiers := []DialerWrapper{
-			func(dialer model.Dialer) model.Dialer {
-				return &extensionDialerFirst{dialer}
-			},
-			func(dialer model.Dialer) model.Dialer {
-				return &extensionDialerSecond{dialer}
-			},
+		modifiers := []model.DialerWrapper{
+			&dialerWrapperFirst{},
+			nil, // explicitly test for this documented case
+			&dialerWrapperSecond{},
 		}
 		d := NewDialerWithoutResolver(log.Log, modifiers...)
 		logger := d.(*dialerLogger)

--- a/internal/netxlite/quic_test.go
+++ b/internal/netxlite/quic_test.go
@@ -26,19 +26,30 @@ type extensionQUICDialerFirst struct {
 	model.QUICDialer
 }
 
+type quicDialerWrapperFirst struct{}
+
+func (*quicDialerWrapperFirst) WrapQUICDialer(qd model.QUICDialer) model.QUICDialer {
+	return &extensionQUICDialerFirst{qd}
+}
+
 type extensionQUICDialerSecond struct {
 	model.QUICDialer
 }
 
+type quicDialerWrapperSecond struct {
+	model.QUICDialer
+}
+
+func (*quicDialerWrapperSecond) WrapQUICDialer(qd model.QUICDialer) model.QUICDialer {
+	return &extensionQUICDialerSecond{qd}
+}
+
 func TestNewQUICDialer(t *testing.T) {
 	ql := NewQUICListener()
-	extensions := []QUICDialerWrapper{
-		func(dialer model.QUICDialer) model.QUICDialer {
-			return &extensionQUICDialerFirst{dialer}
-		},
-		func(dialer model.QUICDialer) model.QUICDialer {
-			return &extensionQUICDialerSecond{dialer}
-		},
+	extensions := []model.QUICDialerWrapper{
+		&quicDialerWrapperFirst{},
+		nil, // explicitly test for this documented case
+		&quicDialerWrapperSecond{},
 	}
 	dlr := NewQUICDialerWithoutResolver(ql, log.Log, extensions...)
 	logger := dlr.(*quicDialerLogger)


### PR DESCRIPTION
Rather than passing functions to construct complex objects such
as Dialer and QUICDialer, pass interface implementations.

Ensure that a nil implementation does not cause harm.

Make Saver implement the correct interface either directly or
indirectly. We need to implement the correct interface indirectly
for TCP conns (or connected UDP sockets) because we have two
distinct use cases inside netx: observing just the connect event
and observing just the I/O events.

With this change, the construction of composed Dialers and
QUICDialers is greatly simplified and more obvious.

Part of https://github.com/ooni/probe/issues/2121
