### PR TITLE
fix(netx): ensure we create ~same HTTP3 and HTTP2 transports

### DIFF
--- a/internal/engine/netx/httptransport.go
+++ b/internal/engine/netx/httptransport.go
@@ -10,29 +10,21 @@ import (
 // httpTransportConfig contains the configuration required for constructing an HTTP transport
 type httpTransportConfig struct {
 	Dialer     model.Dialer
+	Logger     model.Logger
 	QUICDialer model.QUICDialer
 	TLSDialer  model.TLSDialer
 	TLSConfig  *tls.Config
 }
 
 // newHTTP3Transport creates a new HTTP3Transport instance.
-//
-// Deprecation warning
-//
-// New code should use netxlite.NewHTTP3Transport instead.
 func newHTTP3Transport(config httpTransportConfig) model.HTTPTransport {
 	// Rationale for using NoLogger here: previously this code did
 	// not use a logger as well, so it's fine to keep it as is.
-	return netxlite.NewHTTP3Transport(model.DiscardLogger,
-		config.QUICDialer, config.TLSConfig)
+	return netxlite.NewHTTP3Transport(config.Logger, config.QUICDialer, config.TLSConfig)
 }
 
 // newSystemTransport creates a new "system" HTTP transport. That is a transport
 // using the Go standard library with custom dialer and TLS dialer.
-//
-// Deprecation warning
-//
-// New code should use netxlite.NewHTTPTransport instead.
 func newSystemTransport(config httpTransportConfig) model.HTTPTransport {
-	return netxlite.NewOOHTTPBaseTransport(config.Dialer, config.TLSDialer)
+	return netxlite.NewHTTPTransport(config.Logger, config.Dialer, config.TLSDialer)
 }

--- a/internal/engine/netx/netx.go
+++ b/internal/engine/netx/netx.go
@@ -145,14 +145,15 @@ func NewHTTPTransport(config Config) model.HTTPTransport {
 	}
 	tInfo := allTransportsInfo[config.HTTP3Enabled]
 	txp := tInfo.Factory(httpTransportConfig{
-		Dialer: config.Dialer, QUICDialer: config.QUICDialer, TLSDialer: config.TLSDialer,
-		TLSConfig: config.TLSConfig})
+		Dialer:     config.Dialer,
+		Logger:     model.ValidLoggerOrDefault(config.Logger),
+		QUICDialer: config.QUICDialer,
+		TLSDialer:  config.TLSDialer,
+		TLSConfig:  config.TLSConfig,
+	})
 	if config.ByteCounter != nil {
 		txp = &bytecounter.HTTPTransport{
 			Counter: config.ByteCounter, HTTPTransport: txp}
-	}
-	if config.Logger != nil {
-		txp = &netxlite.HTTPTransportLogger{Logger: config.Logger, HTTPTransport: txp}
 	}
 	if config.Saver != nil {
 		txp = &tracex.HTTPTransportSaver{

--- a/internal/engine/netx/netx_test.go
+++ b/internal/engine/netx/netx_test.go
@@ -272,13 +272,6 @@ func TestNewTLSDialer(t *testing.T) {
 	})
 }
 
-func TestNewVanilla(t *testing.T) {
-	txp := NewHTTPTransport(Config{})
-	if _, ok := txp.(*netxlite.HTTPTransportWrapper); !ok {
-		t.Fatal("not the transport we expected")
-	}
-}
-
 func TestNewWithDialer(t *testing.T) {
 	expected := errors.New("mocked error")
 	dialer := &mocks.Dialer{
@@ -311,25 +304,7 @@ func TestNewWithByteCounter(t *testing.T) {
 	if bctxp.Counter != counter {
 		t.Fatal("not the byte counter we expected")
 	}
-	if _, ok := bctxp.HTTPTransport.(*netxlite.HTTPTransportWrapper); !ok {
-		t.Fatal("not the transport we expected")
-	}
-}
-
-func TestNewWithLogger(t *testing.T) {
-	txp := NewHTTPTransport(Config{
-		Logger: log.Log,
-	})
-	ltxp, ok := txp.(*netxlite.HTTPTransportLogger)
-	if !ok {
-		t.Fatal("not the transport we expected")
-	}
-	if ltxp.Logger != log.Log {
-		t.Fatal("not the logger we expected")
-	}
-	if _, ok := ltxp.HTTPTransport.(*netxlite.HTTPTransportWrapper); !ok {
-		t.Fatal("not the transport we expected")
-	}
+	// We are going to trust the underlying transport returned by netxlite
 }
 
 func TestNewWithSaver(t *testing.T) {
@@ -347,9 +322,7 @@ func TestNewWithSaver(t *testing.T) {
 	if stxptxp.Saver != saver {
 		t.Fatal("not the logger we expected")
 	}
-	if _, ok := stxptxp.HTTPTransport.(*netxlite.HTTPTransportWrapper); !ok {
-		t.Fatal("not the transport we expected")
-	}
+	// We are going to trust the underlying type returned by netxlite
 }
 
 func TestNewDNSClientInvalidURL(t *testing.T) {

--- a/internal/netxlite/http3.go
+++ b/internal/netxlite/http3.go
@@ -48,19 +48,16 @@ func (txp *http3Transport) CloseIdleConnections() {
 // then the code will use the default TLS configuration.
 func NewHTTP3Transport(
 	logger model.DebugLogger, dialer model.QUICDialer, tlsConfig *tls.Config) model.HTTPTransport {
-	return &httpTransportLogger{
-		HTTPTransport: &http3Transport{
-			child: &http3.RoundTripper{
-				Dial: dialer.DialContext,
-				// The following (1) reduces the number of headers that Go will
-				// automatically send for us and (2) ensures that we always receive
-				// back the true headers, such as Content-Length. This change is
-				// functional to OONI's goal of observing the network.
-				DisableCompression: true,
-				TLSClientConfig:    tlsConfig,
-			},
-			dialer: dialer,
+	return WrapHTTPTransport(logger, &http3Transport{
+		child: &http3.RoundTripper{
+			Dial: dialer.DialContext,
+			// The following (1) reduces the number of headers that Go will
+			// automatically send for us and (2) ensures that we always receive
+			// back the true headers, such as Content-Length. This change is
+			// functional to OONI's goal of observing the network.
+			DisableCompression: true,
+			TLSClientConfig:    tlsConfig,
 		},
-		Logger: logger,
-	}
+		dialer: dialer,
+	})
 }

--- a/internal/netxlite/http3_test.go
+++ b/internal/netxlite/http3_test.go
@@ -72,7 +72,8 @@ func TestNewHTTP3Transport(t *testing.T) {
 		if logger.Logger != log.Log {
 			t.Fatal("invalid logger")
 		}
-		h3txp := logger.HTTPTransport.(*http3Transport)
+		ew := logger.HTTPTransport.(*httpTransportErrWrapper)
+		h3txp := ew.HTTPTransport.(*http3Transport)
 		if h3txp.dialer != qd {
 			t.Fatal("invalid dialer")
 		}

--- a/internal/netxlite/legacy.go
+++ b/internal/netxlite/legacy.go
@@ -17,8 +17,6 @@ var (
 //
 // Deprecated: do not use these names in new code.
 type (
-	HTTPTransportWrapper           = httpTransportConnectionsCloser
-	HTTPTransportLogger            = httpTransportLogger
 	ErrorWrapperResolver           = resolverErrWrapper
 	ResolverSystemDoNotInstantiate = resolverSystem // instantiate => crash w/ nil transport
 	ResolverLogger                 = resolverLogger


### PR DESCRIPTION
1. Use the netxlite.NewHTTPTransport factory for creating a new
HTTP2 (and HTTP1) transport;

2. Recognize the netxlite.NewOOHTTPTransport has now become
an implementation detail so make it private;

3. Recognize that netxlite.NewHTTP3Transport should call
netxlite.WrapTransport so it returns the same typechain
returned by netxlite.NewHTTPTransport (modulo, of course,
the real underlying transport), so ensure that we are
calling netxlite.WrapTransport in NewHTTP3Transport;

4. Recognize that the table based constructor inside of
netx needs a logger to create HTTPTransport instances using
either netxlite.NewHTTP{,3}Transport so pass this argument
along and ensure it's not nil using a constructor inside
model that guarantees that;

5. Cleanup netx's tests to avoid type asserting on the
typechains returned by netxlite since we already test
that inside netxlite;

6. Recognize that now we can make more legacy names inside
of netxlite private because we don't need to use them
inside tests anymore (because of previous point).

Reference issue: https://github.com/ooni/probe/issues/2121
