### PR TITLE
[forwardport] fix(dnscheck): stop emitting progress

### DIFF
--- a/internal/engine/experiment/dnscheck/dnscheck.go
+++ b/internal/engine/experiment/dnscheck/dnscheck.go
@@ -225,7 +225,7 @@ func (m *Measurer) Run(
 	}
 
 	// 8. perform all the required resolutions
-	for output := range Collect(ctx, multi, inputs, callbacks) {
+	for output := range Collect(ctx, multi, inputs, sess.Logger()) {
 		resolverURL := output.Input.Config.ResolverURL
 		tk.Lookups[resolverURL] = output.TestKeys
 		m.Endpoints.maybeRegister(resolverURL)
@@ -259,7 +259,7 @@ func (m *Measurer) tlsServerName(tlsServerName string) string {
 // Collect prints on the output channel the result of running dnscheck
 // on every provided input. It closes the output channel when done.
 func Collect(ctx context.Context, multi urlgetter.Multi, inputs []urlgetter.MultiInput,
-	callbacks model.ExperimentCallbacks) <-chan urlgetter.MultiOutput {
+	logger model.Logger) <-chan urlgetter.MultiOutput {
 	outputch := make(chan urlgetter.MultiOutput)
 	expect := len(inputs)
 	inputch := multi.Run(ctx, inputs)
@@ -269,10 +269,8 @@ func Collect(ctx context.Context, multi urlgetter.Multi, inputs []urlgetter.Mult
 		for count < expect {
 			entry := <-inputch
 			count++
-			percentage := float64(count) / float64(expect)
-			callbacks.OnProgress(percentage, fmt.Sprintf(
-				"dnscheck: measure %s: %+v", entry.Input.Config.ResolverURL, model.ErrorToStringOrOK(entry.Err),
-			))
+			logger.Infof("dnscheck: measure %s: %+v", entry.Input.Config.ResolverURL,
+				model.ErrorToStringOrOK(entry.Err))
 			outputch <- entry
 		}
 	}()


### PR DESCRIPTION
This diff forward ports b606494db8a9293384efaf5c33a88601f6e1e2a6
to the main development branch.

Dnscheck is emitting progress and the experiment controller is
also emitting progress. This messes up the progress bar.

See https://github.com/ooni/probe/issues/2058#issuecomment-1141638067

