### PR TITLE
fix(oonimkall): only set annotations on success

### DIFF
--- a/pkg/oonimkall/taskrunner.go
+++ b/pkg/oonimkall/taskrunner.go
@@ -291,7 +291,6 @@ func (r *runnerForTask) Run(rootCtx context.Context) {
 			// submit measurement and stop at beginning of next iteration
 			break
 		}
-		m.AddAnnotations(r.settings.Annotations)
 		if err != nil {
 			r.emitter.Emit(eventTypeFailureMeasurement, eventMeasurementGeneric{
 				Failure: err.Error(),
@@ -304,6 +303,7 @@ func (r *runnerForTask) Run(rootCtx context.Context) {
 			// now the only valid strategy here is to continue.
 			continue
 		}
+		m.AddAnnotations(r.settings.Annotations)
 		data, err := json.Marshal(m)
 		runtimex.PanicOnError(err, "measurement.MarshalJSON failed")
 		r.emitter.Emit(eventTypeMeasurement, eventMeasurementGeneric{


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2173
- [x] if you changed anything related how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A

## Description

This bug is one of these bugs that definitely help one to stay
humble and focused on improving the codebase.

Of course I `<facepalmed>` when I understood the root cause.

We did not move the annotations below the `if` which is checking
whether the measurement was successful when we refactored the
codebase to support returning multiple measurements per run, which
happened in https://github.com/ooni/probe-cli/pull/527.

While I am not going to whip myself too much because of this, it's
clearly a bummer that we didn't notice this bug back then. On top
of this, it's also quite sad it took us so much time to notice that
there was this bug inside the tree.

The lesson (hopefully) learned is probably that we need to be more
careful when we refactor and we should always ask the question of
whether, not only we have tests, but whether these tests could maybe
be improved to give us even more confidence about correctness.

