### PR TITLE
refactor: start refactoring session resolver

### DIFF
--- a/internal/engine/internal/sessionresolver/clientmaker.go
+++ b/internal/engine/internal/sessionresolver/clientmaker.go
@@ -1,11 +1,14 @@
 package sessionresolver
 
-import "github.com/ooni/probe-cli/v3/internal/engine/netx"
+import (
+	"github.com/ooni/probe-cli/v3/internal/engine/netx"
+	"github.com/ooni/probe-cli/v3/internal/model"
+)
 
 // dnsclientmaker makes a new resolver.
 type dnsclientmaker interface {
 	// Make makes a new resolver.
-	Make(config netx.Config, URL string) (childResolver, error)
+	Make(config netx.Config, URL string) (model.Resolver, error)
 }
 
 // clientmaker returns a valid dnsclientmaker
@@ -20,6 +23,6 @@ func (r *Resolver) clientmaker() dnsclientmaker {
 type defaultDNSClientMaker struct{}
 
 // Make implements dnsclientmaker.Make.
-func (*defaultDNSClientMaker) Make(config netx.Config, URL string) (childResolver, error) {
+func (*defaultDNSClientMaker) Make(config netx.Config, URL string) (model.Resolver, error) {
 	return netx.NewDNSClient(config, URL)
 }

--- a/internal/engine/internal/sessionresolver/clientmaker_test.go
+++ b/internal/engine/internal/sessionresolver/clientmaker_test.go
@@ -7,16 +7,17 @@ import (
 	"testing"
 
 	"github.com/ooni/probe-cli/v3/internal/engine/netx"
+	"github.com/ooni/probe-cli/v3/internal/model"
 )
 
 type fakeDNSClientMaker struct {
-	reso        childResolver
+	reso        model.Resolver
 	err         error
 	savedConfig netx.Config
 	savedURL    string
 }
 
-func (c *fakeDNSClientMaker) Make(config netx.Config, URL string) (childResolver, error) {
+func (c *fakeDNSClientMaker) Make(config netx.Config, URL string) (model.Resolver, error) {
 	c.savedConfig = config
 	c.savedURL = URL
 	return c.reso, c.err

--- a/internal/engine/internal/sessionresolver/sessionresolver.go
+++ b/internal/engine/internal/sessionresolver/sessionresolver.go
@@ -95,7 +95,7 @@ type Resolver struct {
 	// res maps a URL to a child resolver. We will
 	// construct child resolvers just once and we
 	// will track them into this field.
-	res map[string]childResolver
+	res map[string]model.Resolver
 }
 
 // CloseIdleConnections closes the idle connections, if any. This
@@ -169,7 +169,7 @@ func (r *Resolver) lookupHost(ctx context.Context, ri *resolverinfo, hostname st
 		ri.Score = 0 // this is a hard error
 		return nil, err
 	}
-	addrs, err := r.timeLimitedLookup(ctx, re, hostname)
+	addrs, err := timeLimitedLookup(ctx, re, hostname)
 	if err == nil {
 		r.logger().Infof("sessionresolver: %s... %v", ri.URL, model.ErrorToStringOrOK(nil))
 		ri.Score = ewma*1.0 + (1-ewma)*ri.Score // increase score

--- a/internal/engine/internal/sessionresolver/sessionresolver_test.go
+++ b/internal/engine/internal/sessionresolver/sessionresolver_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/ooni/probe-cli/v3/internal/atomicx"
 	"github.com/ooni/probe-cli/v3/internal/kvstore"
+	"github.com/ooni/probe-cli/v3/internal/model/mocks"
 	"github.com/ooni/probe-cli/v3/internal/multierror"
 )
 
@@ -85,7 +86,11 @@ func TestTypicalUsageWithSuccess(t *testing.T) {
 	reso := &Resolver{
 		KVStore: &kvstore.Memory{},
 		dnsClientMaker: &fakeDNSClientMaker{
-			reso: &FakeResolver{Data: expected},
+			reso: &mocks.Resolver{
+				MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
+					return expected, nil
+				},
+			},
 		},
 	}
 	addrs, err := reso.LookupHost(ctx, "dns.google")
@@ -117,7 +122,11 @@ func TestLittleLLookupHostWithSuccess(t *testing.T) {
 	expected := []string{"8.8.8.8", "8.8.4.4"}
 	reso := &Resolver{
 		dnsClientMaker: &fakeDNSClientMaker{
-			reso: &FakeResolver{Data: expected},
+			reso: &mocks.Resolver{
+				MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
+					return expected, nil
+				},
+			},
 		},
 	}
 	ctx := context.Background()
@@ -138,7 +147,11 @@ func TestLittleLLookupHostWithFailure(t *testing.T) {
 	errMocked := errors.New("mocked error")
 	reso := &Resolver{
 		dnsClientMaker: &fakeDNSClientMaker{
-			reso: &FakeResolver{Err: errMocked},
+			reso: &mocks.Resolver{
+				MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
+					return nil, errMocked
+				},
+			},
 		},
 	}
 	ctx := context.Background()


### PR DESCRIPTION
This diff addresses the following points of https://github.com/ooni/probe/issues/2135:

- [x] the `childResolver` type is useless and we can use `model.Resolver` directly;
- [x] we should use `model/mocks` instead of custom fakes;
- [x] we should not use `log.Log` rather we should use `model.DiscardLogger`;
- [x] make `timeLimitedLookup` easier to test with a `-short` tests;
- [x] ensure `timeLimitedLookup` returns as soon as its context expires regardless of the child resolver;

Subsequent diffs will address more points mentioned in there.
