### PR TITLE
fix(tracex): generate archival from single transaction-done event

### DIFF
--- a/internal/engine/experiment/urlgetter/getter_integration_test.go
+++ b/internal/engine/experiment/urlgetter/getter_integration_test.go
@@ -37,17 +37,14 @@ func TestGetterWithVeryShortTimeout(t *testing.T) {
 	if tk.Failure == nil || *tk.Failure != "generic_timeout_error" {
 		t.Fatal("not the Failure we expected")
 	}
-	if len(tk.NetworkEvents) != 3 {
+	if len(tk.NetworkEvents) != 2 {
 		t.Fatal("not the NetworkEvents we expected")
 	}
 	if tk.NetworkEvents[0].Operation != "http_transaction_start" {
 		t.Fatal("not the NetworkEvents[0].Operation we expected")
 	}
-	if tk.NetworkEvents[1].Operation != "http_request_metadata" {
+	if tk.NetworkEvents[1].Operation != "http_transaction_done" {
 		t.Fatal("not the NetworkEvents[1].Operation we expected")
-	}
-	if tk.NetworkEvents[2].Operation != "http_transaction_done" {
-		t.Fatal("not the NetworkEvents[2].Operation we expected")
 	}
 	if len(tk.Queries) != 0 {
 		t.Fatal("not the Queries we expected")
@@ -104,17 +101,14 @@ func TestGetterWithCancelledContextVanilla(t *testing.T) {
 	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "interrupted") {
 		t.Fatal("not the Failure we expected")
 	}
-	if len(tk.NetworkEvents) != 3 {
+	if len(tk.NetworkEvents) != 2 {
 		t.Fatal("not the NetworkEvents we expected")
 	}
 	if tk.NetworkEvents[0].Operation != "http_transaction_start" {
 		t.Fatal("not the NetworkEvents[0].Operation we expected")
 	}
-	if tk.NetworkEvents[1].Operation != "http_request_metadata" {
+	if tk.NetworkEvents[1].Operation != "http_transaction_done" {
 		t.Fatal("not the NetworkEvents[1].Operation we expected")
-	}
-	if tk.NetworkEvents[2].Operation != "http_transaction_done" {
-		t.Fatal("not the NetworkEvents[2].Operation we expected")
 	}
 	if len(tk.Queries) != 0 {
 		t.Fatal("not the Queries we expected")
@@ -172,17 +166,14 @@ func TestGetterWithCancelledContextAndMethod(t *testing.T) {
 	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "interrupted") {
 		t.Fatal("not the Failure we expected")
 	}
-	if len(tk.NetworkEvents) != 3 {
+	if len(tk.NetworkEvents) != 2 {
 		t.Fatal("not the NetworkEvents we expected")
 	}
 	if tk.NetworkEvents[0].Operation != "http_transaction_start" {
 		t.Fatal("not the NetworkEvents[0].Operation we expected")
 	}
-	if tk.NetworkEvents[1].Operation != "http_request_metadata" {
+	if tk.NetworkEvents[1].Operation != "http_transaction_done" {
 		t.Fatal("not the NetworkEvents[1].Operation we expected")
-	}
-	if tk.NetworkEvents[2].Operation != "http_transaction_done" {
-		t.Fatal("not the NetworkEvents[2].Operation we expected")
 	}
 	if len(tk.Queries) != 0 {
 		t.Fatal("not the Queries we expected")
@@ -242,16 +233,13 @@ func TestGetterWithCancelledContextNoFollowRedirects(t *testing.T) {
 	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "interrupted") {
 		t.Fatal("not the Failure we expected")
 	}
-	if len(tk.NetworkEvents) != 3 {
+	if len(tk.NetworkEvents) != 2 {
 		t.Fatal("not the NetworkEvents we expected")
 	}
 	if tk.NetworkEvents[0].Operation != "http_transaction_start" {
 		t.Fatal("not the NetworkEvents[0].Operation we expected")
 	}
-	if tk.NetworkEvents[1].Operation != "http_request_metadata" {
-		t.Fatal("not the NetworkEvents[1].Operation we expected")
-	}
-	if tk.NetworkEvents[2].Operation != "http_transaction_done" {
+	if tk.NetworkEvents[1].Operation != "http_transaction_done" {
 		t.Fatal("not the NetworkEvents[2].Operation we expected")
 	}
 	if len(tk.Queries) != 0 {
@@ -422,23 +410,18 @@ func TestGetterIntegrationHTTPS(t *testing.T) {
 		t.Fatal("not the Failure we expected")
 	}
 	var (
-		httpTransactionStart     bool
-		httpRequestMetadata      bool
-		resolveStart             bool
-		resolveDone              bool
-		connect                  bool
-		tlsHandshakeStart        bool
-		tlsHandshakeDone         bool
-		httpResponseMetadata     bool
-		httpResponseBodySnapshot bool
-		httpTransactionDone      bool
+		httpTransactionStart bool
+		resolveStart         bool
+		resolveDone          bool
+		connect              bool
+		tlsHandshakeStart    bool
+		tlsHandshakeDone     bool
+		httpTransactionDone  bool
 	)
 	for _, ev := range tk.NetworkEvents {
 		switch ev.Operation {
 		case "http_transaction_start":
 			httpTransactionStart = true
-		case "http_request_metadata":
-			httpRequestMetadata = true
 		case "resolve_start":
 			resolveStart = true
 		case "resolve_done":
@@ -449,24 +432,17 @@ func TestGetterIntegrationHTTPS(t *testing.T) {
 			tlsHandshakeStart = true
 		case "tls_handshake_done":
 			tlsHandshakeDone = true
-		case "http_response_metadata":
-			httpResponseMetadata = true
-		case "http_response_body_snapshot":
-			httpResponseBodySnapshot = true
 		case "http_transaction_done":
 			httpTransactionDone = true
 		}
 	}
 	ok := true
 	ok = ok && httpTransactionStart
-	ok = ok && httpRequestMetadata
 	ok = ok && resolveStart
 	ok = ok && resolveDone
 	ok = ok && connect
 	ok = ok && tlsHandshakeStart
 	ok = ok && tlsHandshakeDone
-	ok = ok && httpResponseMetadata
-	ok = ok && httpResponseBodySnapshot
 	ok = ok && httpTransactionDone
 	if !ok {
 		t.Fatal("not the NetworkEvents we expected")
@@ -657,23 +633,18 @@ func TestGetterHTTPSWithTunnel(t *testing.T) {
 		t.Fatal("not the Failure we expected")
 	}
 	var (
-		httpTransactionStart     bool
-		httpRequestMetadata      bool
-		resolveStart             bool
-		resolveDone              bool
-		connect                  bool
-		tlsHandshakeStart        bool
-		tlsHandshakeDone         bool
-		httpResponseMetadata     bool
-		httpResponseBodySnapshot bool
-		httpTransactionDone      bool
+		httpTransactionStart bool
+		resolveStart         bool
+		resolveDone          bool
+		connect              bool
+		tlsHandshakeStart    bool
+		tlsHandshakeDone     bool
+		httpTransactionDone  bool
 	)
 	for _, ev := range tk.NetworkEvents {
 		switch ev.Operation {
 		case "http_transaction_start":
 			httpTransactionStart = true
-		case "http_request_metadata":
-			httpRequestMetadata = true
 		case "resolve_start":
 			resolveStart = true
 		case "resolve_done":
@@ -684,24 +655,17 @@ func TestGetterHTTPSWithTunnel(t *testing.T) {
 			tlsHandshakeStart = true
 		case "tls_handshake_done":
 			tlsHandshakeDone = true
-		case "http_response_metadata":
-			httpResponseMetadata = true
-		case "http_response_body_snapshot":
-			httpResponseBodySnapshot = true
 		case "http_transaction_done":
 			httpTransactionDone = true
 		}
 	}
 	ok := true
 	ok = ok && httpTransactionStart
-	ok = ok && httpRequestMetadata
 	ok = ok && resolveStart == false
 	ok = ok && resolveDone == false
 	ok = ok && connect
 	ok = ok && tlsHandshakeStart
 	ok = ok && tlsHandshakeDone
-	ok = ok && httpResponseMetadata
-	ok = ok && httpResponseBodySnapshot
 	ok = ok && httpTransactionDone
 	if !ok {
 		t.Fatalf("not the NetworkEvents we expected: %+v", tk.NetworkEvents)

--- a/internal/engine/netx/netx.go
+++ b/internal/engine/netx/netx.go
@@ -187,10 +187,6 @@ func NewHTTPTransport(config Config) model.HTTPTransport {
 		txp = &netxlite.HTTPTransportLogger{Logger: config.Logger, HTTPTransport: txp}
 	}
 	if config.HTTPSaver != nil {
-		txp = &tracex.SaverMetadataHTTPTransport{
-			HTTPTransport: txp, Saver: config.HTTPSaver}
-		txp = &tracex.SaverBodyHTTPTransport{
-			HTTPTransport: txp, Saver: config.HTTPSaver}
 		txp = &tracex.SaverTransactionHTTPTransport{
 			HTTPTransport: txp, Saver: config.HTTPSaver}
 	}

--- a/internal/engine/netx/netx_test.go
+++ b/internal/engine/netx/netx_test.go
@@ -511,21 +511,10 @@ func TestNewWithSaver(t *testing.T) {
 	if stxptxp.Saver != saver {
 		t.Fatal("not the logger we expected")
 	}
-	sbtxp, ok := stxptxp.HTTPTransport.(*tracex.SaverBodyHTTPTransport)
-	if !ok {
-		t.Fatal("not the transport we expected")
-	}
-	if sbtxp.Saver != saver {
+	if stxptxp.Saver != saver {
 		t.Fatal("not the logger we expected")
 	}
-	smtxp, ok := sbtxp.HTTPTransport.(*tracex.SaverMetadataHTTPTransport)
-	if !ok {
-		t.Fatal("not the transport we expected")
-	}
-	if smtxp.Saver != saver {
-		t.Fatal("not the logger we expected")
-	}
-	if _, ok := smtxp.HTTPTransport.(*netxlite.HTTPTransportWrapper); !ok {
+	if _, ok := stxptxp.HTTPTransport.(*netxlite.HTTPTransportWrapper); !ok {
 		t.Fatal("not the transport we expected")
 	}
 }

--- a/internal/engine/netx/tracex/event.go
+++ b/internal/engine/netx/tracex/event.go
@@ -147,32 +147,6 @@ func (ev *EventReadFromOperation) Name() string {
 	return netxlite.ReadFromOperation
 }
 
-// EventHTTPRequestMetadata contains HTTP request metadata.
-type EventHTTPRequestMetadata struct {
-	V *EventValue
-}
-
-func (ev *EventHTTPRequestMetadata) Value() *EventValue {
-	return ev.V
-}
-
-func (ev *EventHTTPRequestMetadata) Name() string {
-	return "http_request_metadata"
-}
-
-// EventHTTPResponseMetadata contains HTTP response metadata.
-type EventHTTPResponseMetadata struct {
-	V *EventValue
-}
-
-func (ev *EventHTTPResponseMetadata) Value() *EventValue {
-	return ev.V
-}
-
-func (ev *EventHTTPResponseMetadata) Name() string {
-	return "http_response_metadata"
-}
-
 // EventHTTPTransactionStart is the beginning of an HTTP transaction.
 type EventHTTPTransactionStart struct {
 	V *EventValue
@@ -197,32 +171,6 @@ func (ev *EventHTTPTransactionDone) Value() *EventValue {
 
 func (ev *EventHTTPTransactionDone) Name() string {
 	return "http_transaction_done"
-}
-
-// EventHTTPRequestBodySnapshot contains a snapshot of the request body.
-type EventHTTPRequestBodySnapshot struct {
-	V *EventValue
-}
-
-func (ev *EventHTTPRequestBodySnapshot) Value() *EventValue {
-	return ev.V
-}
-
-func (ev *EventHTTPRequestBodySnapshot) Name() string {
-	return "http_request_body_snapshot"
-}
-
-// EventHTTPResponseBodySnapshot contains a snapshot of the response body.
-type EventHTTPResponseBodySnapshot struct {
-	V *EventValue
-}
-
-func (ev *EventHTTPResponseBodySnapshot) Value() *EventValue {
-	return ev.V
-}
-
-func (ev *EventHTTPResponseBodySnapshot) Name() string {
-	return "http_response_body_snapshot"
 }
 
 // EventConnectOperation contains information about the connect operation.
@@ -266,29 +214,30 @@ func (ev *EventWriteOperation) Name() string {
 
 // Event is one of the events within a trace
 type EventValue struct {
-	Addresses           []string            `json:",omitempty"`
-	Address             string              `json:",omitempty"`
-	DNSQuery            []byte              `json:",omitempty"`
-	DNSResponse         []byte              `json:",omitempty"`
-	DataIsTruncated     bool                `json:",omitempty"`
-	Data                []byte              `json:",omitempty"`
-	Duration            time.Duration       `json:",omitempty"`
-	Err                 error               `json:",omitempty"`
-	HTTPMethod          string              `json:",omitempty"`
-	HTTPRequestHeaders  http.Header         `json:",omitempty"`
-	HTTPResponseHeaders http.Header         `json:",omitempty"`
-	HTTPStatusCode      int                 `json:",omitempty"`
-	HTTPURL             string              `json:",omitempty"`
-	Hostname            string              `json:",omitempty"`
-	NoTLSVerify         bool                `json:",omitempty"`
-	NumBytes            int                 `json:",omitempty"`
-	Proto               string              `json:",omitempty"`
-	TLSServerName       string              `json:",omitempty"`
-	TLSCipherSuite      string              `json:",omitempty"`
-	TLSNegotiatedProto  string              `json:",omitempty"`
-	TLSNextProtos       []string            `json:",omitempty"`
-	TLSPeerCerts        []*x509.Certificate `json:",omitempty"`
-	TLSVersion          string              `json:",omitempty"`
-	Time                time.Time           `json:",omitempty"`
-	Transport           string              `json:",omitempty"`
+	Addresses                   []string            `json:",omitempty"`
+	Address                     string              `json:",omitempty"`
+	DNSQuery                    []byte              `json:",omitempty"`
+	DNSResponse                 []byte              `json:",omitempty"`
+	Data                        []byte              `json:",omitempty"`
+	Duration                    time.Duration       `json:",omitempty"`
+	Err                         error               `json:",omitempty"`
+	HTTPMethod                  string              `json:",omitempty"`
+	HTTPRequestHeaders          http.Header         `json:",omitempty"`
+	HTTPResponseHeaders         http.Header         `json:",omitempty"`
+	HTTPResponseBody            []byte              `json:",omitempty"`
+	HTTPResponseBodyIsTruncated bool                `json:",omitempty"`
+	HTTPStatusCode              int                 `json:",omitempty"`
+	HTTPURL                     string              `json:",omitempty"`
+	Hostname                    string              `json:",omitempty"`
+	NoTLSVerify                 bool                `json:",omitempty"`
+	NumBytes                    int                 `json:",omitempty"`
+	Proto                       string              `json:",omitempty"`
+	TLSServerName               string              `json:",omitempty"`
+	TLSCipherSuite              string              `json:",omitempty"`
+	TLSNegotiatedProto          string              `json:",omitempty"`
+	TLSNextProtos               []string            `json:",omitempty"`
+	TLSPeerCerts                []*x509.Certificate `json:",omitempty"`
+	TLSVersion                  string              `json:",omitempty"`
+	Time                        time.Time           `json:",omitempty"`
+	Transport                   string              `json:",omitempty"`
 }

--- a/internal/netxlite/filtering/http.go
+++ b/internal/netxlite/filtering/http.go
@@ -51,7 +51,8 @@ func (p *HTTPProxy) Start(address string) (net.Listener, error) {
 	return listener, nil
 }
 
-var httpBlockpage451 = []byte(`<html><head>
+// HTTPBlockPage451 is the block page returned along with status 451
+var HTTPBlockpage451 = []byte(`<html><head>
   <title>451 Unavailable For Legal Reasons</title>
 </head><body>
   <center><h1>451 Unavailable For Legal Reasons</h1></center>
@@ -80,7 +81,7 @@ func (p *HTTPProxy) handle(w http.ResponseWriter, r *http.Request) {
 		p.hijack(w, r, policy)
 	case HTTPAction451:
 		w.WriteHeader(http.StatusUnavailableForLegalReasons)
-		w.Write(httpBlockpage451)
+		w.Write(HTTPBlockpage451)
 	default:
 		w.WriteHeader(http.StatusInternalServerError)
 	}


### PR DESCRIPTION
Tracex contained some fragile code that assembled HTTP measurements
from scattered events, which worked because we were sure we were
performing a single measurement at any given time.

This diff restructures the code to emit a transaction-start and a
transaction-done events only. We have basically removed all the other
events (which we were not using). We kept the transaction-start
though, because it may be useful to see it when reading events. In
any case, what matters here is that we're now using the transaction-done
event aline to generate the archival HTTP measurement.

Hence, the original issue has been addressed. We will possibly
do more refactoring in the future, but for now this seems sufficient.

Part of https://github.com/ooni/probe/issues/2121
