### PR TITLE
cleanup(netxlite): drop the DefaultDialer legacy name

### DIFF
--- a/internal/cmd/oohelperd/internal/webconnectivity/webconnectivity_test.go
+++ b/internal/cmd/oohelperd/internal/webconnectivity/webconnectivity_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
@@ -51,7 +52,7 @@ const requestWithoutDomainName = `{
 func TestWorkingAsIntended(t *testing.T) {
 	handler := Handler{
 		Client:            http.DefaultClient,
-		Dialer:            netxlite.DefaultDialer,
+		Dialer:            netxlite.NewDialerWithStdlibResolver(model.DiscardLogger),
 		MaxAcceptableBody: 1 << 24,
 		Resolver:          netxlite.NewResolverSystem(),
 	}

--- a/internal/netxlite/dialer.go
+++ b/internal/netxlite/dialer.go
@@ -14,6 +14,14 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
 
+// NewDialerWithStdlibResolver is equivalent to creating a system resolver
+// using NewResolverStdlib and then a dialer using NewDialerWithResolver where
+// the resolver argument is the previously created resolver.
+func NewDialerWithStdlibResolver(dl model.DebugLogger) model.Dialer {
+	reso := NewResolverStdlib(dl)
+	return NewDialerWithResolver(dl, reso)
+}
+
 // NewDialerWithResolver is equivalent to calling WrapDialer with
 // the dialer argument being equal to &DialerSystem{}.
 func NewDialerWithResolver(dl model.DebugLogger, r model.Resolver, w ...model.DialerWrapper) model.Dialer {

--- a/internal/netxlite/dialer_test.go
+++ b/internal/netxlite/dialer_test.go
@@ -15,6 +15,24 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/model/mocks"
 )
 
+func TestNewDialerWithStdlibResolver(t *testing.T) {
+	dialer := NewDialerWithStdlibResolver(model.DiscardLogger)
+	logger := dialer.(*dialerLogger)
+	if logger.DebugLogger != model.DiscardLogger {
+		t.Fatal("invalid logger")
+	}
+	// typecheck the resolver
+	reso := logger.Dialer.(*dialerResolver)
+	typecheckForSystemResolver(t, reso.Resolver, model.DiscardLogger)
+	// typecheck the dialer
+	logger = reso.Dialer.(*dialerLogger)
+	if logger.DebugLogger != model.DiscardLogger {
+		t.Fatal("invalid logger")
+	}
+	errWrapper := logger.Dialer.(*dialerErrWrapper)
+	_ = errWrapper.Dialer.(*DialerSystem)
+}
+
 type extensionDialerFirst struct {
 	model.Dialer
 }

--- a/internal/netxlite/legacy.go
+++ b/internal/netxlite/legacy.go
@@ -8,7 +8,6 @@ package netxlite
 //
 // Deprecated: do not use these names in new code.
 var (
-	DefaultDialer     = &DialerSystem{}
 	NewResolverSystem = newResolverSystem
 	DefaultResolver   = newResolverSystem()
 )

--- a/internal/netxlite/resolvercore_test.go
+++ b/internal/netxlite/resolvercore_test.go
@@ -15,18 +15,22 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/model/mocks"
 )
 
-func TestNewResolverSystem(t *testing.T) {
-	resolver := NewResolverStdlib(log.Log)
+func typecheckForSystemResolver(t *testing.T, resolver model.Resolver, logger model.DebugLogger) {
 	idna := resolver.(*resolverIDNA)
-	logger := idna.Resolver.(*resolverLogger)
-	if logger.Logger != log.Log {
+	loggerReso := idna.Resolver.(*resolverLogger)
+	if loggerReso.Logger != logger {
 		t.Fatal("invalid logger")
 	}
-	shortCircuit := logger.Resolver.(*resolverShortCircuitIPAddr)
+	shortCircuit := loggerReso.Resolver.(*resolverShortCircuitIPAddr)
 	errWrapper := shortCircuit.Resolver.(*resolverErrWrapper)
 	reso := errWrapper.Resolver.(*resolverSystem)
 	txpErrWrapper := reso.t.(*dnsTransportErrWrapper)
 	_ = txpErrWrapper.DNSTransport.(*dnsOverGetaddrinfoTransport)
+}
+
+func TestNewResolverSystem(t *testing.T) {
+	resolver := NewResolverStdlib(model.DiscardLogger)
+	typecheckForSystemResolver(t, resolver, model.DiscardLogger)
 }
 
 func TestNewSerialResolverUDP(t *testing.T) {


### PR DESCRIPTION
Part of https://github.com/ooni/probe/issues/2121
