### PR TITLE
refactor(oohelperd): use netxlite rather than netx

### DIFF
--- a/internal/cmd/oohelperd/internal/webconnectivity/http.go
+++ b/internal/cmd/oohelperd/internal/webconnectivity/http.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/webconnectivity"
+	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/tracex"
 )
@@ -18,7 +19,7 @@ type CtrlHTTPResponse = webconnectivity.ControlHTTPRequestResult
 
 // HTTPConfig configures the HTTP check.
 type HTTPConfig struct {
-	Client            *http.Client
+	Client            model.HTTPClient
 	Headers           map[string][]string
 	MaxAcceptableBody int64
 	Out               chan CtrlHTTPResponse

--- a/internal/cmd/oohelperd/internal/webconnectivity/measure.go
+++ b/internal/cmd/oohelperd/internal/webconnectivity/measure.go
@@ -3,7 +3,6 @@ package webconnectivity
 import (
 	"context"
 	"net"
-	"net/http"
 	"net/url"
 	"sync"
 
@@ -21,7 +20,7 @@ type (
 
 // MeasureConfig contains configuration for Measure.
 type MeasureConfig struct {
-	Client            *http.Client
+	Client            model.HTTPClient
 	Dialer            model.Dialer
 	MaxAcceptableBody int64
 	Resolver          model.Resolver

--- a/internal/cmd/oohelperd/internal/webconnectivity/webconnectivity.go
+++ b/internal/cmd/oohelperd/internal/webconnectivity/webconnectivity.go
@@ -14,7 +14,7 @@ import (
 
 // Handler implements the Web Connectivity test helper HTTP API.
 type Handler struct {
-	Client            *http.Client
+	Client            model.HTTPClient
 	Dialer            model.Dialer
 	MaxAcceptableBody int64
 	Resolver          model.Resolver


### PR DESCRIPTION
The oohelperd implementation did not actually need using netx because
it was just constructing default types with logging, which is what
netxlite already does. Hence, let's avoid using netx here.

See https://github.com/ooni/probe/issues/2121

