### PR TITLE
refactor(oohelper): use netxlite rather than netx

### DIFF
--- a/internal/cmd/oohelper/internal/client.go
+++ b/internal/cmd/oohelper/internal/client.go
@@ -45,7 +45,7 @@ type Resolver interface {
 // OOClient is a client for the OONI Web Connectivity test helper.
 type OOClient struct {
 	// HTTPClient is the HTTP client to use.
-	HTTPClient *http.Client
+	HTTPClient model.HTTPClient
 
 	// Resolver is the resolver to user.
 	Resolver Resolver

--- a/internal/netxlite/http.go
+++ b/internal/netxlite/http.go
@@ -332,6 +332,11 @@ func NewHTTPTransportStdlib(logger model.DebugLogger) model.HTTPTransport {
 // standard library for TLS and DNS resolutions.
 func NewHTTPClientStdlib(logger model.DebugLogger) model.HTTPClient {
 	txp := NewHTTPTransportStdlib(logger)
+	return NewHTTPClient(txp)
+}
+
+// NewHTTPClient creates a new, wrapped HTTPClient using the given transport.
+func NewHTTPClient(txp model.HTTPTransport) model.HTTPClient {
 	return WrapHTTPClient(&http.Client{Transport: txp})
 }
 


### PR DESCRIPTION
The oohelper does not need to use netx and it's enough to use
netxlite, hence let us apply this refactor.

The original code used DoT but the explanatory comment said we were
using DoT because of unclear issues inside GitHub actions.

We are now using DoH and this is fine as well. The comment implied
that any encrypted transport would do.

See https://github.com/ooni/probe/issues/2121
