### PR TITLE
refactor(tracex): convert to unit testing

### DIFF
--- a/internal/engine/experiment/urlgetter/configurer_test.go
+++ b/internal/engine/experiment/urlgetter/configurer_test.go
@@ -119,7 +119,7 @@ func TestConfigurerNewConfigurationResolverDNSOverHTTPSPowerdns(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	stxp, ok := sr.Txp.(*tracex.SaverDNSTransport)
+	stxp, ok := sr.Txp.(*tracex.DNSTransportSaver)
 	if !ok {
 		t.Fatal("not the DNS transport we expected")
 	}
@@ -195,7 +195,7 @@ func TestConfigurerNewConfigurationResolverDNSOverHTTPSGoogle(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	stxp, ok := sr.Txp.(*tracex.SaverDNSTransport)
+	stxp, ok := sr.Txp.(*tracex.DNSTransportSaver)
 	if !ok {
 		t.Fatal("not the DNS transport we expected")
 	}
@@ -271,7 +271,7 @@ func TestConfigurerNewConfigurationResolverDNSOverHTTPSCloudflare(t *testing.T) 
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	stxp, ok := sr.Txp.(*tracex.SaverDNSTransport)
+	stxp, ok := sr.Txp.(*tracex.DNSTransportSaver)
 	if !ok {
 		t.Fatal("not the DNS transport we expected")
 	}
@@ -347,7 +347,7 @@ func TestConfigurerNewConfigurationResolverUDP(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	stxp, ok := sr.Txp.(*tracex.SaverDNSTransport)
+	stxp, ok := sr.Txp.(*tracex.DNSTransportSaver)
 	if !ok {
 		t.Fatal("not the DNS transport we expected")
 	}

--- a/internal/engine/netx/netx.go
+++ b/internal/engine/netx/netx.go
@@ -187,7 +187,7 @@ func NewHTTPTransport(config Config) model.HTTPTransport {
 		txp = &netxlite.HTTPTransportLogger{Logger: config.Logger, HTTPTransport: txp}
 	}
 	if config.HTTPSaver != nil {
-		txp = &tracex.SaverTransactionHTTPTransport{
+		txp = &tracex.HTTPTransportSaver{
 			HTTPTransport: txp, Saver: config.HTTPSaver}
 	}
 	return txp

--- a/internal/engine/netx/netx_test.go
+++ b/internal/engine/netx/netx_test.go
@@ -126,7 +126,7 @@ func TestNewResolverWithSaver(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	sr, ok := ir.Resolver.(*tracex.SaverResolver)
+	sr, ok := ir.Resolver.(*tracex.ResolverSaver)
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
@@ -332,7 +332,7 @@ func TestNewTLSDialerWithSaver(t *testing.T) {
 	if rtd.TLSHandshaker == nil {
 		t.Fatal("invalid TLSHandshaker")
 	}
-	sth, ok := rtd.TLSHandshaker.(*tracex.SaverTLSHandshaker)
+	sth, ok := rtd.TLSHandshaker.(*tracex.TLSHandshakerSaver)
 	if !ok {
 		t.Fatal("not the TLSHandshaker we expected")
 	}
@@ -504,7 +504,7 @@ func TestNewWithSaver(t *testing.T) {
 	txp := netx.NewHTTPTransport(netx.Config{
 		HTTPSaver: saver,
 	})
-	stxptxp, ok := txp.(*tracex.SaverTransactionHTTPTransport)
+	stxptxp, ok := txp.(*tracex.HTTPTransportSaver)
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}
@@ -622,7 +622,7 @@ func TestNewDNSClientCloudflareDoHSaver(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	txp, ok := r.Transport().(*tracex.SaverDNSTransport)
+	txp, ok := r.Transport().(*tracex.DNSTransportSaver)
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}
@@ -659,7 +659,7 @@ func TestNewDNSClientUDPDNSSaver(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	txp, ok := r.Transport().(*tracex.SaverDNSTransport)
+	txp, ok := r.Transport().(*tracex.DNSTransportSaver)
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}
@@ -700,7 +700,7 @@ func TestNewDNSClientTCPDNSSaver(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	txp, ok := r.Transport().(*tracex.SaverDNSTransport)
+	txp, ok := r.Transport().(*tracex.DNSTransportSaver)
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}
@@ -745,7 +745,7 @@ func TestNewDNSClientDoTDNSSaver(t *testing.T) {
 	if !ok {
 		t.Fatal("not the resolver we expected")
 	}
-	txp, ok := r.Transport().(*tracex.SaverDNSTransport)
+	txp, ok := r.Transport().(*tracex.DNSTransportSaver)
 	if !ok {
 		t.Fatal("not the transport we expected")
 	}

--- a/internal/engine/netx/tracex/dialer_test.go
+++ b/internal/engine/netx/tracex/dialer_test.go
@@ -12,127 +12,268 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
-func TestSaverDialerFailure(t *testing.T) {
-	expected := errors.New("mocked error")
+func TestDialerConnectObserver(t *testing.T) {
 	saver := &Saver{}
-	dlr := &SaverDialer{
-		Dialer: &mocks.Dialer{
-			MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
-				return nil, expected
-			},
-		},
-		Saver: saver,
+	obs := &dialerConnectObserver{
+		saver: saver,
 	}
-	conn, err := dlr.DialContext(context.Background(), "tcp", "www.google.com:443")
-	if !errors.Is(err, expected) {
-		t.Fatal("expected another error here")
+	dialer := &mocks.Dialer{}
+	out := obs.WrapDialer(dialer)
+	dialSaver := out.(*DialerSaver)
+	if dialSaver.Dialer != dialer {
+		t.Fatal("invalid dialer")
 	}
-	if conn != nil {
-		t.Fatal("expected nil conn here")
-	}
-	ev := saver.Read()
-	if len(ev) != 1 {
-		t.Fatal("expected a single event here")
-	}
-	if ev[0].Value().Address != "www.google.com:443" {
-		t.Fatal("unexpected Address")
-	}
-	if ev[0].Value().Duration <= 0 {
-		t.Fatal("unexpected Duration")
-	}
-	if !errors.Is(ev[0].Value().Err, expected) {
-		t.Fatal("unexpected Err")
-	}
-	if ev[0].Name() != netxlite.ConnectOperation {
-		t.Fatal("unexpected Name")
-	}
-	if ev[0].Value().Proto != "tcp" {
-		t.Fatal("unexpected Proto")
-	}
-	if !ev[0].Value().Time.Before(time.Now()) {
-		t.Fatal("unexpected Time")
+	if dialSaver.Saver != saver {
+		t.Fatal("invalid saver")
 	}
 }
 
-func TestSaverConnDialerFailure(t *testing.T) {
-	expected := errors.New("mocked error")
-	saver := &Saver{}
-	dlr := &SaverConnDialer{
-		Dialer: &mocks.Dialer{
-			MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
-				return nil, expected
-			},
-		},
-		Saver: saver,
-	}
-	conn, err := dlr.DialContext(context.Background(), "tcp", "www.google.com:443")
-	if !errors.Is(err, expected) {
-		t.Fatal("not the error we expected")
-	}
-	if conn != nil {
-		t.Fatal("expected nil conn here")
-	}
-}
-
-func TestSaverConnDialerSuccess(t *testing.T) {
-	saver := &Saver{}
-	dlr := &SaverConnDialer{
-		Dialer: &SaverDialer{
+func TestDialerSaver(t *testing.T) {
+	t.Run("on failure", func(t *testing.T) {
+		expected := errors.New("mocked error")
+		saver := &Saver{}
+		dlr := &DialerSaver{
 			Dialer: &mocks.Dialer{
 				MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
-					return &mocks.Conn{
-						MockRead: func(b []byte) (int, error) {
-							return 0, io.EOF
-						},
-						MockWrite: func(b []byte) (int, error) {
-							return 0, io.EOF
-						},
-						MockClose: func() error {
-							return io.EOF
-						},
-						MockLocalAddr: func() net.Addr {
-							return &net.TCPAddr{Port: 12345}
-						},
-					}, nil
+					return nil, expected
 				},
 			},
 			Saver: saver,
-		},
-		Saver: saver,
-	}
-	conn, err := dlr.DialContext(context.Background(), "tcp", "www.google.com:443")
-	if err != nil {
-		t.Fatal("not the error we expected", err)
-	}
-	conn.Read(nil)
-	conn.Write(nil)
-	conn.Close()
-	events := saver.Read()
-	if len(events) != 3 {
-		t.Fatal("unexpected number of events saved", len(events))
-	}
-	if events[0].Name() != "connect" {
-		t.Fatal("expected a connect event")
-	}
-	saverCheckConnectEvent(t, &events[0])
-	if events[1].Name() != "read" {
-		t.Fatal("expected a read event")
-	}
-	saverCheckReadEvent(t, &events[1])
-	if events[2].Name() != "write" {
-		t.Fatal("expected a write event")
-	}
-	saverCheckWriteEvent(t, &events[2])
+		}
+		conn, err := dlr.DialContext(context.Background(), "tcp", "www.google.com:443")
+		if !errors.Is(err, expected) {
+			t.Fatal("expected another error here")
+		}
+		if conn != nil {
+			t.Fatal("expected nil conn here")
+		}
+		ev := saver.Read()
+		if len(ev) != 1 {
+			t.Fatal("expected a single event here")
+		}
+		if ev[0].Value().Address != "www.google.com:443" {
+			t.Fatal("unexpected Address")
+		}
+		if ev[0].Value().Duration <= 0 {
+			t.Fatal("unexpected Duration")
+		}
+		if !errors.Is(ev[0].Value().Err, expected) {
+			t.Fatal("unexpected Err")
+		}
+		if ev[0].Name() != netxlite.ConnectOperation {
+			t.Fatal("unexpected Name")
+		}
+		if ev[0].Value().Proto != "tcp" {
+			t.Fatal("unexpected Proto")
+		}
+		if !ev[0].Value().Time.Before(time.Now()) {
+			t.Fatal("unexpected Time")
+		}
+	})
+
+	t.Run("CloseIdleConnections", func(t *testing.T) {
+		var called bool
+		child := &mocks.Dialer{
+			MockCloseIdleConnections: func() {
+				called = true
+			},
+		}
+		dialer := &DialerSaver{
+			Dialer: child,
+			Saver:  &Saver{},
+		}
+		dialer.CloseIdleConnections()
+		if !called {
+			t.Fatal("not called")
+		}
+	})
 }
 
-func saverCheckConnectEvent(t *testing.T, ev *Event) {
-	// TODO(bassosimone): implement
+func TestDialerReadWriteObserver(t *testing.T) {
+	saver := &Saver{}
+	obs := &dialerReadWriteObserver{
+		saver: saver,
+	}
+	dialer := &mocks.Dialer{}
+	out := obs.WrapDialer(dialer)
+	dialSaver := out.(*DialerConnSaver)
+	if dialSaver.Dialer != dialer {
+		t.Fatal("invalid dialer")
+	}
+	if dialSaver.Saver != saver {
+		t.Fatal("invalid saver")
+	}
 }
 
-func saverCheckReadEvent(t *testing.T, ev *Event) {
-	// TODO(bassosimone): implement
+func TestDialerConnSaver(t *testing.T) {
+	t.Run("DialContext", func(t *testing.T) {
+		t.Run("on failure", func(t *testing.T) {
+			expected := errors.New("mocked error")
+			saver := &Saver{}
+			dlr := &DialerConnSaver{
+				Dialer: &mocks.Dialer{
+					MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
+						return nil, expected
+					},
+				},
+				Saver: saver,
+			}
+			conn, err := dlr.DialContext(context.Background(), "tcp", "www.google.com:443")
+			if !errors.Is(err, expected) {
+				t.Fatal("not the error we expected")
+			}
+			if conn != nil {
+				t.Fatal("expected nil conn here")
+			}
+		})
+
+		t.Run("on success", func(t *testing.T) {
+			origConn := &mocks.Conn{}
+			saver := &Saver{}
+			dlr := &DialerConnSaver{
+				Dialer: &DialerSaver{
+					Dialer: &mocks.Dialer{
+						MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
+							return origConn, nil
+						},
+					},
+					Saver: saver,
+				},
+				Saver: saver,
+			}
+			conn, err := dlr.DialContext(context.Background(), "tcp", "www.google.com:443")
+			if err != nil {
+				t.Fatal("not the error we expected", err)
+			}
+			cw := conn.(*dialerConnWrapper)
+			if cw.Conn != origConn {
+				t.Fatal("unexpected conn")
+			}
+		})
+	})
+
+	t.Run("CloseIdleConnections", func(t *testing.T) {
+		var called bool
+		child := &mocks.Dialer{
+			MockCloseIdleConnections: func() {
+				called = true
+			},
+		}
+		dialer := &DialerConnSaver{
+			Dialer: child,
+			Saver:  &Saver{},
+		}
+		dialer.CloseIdleConnections()
+		if !called {
+			t.Fatal("not called")
+		}
+	})
 }
 
-func saverCheckWriteEvent(t *testing.T, ev *Event) {
-	// TODO(bassosimone): implement
+func TestDialerConnWrapper(t *testing.T) {
+	t.Run("Read", func(t *testing.T) {
+		baseConn := &mocks.Conn{
+			MockRead: func(b []byte) (int, error) {
+				return 0, io.EOF
+			},
+			MockRemoteAddr: func() net.Addr {
+				return &mocks.Addr{
+					MockString: func() string {
+						return "www.google.com:443"
+					},
+					MockNetwork: func() string {
+						return "tcp"
+					},
+				}
+			},
+		}
+		saver := &Saver{}
+		conn := &dialerConnWrapper{
+			Conn:  baseConn,
+			saver: saver,
+		}
+		data := make([]byte, 155)
+		count, err := conn.Read(data)
+		if !errors.Is(err, io.EOF) {
+			t.Fatal("unexpected err", err)
+		}
+		if count != 0 {
+			t.Fatal("unexpected count")
+		}
+		ev := saver.Read()
+		if len(ev) != 1 {
+			t.Fatal("expected a single event here")
+		}
+		if ev[0].Value().Address != "www.google.com:443" {
+			t.Fatal("unexpected Address")
+		}
+		if ev[0].Value().Duration <= 0 {
+			t.Fatal("unexpected Duration")
+		}
+		if !errors.Is(ev[0].Value().Err, io.EOF) {
+			t.Fatal("unexpected Err")
+		}
+		if ev[0].Name() != netxlite.ReadOperation {
+			t.Fatal("unexpected Name")
+		}
+		if ev[0].Value().Proto != "tcp" {
+			t.Fatal("unexpected Proto")
+		}
+		if !ev[0].Value().Time.Before(time.Now()) {
+			t.Fatal("unexpected Time")
+		}
+	})
+
+	t.Run("Write", func(t *testing.T) {
+		baseConn := &mocks.Conn{
+			MockWrite: func(b []byte) (int, error) {
+				return 0, io.EOF
+			},
+			MockRemoteAddr: func() net.Addr {
+				return &mocks.Addr{
+					MockString: func() string {
+						return "www.google.com:443"
+					},
+					MockNetwork: func() string {
+						return "tcp"
+					},
+				}
+			},
+		}
+		saver := &Saver{}
+		conn := &dialerConnWrapper{
+			Conn:  baseConn,
+			saver: saver,
+		}
+		data := make([]byte, 155)
+		count, err := conn.Write(data)
+		if !errors.Is(err, io.EOF) {
+			t.Fatal("unexpected err", err)
+		}
+		if count != 0 {
+			t.Fatal("unexpected count")
+		}
+		ev := saver.Read()
+		if len(ev) != 1 {
+			t.Fatal("expected a single event here")
+		}
+		if ev[0].Value().Address != "www.google.com:443" {
+			t.Fatal("unexpected Address")
+		}
+		if ev[0].Value().Duration <= 0 {
+			t.Fatal("unexpected Duration")
+		}
+		if !errors.Is(ev[0].Value().Err, io.EOF) {
+			t.Fatal("unexpected Err")
+		}
+		if ev[0].Name() != netxlite.WriteOperation {
+			t.Fatal("unexpected Name")
+		}
+		if ev[0].Value().Proto != "tcp" {
+			t.Fatal("unexpected Proto")
+		}
+		if !ev[0].Value().Time.Before(time.Now()) {
+			t.Fatal("unexpected Time")
+		}
+	})
 }

--- a/internal/engine/netx/tracex/event.go
+++ b/internal/engine/netx/tracex/event.go
@@ -1,5 +1,9 @@
 package tracex
 
+//
+// All the possible events
+//
+
 import (
 	"crypto/x509"
 	"net/http"

--- a/internal/engine/netx/tracex/http_test.go
+++ b/internal/engine/netx/tracex/http_test.go
@@ -16,227 +16,262 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/netxlite/filtering"
 )
 
-func TestSaverTransactionHTTPTransport(t *testing.T) {
+func TestHTTPTransportSaver(t *testing.T) {
 
-	startServer := func(t *testing.T, action filtering.HTTPAction) (net.Listener, *url.URL) {
-		server := &filtering.HTTPProxy{
-			OnIncomingHost: func(host string) filtering.HTTPAction {
-				return action
+	t.Run("CloseIdleConnections", func(t *testing.T) {
+		var called bool
+		child := &mocks.HTTPTransport{
+			MockCloseIdleConnections: func() {
+				called = true
 			},
 		}
-		listener, err := server.Start("127.0.0.1:0")
-		if err != nil {
-			t.Fatal(err)
+		dialer := &HTTPTransportSaver{
+			HTTPTransport: child,
+			Saver:         &Saver{},
 		}
-		URL := &url.URL{
-			Scheme: "http",
-			Host:   listener.Addr().String(),
-			Path:   "/",
-		}
-		return listener, URL
-	}
-
-	measureHTTP := func(t *testing.T, URL *url.URL) (*http.Response, *Saver, error) {
-		saver := &Saver{}
-		txp := &SaverTransactionHTTPTransport{
-			HTTPTransport: netxlite.NewHTTPTransportStdlib(model.DiscardLogger),
-			Saver:         saver,
-		}
-		req, err := http.NewRequest("GET", URL.String(), nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		req.Header.Add("User-Agent", "miniooni")
-		resp, err := txp.RoundTrip(req)
-		return resp, saver, err
-	}
-
-	validateRequestFields := func(t *testing.T, value *EventValue, URL *url.URL) {
-		if value.HTTPMethod != "GET" {
-			t.Fatal("invalid method")
-		}
-		if value.HTTPRequestHeaders.Get("Host") != URL.Host {
-			t.Fatal("invalid Host header")
-		}
-		if value.HTTPRequestHeaders.Get("User-Agent") != "miniooni" {
-			t.Fatal("invalid User-Agent header")
-		}
-		if value.HTTPURL != URL.String() {
-			t.Fatal("invalid URL")
-		}
-		if value.Time.IsZero() {
-			t.Fatal("expected nonzero Time")
-		}
-		if value.Transport != "tcp" {
-			t.Fatal("expected Transport to be tcp")
-		}
-	}
-
-	validateRequest := func(t *testing.T, ev Event, URL *url.URL) {
-		if _, good := ev.(*EventHTTPTransactionStart); !good {
-			t.Fatal("invalid event type")
-		}
-		if ev.Name() != "http_transaction_start" {
-			t.Fatal("invalid event name")
-		}
-		value := ev.Value()
-		validateRequestFields(t, value, URL)
-	}
-
-	validateResponseSuccess := func(t *testing.T, ev Event, URL *url.URL) {
-		if _, good := ev.(*EventHTTPTransactionDone); !good {
-			t.Fatal("invalid event type")
-		}
-		if ev.Name() != "http_transaction_done" {
-			t.Fatal("invalid event name")
-		}
-		value := ev.Value()
-		validateRequestFields(t, value, URL)
-		if value.Duration <= 0 {
-			t.Fatal("expected nonzero duration")
-		}
-		if len(value.HTTPResponseHeaders) <= 0 {
-			t.Fatal("expected at least one response header")
-		}
-		if !bytes.Equal(value.HTTPResponseBody, filtering.HTTPBlockpage451) {
-			t.Fatal("unexpected value for response body")
-		}
-		if value.HTTPStatusCode != 451 {
-			t.Fatal("unexpected status code")
-		}
-	}
-
-	t.Run("on success", func(t *testing.T) {
-		listener, URL := startServer(t, filtering.HTTPAction451)
-		defer listener.Close()
-		resp, saver, err := measureHTTP(t, URL)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode != 451 {
-			t.Fatal("unexpected status code", resp.StatusCode)
-		}
-		events := saver.Read()
-		if len(events) != 2 {
-			t.Fatal("unexpected number of events")
-		}
-		validateRequest(t, events[0], URL)
-		validateResponseSuccess(t, events[1], URL)
-		data, err := netxlite.ReadAllContext(context.Background(), resp.Body)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !bytes.Equal(data, filtering.HTTPBlockpage451) {
-			t.Fatal("we cannot re-read the same body")
+		dialer.CloseIdleConnections()
+		if !called {
+			t.Fatal("not called")
 		}
 	})
 
-	validateResponseFailure := func(t *testing.T, ev Event, URL *url.URL) {
-		if _, good := ev.(*EventHTTPTransactionDone); !good {
-			t.Fatal("invalid event type")
+	t.Run("Network", func(t *testing.T) {
+		expected := "antani"
+		child := &mocks.HTTPTransport{
+			MockNetwork: func() string {
+				return expected
+			},
 		}
-		if ev.Name() != "http_transaction_done" {
-			t.Fatal("invalid event name")
+		dialer := &HTTPTransportSaver{
+			HTTPTransport: child,
+			Saver:         &Saver{},
 		}
-		value := ev.Value()
-		validateRequestFields(t, value, URL)
-		if value.Duration <= 0 {
-			t.Fatal("expected nonzero duration")
+		if dialer.Network() != expected {
+			t.Fatal("unexpected Network")
 		}
-		if value.Err.Error() != "connection_reset" {
-			t.Fatal("unexpected Err value")
-		}
-		if len(value.HTTPResponseHeaders) > 0 {
-			t.Fatal("expected zero response headers")
-		}
-		if !bytes.Equal(value.HTTPResponseBody, nil) {
-			t.Fatal("unexpected value for response body")
-		}
-		if value.HTTPStatusCode != 0 {
-			t.Fatal("unexpected status code")
-		}
-	}
-
-	t.Run("on round trip failure", func(t *testing.T) {
-		listener, URL := startServer(t, filtering.HTTPActionReset)
-		defer listener.Close()
-		resp, saver, err := measureHTTP(t, URL)
-		if err == nil || err.Error() != "connection_reset" {
-			t.Fatal("unexpected err", err)
-		}
-		if resp != nil {
-			t.Fatal("expected nil response")
-		}
-		events := saver.Read()
-		if len(events) != 2 {
-			t.Fatal("unexpected number of events")
-		}
-		validateRequest(t, events[0], URL)
-		validateResponseFailure(t, events[1], URL)
 	})
 
-	// Sometimes useful for testing
-	/*
-		dumplog := func(t *testing.T, ev Event) {
-			data, _ := json.MarshalIndent(ev.Value(), " ", " ")
-			t.Log(string(data))
-			t.FailNow()
+	t.Run("RoundTrip", func(t *testing.T) {
+		startServer := func(t *testing.T, action filtering.HTTPAction) (net.Listener, *url.URL) {
+			server := &filtering.HTTPProxy{
+				OnIncomingHost: func(host string) filtering.HTTPAction {
+					return action
+				},
+			}
+			listener, err := server.Start("127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			URL := &url.URL{
+				Scheme: "http",
+				Host:   listener.Addr().String(),
+				Path:   "/",
+			}
+			return listener, URL
 		}
-	*/
 
-	t.Run("on error reading the response body", func(t *testing.T) {
-		saver := &Saver{}
-		expected := errors.New("mocked error")
-		txp := SaverTransactionHTTPTransport{
-			HTTPTransport: &mocks.HTTPTransport{
-				MockRoundTrip: func(req *http.Request) (*http.Response, error) {
-					return &http.Response{
-						Header: http.Header{
-							"Server": {"antani"},
-						},
-						StatusCode: 200,
-						Body: io.NopCloser(&mocks.Reader{
-							MockRead: func(b []byte) (int, error) {
-								return 0, expected
+		measureHTTP := func(t *testing.T, URL *url.URL) (*http.Response, *Saver, error) {
+			saver := &Saver{}
+			txp := &HTTPTransportSaver{
+				HTTPTransport: netxlite.NewHTTPTransportStdlib(model.DiscardLogger),
+				Saver:         saver,
+			}
+			req, err := http.NewRequest("GET", URL.String(), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Add("User-Agent", "miniooni")
+			resp, err := txp.RoundTrip(req)
+			return resp, saver, err
+		}
+
+		validateRequestFields := func(t *testing.T, value *EventValue, URL *url.URL) {
+			if value.HTTPMethod != "GET" {
+				t.Fatal("invalid method")
+			}
+			if value.HTTPRequestHeaders.Get("Host") != URL.Host {
+				t.Fatal("invalid Host header")
+			}
+			if value.HTTPRequestHeaders.Get("User-Agent") != "miniooni" {
+				t.Fatal("invalid User-Agent header")
+			}
+			if value.HTTPURL != URL.String() {
+				t.Fatal("invalid URL")
+			}
+			if value.Time.IsZero() {
+				t.Fatal("expected nonzero Time")
+			}
+			if value.Transport != "tcp" {
+				t.Fatal("expected Transport to be tcp")
+			}
+		}
+
+		validateRequest := func(t *testing.T, ev Event, URL *url.URL) {
+			if _, good := ev.(*EventHTTPTransactionStart); !good {
+				t.Fatal("invalid event type")
+			}
+			if ev.Name() != "http_transaction_start" {
+				t.Fatal("invalid event name")
+			}
+			value := ev.Value()
+			validateRequestFields(t, value, URL)
+		}
+
+		validateResponseSuccess := func(t *testing.T, ev Event, URL *url.URL) {
+			if _, good := ev.(*EventHTTPTransactionDone); !good {
+				t.Fatal("invalid event type")
+			}
+			if ev.Name() != "http_transaction_done" {
+				t.Fatal("invalid event name")
+			}
+			value := ev.Value()
+			validateRequestFields(t, value, URL)
+			if value.Duration <= 0 {
+				t.Fatal("expected nonzero duration")
+			}
+			if len(value.HTTPResponseHeaders) <= 0 {
+				t.Fatal("expected at least one response header")
+			}
+			if !bytes.Equal(value.HTTPResponseBody, filtering.HTTPBlockpage451) {
+				t.Fatal("unexpected value for response body")
+			}
+			if value.HTTPStatusCode != 451 {
+				t.Fatal("unexpected status code")
+			}
+		}
+
+		t.Run("on success", func(t *testing.T) {
+			listener, URL := startServer(t, filtering.HTTPAction451)
+			defer listener.Close()
+			resp, saver, err := measureHTTP(t, URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != 451 {
+				t.Fatal("unexpected status code", resp.StatusCode)
+			}
+			events := saver.Read()
+			if len(events) != 2 {
+				t.Fatal("unexpected number of events")
+			}
+			validateRequest(t, events[0], URL)
+			validateResponseSuccess(t, events[1], URL)
+			data, err := netxlite.ReadAllContext(context.Background(), resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(data, filtering.HTTPBlockpage451) {
+				t.Fatal("we cannot re-read the same body")
+			}
+		})
+
+		validateResponseFailure := func(t *testing.T, ev Event, URL *url.URL) {
+			if _, good := ev.(*EventHTTPTransactionDone); !good {
+				t.Fatal("invalid event type")
+			}
+			if ev.Name() != "http_transaction_done" {
+				t.Fatal("invalid event name")
+			}
+			value := ev.Value()
+			validateRequestFields(t, value, URL)
+			if value.Duration <= 0 {
+				t.Fatal("expected nonzero duration")
+			}
+			if value.Err.Error() != "connection_reset" {
+				t.Fatal("unexpected Err value")
+			}
+			if len(value.HTTPResponseHeaders) > 0 {
+				t.Fatal("expected zero response headers")
+			}
+			if !bytes.Equal(value.HTTPResponseBody, nil) {
+				t.Fatal("unexpected value for response body")
+			}
+			if value.HTTPStatusCode != 0 {
+				t.Fatal("unexpected status code")
+			}
+		}
+
+		t.Run("on round trip failure", func(t *testing.T) {
+			listener, URL := startServer(t, filtering.HTTPActionReset)
+			defer listener.Close()
+			resp, saver, err := measureHTTP(t, URL)
+			if err == nil || err.Error() != "connection_reset" {
+				t.Fatal("unexpected err", err)
+			}
+			if resp != nil {
+				t.Fatal("expected nil response")
+			}
+			events := saver.Read()
+			if len(events) != 2 {
+				t.Fatal("unexpected number of events")
+			}
+			validateRequest(t, events[0], URL)
+			validateResponseFailure(t, events[1], URL)
+		})
+
+		// Sometimes useful for testing
+		/*
+			dump := func(t *testing.T, ev Event) {
+				data, _ := json.MarshalIndent(ev.Value(), " ", " ")
+				t.Log(string(data))
+				t.Fail()
+			}
+		*/
+
+		t.Run("on error reading the response body", func(t *testing.T) {
+			saver := &Saver{}
+			expected := errors.New("mocked error")
+			txp := HTTPTransportSaver{
+				HTTPTransport: &mocks.HTTPTransport{
+					MockRoundTrip: func(req *http.Request) (*http.Response, error) {
+						return &http.Response{
+							Header: http.Header{
+								"Server": {"antani"},
 							},
-						}),
-					}, nil
+							StatusCode: 200,
+							Body: io.NopCloser(&mocks.Reader{
+								MockRead: func(b []byte) (int, error) {
+									return 0, expected
+								},
+							}),
+						}, nil
+					},
+					MockNetwork: func() string {
+						return "tcp"
+					},
 				},
-				MockNetwork: func() string {
-					return "tcp"
-				},
-			},
-			SnapshotSize: 4,
-			Saver:        saver,
-		}
-		URL := &url.URL{
-			Scheme: "http",
-			Host:   "127.0.0.1:9050",
-		}
-		req, err := http.NewRequest("GET", URL.String(), nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		req.Header.Add("User-Agent", "miniooni")
-		resp, err := txp.RoundTrip(req)
-		if !errors.Is(err, expected) {
-			t.Fatal("not the error we expected")
-		}
-		if resp != nil {
-			t.Fatal("expected nil response")
-		}
-		ev := saver.Read()
-		validateRequest(t, ev[0], URL)
-		if ev[1].Value().HTTPStatusCode != 200 {
-			t.Fatal("invalid status code")
-		}
-		if ev[1].Value().HTTPResponseHeaders.Get("Server") != "antani" {
-			t.Fatal("invalid Server header")
-		}
-		if ev[1].Value().Err.Error() != "unknown_failure: mocked error" {
-			t.Fatal("invalid error")
-		}
+				SnapshotSize: 4,
+				Saver:        saver,
+			}
+			URL := &url.URL{
+				Scheme: "http",
+				Host:   "127.0.0.1:9050",
+			}
+			req, err := http.NewRequest("GET", URL.String(), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Add("User-Agent", "miniooni")
+			resp, err := txp.RoundTrip(req)
+			if !errors.Is(err, expected) {
+				t.Fatal("not the error we expected")
+			}
+			if resp != nil {
+				t.Fatal("expected nil response")
+			}
+			ev := saver.Read()
+			validateRequest(t, ev[0], URL)
+			if ev[1].Value().HTTPStatusCode != 200 {
+				t.Fatal("invalid status code")
+			}
+			if ev[1].Value().HTTPResponseHeaders.Get("Server") != "antani" {
+				t.Fatal("invalid Server header")
+			}
+			if ev[1].Value().Err.Error() != "unknown_failure: mocked error" {
+				t.Fatal("invalid error")
+			}
+		})
 	})
 }
 

--- a/internal/engine/netx/tracex/resolver.go
+++ b/internal/engine/netx/tracex/resolver.go
@@ -12,8 +12,8 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
 
-// SaverResolver is a resolver that saves events.
-type SaverResolver struct {
+// ResolverSaver is a resolver that saves events.
+type ResolverSaver struct {
 	// Resolver is the underlying resolver.
 	Resolver model.Resolver
 
@@ -30,14 +30,14 @@ func (s *Saver) WrapResolver(r model.Resolver) model.Resolver {
 	if s == nil {
 		return r
 	}
-	return &SaverResolver{
+	return &ResolverSaver{
 		Resolver: r,
 		Saver:    s,
 	}
 }
 
 // LookupHost implements Resolver.LookupHost
-func (r *SaverResolver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
+func (r *ResolverSaver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
 	start := time.Now()
 	r.Saver.Write(&EventResolveStart{&EventValue{
 		Address:  r.Resolver.Address(),
@@ -59,30 +59,30 @@ func (r *SaverResolver) LookupHost(ctx context.Context, hostname string) ([]stri
 	return addrs, err
 }
 
-func (r *SaverResolver) Network() string {
+func (r *ResolverSaver) Network() string {
 	return r.Resolver.Network()
 }
 
-func (r *SaverResolver) Address() string {
+func (r *ResolverSaver) Address() string {
 	return r.Resolver.Address()
 }
 
-func (r *SaverResolver) CloseIdleConnections() {
+func (r *ResolverSaver) CloseIdleConnections() {
 	r.Resolver.CloseIdleConnections()
 }
 
-func (r *SaverResolver) LookupHTTPS(ctx context.Context, domain string) (*model.HTTPSSvc, error) {
+func (r *ResolverSaver) LookupHTTPS(ctx context.Context, domain string) (*model.HTTPSSvc, error) {
 	// TODO(bassosimone): we should probably implement this method
 	return r.Resolver.LookupHTTPS(ctx, domain)
 }
 
-func (r *SaverResolver) LookupNS(ctx context.Context, domain string) ([]*net.NS, error) {
+func (r *ResolverSaver) LookupNS(ctx context.Context, domain string) ([]*net.NS, error) {
 	// TODO(bassosimone): we should probably implement this method
 	return r.Resolver.LookupNS(ctx, domain)
 }
 
-// SaverDNSTransport is a DNS transport that saves events.
-type SaverDNSTransport struct {
+// DNSTransportSaver is a DNS transport that saves events.
+type DNSTransportSaver struct {
 	// DNSTransport is the underlying DNS transport.
 	DNSTransport model.DNSTransport
 
@@ -99,14 +99,14 @@ func (s *Saver) WrapDNSTransport(txp model.DNSTransport) model.DNSTransport {
 	if s == nil {
 		return txp
 	}
-	return &SaverDNSTransport{
+	return &DNSTransportSaver{
 		DNSTransport: txp,
 		Saver:        s,
 	}
 }
 
 // RoundTrip implements RoundTripper.RoundTrip
-func (txp *SaverDNSTransport) RoundTrip(
+func (txp *DNSTransportSaver) RoundTrip(
 	ctx context.Context, query model.DNSQuery) (model.DNSResponse, error) {
 	start := time.Now()
 	txp.Saver.Write(&EventDNSRoundTripStart{&EventValue{
@@ -129,19 +129,19 @@ func (txp *SaverDNSTransport) RoundTrip(
 	return response, err
 }
 
-func (txp *SaverDNSTransport) Network() string {
+func (txp *DNSTransportSaver) Network() string {
 	return txp.DNSTransport.Network()
 }
 
-func (txp *SaverDNSTransport) Address() string {
+func (txp *DNSTransportSaver) Address() string {
 	return txp.DNSTransport.Address()
 }
 
-func (txp *SaverDNSTransport) CloseIdleConnections() {
+func (txp *DNSTransportSaver) CloseIdleConnections() {
 	txp.DNSTransport.CloseIdleConnections()
 }
 
-func (txp *SaverDNSTransport) RequiresPadding() bool {
+func (txp *DNSTransportSaver) RequiresPadding() bool {
 	return txp.DNSTransport.RequiresPadding()
 }
 
@@ -157,5 +157,5 @@ func dnsMaybeResponseBytes(response model.DNSResponse) []byte {
 	return response.Bytes()
 }
 
-var _ model.Resolver = &SaverResolver{}
-var _ model.DNSTransport = &SaverDNSTransport{}
+var _ model.Resolver = &ResolverSaver{}
+var _ model.DNSTransport = &DNSTransportSaver{}

--- a/internal/engine/netx/tracex/resolver_test.go
+++ b/internal/engine/netx/tracex/resolver_test.go
@@ -14,220 +14,224 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
-func TestSaverResolverFailure(t *testing.T) {
-	expected := errors.New("no such host")
-	saver := &Saver{}
-	reso := saver.WrapResolver(NewFakeResolverWithExplicitError(expected))
-	addrs, err := reso.LookupHost(context.Background(), "www.google.com")
-	if !errors.Is(err, expected) {
-		t.Fatal("not the error we expected")
-	}
-	if addrs != nil {
-		t.Fatal("expected nil address here")
-	}
-	ev := saver.Read()
-	if len(ev) != 2 {
-		t.Fatal("expected number of events")
-	}
-	if ev[0].Value().Hostname != "www.google.com" {
-		t.Fatal("unexpected Hostname")
-	}
-	if ev[0].Name() != "resolve_start" {
-		t.Fatal("unexpected name")
-	}
-	if !ev[0].Value().Time.Before(time.Now()) {
-		t.Fatal("the saved time is wrong")
-	}
-	if ev[1].Value().Addresses != nil {
-		t.Fatal("unexpected Addresses")
-	}
-	if ev[1].Value().Duration <= 0 {
-		t.Fatal("unexpected Duration")
-	}
-	if !errors.Is(ev[1].Value().Err, expected) {
-		t.Fatal("unexpected Err")
-	}
-	if ev[1].Value().Hostname != "www.google.com" {
-		t.Fatal("unexpected Hostname")
-	}
-	if ev[1].Name() != "resolve_done" {
-		t.Fatal("unexpected name")
-	}
-	if !ev[1].Value().Time.After(ev[0].Value().Time) {
-		t.Fatal("the saved time is wrong")
-	}
-}
-
-func TestSaverResolverSuccess(t *testing.T) {
-	expected := []string{"8.8.8.8", "8.8.4.4"}
-	saver := &Saver{}
-	reso := saver.WrapResolver(NewFakeResolverWithResult(expected))
-	addrs, err := reso.LookupHost(context.Background(), "www.google.com")
-	if err != nil {
-		t.Fatal("expected nil error here")
-	}
-	if !reflect.DeepEqual(addrs, expected) {
-		t.Fatal("not the result we expected")
-	}
-	ev := saver.Read()
-	if len(ev) != 2 {
-		t.Fatal("expected number of events")
-	}
-	if ev[0].Value().Hostname != "www.google.com" {
-		t.Fatal("unexpected Hostname")
-	}
-	if ev[0].Name() != "resolve_start" {
-		t.Fatal("unexpected name")
-	}
-	if !ev[0].Value().Time.Before(time.Now()) {
-		t.Fatal("the saved time is wrong")
-	}
-	if !reflect.DeepEqual(ev[1].Value().Addresses, expected) {
-		t.Fatal("unexpected Addresses")
-	}
-	if ev[1].Value().Duration <= 0 {
-		t.Fatal("unexpected Duration")
-	}
-	if ev[1].Value().Err != nil {
-		t.Fatal("unexpected Err")
-	}
-	if ev[1].Value().Hostname != "www.google.com" {
-		t.Fatal("unexpected Hostname")
-	}
-	if ev[1].Name() != "resolve_done" {
-		t.Fatal("unexpected name")
-	}
-	if !ev[1].Value().Time.After(ev[0].Value().Time) {
-		t.Fatal("the saved time is wrong")
-	}
-}
-
-func TestSaverDNSTransportFailure(t *testing.T) {
-	expected := errors.New("no such host")
-	saver := &Saver{}
-	txp := saver.WrapDNSTransport(&mocks.DNSTransport{
-		MockRoundTrip: func(ctx context.Context, query model.DNSQuery) (model.DNSResponse, error) {
-			return nil, expected
-		},
-		MockNetwork: func() string {
-			return "fake"
-		},
-		MockAddress: func() string {
-			return ""
-		},
+func TestResolverSaver(t *testing.T) {
+	t.Run("on failure", func(t *testing.T) {
+		expected := errors.New("no such host")
+		saver := &Saver{}
+		reso := saver.WrapResolver(newFakeResolverWithExplicitError(expected))
+		addrs, err := reso.LookupHost(context.Background(), "www.google.com")
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+		if addrs != nil {
+			t.Fatal("expected nil address here")
+		}
+		ev := saver.Read()
+		if len(ev) != 2 {
+			t.Fatal("expected number of events")
+		}
+		if ev[0].Value().Hostname != "www.google.com" {
+			t.Fatal("unexpected Hostname")
+		}
+		if ev[0].Name() != "resolve_start" {
+			t.Fatal("unexpected name")
+		}
+		if !ev[0].Value().Time.Before(time.Now()) {
+			t.Fatal("the saved time is wrong")
+		}
+		if ev[1].Value().Addresses != nil {
+			t.Fatal("unexpected Addresses")
+		}
+		if ev[1].Value().Duration <= 0 {
+			t.Fatal("unexpected Duration")
+		}
+		if !errors.Is(ev[1].Value().Err, expected) {
+			t.Fatal("unexpected Err")
+		}
+		if ev[1].Value().Hostname != "www.google.com" {
+			t.Fatal("unexpected Hostname")
+		}
+		if ev[1].Name() != "resolve_done" {
+			t.Fatal("unexpected name")
+		}
+		if !ev[1].Value().Time.After(ev[0].Value().Time) {
+			t.Fatal("the saved time is wrong")
+		}
 	})
-	rawQuery := []byte{0xde, 0xad, 0xbe, 0xef}
-	query := &mocks.DNSQuery{
-		MockBytes: func() ([]byte, error) {
-			return rawQuery, nil
-		},
-	}
-	reply, err := txp.RoundTrip(context.Background(), query)
-	if !errors.Is(err, expected) {
-		t.Fatal("not the error we expected")
-	}
-	if reply != nil {
-		t.Fatal("expected nil reply here")
-	}
-	ev := saver.Read()
-	if len(ev) != 2 {
-		t.Fatal("expected number of events")
-	}
-	if !bytes.Equal(ev[0].Value().DNSQuery, rawQuery) {
-		t.Fatal("unexpected DNSQuery")
-	}
-	if ev[0].Name() != "dns_round_trip_start" {
-		t.Fatal("unexpected name")
-	}
-	if !ev[0].Value().Time.Before(time.Now()) {
-		t.Fatal("the saved time is wrong")
-	}
-	if !bytes.Equal(ev[1].Value().DNSQuery, rawQuery) {
-		t.Fatal("unexpected DNSQuery")
-	}
-	if ev[1].Value().DNSResponse != nil {
-		t.Fatal("unexpected DNSReply")
-	}
-	if ev[1].Value().Duration <= 0 {
-		t.Fatal("unexpected Duration")
-	}
-	if !errors.Is(ev[1].Value().Err, expected) {
-		t.Fatal("unexpected Err")
-	}
-	if ev[1].Name() != "dns_round_trip_done" {
-		t.Fatal("unexpected name")
-	}
-	if !ev[1].Value().Time.After(ev[0].Value().Time) {
-		t.Fatal("the saved time is wrong")
-	}
-}
 
-func TestSaverDNSTransportSuccess(t *testing.T) {
-	expected := []byte{0xef, 0xbe, 0xad, 0xde}
-	saver := &Saver{}
-	response := &mocks.DNSResponse{
-		MockBytes: func() []byte {
-			return expected
-		},
-	}
-	txp := saver.WrapDNSTransport(&mocks.DNSTransport{
-		MockRoundTrip: func(ctx context.Context, query model.DNSQuery) (model.DNSResponse, error) {
-			return response, nil
-		},
-		MockNetwork: func() string {
-			return "fake"
-		},
-		MockAddress: func() string {
-			return ""
-		},
+	t.Run("on success", func(t *testing.T) {
+		expected := []string{"8.8.8.8", "8.8.4.4"}
+		saver := &Saver{}
+		reso := saver.WrapResolver(newFakeResolverWithResult(expected))
+		addrs, err := reso.LookupHost(context.Background(), "www.google.com")
+		if err != nil {
+			t.Fatal("expected nil error here")
+		}
+		if !reflect.DeepEqual(addrs, expected) {
+			t.Fatal("not the result we expected")
+		}
+		ev := saver.Read()
+		if len(ev) != 2 {
+			t.Fatal("expected number of events")
+		}
+		if ev[0].Value().Hostname != "www.google.com" {
+			t.Fatal("unexpected Hostname")
+		}
+		if ev[0].Name() != "resolve_start" {
+			t.Fatal("unexpected name")
+		}
+		if !ev[0].Value().Time.Before(time.Now()) {
+			t.Fatal("the saved time is wrong")
+		}
+		if !reflect.DeepEqual(ev[1].Value().Addresses, expected) {
+			t.Fatal("unexpected Addresses")
+		}
+		if ev[1].Value().Duration <= 0 {
+			t.Fatal("unexpected Duration")
+		}
+		if ev[1].Value().Err != nil {
+			t.Fatal("unexpected Err")
+		}
+		if ev[1].Value().Hostname != "www.google.com" {
+			t.Fatal("unexpected Hostname")
+		}
+		if ev[1].Name() != "resolve_done" {
+			t.Fatal("unexpected name")
+		}
+		if !ev[1].Value().Time.After(ev[0].Value().Time) {
+			t.Fatal("the saved time is wrong")
+		}
 	})
-	rawQuery := []byte{0xde, 0xad, 0xbe, 0xef}
-	query := &mocks.DNSQuery{
-		MockBytes: func() ([]byte, error) {
-			return rawQuery, nil
-		},
-	}
-	reply, err := txp.RoundTrip(context.Background(), query)
-	if err != nil {
-		t.Fatal("we expected nil error here")
-	}
-	if !bytes.Equal(reply.Bytes(), expected) {
-		t.Fatal("expected another reply here")
-	}
-	ev := saver.Read()
-	if len(ev) != 2 {
-		t.Fatal("expected number of events")
-	}
-	if !bytes.Equal(ev[0].Value().DNSQuery, rawQuery) {
-		t.Fatal("unexpected DNSQuery")
-	}
-	if ev[0].Name() != "dns_round_trip_start" {
-		t.Fatal("unexpected name")
-	}
-	if !ev[0].Value().Time.Before(time.Now()) {
-		t.Fatal("the saved time is wrong")
-	}
-	if !bytes.Equal(ev[1].Value().DNSQuery, rawQuery) {
-		t.Fatal("unexpected DNSQuery")
-	}
-	if !bytes.Equal(ev[1].Value().DNSResponse, expected) {
-		t.Fatal("unexpected DNSReply")
-	}
-	if ev[1].Value().Duration <= 0 {
-		t.Fatal("unexpected Duration")
-	}
-	if ev[1].Value().Err != nil {
-		t.Fatal("unexpected Err")
-	}
-	if ev[1].Name() != "dns_round_trip_done" {
-		t.Fatal("unexpected name")
-	}
-	if !ev[1].Value().Time.After(ev[0].Value().Time) {
-		t.Fatal("the saved time is wrong")
-	}
 }
 
-func NewFakeResolverWithExplicitError(err error) model.Resolver {
+func TestDNSTransportSaver(t *testing.T) {
+	t.Run("on failure", func(t *testing.T) {
+		expected := errors.New("no such host")
+		saver := &Saver{}
+		txp := saver.WrapDNSTransport(&mocks.DNSTransport{
+			MockRoundTrip: func(ctx context.Context, query model.DNSQuery) (model.DNSResponse, error) {
+				return nil, expected
+			},
+			MockNetwork: func() string {
+				return "fake"
+			},
+			MockAddress: func() string {
+				return ""
+			},
+		})
+		rawQuery := []byte{0xde, 0xad, 0xbe, 0xef}
+		query := &mocks.DNSQuery{
+			MockBytes: func() ([]byte, error) {
+				return rawQuery, nil
+			},
+		}
+		reply, err := txp.RoundTrip(context.Background(), query)
+		if !errors.Is(err, expected) {
+			t.Fatal("not the error we expected")
+		}
+		if reply != nil {
+			t.Fatal("expected nil reply here")
+		}
+		ev := saver.Read()
+		if len(ev) != 2 {
+			t.Fatal("expected number of events")
+		}
+		if !bytes.Equal(ev[0].Value().DNSQuery, rawQuery) {
+			t.Fatal("unexpected DNSQuery")
+		}
+		if ev[0].Name() != "dns_round_trip_start" {
+			t.Fatal("unexpected name")
+		}
+		if !ev[0].Value().Time.Before(time.Now()) {
+			t.Fatal("the saved time is wrong")
+		}
+		if !bytes.Equal(ev[1].Value().DNSQuery, rawQuery) {
+			t.Fatal("unexpected DNSQuery")
+		}
+		if ev[1].Value().DNSResponse != nil {
+			t.Fatal("unexpected DNSReply")
+		}
+		if ev[1].Value().Duration <= 0 {
+			t.Fatal("unexpected Duration")
+		}
+		if !errors.Is(ev[1].Value().Err, expected) {
+			t.Fatal("unexpected Err")
+		}
+		if ev[1].Name() != "dns_round_trip_done" {
+			t.Fatal("unexpected name")
+		}
+		if !ev[1].Value().Time.After(ev[0].Value().Time) {
+			t.Fatal("the saved time is wrong")
+		}
+	})
+
+	t.Run("on success", func(t *testing.T) {
+		expected := []byte{0xef, 0xbe, 0xad, 0xde}
+		saver := &Saver{}
+		response := &mocks.DNSResponse{
+			MockBytes: func() []byte {
+				return expected
+			},
+		}
+		txp := saver.WrapDNSTransport(&mocks.DNSTransport{
+			MockRoundTrip: func(ctx context.Context, query model.DNSQuery) (model.DNSResponse, error) {
+				return response, nil
+			},
+			MockNetwork: func() string {
+				return "fake"
+			},
+			MockAddress: func() string {
+				return ""
+			},
+		})
+		rawQuery := []byte{0xde, 0xad, 0xbe, 0xef}
+		query := &mocks.DNSQuery{
+			MockBytes: func() ([]byte, error) {
+				return rawQuery, nil
+			},
+		}
+		reply, err := txp.RoundTrip(context.Background(), query)
+		if err != nil {
+			t.Fatal("we expected nil error here")
+		}
+		if !bytes.Equal(reply.Bytes(), expected) {
+			t.Fatal("expected another reply here")
+		}
+		ev := saver.Read()
+		if len(ev) != 2 {
+			t.Fatal("expected number of events")
+		}
+		if !bytes.Equal(ev[0].Value().DNSQuery, rawQuery) {
+			t.Fatal("unexpected DNSQuery")
+		}
+		if ev[0].Name() != "dns_round_trip_start" {
+			t.Fatal("unexpected name")
+		}
+		if !ev[0].Value().Time.Before(time.Now()) {
+			t.Fatal("the saved time is wrong")
+		}
+		if !bytes.Equal(ev[1].Value().DNSQuery, rawQuery) {
+			t.Fatal("unexpected DNSQuery")
+		}
+		if !bytes.Equal(ev[1].Value().DNSResponse, expected) {
+			t.Fatal("unexpected DNSReply")
+		}
+		if ev[1].Value().Duration <= 0 {
+			t.Fatal("unexpected Duration")
+		}
+		if ev[1].Value().Err != nil {
+			t.Fatal("unexpected Err")
+		}
+		if ev[1].Name() != "dns_round_trip_done" {
+			t.Fatal("unexpected name")
+		}
+		if !ev[1].Value().Time.After(ev[0].Value().Time) {
+			t.Fatal("the saved time is wrong")
+		}
+	})
+}
+
+func newFakeResolverWithExplicitError(err error) model.Resolver {
 	runtimex.PanicIfNil(err, "passed nil error")
 	return &mocks.Resolver{
 		MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
@@ -251,7 +255,7 @@ func NewFakeResolverWithExplicitError(err error) model.Resolver {
 	}
 }
 
-func NewFakeResolverWithResult(r []string) model.Resolver {
+func newFakeResolverWithResult(r []string) model.Resolver {
 	return &mocks.Resolver{
 		MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
 			return r, nil

--- a/internal/engine/netx/tracex/saver_test.go
+++ b/internal/engine/netx/tracex/saver_test.go
@@ -3,22 +3,88 @@ package tracex
 import (
 	"sync"
 	"testing"
+
+	"github.com/ooni/probe-cli/v3/internal/model/mocks"
 )
 
 func TestSaver(t *testing.T) {
-	saver := Saver{}
-	var wg sync.WaitGroup
-	const parallel = 10
-	wg.Add(parallel)
-	for idx := 0; idx < parallel; idx++ {
-		go func() {
-			saver.Write(&EventReadFromOperation{&EventValue{}})
-			wg.Done()
-		}()
-	}
-	wg.Wait()
-	ev := saver.Read()
-	if len(ev) != parallel {
-		t.Fatal("unexpected number of events read")
-	}
+	t.Run("concurrent writes followed by read", func(t *testing.T) {
+		saver := Saver{}
+		var wg sync.WaitGroup
+		const parallel = 10
+		wg.Add(parallel)
+		for idx := 0; idx < parallel; idx++ {
+			go func() {
+				saver.Write(&EventReadFromOperation{&EventValue{}})
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+		ev := saver.Read()
+		if len(ev) != parallel {
+			t.Fatal("unexpected number of events read")
+		}
+	})
+
+	t.Run("NewConnectObserver", func(t *testing.T) {
+		t.Run("nil Saver", func(t *testing.T) {
+			var saver *Saver
+			obs := saver.NewConnectObserver()
+			if obs != nil {
+				t.Fatal("expected nil observer")
+			}
+		})
+
+		t.Run("nonnnil Saver", func(t *testing.T) {
+			saver := &Saver{}
+			obs := saver.NewConnectObserver()
+			underlying := obs.(*dialerConnectObserver)
+			if underlying.saver != saver {
+				t.Fatal("invalid saver")
+			}
+		})
+	})
+
+	t.Run("NewReadWriteObserver", func(t *testing.T) {
+		t.Run("nil Saver", func(t *testing.T) {
+			var saver *Saver
+			obs := saver.NewReadWriteObserver()
+			if obs != nil {
+				t.Fatal("expected nil observer")
+			}
+		})
+
+		t.Run("nonnnil Saver", func(t *testing.T) {
+			saver := &Saver{}
+			obs := saver.NewReadWriteObserver()
+			underlying := obs.(*dialerReadWriteObserver)
+			if underlying.saver != saver {
+				t.Fatal("invalid saver")
+			}
+		})
+	})
+
+	t.Run("WrapQUICDialer", func(t *testing.T) {
+		t.Run("nil Saver", func(t *testing.T) {
+			var saver *Saver
+			base := &mocks.QUICDialer{}
+			qd := saver.WrapQUICDialer(base)
+			if qd != base {
+				t.Fatal("unexpected returned QUICDialer")
+			}
+		})
+
+		t.Run("nonnnil Saver", func(t *testing.T) {
+			saver := &Saver{}
+			base := &mocks.QUICDialer{}
+			qd := saver.WrapQUICDialer(base)
+			underlying := qd.(*QUICDialerSaver)
+			if underlying.Saver != saver {
+				t.Fatal("invalid Saver")
+			}
+			if underlying.QUICDialer != base {
+				t.Fatal("invalid QUICDialer")
+			}
+		})
+	})
 }

--- a/internal/engine/netx/tracex/tls_test.go
+++ b/internal/engine/netx/tracex/tls_test.go
@@ -3,291 +3,250 @@ package tracex
 import (
 	"context"
 	"crypto/tls"
-	"reflect"
+	"crypto/x509"
+	"errors"
+	"net"
 	"testing"
-	"time"
 
-	"github.com/ooni/probe-cli/v3/internal/model"
-	"github.com/ooni/probe-cli/v3/internal/netxlite"
+	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/probe-cli/v3/internal/model/mocks"
 )
 
-func TestSaverTLSHandshakerSuccessWithReadWrite(t *testing.T) {
-	// This is the most common use case for collecting reads, writes
-	if testing.Short() {
-		t.Skip("skip test in short mode")
-	}
-	nextprotos := []string{"h2"}
-	saver := &Saver{}
-	tlsdlr := &netxlite.TLSDialerLegacy{
-		Config: &tls.Config{NextProtos: nextprotos},
-		Dialer: netxlite.NewDialerWithResolver(
-			model.DiscardLogger,
-			netxlite.NewResolverStdlib(model.DiscardLogger),
-			saver.NewReadWriteObserver(),
-		),
-		TLSHandshaker: saver.WrapTLSHandshaker(&netxlite.TLSHandshakerConfigurable{}),
-	}
-	// Implementation note: we don't close the connection here because it is
-	// very handy to have the last event being the end of the handshake
-	_, err := tlsdlr.DialTLSContext(context.Background(), "tcp", "www.google.com:443")
-	if err != nil {
-		t.Fatal(err)
-	}
-	ev := saver.Read()
-	if len(ev) < 4 {
-		// it's a bit tricky to be sure about the right number of
-		// events because network conditions may influence that
-		t.Fatal("unexpected number of events")
-	}
-	if ev[0].Name() != "tls_handshake_start" {
-		t.Fatal("unexpected Name")
-	}
-	if ev[0].Value().TLSServerName != "www.google.com" {
-		t.Fatal("unexpected TLSServerName")
-	}
-	if !reflect.DeepEqual(ev[0].Value().TLSNextProtos, nextprotos) {
-		t.Fatal("unexpected TLSNextProtos")
-	}
-	if ev[0].Value().Time.After(time.Now()) {
-		t.Fatal("unexpected Time")
-	}
-	last := len(ev) - 1
-	for idx := 1; idx < last; idx++ {
-		if ev[idx].Value().Data == nil {
-			t.Fatal("unexpected Data")
+func TestTLSHandshakerSaver(t *testing.T) {
+
+	t.Run("Handshake", func(t *testing.T) {
+		checkStartEventFields := func(t *testing.T, value *EventValue) {
+			if value.Address != "8.8.8.8:443" {
+				t.Fatal("invalid Address")
+			}
+			if !value.NoTLSVerify {
+				t.Fatal("expected NoTLSVerify to be true")
+			}
+			if value.Proto != "tcp" {
+				t.Fatal("wrong protocol")
+			}
+			if diff := cmp.Diff(value.TLSNextProtos, []string{"h2"}); diff != "" {
+				t.Fatal(diff)
+			}
+			if value.TLSServerName != "dns.google" {
+				t.Fatal("invalid TLSServerName")
+			}
+			if value.Time.IsZero() {
+				t.Fatal("expected non zero time")
+			}
 		}
-		if ev[idx].Value().Duration <= 0 {
-			t.Fatal("unexpected Duration")
+
+		checkStartedEvent := func(t *testing.T, ev Event) {
+			if _, good := ev.(*EventTLSHandshakeStart); !good {
+				t.Fatal("invalid event type")
+			}
+			value := ev.Value()
+			checkStartEventFields(t, value)
 		}
-		if ev[idx].Value().Err != nil {
-			t.Fatal("unexpected Err")
+
+		checkDoneEventFieldsSuccess := func(t *testing.T, value *EventValue) {
+			if value.Duration <= 0 {
+				t.Fatal("expected non-zero duration")
+			}
+			if value.Err != nil {
+				t.Fatal("expected no error here")
+			}
+			if value.TLSCipherSuite != "TLS_RSA_WITH_RC4_128_SHA" {
+				t.Fatal("invalid cipher suite")
+			}
+			if value.TLSNegotiatedProto != "h2" {
+				t.Fatal("invalid negotiated protocol")
+			}
+			if diff := cmp.Diff(value.TLSPeerCerts, []*x509.Certificate{}); diff != "" {
+				t.Fatal(diff)
+			}
+			if value.TLSVersion != "TLSv1.3" {
+				t.Fatal("invalid TLS version")
+			}
 		}
-		if ev[idx].Value().NumBytes <= 0 {
-			t.Fatal("unexpected NumBytes")
+
+		checkDoneEvent := func(t *testing.T, ev Event, fun func(t *testing.T, value *EventValue)) {
+			if _, good := ev.(*EventTLSHandshakeDone); !good {
+				t.Fatal("invalid event type")
+			}
+			value := ev.Value()
+			checkStartEventFields(t, value)
+			fun(t, value)
 		}
-		switch ev[idx].Name() {
-		case netxlite.ReadOperation, netxlite.WriteOperation:
-		default:
-			t.Fatal("unexpected Name")
+
+		t.Run("on success", func(t *testing.T) {
+			saver := &Saver{}
+			returnedConnState := tls.ConnectionState{
+				CipherSuite:        tls.TLS_RSA_WITH_RC4_128_SHA,
+				NegotiatedProtocol: "h2",
+				PeerCertificates:   []*x509.Certificate{},
+				Version:            tls.VersionTLS13,
+			}
+			returnedConn := &mocks.TLSConn{
+				MockConnectionState: func() tls.ConnectionState {
+					return returnedConnState
+				},
+			}
+			thx := saver.WrapTLSHandshaker(&mocks.TLSHandshaker{
+				MockHandshake: func(ctx context.Context, conn net.Conn,
+					config *tls.Config) (net.Conn, tls.ConnectionState, error) {
+					return returnedConn, returnedConnState, nil
+				},
+			})
+			ctx := context.Background()
+			tlsConfig := &tls.Config{
+				InsecureSkipVerify: true,
+				NextProtos:         []string{"h2"},
+				ServerName:         "dns.google",
+			}
+			tcpConn := &mocks.Conn{
+				MockRemoteAddr: func() net.Addr {
+					return &mocks.Addr{
+						MockString: func() string {
+							return "8.8.8.8:443"
+						},
+						MockNetwork: func() string {
+							return "tcp"
+						},
+					}
+				},
+			}
+			conn, _, err := thx.Handshake(ctx, tcpConn, tlsConfig)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if conn == nil {
+				t.Fatal("expected non-nil conn")
+			}
+			events := saver.Read()
+			if len(events) != 2 {
+				t.Fatal("expected two events")
+			}
+			checkStartedEvent(t, events[0])
+			checkDoneEvent(t, events[1], checkDoneEventFieldsSuccess)
+		})
+
+		checkDoneEventFieldsFailure := func(t *testing.T, value *EventValue) {
+			if value.Duration <= 0 {
+				t.Fatal("expected non-zero duration")
+			}
+			if value.Err == nil {
+				t.Fatal("expected non-nil error here")
+			}
+			if value.TLSCipherSuite != "" {
+				t.Fatal("invalid TLS cipher suite")
+			}
+			if value.TLSNegotiatedProto != "" {
+				t.Fatal("invalid negotiated proto")
+			}
+			if len(value.TLSPeerCerts) > 0 {
+				t.Fatal("expected no peer certs")
+			}
+			if value.TLSVersion != "" {
+				t.Fatal("invalid TLS version")
+			}
 		}
-		if ev[idx].Value().Time.Before(ev[idx-1].Value().Time) {
-			t.Fatal("unexpected Time")
-		}
-	}
-	if ev[last].Value().Duration <= 0 {
-		t.Fatal("unexpected Duration")
-	}
-	if ev[last].Value().Err != nil {
-		t.Fatal("unexpected Err")
-	}
-	if ev[last].Name() != "tls_handshake_done" {
-		t.Fatal("unexpected Name")
-	}
-	if ev[last].Value().TLSCipherSuite == "" {
-		t.Fatal("unexpected TLSCipherSuite")
-	}
-	if ev[last].Value().TLSNegotiatedProto != "h2" {
-		t.Fatal("unexpected TLSNegotiatedProto")
-	}
-	if !reflect.DeepEqual(ev[last].Value().TLSNextProtos, nextprotos) {
-		t.Fatal("unexpected TLSNextProtos")
-	}
-	if ev[last].Value().TLSPeerCerts == nil {
-		t.Fatal("unexpected TLSPeerCerts")
-	}
-	if ev[last].Value().TLSServerName != "www.google.com" {
-		t.Fatal("unexpected TLSServerName")
-	}
-	if ev[last].Value().TLSVersion == "" {
-		t.Fatal("unexpected TLSVersion")
-	}
-	if ev[last].Value().Time.Before(ev[last-1].Value().Time) {
-		t.Fatal("unexpected Time")
-	}
+
+		t.Run("on failure", func(t *testing.T) {
+			expected := errors.New("mocked error")
+			saver := &Saver{}
+			thx := saver.WrapTLSHandshaker(&mocks.TLSHandshaker{
+				MockHandshake: func(ctx context.Context, conn net.Conn,
+					config *tls.Config) (net.Conn, tls.ConnectionState, error) {
+					return nil, tls.ConnectionState{}, expected
+				},
+			})
+			ctx := context.Background()
+			tlsConfig := &tls.Config{
+				InsecureSkipVerify: true,
+				NextProtos:         []string{"h2"},
+				ServerName:         "dns.google",
+			}
+			tcpConn := &mocks.Conn{
+				MockRemoteAddr: func() net.Addr {
+					return &mocks.Addr{
+						MockString: func() string {
+							return "8.8.8.8:443"
+						},
+						MockNetwork: func() string {
+							return "tcp"
+						},
+					}
+				},
+			}
+			conn, _, err := thx.Handshake(ctx, tcpConn, tlsConfig)
+			if !errors.Is(err, expected) {
+				t.Fatal("unexpected err", err)
+			}
+			if conn != nil {
+				t.Fatal("expected nil conn")
+			}
+			events := saver.Read()
+			if len(events) != 2 {
+				t.Fatal("expected two events")
+			}
+			checkStartedEvent(t, events[0])
+			checkDoneEvent(t, events[1], checkDoneEventFieldsFailure)
+		})
+	})
 }
 
-func TestSaverTLSHandshakerSuccess(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skip test in short mode")
+func Test_tlsPeerCerts(t *testing.T) {
+	cert0 := &x509.Certificate{Raw: []byte{1, 2, 3, 4}}
+	type args struct {
+		state tls.ConnectionState
+		err   error
 	}
-	nextprotos := []string{"h2"}
-	saver := &Saver{}
-	tlsdlr := &netxlite.TLSDialerLegacy{
-		Config:        &tls.Config{NextProtos: nextprotos},
-		Dialer:        &netxlite.DialerSystem{},
-		TLSHandshaker: saver.WrapTLSHandshaker(&netxlite.TLSHandshakerConfigurable{}),
-	}
-	conn, err := tlsdlr.DialTLSContext(context.Background(), "tcp", "www.google.com:443")
-	if err != nil {
-		t.Fatal(err)
-	}
-	conn.Close()
-	ev := saver.Read()
-	if len(ev) != 2 {
-		t.Fatal("unexpected number of events")
-	}
-	if ev[0].Name() != "tls_handshake_start" {
-		t.Fatal("unexpected Name")
-	}
-	if ev[0].Value().TLSServerName != "www.google.com" {
-		t.Fatal("unexpected TLSServerName")
-	}
-	if !reflect.DeepEqual(ev[0].Value().TLSNextProtos, nextprotos) {
-		t.Fatal("unexpected TLSNextProtos")
-	}
-	if ev[0].Value().Time.After(time.Now()) {
-		t.Fatal("unexpected Time")
-	}
-	if ev[1].Value().Duration <= 0 {
-		t.Fatal("unexpected Duration")
-	}
-	if ev[1].Value().Err != nil {
-		t.Fatal("unexpected Err")
-	}
-	if ev[1].Name() != "tls_handshake_done" {
-		t.Fatal("unexpected Name")
-	}
-	if ev[1].Value().TLSCipherSuite == "" {
-		t.Fatal("unexpected TLSCipherSuite")
-	}
-	if ev[1].Value().TLSNegotiatedProto != "h2" {
-		t.Fatal("unexpected TLSNegotiatedProto")
-	}
-	if !reflect.DeepEqual(ev[1].Value().TLSNextProtos, nextprotos) {
-		t.Fatal("unexpected TLSNextProtos")
-	}
-	if ev[1].Value().TLSPeerCerts == nil {
-		t.Fatal("unexpected TLSPeerCerts")
-	}
-	if ev[1].Value().TLSServerName != "www.google.com" {
-		t.Fatal("unexpected TLSServerName")
-	}
-	if ev[1].Value().TLSVersion == "" {
-		t.Fatal("unexpected TLSVersion")
-	}
-	if ev[1].Value().Time.Before(ev[0].Value().Time) {
-		t.Fatal("unexpected Time")
-	}
-}
-
-func TestSaverTLSHandshakerHostnameError(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skip test in short mode")
-	}
-	saver := &Saver{}
-	tlsdlr := &netxlite.TLSDialerLegacy{
-		Dialer:        &netxlite.DialerSystem{},
-		TLSHandshaker: saver.WrapTLSHandshaker(&netxlite.TLSHandshakerConfigurable{}),
-	}
-	conn, err := tlsdlr.DialTLSContext(
-		context.Background(), "tcp", "wrong.host.badssl.com:443")
-	if err == nil {
-		t.Fatal("expected an error here")
-	}
-	if conn != nil {
-		t.Fatal("expected nil conn here")
-	}
-	for _, ev := range saver.Read() {
-		if ev.Name() != "tls_handshake_done" {
-			continue
-		}
-		if ev.Value().NoTLSVerify == true {
-			t.Fatal("expected NoTLSVerify to be false")
-		}
-		if len(ev.Value().TLSPeerCerts) < 1 {
-			t.Fatal("expected at least a certificate here")
-		}
-	}
-}
-
-func TestSaverTLSHandshakerInvalidCertError(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skip test in short mode")
-	}
-	saver := &Saver{}
-	tlsdlr := &netxlite.TLSDialerLegacy{
-		Dialer:        &netxlite.DialerSystem{},
-		TLSHandshaker: saver.WrapTLSHandshaker(&netxlite.TLSHandshakerConfigurable{}),
-	}
-	conn, err := tlsdlr.DialTLSContext(
-		context.Background(), "tcp", "expired.badssl.com:443")
-	if err == nil {
-		t.Fatal("expected an error here")
-	}
-	if conn != nil {
-		t.Fatal("expected nil conn here")
-	}
-	for _, ev := range saver.Read() {
-		if ev.Name() != "tls_handshake_done" {
-			continue
-		}
-		if ev.Value().NoTLSVerify == true {
-			t.Fatal("expected NoTLSVerify to be false")
-		}
-		if len(ev.Value().TLSPeerCerts) < 1 {
-			t.Fatal("expected at least a certificate here")
-		}
-	}
-}
-
-func TestSaverTLSHandshakerAuthorityError(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skip test in short mode")
-	}
-	saver := &Saver{}
-	tlsdlr := &netxlite.TLSDialerLegacy{
-		Dialer:        &netxlite.DialerSystem{},
-		TLSHandshaker: saver.WrapTLSHandshaker(&netxlite.TLSHandshakerConfigurable{}),
-	}
-	conn, err := tlsdlr.DialTLSContext(
-		context.Background(), "tcp", "self-signed.badssl.com:443")
-	if err == nil {
-		t.Fatal("expected an error here")
-	}
-	if conn != nil {
-		t.Fatal("expected nil conn here")
-	}
-	for _, ev := range saver.Read() {
-		if ev.Name() != "tls_handshake_done" {
-			continue
-		}
-		if ev.Value().NoTLSVerify == true {
-			t.Fatal("expected NoTLSVerify to be false")
-		}
-		if len(ev.Value().TLSPeerCerts) < 1 {
-			t.Fatal("expected at least a certificate here")
-		}
-	}
-}
-
-func TestSaverTLSHandshakerNoTLSVerify(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skip test in short mode")
-	}
-	saver := &Saver{}
-	tlsdlr := &netxlite.TLSDialerLegacy{
-		Config:        &tls.Config{InsecureSkipVerify: true},
-		Dialer:        &netxlite.DialerSystem{},
-		TLSHandshaker: saver.WrapTLSHandshaker(&netxlite.TLSHandshakerConfigurable{}),
-	}
-	conn, err := tlsdlr.DialTLSContext(
-		context.Background(), "tcp", "self-signed.badssl.com:443")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if conn == nil {
-		t.Fatal("expected non-nil conn here")
-	}
-	conn.Close()
-	for _, ev := range saver.Read() {
-		if ev.Name() != "tls_handshake_done" {
-			continue
-		}
-		if ev.Value().NoTLSVerify != true {
-			t.Fatal("expected NoTLSVerify to be true")
-		}
-		if len(ev.Value().TLSPeerCerts) < 1 {
-			t.Fatal("expected at least a certificate here")
-		}
+	tests := []struct {
+		name string
+		args args
+		want []*x509.Certificate
+	}{{
+		name: "no error",
+		args: args{
+			state: tls.ConnectionState{
+				PeerCertificates: []*x509.Certificate{cert0},
+			},
+		},
+		want: []*x509.Certificate{cert0},
+	}, {
+		name: "all empty",
+		args: args{},
+		want: nil,
+	}, {
+		name: "x509.HostnameError",
+		args: args{
+			state: tls.ConnectionState{},
+			err: x509.HostnameError{
+				Certificate: cert0,
+			},
+		},
+		want: []*x509.Certificate{cert0},
+	}, {
+		name: "x509.UnknownAuthorityError",
+		args: args{
+			state: tls.ConnectionState{},
+			err: x509.UnknownAuthorityError{
+				Cert: cert0,
+			},
+		},
+		want: []*x509.Certificate{cert0},
+	}, {
+		name: "x509.CertificateInvalidError",
+		args: args{
+			state: tls.ConnectionState{},
+			err: x509.CertificateInvalidError{
+				Cert: cert0,
+			},
+		},
+		want: []*x509.Certificate{cert0},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tlsPeerCerts(tt.args.state, tt.args.err)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
The exercise already allowed me to notice issues such as fields not
being properly initialized by savers.

This is one of the last steps before moving tracex away from the
internal/netx package and into the internal package.

See https://github.com/ooni/probe/issues/2121

