### PR TITLE
[forwardport] fix(stunreachability): don't emit spurious progress events

### DIFF
--- a/internal/engine/experiment/stunreachability/stunreachability.go
+++ b/internal/engine/experiment/stunreachability/stunreachability.go
@@ -6,7 +6,6 @@ package stunreachability
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net"
 	"net/url"
 	"time"
@@ -108,9 +107,6 @@ func (tk *TestKeys) run(
 	measurement *model.Measurement, callbacks model.ExperimentCallbacks,
 	endpoint string,
 ) error {
-	callbacks.OnProgress(0, fmt.Sprintf("stunreachability: measuring: %s...", endpoint))
-	defer callbacks.OnProgress(
-		1, fmt.Sprintf("stunreachability: measuring: %s... done", endpoint))
 	tk.Endpoint = endpoint
 	saver := new(tracex.Saver)
 	begin := time.Now()
@@ -120,6 +116,7 @@ func (tk *TestKeys) run(
 		ReadWriteSaver:      saver,
 		Saver:               saver,
 	}), endpoint)
+	sess.Logger().Infof("stunreachability: measuring: %s... %s", endpoint, model.ErrorToStringOrOK(err))
 	events := saver.Read()
 	tk.NetworkEvents = append(
 		tk.NetworkEvents, tracex.NewNetworkEventsList(begin, events)...,

--- a/internal/engine/experiment/stunreachability/stunreachability_test.go
+++ b/internal/engine/experiment/stunreachability/stunreachability_test.go
@@ -94,7 +94,9 @@ func TestRunWithInput(t *testing.T) {
 	measurement.Input = model.MeasurementTarget(defaultInput)
 	err := measurer.Run(
 		context.Background(),
-		&mockable.Session{},
+		&mockable.Session{
+			MockableLogger: model.DiscardLogger,
+		},
 		measurement,
 		model.NewPrinterCallbacks(log.Log),
 	)
@@ -124,7 +126,9 @@ func TestCancelledContext(t *testing.T) {
 	measurement.Input = model.MeasurementTarget(defaultInput)
 	err := measurer.Run(
 		ctx,
-		&mockable.Session{},
+		&mockable.Session{
+			MockableLogger: model.DiscardLogger,
+		},
 		measurement,
 		model.NewPrinterCallbacks(log.Log),
 	)
@@ -164,7 +168,9 @@ func TestNewClientFailure(t *testing.T) {
 	measurement.Input = model.MeasurementTarget(defaultInput)
 	err := measurer.Run(
 		context.Background(),
-		&mockable.Session{},
+		&mockable.Session{
+			MockableLogger: model.DiscardLogger,
+		},
 		measurement,
 		model.NewPrinterCallbacks(log.Log),
 	)
@@ -198,7 +204,9 @@ func TestStartFailure(t *testing.T) {
 	measurement.Input = model.MeasurementTarget(defaultInput)
 	err := measurer.Run(
 		context.Background(),
-		&mockable.Session{},
+		&mockable.Session{
+			MockableLogger: model.DiscardLogger,
+		},
 		measurement,
 		model.NewPrinterCallbacks(log.Log),
 	)
@@ -236,7 +244,9 @@ func TestReadFailure(t *testing.T) {
 	measurement.Input = model.MeasurementTarget(defaultInput)
 	err := measurer.Run(
 		context.Background(),
-		&mockable.Session{},
+		&mockable.Session{
+			MockableLogger: model.DiscardLogger,
+		},
 		measurement,
 		model.NewPrinterCallbacks(log.Log),
 	)


### PR DESCRIPTION
This diff forward ports 4fb5f7de69b900cfc2bd211f723108a67bda350d to master.

See https://github.com/ooni/probe/issues/2058#issuecomment-1145847069

This diff WILL need to be forwardported to master.
