### PR TITLE
[backport] fix(workflows): elevate GITHUB_TOKEN permissions when needed

### DIFF
--- a/.github/workflows/alltests.yml
+++ b/.github/workflows/alltests.yml
@@ -1,9 +1,10 @@
-# alltests runs the whole test suite
+# Runs the whole test suite
 name: alltests
 on:
   push:
     branches:
       - "release/**"
+
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,4 +1,4 @@
-# android checks whether we can build for Android
+# Builds and publishes Android packages
 name: android
 on:
   push:
@@ -10,6 +10,9 @@ on:
 jobs:
   build_and_publish:
     runs-on: ubuntu-20.04
+    permissions: # See https://github.com/ooni/probe/issues/2154
+      contents: write
+
     steps:
       - uses: actions/setup-go@v1
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,10 +1,11 @@
-# performs several code quality checks
+# Performs code quality checks
 name: checks
 on:
   pull_request:
   push:
     branches:
       - "master"
+
 jobs:
   perform_code_quality_checks:
     runs-on: "${{ matrix.os }}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,10 +1,4 @@
-# CodeQL runs a CodeQL scan.
-#
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
+# Runs a CodeQL scan.
 name: "CodeQL"
 
 on:
@@ -17,6 +11,8 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-20.04
+    permissions: # See https://github.com/ooni/probe/issues/2154
+      security-events: write
 
     strategy:
       fail-fast: false
@@ -27,31 +23,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+      uses: github/codeql-action/autobuild@v2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,4 @@
-# runs tests and computes the code coverage
+# Runs tests and computes the code coverage
 name: coverage
 on:
   pull_request:
@@ -6,8 +6,8 @@ on:
     branches:
       - "master"
       - "release/**"
-jobs:
 
+jobs:
   measure_coverage:
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/debianrepo.yml
+++ b/.github/workflows/debianrepo.yml
@@ -1,4 +1,4 @@
-# debianrepo ensures we can install on debian with the official build instructions
+# Ensures we can install on debian with the official build instructions
 name: debianrepo
 on:
   push:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,9 +1,10 @@
-# generate verifies that `go generate ./...` is not broken
+# Verifies that `go generate ./...` is not broken
 name: generate
 on:
   push:
     branches:
       - "release/**"
+
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,4 +1,4 @@
-# ios checks whether we can build for iOS
+# Builds for iOS and publishes packages
 name: ios
 on:
   push:
@@ -10,6 +10,9 @@ on:
 jobs:
   build_and_publish:
     runs-on: macos-10.15
+    permissions: # See https://github.com/ooni/probe/issues/2154
+      contents: write
+
     steps:
       - uses: actions/setup-go@v1
         with:

--- a/.github/workflows/jafar.yml
+++ b/.github/workflows/jafar.yml
@@ -1,9 +1,10 @@
-# jafar checks whether the jafar tool is still WAI.
+# Checks whether the jafar tool is still WAI.
 name: jafar
 on:
   push:
     branches:
       - "release/**"
+
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,4 +1,4 @@
-# linux builds and publishes ooniprobe for Linux
+# Builds and publishes ooniprobe for Linux
 name: linux
 on:
   push:
@@ -10,6 +10,8 @@ on:
 jobs:
   build_and_publish_386:
     runs-on: "ubuntu-20.04"
+    permissions: # See https://github.com/ooni/probe/issues/2154
+      contents: write
     steps:
       - uses: actions/checkout@v2
         with:
@@ -33,6 +35,8 @@ jobs:
 
   build_and_publish_amd64:
     runs-on: "ubuntu-20.04"
+    permissions: # See https://github.com/ooni/probe/issues/2154
+      contents: write
     steps:
       - uses: actions/checkout@v2
         with:
@@ -55,6 +59,8 @@ jobs:
 
   build_and_publish_armv7:
     runs-on: "ubuntu-20.04"
+    permissions: # See https://github.com/ooni/probe/issues/2154
+      contents: write
     steps:
       - uses: actions/checkout@v2
         with:
@@ -79,6 +85,8 @@ jobs:
 
   build_and_publish_arm64:
     runs-on: "ubuntu-20.04"
+    permissions: # See https://github.com/ooni/probe/issues/2154
+      contents: write
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-# macos builds ooniprobe for macos
+# Builds ooniprobe for macos
 name: macos
 on:
   push:
@@ -10,6 +10,8 @@ on:
 jobs:
   build_and_publish:
     runs-on: "macos-11"
+    permissions: # See https://github.com/ooni/probe/issues/2154
+      contents: write
     steps:
       - uses: actions/setup-go@v1
         with:

--- a/.github/workflows/miniooni.yml
+++ b/.github/workflows/miniooni.yml
@@ -1,4 +1,4 @@
-# miniooni checks whether we can build the research client miniooni
+# This workflow checks whether we can build the research client miniooni
 # and publishes the linux binaries as artifacts and, if we're building
 # a tag, into the current release. We don't publish artifacts for
 # Windows and macOS because they're not signed. For releases, we have
@@ -15,6 +15,8 @@ on:
 jobs:
   build_and_publish:
     runs-on: ubuntu-20.04
+    permissions: # See https://github.com/ooni/probe/issues/2154
+      contents: write
     steps:
 
       - uses: actions/setup-go@v1
@@ -39,14 +41,17 @@ jobs:
         with:
           name: miniooni-linux-386
           path: ./CLI/miniooni-linux-386
+
       - uses: actions/upload-artifact@v1
         with:
           name: miniooni-linux-amd64
           path: ./CLI/miniooni-linux-amd64
+
       - uses: actions/upload-artifact@v1
         with:
           name: miniooni-linux-armv7
           path: ./CLI/miniooni-linux-armv7
+
       - uses: actions/upload-artifact@v1
         with:
           name: miniooni-linux-arm64

--- a/.github/workflows/netxlite.yml
+++ b/.github/workflows/netxlite.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - "master"
+      - "release/**"
+
 jobs:
   test_netxlite_package:
     runs-on: "${{ matrix.os }}"

--- a/.github/workflows/oohelperd.yml
+++ b/.github/workflows/oohelperd.yml
@@ -1,4 +1,4 @@
-# oohelperd builds and publishes oohelperd for Linux
+# Builds and publishes oohelperd for Linux
 name: oohelperd
 on:
   push:
@@ -10,6 +10,8 @@ on:
 jobs:
   build_and_publish:
     runs-on: "ubuntu-20.04"
+    permissions: # See https://github.com/ooni/probe/issues/2154
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1

--- a/.github/workflows/qafbmessenger.yml
+++ b/.github/workflows/qafbmessenger.yml
@@ -1,9 +1,10 @@
-# qafbmessenger runs QA checks for the fbmessenger experiment
+# Runs QA checks for the fbmessenger experiment
 name: "qafbmessenger"
 on:
   push:
     branches:
       - "release/**"
+
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/qahhfm.yml
+++ b/.github/workflows/qahhfm.yml
@@ -1,9 +1,10 @@
-# qahhfm runs QA checks for the hhfm experiment
+# Runs QA checks for the hhfm experiment
 name: "qahhfm"
 on:
   push:
     branches:
       - "release/**"
+
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/qahirl.yml
+++ b/.github/workflows/qahirl.yml
@@ -1,9 +1,10 @@
-# qahirl runs QA checks for the hirl experiment
+# Runs QA checks for the hirl experiment
 name: "qahirl"
 on:
   push:
     branches:
       - "release/**"
+
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/qatelegram.yml
+++ b/.github/workflows/qatelegram.yml
@@ -1,9 +1,10 @@
-# qatelegram runs QA checks for the telegram experiment
+# Runs QA checks for the telegram experiment
 name: "qatelegram"
 on:
   push:
     branches:
       - "release/**"
+
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/qawebconnectivity.yml
+++ b/.github/workflows/qawebconnectivity.yml
@@ -1,9 +1,10 @@
-# qawebconnectivity runs QA checks for the webconnectivity experiment
+# Runs QA checks for the webconnectivity experiment
 name: "qawebconnectivity"
 on:
   push:
     branches:
       - "release/**"
+
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/qawhatsapp.yml
+++ b/.github/workflows/qawhatsapp.yml
@@ -1,9 +1,10 @@
-# qawhatsapp runs QA checks for the whatsapp experiment
+# Runs QA checks for the whatsapp experiment
 name: "qawhatsapp"
 on:
   push:
     branches:
       - "release/**"
+
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -1,4 +1,4 @@
-# vendors Go modules and publishes tarball
+# Vendors Go modules and publishes tarball
 name: tarball
 on:
   push:
@@ -8,6 +8,9 @@ on:
 jobs:
   generate_tarball:
     runs-on: "ubuntu-20.04"
+    permissions: # See https://github.com/ooni/probe/issues/2154
+      contents: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,4 @@
-# windows builds ooniprobe for Windows
+# Builds ooniprobe for Windows and publishes binaries.
 name: windows
 on:
   push:
@@ -37,6 +37,8 @@ jobs:
   test:
     needs: build
     runs-on: "windows-2019"
+    permissions: # See https://github.com/ooni/probe/issues/2154
+      actions: read
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -47,6 +49,10 @@ jobs:
   publish:
     needs: test
     runs-on: "ubuntu-20.04"
+    permissions: # See https://github.com/ooni/probe/issues/2154
+      contents: write
+      actions: read
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
This diff backports 937f6e29043dbdab65fe663963e209afa66bddac from
the `master` branch. Original commit message follows:

- - -

I am not 100% sure I was able to fix all the cases in which we
need higher permissions than the strict default.

At least, I tried.

It may be reasonable to make an interim release to check whether I
successfully fixed all the cases.

Ref issue: https://github.com/ooni/probe/issues/2154

- - -

Conflicts:
	.github/workflows/android.yml
	.github/workflows/gosec.yml
	.github/workflows/netxlite.yml
