### PR TITLE
fix(oohelperd): use throw-away HTTPClient, Dialer, Resolver

### DIFF
--- a/internal/cmd/oohelperd/internal/webconnectivity/http.go
+++ b/internal/cmd/oohelperd/internal/webconnectivity/http.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/webconnectivity"
 	"github.com/ooni/probe-cli/v3/internal/engine/netx/archival"
+	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
@@ -18,9 +19,9 @@ type CtrlHTTPResponse = webconnectivity.ControlHTTPRequestResult
 
 // HTTPConfig configures the HTTP check.
 type HTTPConfig struct {
-	Client            *http.Client
 	Headers           map[string][]string
 	MaxAcceptableBody int64
+	NewClient         func() model.HTTPClient
 	Out               chan CtrlHTTPResponse
 	URL               string
 	Wg                *sync.WaitGroup
@@ -49,7 +50,9 @@ func HTTPDo(ctx context.Context, config *HTTPConfig) {
 			}
 		}
 	}
-	resp, err := config.Client.Do(req)
+	clnt := config.NewClient()
+	defer clnt.CloseIdleConnections()
+	resp, err := clnt.Do(req)
 	if err != nil {
 		config.Out <- CtrlHTTPResponse{ // fix: emit -1 like old test helper does
 			BodyLength: -1,

--- a/internal/cmd/oohelperd/internal/webconnectivity/measure.go
+++ b/internal/cmd/oohelperd/internal/webconnectivity/measure.go
@@ -3,7 +3,6 @@ package webconnectivity
 import (
 	"context"
 	"net"
-	"net/http"
 	"net/url"
 	"sync"
 
@@ -21,10 +20,10 @@ type (
 
 // MeasureConfig contains configuration for Measure.
 type MeasureConfig struct {
-	Client            *http.Client
-	Dialer            model.Dialer
 	MaxAcceptableBody int64
-	Resolver          model.Resolver
+	NewClient         func() model.HTTPClient
+	NewDialer         func() model.Dialer
+	NewResolver       func() model.Resolver
 }
 
 // Measure performs the measurement described by the request and
@@ -41,10 +40,10 @@ func Measure(ctx context.Context, config MeasureConfig, creq *CtrlRequest) (*Ctr
 	if net.ParseIP(URL.Hostname()) == nil {
 		wg.Add(1)
 		go DNSDo(ctx, &DNSConfig{
-			Domain:   URL.Hostname(),
-			Out:      dnsch,
-			Resolver: config.Resolver,
-			Wg:       wg,
+			Domain:      URL.Hostname(),
+			NewResolver: config.NewResolver,
+			Out:         dnsch,
+			Wg:          wg,
 		})
 	}
 	// tcpconnect: start
@@ -52,19 +51,19 @@ func Measure(ctx context.Context, config MeasureConfig, creq *CtrlRequest) (*Ctr
 	for _, endpoint := range creq.TCPConnect {
 		wg.Add(1)
 		go TCPDo(ctx, &TCPConfig{
-			Dialer:   config.Dialer,
-			Endpoint: endpoint,
-			Out:      tcpconnch,
-			Wg:       wg,
+			Endpoint:  endpoint,
+			NewDialer: config.NewDialer,
+			Out:       tcpconnch,
+			Wg:        wg,
 		})
 	}
 	// http: start
 	httpch := make(chan CtrlHTTPResponse, 1)
 	wg.Add(1)
 	go HTTPDo(ctx, &HTTPConfig{
-		Client:            config.Client,
 		Headers:           creq.HTTPRequestHeaders,
 		MaxAcceptableBody: config.MaxAcceptableBody,
+		NewClient:         config.NewClient,
 		Out:               httpch,
 		URL:               creq.HTTPRequest,
 		Wg:                wg,

--- a/internal/cmd/oohelperd/internal/webconnectivity/tcpconnect.go
+++ b/internal/cmd/oohelperd/internal/webconnectivity/tcpconnect.go
@@ -20,16 +20,18 @@ type TCPResultPair struct {
 
 // TCPConfig configures the TCP connect check.
 type TCPConfig struct {
-	Dialer   model.Dialer
-	Endpoint string
-	Out      chan TCPResultPair
-	Wg       *sync.WaitGroup
+	Endpoint  string
+	NewDialer func() model.Dialer
+	Out       chan TCPResultPair
+	Wg        *sync.WaitGroup
 }
 
 // TCPDo performs the TCP check.
 func TCPDo(ctx context.Context, config *TCPConfig) {
 	defer config.Wg.Done()
-	conn, err := config.Dialer.DialContext(ctx, "tcp", config.Endpoint)
+	dialer := config.NewDialer()
+	defer dialer.CloseIdleConnections()
+	conn, err := dialer.DialContext(ctx, "tcp", config.Endpoint)
 	if conn != nil {
 		conn.Close()
 	}

--- a/internal/cmd/oohelperd/internal/webconnectivity/webconnectivity.go
+++ b/internal/cmd/oohelperd/internal/webconnectivity/webconnectivity.go
@@ -14,10 +14,10 @@ import (
 
 // Handler implements the Web Connectivity test helper HTTP API.
 type Handler struct {
-	Client            *http.Client
-	Dialer            model.Dialer
 	MaxAcceptableBody int64
-	Resolver          model.Resolver
+	NewClient         func() model.HTTPClient
+	NewDialer         func() model.Dialer
+	NewResolver       func() model.Resolver
 }
 
 func (h Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {

--- a/internal/cmd/oohelperd/internal/webconnectivity/webconnectivity_test.go
+++ b/internal/cmd/oohelperd/internal/webconnectivity/webconnectivity_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
@@ -50,10 +51,16 @@ const requestWithoutDomainName = `{
 
 func TestWorkingAsIntended(t *testing.T) {
 	handler := Handler{
-		Client:            http.DefaultClient,
-		Dialer:            netxlite.DefaultDialer,
 		MaxAcceptableBody: 1 << 24,
-		Resolver:          &netxlite.ResolverSystem{},
+		NewClient: func() model.HTTPClient {
+			return http.DefaultClient
+		},
+		NewDialer: func() model.Dialer {
+			return netxlite.DefaultDialer
+		},
+		NewResolver: func() model.Resolver {
+			return &netxlite.ResolverSystem{}
+		},
 	}
 	srv := httptest.NewServer(handler)
 	defer srv.Close()

--- a/internal/cmd/oohelperd/oohelperd.go
+++ b/internal/cmd/oohelperd/oohelperd.go
@@ -16,13 +16,13 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
+// TODO(bassosimone): we should refactor this package to be flat w/o the internal
+// package. We're now past the many-small-packages time.
+
 const maxAcceptableBody = 1 << 24
 
 var (
-	dialer    model.Dialer
 	endpoint  = flag.String("endpoint", ":8080", "Endpoint where to listen")
-	httpx     *http.Client
-	resolver  model.Resolver
 	srvcancel context.CancelFunc
 	srvctx    context.Context
 	srvwg     = new(sync.WaitGroup)
@@ -30,13 +30,13 @@ var (
 
 func init() {
 	srvctx, srvcancel = context.WithCancel(context.Background())
-	dialer = netx.NewDialer(netx.Config{Logger: log.Log})
-	txp := netx.NewHTTPTransport(netx.Config{Logger: log.Log})
-	httpx = &http.Client{Transport: txp}
+}
+
+func newresolver() model.Resolver {
 	// fix: use 8.8.8.8:53/udp so we pin to a specific resolver.
-	var err error
-	resolver, err = netx.NewDNSClient(netx.Config{Logger: log.Log}, "udp://8.8.8.8:53")
+	resolver, err := netx.NewDNSClient(netx.Config{Logger: log.Log}, "udp://8.8.8.8:53")
 	runtimex.PanicOnError(err, "NewDNSClient failed")
+	return resolver
 }
 
 func shutdown(srv *http.Server) {
@@ -60,10 +60,21 @@ func testableMain() {
 	mux := http.NewServeMux()
 	mux.Handle("/api/v1/websteps", &webstepsx.THHandler{})
 	mux.Handle("/", webconnectivity.Handler{
-		Client:            httpx,
-		Dialer:            dialer,
 		MaxAcceptableBody: maxAcceptableBody,
-		Resolver:          resolver,
+		NewClient: func() model.HTTPClient {
+			txp := netx.NewHTTPTransport(netx.Config{
+				FullResolver: newresolver(),
+				Logger:       log.Log,
+			})
+			return &http.Client{Transport: txp}
+		},
+		NewDialer: func() model.Dialer {
+			return netx.NewDialer(netx.Config{
+				FullResolver: newresolver(),
+				Logger:       log.Log,
+			})
+		},
+		NewResolver: newresolver,
 	})
 	srv := &http.Server{Addr: *endpoint, Handler: mux}
 	srvwg.Add(1)

--- a/internal/cmd/oohelperd/oohelperd.go
+++ b/internal/cmd/oohelperd/oohelperd.go
@@ -16,9 +16,6 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
-// TODO(bassosimone): we should refactor this package to be flat w/o the internal
-// package. We're now past the many-small-packages time.
-
 const maxAcceptableBody = 1 << 24
 
 var (


### PR DESCRIPTION
This diff modifies the implementation of oohelperd in the release/3.15
branch to always use throw-away HTTPClient, Dialer, and Resolver.

The rationale of this change is to ensure we're not hitting limits of the
HTTPClient regarding the max number of connections per host.

This issue is described at https://github.com/ooni/probe/issues/2182.

While there, it feels more correct to use throw-away Dialer and Resolver.

While there, ensure we use the 8.8.8.8:53 resolver for the dialer and
the HTTPClient, which previously we were not doing 🤦.

We will need a different patch for `master` because there we have done
lots of refactoring of code using netx and netxlite (but the diff is going
to be more obvious to understand, so...)
