### PR TITLE
fix(oohelperd): use throw-away HTTPClient, Dialer, Resolver

### DIFF
--- a/internal/cmd/oohelperd/internal/webconnectivity/http.go
+++ b/internal/cmd/oohelperd/internal/webconnectivity/http.go
@@ -19,9 +19,9 @@ type CtrlHTTPResponse = webconnectivity.ControlHTTPRequestResult
 
 // HTTPConfig configures the HTTP check.
 type HTTPConfig struct {
-	Client            model.HTTPClient
 	Headers           map[string][]string
 	MaxAcceptableBody int64
+	NewClient         func() model.HTTPClient
 	Out               chan CtrlHTTPResponse
 	URL               string
 	Wg                *sync.WaitGroup
@@ -50,7 +50,9 @@ func HTTPDo(ctx context.Context, config *HTTPConfig) {
 			}
 		}
 	}
-	resp, err := config.Client.Do(req)
+	clnt := config.NewClient()
+	defer clnt.CloseIdleConnections()
+	resp, err := clnt.Do(req)
 	if err != nil {
 		config.Out <- CtrlHTTPResponse{ // fix: emit -1 like old test helper does
 			BodyLength: -1,

--- a/internal/cmd/oohelperd/internal/webconnectivity/tcpconnect.go
+++ b/internal/cmd/oohelperd/internal/webconnectivity/tcpconnect.go
@@ -20,16 +20,18 @@ type TCPResultPair struct {
 
 // TCPConfig configures the TCP connect check.
 type TCPConfig struct {
-	Dialer   model.Dialer
-	Endpoint string
-	Out      chan TCPResultPair
-	Wg       *sync.WaitGroup
+	Endpoint  string
+	NewDialer func() model.Dialer
+	Out       chan TCPResultPair
+	Wg        *sync.WaitGroup
 }
 
 // TCPDo performs the TCP check.
 func TCPDo(ctx context.Context, config *TCPConfig) {
 	defer config.Wg.Done()
-	conn, err := config.Dialer.DialContext(ctx, "tcp", config.Endpoint)
+	dialer := config.NewDialer()
+	defer dialer.CloseIdleConnections()
+	conn, err := dialer.DialContext(ctx, "tcp", config.Endpoint)
 	if conn != nil {
 		conn.Close()
 	}

--- a/internal/cmd/oohelperd/internal/webconnectivity/webconnectivity.go
+++ b/internal/cmd/oohelperd/internal/webconnectivity/webconnectivity.go
@@ -14,10 +14,10 @@ import (
 
 // Handler implements the Web Connectivity test helper HTTP API.
 type Handler struct {
-	Client            model.HTTPClient
-	Dialer            model.Dialer
 	MaxAcceptableBody int64
-	Resolver          model.Resolver
+	NewClient         func() model.HTTPClient
+	NewDialer         func() model.Dialer
+	NewResolver       func() model.Resolver
 }
 
 func (h Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {

--- a/internal/cmd/oohelperd/internal/webconnectivity/webconnectivity_test.go
+++ b/internal/cmd/oohelperd/internal/webconnectivity/webconnectivity_test.go
@@ -51,10 +51,16 @@ const requestWithoutDomainName = `{
 
 func TestWorkingAsIntended(t *testing.T) {
 	handler := Handler{
-		Client:            http.DefaultClient,
-		Dialer:            netxlite.NewDialerWithStdlibResolver(model.DiscardLogger),
 		MaxAcceptableBody: 1 << 24,
-		Resolver:          netxlite.NewUnwrappedStdlibResolver(),
+		NewClient: func() model.HTTPClient {
+			return http.DefaultClient
+		},
+		NewDialer: func() model.Dialer {
+			return netxlite.NewDialerWithStdlibResolver(model.DiscardLogger)
+		},
+		NewResolver: func() model.Resolver {
+			return netxlite.NewUnwrappedStdlibResolver()
+		},
 	}
 	srv := httptest.NewServer(handler)
 	defer srv.Close()


### PR DESCRIPTION
This diff modifies the implementation of oohelperd in the master branch
to always use throw-away HTTPClient, Dialer, and Resolver.

The rationale of this change is to ensure we're not hitting limits of the
HTTPClient regarding the max number of connections per host.

This issue is described at https://github.com/ooni/probe/issues/2182.

While there, it feels more correct to use throw-away Dialer and Resolver.

We have a different patch for the release/3.15 branch because of
netx-related refactorings: https://github.com/ooni/probe-cli/pull/832.
