### PR TITLE
cleanup: move caching resolvers from netx to netxlite

### DIFF
--- a/internal/engine/netx/netx.go
+++ b/internal/engine/netx/netx.go
@@ -67,8 +67,8 @@ func NewResolver(config Config) model.Resolver {
 		model.ValidLoggerOrDefault(config.Logger),
 		config.BaseResolver,
 	)
-	r = MaybeWrapWithCachingResolver(config.CacheResolutions, r)
-	r = MaybeWrapWithStaticDNSCache(config.DNSCache, r)
+	r = netxlite.MaybeWrapWithCachingResolver(config.CacheResolutions, r)
+	r = netxlite.MaybeWrapWithStaticDNSCache(config.DNSCache, r)
 	r = netxlite.MaybeWrapWithBogonResolver(config.BogonIsError, r)
 	return config.Saver.WrapResolver(r) // WAI when config.Saver==nil
 }

--- a/internal/netxlite/bogon_test.go
+++ b/internal/netxlite/bogon_test.go
@@ -13,7 +13,7 @@ func TestMaybeWrapWithBogonResolver(t *testing.T) {
 	t.Run("with enabled equal to true", func(t *testing.T) {
 		underlying := &mocks.Resolver{}
 		reso := MaybeWrapWithBogonResolver(true, underlying)
-		bogoreso := reso.(*BogonResolver)
+		bogoreso := reso.(*bogonResolver)
 		if bogoreso.Resolver != underlying {
 			t.Fatal("did not wrap")
 		}
@@ -32,7 +32,7 @@ func TestBogonResolver(t *testing.T) {
 	t.Run("LookupHost", func(t *testing.T) {
 		t.Run("with failure", func(t *testing.T) {
 			expected := errors.New("mocked")
-			reso := &BogonResolver{
+			reso := &bogonResolver{
 				Resolver: &mocks.Resolver{
 					MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
 						return nil, expected
@@ -51,7 +51,7 @@ func TestBogonResolver(t *testing.T) {
 
 		t.Run("with success and no bogon", func(t *testing.T) {
 			expected := []string{"8.8.8.8", "149.112.112.112"}
-			reso := &BogonResolver{
+			reso := &bogonResolver{
 				Resolver: &mocks.Resolver{
 					MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
 						return expected, nil
@@ -69,7 +69,7 @@ func TestBogonResolver(t *testing.T) {
 		})
 
 		t.Run("with success and bogon", func(t *testing.T) {
-			reso := &BogonResolver{
+			reso := &bogonResolver{
 				Resolver: &mocks.Resolver{
 					MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
 						return []string{"8.8.8.8", "10.34.34.35", "149.112.112.112"}, nil
@@ -93,7 +93,7 @@ func TestBogonResolver(t *testing.T) {
 
 	t.Run("LookupHTTPS", func(t *testing.T) {
 		ctx := context.Background()
-		reso := &BogonResolver{}
+		reso := &bogonResolver{}
 		https, err := reso.LookupHTTPS(ctx, "dns.google")
 		if !errors.Is(err, ErrNoDNSTransport) {
 			t.Fatal("unexpected err", err)
@@ -105,7 +105,7 @@ func TestBogonResolver(t *testing.T) {
 
 	t.Run("LookupNS", func(t *testing.T) {
 		ctx := context.Background()
-		reso := &BogonResolver{}
+		reso := &bogonResolver{}
 		ns, err := reso.LookupNS(ctx, "dns.google")
 		if !errors.Is(err, ErrNoDNSTransport) {
 			t.Fatal("unexpected err", err)
@@ -117,7 +117,7 @@ func TestBogonResolver(t *testing.T) {
 
 	t.Run("Network", func(t *testing.T) {
 		expected := "antani"
-		reso := &BogonResolver{
+		reso := &bogonResolver{
 			Resolver: &mocks.Resolver{
 				MockNetwork: func() string {
 					return expected
@@ -131,7 +131,7 @@ func TestBogonResolver(t *testing.T) {
 
 	t.Run("Address", func(t *testing.T) {
 		expected := "antani"
-		reso := &BogonResolver{
+		reso := &bogonResolver{
 			Resolver: &mocks.Resolver{
 				MockAddress: func() string {
 					return expected
@@ -145,7 +145,7 @@ func TestBogonResolver(t *testing.T) {
 
 	t.Run("CloseIdleConnections", func(t *testing.T) {
 		var called bool
-		reso := &BogonResolver{
+		reso := &bogonResolver{
 			Resolver: &mocks.Resolver{
 				MockCloseIdleConnections: func() {
 					called = true

--- a/internal/netxlite/resolvercache.go
+++ b/internal/netxlite/resolvercache.go
@@ -1,4 +1,4 @@
-package netx
+package netxlite
 
 import (
 	"context"
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/ooni/probe-cli/v3/internal/model"
-	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
 // MaybeWrapWithCachingResolver wraps the provided resolver with a resolver
@@ -111,10 +110,10 @@ func (r *cacheResolver) CloseIdleConnections() {
 
 // LookupHTTPS implements model.Resolver.LookupHTTPS.
 func (r *cacheResolver) LookupHTTPS(ctx context.Context, domain string) (*model.HTTPSSvc, error) {
-	return nil, netxlite.ErrNoDNSTransport
+	return nil, ErrNoDNSTransport
 }
 
 // LookupNS implements model.Resolver.LookupNS.
 func (r *cacheResolver) LookupNS(ctx context.Context, domain string) ([]*net.NS, error) {
-	return nil, netxlite.ErrNoDNSTransport
+	return nil, ErrNoDNSTransport
 }

--- a/internal/netxlite/resolvercache_test.go
+++ b/internal/netxlite/resolvercache_test.go
@@ -1,4 +1,4 @@
-package netx
+package netxlite
 
 import (
 	"context"
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/ooni/probe-cli/v3/internal/model/mocks"
-	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
 func TestMaybeWrapWithCachingResolver(t *testing.T) {
@@ -184,7 +183,7 @@ func TestCacheResolver(t *testing.T) {
 		t.Run("LookupHTTPS", func(t *testing.T) {
 			reso := &cacheResolver{}
 			https, err := reso.LookupHTTPS(context.Background(), "dns.google")
-			if !errors.Is(err, netxlite.ErrNoDNSTransport) {
+			if !errors.Is(err, ErrNoDNSTransport) {
 				t.Fatal("unexpected err", err)
 			}
 			if https != nil {
@@ -195,7 +194,7 @@ func TestCacheResolver(t *testing.T) {
 		t.Run("LookupNS", func(t *testing.T) {
 			reso := &cacheResolver{}
 			ns, err := reso.LookupNS(context.Background(), "dns.google")
-			if !errors.Is(err, netxlite.ErrNoDNSTransport) {
+			if !errors.Is(err, ErrNoDNSTransport) {
 				t.Fatal("unexpected err", err)
 			}
 			if len(ns) != 0 {


### PR DESCRIPTION
Now that we have properly refactored the caching resolvers we can
move them into netxlite as optional resolvers created using the
proper abstract factories we just added.

This diff reduces the complexity and the code size of netx.

See https://github.com/ooni/probe/issues/2121.
