### PR TITLE
cleanup(jafar): do not depend on netx and urlgetter

### DIFF
--- a/internal/cmd/jafar/README.md
+++ b/internal/cmd/jafar/README.md
@@ -8,7 +8,7 @@ any system but it really only works on Linux.
 
 ## Building
 
-We use Go >= 1.16. Jafar also needs the C library headers,
+We use Go >= 1.18. Jafar also needs the C library headers,
 iptables installed, and root permissions.
 
 With Linux Alpine edge, you can compile Jafar with:
@@ -198,24 +198,21 @@ the client Hello message will cause the TLS handshake to fail.
 ### uncensored
 
 ```bash
-  -uncensored-resolver-url string
-    	URL of an hopefully uncensored resolver (default "dot://1.1.1.1:853")
+  -uncensored-resolver-doh string
+     URL of an hopefully uncensored DoH resolver (default "https://1.1.1.1/dns-query")
 ```
 
 The HTTP, DNS, and TLS proxies need to resolve domain names. If you setup DNS
 censorship, they may be affected as well. To avoid this issue, we use a different
-resolver for them, which by default is `dot://1.1.1.1:853`. You can change such
-default by using the `-uncensored-resolver-url` command line flag. The input
-URL is `<transport>://<domain>[:<port>][/<path>]`. Here are some examples:
+resolver for them, which by default is the one shown above. You can change such
+default by using the `-uncensored-resolver-doh` command line flag. The input
+URL is an HTTPS URL pointing to a DoH server. Here are some examples:
 
-* `system:///` uses the system resolver (i.e. `getaddrinfo`)
-* `udp://8.8.8.8:53` uses DNS over UDP
-* `tcp://8.8.8.8:53` used DNS over TCP
-* `dot://8.8.8.8:853` uses DNS over TLS
-* `https://dns.google/dns-query` uses DNS over HTTPS
+* `https://dns.google/dns-query`
+* `https://dns.quad9.net/dns-query`
 
-So, for example, if you are using Jafar to censor `1.1.1.1:853`, then you
-most likely want to use `-uncensored-resolver-url`.
+So, for example, if you are using Jafar to censor `1.1.1.1:443`, then you
+most likely want to use `-uncensored-resolver-doh`.
 
 ## Examples
 

--- a/internal/cmd/jafar/httpproxy/httpproxy_test.go
+++ b/internal/cmd/jafar/httpproxy/httpproxy_test.go
@@ -42,7 +42,7 @@ func TestLoop(t *testing.T) {
 }
 
 func TestListenError(t *testing.T) {
-	proxy := NewCensoringProxy([]string{""}, uncensored.DefaultClient)
+	proxy := NewCensoringProxy([]string{""}, uncensored.NewClient("https://1.1.1.1/dns-query"))
 	server, addr, err := proxy.Start("8.8.8.8:80")
 	if err == nil {
 		t.Fatal("expected an error here")
@@ -56,7 +56,7 @@ func TestListenError(t *testing.T) {
 }
 
 func newproxy(t *testing.T, blocked string) (*http.Server, net.Addr) {
-	proxy := NewCensoringProxy([]string{blocked}, uncensored.DefaultClient)
+	proxy := NewCensoringProxy([]string{blocked}, uncensored.NewClient("https://1.1.1.1/dns-query"))
 	server, addr, err := proxy.Start("127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cmd/jafar/iptables/iptables_integration_test.go
+++ b/internal/cmd/jafar/iptables/iptables_integration_test.go
@@ -240,7 +240,7 @@ func TestHijackDNS(t *testing.T) {
 	}
 	resolver := resolver.NewCensoringResolver(
 		[]string{"ooni.io"}, nil, nil,
-		uncensored.Must(uncensored.NewClient("dot://1.1.1.1:853")),
+		uncensored.NewClient("https://1.1.1.1/dns-query"),
 	)
 	server, err := resolver.Start("127.0.0.1:0")
 	if err != nil {

--- a/internal/cmd/jafar/main.go
+++ b/internal/cmd/jafar/main.go
@@ -234,9 +234,7 @@ func tlsProxyStart(uncensored *uncensored.Client) net.Listener {
 }
 
 func newUncensoredClient() *uncensored.Client {
-	clnt, err := uncensored.NewClient(*uncensoredResolverDoH)
-	runtimex.PanicOnError(err, "uncensored.NewClient failed")
-	return clnt
+	return uncensored.NewClient(*uncensoredResolverDoH)
 }
 
 func mustx(err error, message string, osExit func(int)) {

--- a/internal/cmd/jafar/main.go
+++ b/internal/cmd/jafar/main.go
@@ -61,7 +61,7 @@ var (
 	tlsProxyAddress *string
 	tlsProxyBlock   flagx.StringArray
 
-	uncensoredResolverURL *string
+	uncensoredResolverDoH *string
 )
 
 func init() {
@@ -167,9 +167,9 @@ func init() {
 	)
 
 	// uncensored
-	uncensoredResolverURL = flag.String(
-		"uncensored-resolver-url", "dot://1.1.1.1:853",
-		"URL of an hopefully uncensored resolver",
+	uncensoredResolverDoH = flag.String(
+		"uncensored-resolver-doh", "https://1.1.1.1/dns-query",
+		"URL of an hopefully uncensored DoH resolver",
 	)
 }
 
@@ -234,7 +234,7 @@ func tlsProxyStart(uncensored *uncensored.Client) net.Listener {
 }
 
 func newUncensoredClient() *uncensored.Client {
-	clnt, err := uncensored.NewClient(*uncensoredResolverURL)
+	clnt, err := uncensored.NewClient(*uncensoredResolverDoH)
 	runtimex.PanicOnError(err, "uncensored.NewClient failed")
 	return clnt
 }

--- a/internal/cmd/jafar/resolver/resolver_test.go
+++ b/internal/cmd/jafar/resolver/resolver_test.go
@@ -45,14 +45,14 @@ func TestLookupFailure(t *testing.T) {
 
 func TestFailureNoQuestion(t *testing.T) {
 	resolver := NewCensoringResolver(
-		nil, nil, nil, uncensored.DefaultClient,
+		nil, nil, nil, uncensored.NewClient("https://1.1.1.1/dns-query"),
 	)
 	resolver.ServeDNS(&fakeResponseWriter{t: t}, new(dns.Msg))
 }
 
 func TestListenFailure(t *testing.T) {
 	resolver := NewCensoringResolver(
-		nil, nil, nil, uncensored.DefaultClient,
+		nil, nil, nil, uncensored.NewClient("https://1.1.1.1/dns-query"),
 	)
 	server, err := resolver.Start("8.8.8.8:53")
 	if err == nil {
@@ -66,9 +66,7 @@ func TestListenFailure(t *testing.T) {
 func newresolver(t *testing.T, blocked, hijacked, ignored []string) *dns.Server {
 	resolver := NewCensoringResolver(
 		blocked, hijacked, ignored,
-		// using faster dns because dot here causes miekg/dns's
-		// dns.Exchange to timeout and I don't want more complexity
-		uncensored.Must(uncensored.NewClient("system:///")),
+		uncensored.NewClient("https://1.1.1.1/dns-query"),
 	)
 	server, err := resolver.Start("127.0.0.1:0")
 	if err != nil {

--- a/internal/cmd/jafar/tlsproxy/tlsproxy_test.go
+++ b/internal/cmd/jafar/tlsproxy/tlsproxy_test.go
@@ -94,7 +94,7 @@ func TestFailWriteAfterConnect(t *testing.T) {
 
 func TestListenError(t *testing.T) {
 	proxy := NewCensoringProxy(
-		[]string{""}, uncensored.DefaultClient,
+		[]string{""}, uncensored.NewClient("https://1.1.1.1/dns-query"),
 	)
 	listener, err := proxy.Start("8.8.8.8:80")
 	if err == nil {
@@ -107,7 +107,7 @@ func TestListenError(t *testing.T) {
 
 func newproxy(t *testing.T, blocked string) net.Listener {
 	proxy := NewCensoringProxy(
-		[]string{blocked}, uncensored.DefaultClient,
+		[]string{blocked}, uncensored.NewClient("https://1.1.1.1/dns-query"),
 	)
 	listener, err := proxy.Start("127.0.0.1:0")
 	if err != nil {

--- a/internal/cmd/jafar/uncensored/uncensored_test.go
+++ b/internal/cmd/jafar/uncensored/uncensored_test.go
@@ -10,16 +10,13 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
-func TestGood(t *testing.T) {
-	client, err := NewClient("dot://1.1.1.1:853")
-	if err != nil {
-		t.Fatal(err)
-	}
+func TestNewClient(t *testing.T) {
+	client := NewClient("https://1.1.1.1/dns-query")
 	defer client.CloseIdleConnections()
-	if client.Address() != "1.1.1.1:853" {
+	if client.Address() != "https://1.1.1.1/dns-query" {
 		t.Fatal("invalid address")
 	}
-	if client.Network() != "dot" {
+	if client.Network() != "doh" {
 		t.Fatal("invalid network")
 	}
 	ctx := context.Background()
@@ -62,15 +59,5 @@ func TestGood(t *testing.T) {
 	}
 	if !bytes.HasPrefix(data, []byte("Google is built by a large team")) {
 		t.Fatal("not the expected body")
-	}
-}
-
-func TestNewClientFailure(t *testing.T) {
-	clnt, err := NewClient("antani:///")
-	if err == nil {
-		t.Fatal("expected an error here")
-	}
-	if clnt != nil {
-		t.Fatal("expected nil client here")
 	}
 }

--- a/internal/netxlite/filtering/dns.go
+++ b/internal/netxlite/filtering/dns.go
@@ -153,14 +153,14 @@ func (p *DNSServer) nxdomain(query *dns.Msg) *dns.Msg {
 }
 
 func (p *DNSServer) localHost(query *dns.Msg) *dns.Msg {
-	return p.compose(query, net.IPv6loopback, net.IPv4(127, 0, 0, 1))
+	return dnsCompose(query, net.IPv6loopback, net.IPv4(127, 0, 0, 1))
 }
 
 func (p *DNSServer) empty(query *dns.Msg) *dns.Msg {
-	return p.compose(query)
+	return dnsCompose(query)
 }
 
-func (p *DNSServer) compose(query *dns.Msg, ips ...net.IP) *dns.Msg {
+func dnsCompose(query *dns.Msg, ips ...net.IP) *dns.Msg {
 	runtimex.PanicIfTrue(len(query.Question) != 1, "expecting a single question")
 	question := query.Question[0]
 	reply := new(dns.Msg)
@@ -205,5 +205,5 @@ func (p *DNSServer) cache(name string, query *dns.Msg) *dns.Msg {
 	if len(ipAddrs) <= 0 {
 		return p.nxdomain(query)
 	}
-	return p.compose(query, ipAddrs...)
+	return dnsCompose(query, ipAddrs...)
 }

--- a/internal/netxlite/filtering/http_test.go
+++ b/internal/netxlite/filtering/http_test.go
@@ -1,9 +1,11 @@
 package filtering
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
-	"net"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -11,6 +13,7 @@ import (
 	"time"
 
 	"github.com/apex/log"
+	"github.com/miekg/dns"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
@@ -19,137 +22,111 @@ func TestHTTPProxy(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip test in short mode")
 	}
-	newproxy := func(action HTTPAction) (net.Listener, error) {
-		p := &HTTPProxy{
-			OnIncomingHost: func(host string) HTTPAction {
-				return action
-			},
-		}
-		return p.Start("127.0.0.1:0")
-	}
 
-	httpGET := func(ctx context.Context, addr net.Addr, host string) (*http.Response, error) {
-		txp := netxlite.NewHTTPTransportStdlib(log.Log)
+	httpGET := func(ctx context.Context, URL *url.URL, host string, config *tls.Config) (*http.Response, error) {
+		reso := netxlite.NewResolverStdlib(log.Log)
+		dialer := netxlite.NewDialerWithResolver(log.Log, reso)
+		thx := netxlite.NewTLSHandshakerStdlib(log.Log)
+		config = netxlite.ClonedTLSConfigOrNewEmptyConfig(config)
+		config.ServerName = host
+		tlsDialer := netxlite.NewTLSDialerWithConfig(dialer, thx, config)
+		txp := netxlite.NewHTTPTransport(log.Log, dialer, tlsDialer)
 		clnt := &http.Client{Transport: txp}
-		URL := &url.URL{
-			Scheme: "http",
-			Host:   addr.String(),
-			Path:   "/",
-		}
 		req, err := http.NewRequestWithContext(ctx, "GET", URL.String(), nil)
 		runtimex.PanicOnError(err, "http.NewRequest failed")
 		req.Host = host
 		return clnt.Do(req)
 	}
 
-	t.Run("HTTPActionPass", func(t *testing.T) {
-		ctx := context.Background()
-		listener, err := newproxy(HTTPActionPass)
-		if err != nil {
-			t.Fatal(err)
-		}
-		resp, err := httpGET(ctx, listener.Addr(), "nexa.polito.it")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if resp.StatusCode != 200 {
-			t.Fatal("unexpected status code", resp.StatusCode)
-		}
-		resp.Body.Close()
-		listener.Close()
-	})
-
-	t.Run("HTTPActionPass with self connect", func(t *testing.T) {
-		ctx := context.Background()
-		listener, err := newproxy(HTTPActionPass)
-		if err != nil {
-			t.Fatal(err)
-		}
-		resp, err := httpGET(ctx, listener.Addr(), listener.Addr().String())
-		if err != nil {
-			t.Fatal(err)
-		}
-		if resp.StatusCode != 400 {
-			t.Fatal("unexpected status code", resp.StatusCode)
-		}
-		resp.Body.Close()
-		listener.Close()
-	})
-
 	t.Run("HTTPActionReset", func(t *testing.T) {
 		ctx := context.Background()
-		listener, err := newproxy(HTTPActionReset)
-		if err != nil {
-			t.Fatal(err)
-		}
-		resp, err := httpGET(ctx, listener.Addr(), "nexa.polito.it")
+		srvr := NewHTTPServerCleartext(HTTPActionReset)
+		resp, err := httpGET(ctx, srvr.URL(), "nexa.polito.it", srvr.TLSConfig())
 		if err == nil || !strings.HasSuffix(err.Error(), netxlite.FailureConnectionReset) {
 			t.Fatal("unexpected err", err)
 		}
 		if resp != nil {
 			t.Fatal("expected nil resp")
 		}
-		listener.Close()
+		srvr.Close()
 	})
 
 	t.Run("HTTPActionTimeout", func(t *testing.T) {
 		ctx := context.Background()
-		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 		defer cancel()
-		listener, err := newproxy(HTTPActionTimeout)
-		if err != nil {
-			t.Fatal(err)
-		}
-		resp, err := httpGET(ctx, listener.Addr(), "nexa.polito.it")
+		srvr := NewHTTPServerCleartext(HTTPActionTimeout)
+		resp, err := httpGET(ctx, srvr.URL(), "nexa.polito.it", srvr.TLSConfig())
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatal("unexpected err", err)
 		}
 		if resp != nil {
 			t.Fatal("expected nil resp")
 		}
-		listener.Close()
+		srvr.Close()
 	})
 
 	t.Run("HTTPActionEOF", func(t *testing.T) {
 		ctx := context.Background()
-		listener, err := newproxy(HTTPActionEOF)
-		if err != nil {
-			t.Fatal(err)
-		}
-		resp, err := httpGET(ctx, listener.Addr(), "nexa.polito.it")
+		srvr := NewHTTPServerCleartext(HTTPActionEOF)
+		resp, err := httpGET(ctx, srvr.URL(), "nexa.polito.it", srvr.TLSConfig())
 		if err == nil || !strings.HasSuffix(err.Error(), netxlite.FailureEOFError) {
 			t.Fatal("unexpected err", err)
 		}
 		if resp != nil {
 			t.Fatal("expected nil resp")
 		}
-		listener.Close()
+		srvr.Close()
 	})
 
 	t.Run("HTTPAction451", func(t *testing.T) {
 		ctx := context.Background()
-		listener, err := newproxy(HTTPAction451)
-		if err != nil {
-			t.Fatal(err)
-		}
-		resp, err := httpGET(ctx, listener.Addr(), "nexa.polito.it")
+		srvr := NewHTTPServerCleartext(HTTPAction451)
+		resp, err := httpGET(ctx, srvr.URL(), "nexa.polito.it", srvr.TLSConfig())
 		if err != nil {
 			t.Fatal(err)
 		}
 		if resp.StatusCode != 451 {
 			t.Fatal("unexpected status code", resp.StatusCode)
 		}
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(HTTPBlockpage451, data) {
+			t.Fatal("unexpected data")
+		}
 		resp.Body.Close()
-		listener.Close()
+		srvr.Close()
+	})
+
+	t.Run("HTTPActionDoH", func(t *testing.T) {
+		ctx := context.Background()
+		srvr := NewHTTPServerCleartext(HTTPAction451)
+		resp, err := httpGET(ctx, srvr.URL(), "dns.google", srvr.TLSConfig())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != 200 {
+			t.Fatal("unexpected status code", resp.StatusCode)
+		}
+		data, err := netxlite.ReadAllContext(ctx, resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		response := &dns.Msg{}
+		if err := response.Unpack(data); err != nil {
+			t.Fatal(err)
+		}
+		// It suffices to see it's a DNS response
+		resp.Body.Close()
+		srvr.Close()
 	})
 
 	t.Run("unknown action", func(t *testing.T) {
 		ctx := context.Background()
-		listener, err := newproxy("")
-		if err != nil {
-			t.Fatal(err)
-		}
-		resp, err := httpGET(ctx, listener.Addr(), "nexa.polito.it")
+		srvr := NewHTTPServerCleartext("")
+		resp, err := httpGET(ctx, srvr.URL(), "nexa.polito.it", srvr.TLSConfig())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -157,17 +134,6 @@ func TestHTTPProxy(t *testing.T) {
 			t.Fatal("unexpected status code", resp.StatusCode)
 		}
 		resp.Body.Close()
-		listener.Close()
-	})
-
-	t.Run("Start fails on an invalid address", func(t *testing.T) {
-		p := &HTTPProxy{}
-		listener, err := p.Start("127.0.0.1")
-		if err == nil || !strings.HasSuffix(err.Error(), "missing port in address") {
-			t.Fatal("unexpected err", err)
-		}
-		if listener != nil {
-			t.Fatal("expected nil listener")
-		}
+		srvr.Close()
 	})
 }

--- a/internal/netxlite/filtering/tls.go
+++ b/internal/netxlite/filtering/tls.go
@@ -66,14 +66,19 @@ type TLSServer struct {
 	privkey *rsa.PrivateKey
 }
 
-// NewTLSServer creates and starts a new TLSServer that executes
-// the given action during the TLS handshake.
-func NewTLSServer(action TLSAction) *TLSServer {
-	done := make(chan bool)
+func tlsConfigMITM() (*x509.Certificate, *rsa.PrivateKey, *mitm.Config) {
 	cert, privkey, err := mitm.NewAuthority("jafar", "OONI", 24*time.Hour)
 	runtimex.PanicOnError(err, "mitm.NewAuthority failed")
 	config, err := mitm.NewConfig(cert, privkey)
 	runtimex.PanicOnError(err, "mitm.NewConfig failed")
+	return cert, privkey, config
+}
+
+// NewTLSServer creates and starts a new TLSServer that executes
+// the given action during the TLS handshake.
+func NewTLSServer(action TLSAction) *TLSServer {
+	done := make(chan bool)
+	cert, privkey, config := tlsConfigMITM()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	runtimex.PanicOnError(err, "net.Listen failed")
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/netxlite/filtering/tls_test.go
+++ b/internal/netxlite/filtering/tls_test.go
@@ -116,7 +116,7 @@ func TestTLSServer(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer conn.Close()
-			data, err := io.ReadAll(conn)
+			data, err := netxlite.ReadAllContext(context.Background(), conn)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -134,7 +134,7 @@ func TestTLSServer(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer conn.Close()
-			data, err := io.ReadAll(conn)
+			data, err := netxlite.ReadAllContext(context.Background(), conn)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/netxlite/http.go
+++ b/internal/netxlite/http.go
@@ -105,6 +105,15 @@ func (txp *httpTransportConnectionsCloser) CloseIdleConnections() {
 	txp.TLSDialer.CloseIdleConnections()
 }
 
+// NewHTTPTransportWithResolver creates a new HTTP transport using
+// the stdlib for everything but the given resolver.
+func NewHTTPTransportWithResolver(logger model.DebugLogger, reso model.Resolver) model.HTTPTransport {
+	dialer := NewDialerWithResolver(logger, reso)
+	thx := NewTLSHandshakerStdlib(logger)
+	tlsDialer := NewTLSDialer(dialer, thx)
+	return NewHTTPTransport(logger, dialer, tlsDialer)
+}
+
 // NewHTTPTransport combines NewOOHTTPBaseTransport and WrapHTTPTransport.
 //
 // This factory and NewHTTPTransportStdlib are the recommended

--- a/internal/netxlite/http_test.go
+++ b/internal/netxlite/http_test.go
@@ -16,6 +16,27 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/model/mocks"
 )
 
+func TestNewHTTPTransportWithResolver(t *testing.T) {
+	expected := errors.New("mocked error")
+	reso := &mocks.Resolver{
+		MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
+			return nil, expected
+		},
+	}
+	txp := NewHTTPTransportWithResolver(model.DiscardLogger, reso)
+	req, err := http.NewRequest("GET", "http://x.org", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := txp.RoundTrip(req)
+	if !errors.Is(err, expected) {
+		t.Fatal("unexpected err")
+	}
+	if resp != nil {
+		t.Fatal("expected nil resp")
+	}
+}
+
 func TestHTTPTransportErrWrapper(t *testing.T) {
 	t.Run("RoundTrip", func(t *testing.T) {
 		t.Run("with failure", func(t *testing.T) {

--- a/internal/netxlite/resolvercore_test.go
+++ b/internal/netxlite/resolvercore_test.go
@@ -65,6 +65,23 @@ func TestNewParallelResolverUDP(t *testing.T) {
 	}
 }
 
+func TestNewParallelDNSOverHTTPSResolver(t *testing.T) {
+	resolver := NewParallelDNSOverHTTPSResolver(log.Log, "https://1.1.1.1/dns-query")
+	idna := resolver.(*resolverIDNA)
+	logger := idna.Resolver.(*resolverLogger)
+	if logger.Logger != log.Log {
+		t.Fatal("invalid logger")
+	}
+	shortCircuit := logger.Resolver.(*resolverShortCircuitIPAddr)
+	errWrapper := shortCircuit.Resolver.(*resolverErrWrapper)
+	para := errWrapper.Resolver.(*ParallelResolver)
+	txp := para.Transport().(*dnsTransportErrWrapper)
+	dnsTxp := txp.DNSTransport.(*DNSOverHTTPSTransport)
+	if dnsTxp.Address() != "https://1.1.1.1/dns-query" {
+		t.Fatal("invalid address")
+	}
+}
+
 func TestResolverSystem(t *testing.T) {
 	t.Run("Network", func(t *testing.T) {
 		expected := "antani"

--- a/script/nocopyreadall.bash
+++ b/script/nocopyreadall.bash
@@ -7,7 +7,7 @@ for file in $(find . -type f -name \*.go); do
 		# implement safer wrappers for these functions.
 		continue
 	fi
-	if [ "$file" = "./internal/netxlite/filtering/tls_test.go" ]; then
+	if [ "$file" = "./internal/netxlite/filtering/http.go" ]; then
 		# We're allowed to use ReadAll and Copy in this file to
 		# avoid depending on netxlite, so we can use filtering
 		# inside of netxlite's own test suite.


### PR DESCRIPTION
There's no point in doing that. Also, once this change is merged, it becomes easier to cleanup/simplify netx.

See https://github.com/ooni/probe/issues/2121