### PR TITLE
[forwardport] fix(dnscheck): remove apparently-broken static input

### DIFF
--- a/internal/engine/inputloader.go
+++ b/internal/engine/inputloader.go
@@ -212,7 +212,6 @@ var dnsCheckDefaultInput = []string{
 	"dot://doh.appliedprivacy.ne/dns-query",
 	"https://dnsnl.alekberg.net/dns-query",
 	"https://query.hdns.io/dns-query",
-	"dot://query.hdns.io/dns-query",
 	"https://jp.tiar.app/dns-query",
 	"dot://jp.tiar.app/dns-query",
 	"https://dns.dnshome.de/dns-query",


### PR DESCRIPTION
This diff forward ports 261d1a4cdc88522f6a8f63d6c540f51054566b28 to master.

It's not working for me from a couple of places and also it does not
seem to be documented upstream, see:

https://docs.namebase.io/guides-1/resolving-handshake-1/hdns.io

This diff WILL need to be forwardported to master.
