### PR TITLE
fix(engine): repair broken integration test

### DIFF
--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -391,7 +391,11 @@ var ErrAlreadyUsingProxy = errors.New(
 // for the experiment with the given name, or an error if
 // there's no such experiment with the given name
 func (s *Session) NewExperimentBuilder(name string) (ExperimentBuilder, error) {
-	return newExperimentBuilder(s, name)
+	eb, err := newExperimentBuilder(s, name)
+	if err != nil {
+		return nil, err
+	}
+	return eb, nil
 }
 
 // NewProbeServicesClient creates a new client for talking with the

--- a/internal/model/experiment.go
+++ b/internal/model/experiment.go
@@ -1,28 +1,51 @@
 package model
 
+//
+// Definition of experiment and types used by the
+// implementation of all experiments.
+//
+
 import (
 	"context"
 )
 
-//
-// Definition of experiment and types used by the
-// implemenation of all experiments.
-//
-
 // ExperimentSession is the experiment's view of a session.
 type ExperimentSession interface {
+	// GetTestHelpersByName returns a list of test helpers with the given name.
 	GetTestHelpersByName(name string) ([]OOAPIService, bool)
+
+	// DefaultHTTPClient returns the default HTTPClient used by the session.
 	DefaultHTTPClient() HTTPClient
+
+	// FetchPsiphonConfig returns psiphon's config as a serialized JSON or an error.
 	FetchPsiphonConfig(ctx context.Context) ([]byte, error)
+
+	// FetchTorTargets returns the targets for the Tor experiment or an error.
 	FetchTorTargets(ctx context.Context, cc string) (map[string]OOAPITorTarget, error)
-	FetchURLList(ctx context.Context, config OOAPIURLListConfig) ([]OOAPIURLInfo, error)
+
+	// Logger returns the logger used by the session.
 	Logger() Logger
+
+	// ProbeCC returns the country code.
 	ProbeCC() string
+
+	// ResolverIP returns the resolver's IP.
 	ResolverIP() string
+
+	// TempDir returns the session's temporary directory.
 	TempDir() string
+
+	// TorArgs returns the arguments we should pass to tor when executing it.
 	TorArgs() []string
+
+	// TorBinary returns the path of the tor binary.
 	TorBinary() string
+
+	// TunnelDir is the directory where to store tunnel information.
 	TunnelDir() string
+
+	// UserAgent returns the user agent we should be using when we're fine
+	// with identifying ourselves as ooniprobe.
 	UserAgent() string
 }
 


### PR DESCRIPTION
This diff contains a fix that I come up with while working
on https://github.com/ooni/probe/issues/2184.

The integration test that was broken was:

```
--- FAIL: TestCreateInvalidExperiment (0.35s)
    experiment_integration_test.go:192: expected a nil builder here
```

While there improve the documentation of the ExperimentSession
and acknowledge it contained a method that we are not using, so we
can safely remove such a method from ExperimentSession.
