### PR TITLE
cleanup: use NewHTTPTransportWithResolver more often

### DIFF
--- a/internal/cmd/oohelper/oohelper.go
+++ b/internal/cmd/oohelper/oohelper.go
@@ -29,10 +29,7 @@ func init() {
 	// puzzling https://github.com/ooni/probe/issues/1409 issue.
 	const resolverURL = "https://8.8.8.8/dns-query"
 	resolver = netxlite.NewParallelDNSOverHTTPSResolver(log.Log, resolverURL)
-	thx := netxlite.NewTLSHandshakerStdlib(log.Log)
-	dialer := netxlite.NewDialerWithResolver(log.Log, resolver)
-	tlsDialer := netxlite.NewTLSDialer(dialer, thx)
-	txp := netxlite.NewHTTPTransport(log.Log, dialer, tlsDialer)
+	txp := netxlite.NewHTTPTransportWithResolver(log.Log, resolver)
 	httpClient = netxlite.NewHTTPClient(txp)
 }
 

--- a/internal/cmd/oohelperd/oohelperd.go
+++ b/internal/cmd/oohelperd/oohelperd.go
@@ -32,10 +32,7 @@ func init() {
 	// default resolver configured by the box. Also, use an encrypted transport thus
 	// we're less vulnerable to any policy implemented by the box's provider.
 	resolver = netxlite.NewParallelDNSOverHTTPSResolver(log.Log, "https://8.8.8.8/dns-query")
-	thx := netxlite.NewTLSHandshakerStdlib(log.Log)
-	dialer = netxlite.NewDialerWithResolver(log.Log, resolver)
-	tlsDialer := netxlite.NewTLSDialer(dialer, thx)
-	txp := netxlite.NewHTTPTransport(log.Log, dialer, tlsDialer)
+	txp := netxlite.NewHTTPTransportWithResolver(log.Log, resolver)
 	httpClient = netxlite.NewHTTPClient(txp)
 }
 

--- a/internal/engine/geolocate/iplookup.go
+++ b/internal/engine/geolocate/iplookup.go
@@ -86,10 +86,7 @@ func (c ipLookupClient) doWithCustomFunc(
 	// Implementation note: we MUST use an HTTP client that we're
 	// sure IS NOT using any proxy. To this end, we construct a
 	// client ourself that we know is not proxied.
-	dialer := netxlite.NewDialerWithResolver(c.Logger, c.Resolver)
-	handshaker := netxlite.NewTLSHandshakerStdlib(c.Logger)
-	tlsDialer := netxlite.NewTLSDialer(dialer, handshaker)
-	txp := netxlite.NewHTTPTransport(c.Logger, dialer, tlsDialer)
+	txp := netxlite.NewHTTPTransportWithResolver(c.Logger, c.Resolver)
 	clnt := &http.Client{Transport: txp}
 	defer clnt.CloseIdleConnections()
 	ip, err := fn(ctx, clnt, c.Logger, c.UserAgent)


### PR DESCRIPTION
We can simplify code in a bunch of places using a useful factory.

Part of https://github.com/ooni/probe/issues/2121.