### PR TITLE
refactor(engine): *http.Client -> model.HTTPClient

### DIFF
--- a/internal/engine/mockable/mockable.go
+++ b/internal/engine/mockable/mockable.go
@@ -3,7 +3,6 @@ package mockable
 
 import (
 	"context"
-	"net/http"
 	"net/url"
 
 	"github.com/ooni/probe-cli/v3/internal/engine/probeservices"
@@ -14,7 +13,7 @@ import (
 // Session allows to mock sessions.
 type Session struct {
 	MockableTestHelpers              map[string][]model.OOAPIService
-	MockableHTTPClient               *http.Client
+	MockableHTTPClient               model.HTTPClient
 	MockableLogger                   model.Logger
 	MockableMaybeResolverIP          string
 	MockableProbeASNString           string
@@ -45,7 +44,7 @@ func (sess *Session) GetTestHelpersByName(name string) ([]model.OOAPIService, bo
 }
 
 // DefaultHTTPClient implements ExperimentSession.DefaultHTTPClient
-func (sess *Session) DefaultHTTPClient() *http.Client {
+func (sess *Session) DefaultHTTPClient() model.HTTPClient {
 	return sess.MockableHTTPClient
 }
 

--- a/internal/engine/probeservices/probeservices.go
+++ b/internal/engine/probeservices/probeservices.go
@@ -25,7 +25,6 @@ package probeservices
 
 import (
 	"errors"
-	"net/http"
 	"net/url"
 
 	"github.com/ooni/probe-cli/v3/internal/atomicx"
@@ -56,7 +55,7 @@ var (
 
 // Session is how this package sees a Session.
 type Session interface {
-	DefaultHTTPClient() *http.Client
+	DefaultHTTPClient() model.HTTPClient
 	KeyValueStore() model.KeyValueStore
 	Logger() model.Logger
 	ProxyURL() *url.URL

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -337,7 +337,7 @@ func (s *Session) GetTestHelpersByName(name string) ([]model.OOAPIService, bool)
 }
 
 // DefaultHTTPClient returns the session's default HTTP client.
-func (s *Session) DefaultHTTPClient() *http.Client {
+func (s *Session) DefaultHTTPClient() model.HTTPClient {
 	return &http.Client{Transport: s.httpDefaultTransport}
 }
 

--- a/internal/engine/session_integration_test.go
+++ b/internal/engine/session_integration_test.go
@@ -26,7 +26,11 @@ func TestSessionByteCounter(t *testing.T) {
 	}
 	s := newSessionForTesting(t)
 	client := s.DefaultHTTPClient()
-	resp, err := client.Get("https://www.google.com")
+	req, err := http.NewRequest("GET", "https://www.google.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/model/experiment.go
+++ b/internal/model/experiment.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"context"
-	"net/http"
 )
 
 //
@@ -13,7 +12,7 @@ import (
 // ExperimentSession is the experiment's view of a session.
 type ExperimentSession interface {
 	GetTestHelpersByName(name string) ([]OOAPIService, bool)
-	DefaultHTTPClient() *http.Client
+	DefaultHTTPClient() HTTPClient
 	FetchPsiphonConfig(ctx context.Context) ([]byte, error)
 	FetchTorTargets(ctx context.Context, cc string) (map[string]OOAPITorTarget, error)
 	FetchURLList(ctx context.Context, config OOAPIURLListConfig) ([]OOAPIURLInfo, error)


### PR DESCRIPTION
This diff makes the implementation of the engine package more
abstract by changing HTTPClient() to return a model.HTTPClient
as opposed to returning an *http.Client.

Part of https://github.com/ooni/probe/issues/2184

