### PR TITLE
feat(oonirun): add support for OONIRun v2 links

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.5.0
+	github.com/hexops/gotextdiff v1.0.3
 	github.com/iancoleman/strcase v0.2.0
 	github.com/lucas-clemente/quic-go v0.27.0
 	github.com/mattn/go-colorable v0.1.12

--- a/go.sum
+++ b/go.sum
@@ -378,6 +378,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/internal/cmd/miniooni/libminiooni.go
+++ b/internal/cmd/miniooni/libminiooni.go
@@ -421,7 +421,12 @@ func ooniRunMain(ctx context.Context,
 	for _, URL := range currentOptions.Inputs {
 		r := oonirun.NewLinkRunner(cfg, URL)
 		if err := r.Run(ctx); err != nil {
-			logger.Warnf("oonirun: running link failed: %s", err.Error())
+			if errors.Is(err, oonirun.ErrNeedToAcceptChanges) {
+				logger.Warnf("oonirun: to accept these changes, rerun adding `-y` to the command line")
+				logger.Warnf("oonirun: we'll show this error every time the upstream link changes")
+				panic("oonirun: need to accept changes using `-y`")
+			}
+			logger.Warnf("oonirun: Measure failed: %s", err.Error())
 			continue
 		}
 	}

--- a/internal/oonirun/link.go
+++ b/internal/oonirun/link.go
@@ -84,9 +84,7 @@ func NewLinkRunner(c *LinkConfig, URL string) LinkRunner {
 	case strings.HasPrefix(URL, "ooni://nettest"):
 		out.f = v1Measure
 	default:
-		// TODO(bassosimone): this panic will go away when we merge
-		// the next patch which will implement v2.
-		panic("unsupported OONI Run link")
+		out.f = v2MeasureHTTPS
 	}
 	return out
 }

--- a/internal/oonirun/v2.go
+++ b/internal/oonirun/v2.go
@@ -1,0 +1,236 @@
+package oonirun
+
+//
+// OONI Run v2 implementation
+//
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/hexops/gotextdiff"
+	"github.com/hexops/gotextdiff/myers"
+	"github.com/hexops/gotextdiff/span"
+	"github.com/ooni/probe-cli/v3/internal/kvstore"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
+)
+
+// v2Descriptor describes a single nettest to run.
+type v2Descriptor struct {
+	// Name is the name of this descriptor.
+	Name string `json:"name"`
+
+	// Description contains a long description.
+	Description string `json:"description"`
+
+	// Author contains the author's name.
+	Author string `json:"author"`
+
+	// Nettests contains the list of nettests to run.
+	Nettests []v2Nettest `json:"nettests"`
+}
+
+// v2Nettest specifies how a nettest should run.
+type v2Nettest struct {
+	// Inputs contains inputs for the experiment.
+	Inputs []string `json:"inputs"`
+
+	// Options contains the experiment options.
+	Options map[string]any `json:"options"`
+
+	// TestName contains the nettest name.
+	TestName string `json:"test_name"`
+}
+
+// ErrHTTPRequestFailed indicates that an HTTP request failed.
+var ErrHTTPRequestFailed = errors.New("oonirun: HTTP request failed")
+
+// getV2DescriptorFromHTTPSURL GETs a v2Descriptor instance from
+// a static URL (e.g., from a GitHub repo or from a Gist).
+func getV2DescriptorFromHTTPSURL(
+	ctx context.Context, client model.HTTPClient, URL string) (*v2Descriptor, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", URL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, ErrHTTPRequestFailed
+	}
+	reader := io.LimitReader(resp.Body, 1<<22)
+	data, err := netxlite.ReadAllContext(ctx, reader)
+	if err != nil {
+		return nil, err
+	}
+	var desc v2Descriptor
+	if err := json.Unmarshal(data, &desc); err != nil {
+		return nil, err
+	}
+	return &desc, nil
+}
+
+// v2DescriptorCache contains all the known v2Descriptor entries.
+type v2DescriptorCache struct {
+	// Entries contains all the cached descriptors.
+	Entries map[string]*v2Descriptor
+}
+
+// v2DescriptorCacheKey is the name of the kvstore2 entry keeping
+// information about already known v2Descriptor instances.
+const v2DescriptorCacheKey = "oonirun-v2.state"
+
+// v2DescriptorCacheLoad loads the v2DescriptorCache.
+func v2DescriptorCacheLoad(fsstore model.KeyValueStore) (*v2DescriptorCache, error) {
+	data, err := fsstore.Get(v2DescriptorCacheKey)
+	if err != nil {
+		if errors.Is(err, kvstore.ErrNoSuchKey) {
+			cache := &v2DescriptorCache{
+				Entries: make(map[string]*v2Descriptor),
+			}
+			return cache, nil
+		}
+		return nil, err
+	}
+	var cache v2DescriptorCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return nil, err
+	}
+	if cache.Entries == nil {
+		cache.Entries = make(map[string]*v2Descriptor)
+	}
+	return &cache, nil
+}
+
+// PullChangesWithoutSideEffects fetches v2Descriptor changes.
+//
+// This function DOES NOT change the state of the cache. It just returns to
+// the caller what changed for a given entry. It is up-to-the-caller to choose
+// what to do in case there are changes depending on the CLI flags.
+//
+// Arguments:
+//
+// - ctx is the context for deadline/cancellation;
+//
+// - client is the HTTPClient to use;
+//
+// - URL is the URL from which to download/update the OONIRun v2Descriptor.
+//
+// Return values:
+//
+// - oldValue is the old v2Descriptor, which may be empty;
+//
+// - newValue is the new v2Descriptor;
+//
+// - err is the error that occurred, or nil in case of success.
+func (cache *v2DescriptorCache) PullChangesWithoutSideEffects(ctx context.Context,
+	client model.HTTPClient, URL string) (oldValue, newValue *v2Descriptor, err error) {
+	oldValue = cache.Entries[URL]
+	newValue, err = getV2DescriptorFromHTTPSURL(ctx, client, URL)
+	return
+}
+
+// Update updates the given cache entry and writes back onto the disk.
+func (cache *v2DescriptorCache) Update(
+	fsstore model.KeyValueStore, URL string, entry *v2Descriptor) error {
+	// Note: NOT SAFE for concurrent use (default for methods)
+	cache.Entries[URL] = entry
+	data, err := json.Marshal(cache)
+	if err != nil {
+		return err
+	}
+	return fsstore.Set(v2DescriptorCacheKey, data)
+}
+
+// v2MeasureDescriptor performs the measurement or measurements
+// described by the given list of v2Descriptor.
+func v2MeasureDescriptor(ctx context.Context, config *LinkConfig, desc *v2Descriptor) error {
+	logger := config.Session.Logger()
+	for _, nettest := range desc.Nettests {
+		if nettest.TestName == "" {
+			logger.Warn("nettest name cannot be empty")
+			continue
+		}
+		exp := &Experiment{
+			Annotations:    config.Annotations,
+			ExtraOptions:   nettest.Options,
+			Inputs:         nettest.Inputs,
+			InputFilePaths: nil,
+			MaxRuntime:     config.MaxRuntime,
+			Name:           nettest.TestName,
+			NoCollector:    config.NoCollector,
+			NoJSON:         config.NoJSON,
+			Random:         config.Random,
+			ReportFile:     config.ReportFile,
+			Session:        config.Session,
+		}
+		if err := exp.Run(ctx); err != nil {
+			logger.Warnf("cannot run experiment: %s", err.Error())
+			continue
+		}
+	}
+	return nil
+}
+
+// ErrNeedToAcceptChanges indicates that the user needs to accept
+// changes (i.e., a new or modified set of descriptors) before
+// we can actually run this set of descriptors.
+var ErrNeedToAcceptChanges = errors.New("oonirun: need to accept changes")
+
+// v2DescriptorDiff shows what changed between the old and the new descriptors.
+func v2DescriptorDiff(oldValue, newValue *v2Descriptor, URL string) string {
+	oldData, err := json.MarshalIndent(oldValue, "", "  ")
+	runtimex.PanicOnError(err, "json.MarshalIndent failed unexpectedly")
+	newData, err := json.MarshalIndent(newValue, "", "  ")
+	runtimex.PanicOnError(err, "json.MarshalIndent failed unexpectedly")
+	oldString, newString := string(oldData)+"\n", string(newData)+"\n"
+	oldFile := "OLD " + URL
+	newFile := "NEW " + URL
+	edits := myers.ComputeEdits(span.URIFromPath(oldFile), oldString, newString)
+	return fmt.Sprint(gotextdiff.ToUnified(oldFile, newFile, oldString, edits))
+}
+
+// v2MeasureHTTPS performs a measurement using an HTTPS v2 OONI Run URL
+// and returns whether performing this measurement failed.
+//
+// This function maintains an on-disk cache that tracks the status of
+// OONI Run v2 links. If there are any changes and the user has not
+// provided config.AcceptChanges, this function will log what has changed
+// and will return with an ErrNeedToAcceptChanges error.
+//
+// In such a case, the caller SHOULD print additional information
+// explaining how to accept changes and then SHOULD exit 1 or similar.
+func v2MeasureHTTPS(ctx context.Context, config *LinkConfig, URL string) error {
+	config.Session.Logger().Infof("oonirun/v2: running %s", URL)
+	cache, err := v2DescriptorCacheLoad(config.KVStore)
+	if err != nil {
+		return err
+	}
+	clnt := config.Session.DefaultHTTPClient()
+	oldValue, newValue, err := cache.PullChangesWithoutSideEffects(ctx, clnt, URL)
+	if err != nil {
+		return err
+	}
+	diff := v2DescriptorDiff(oldValue, newValue, URL)
+	if !config.AcceptChanges && diff != "" {
+		logger := config.Session.Logger()
+		logger.Warnf("oonirun: %s changed as follows:\n\n%s", URL, diff)
+		logger.Warnf("oonirun: we are not going to run this link until you accept changes")
+		return ErrNeedToAcceptChanges
+	}
+	if diff != "" {
+		if err := cache.Update(config.KVStore, URL, newValue); err != nil {
+			return err
+		}
+	}
+	return v2MeasureDescriptor(ctx, config, newValue)
+}

--- a/internal/oonirun/v2_test.go
+++ b/internal/oonirun/v2_test.go
@@ -1,0 +1,55 @@
+package oonirun
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ooni/probe-cli/v3/internal/kvstore"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
+)
+
+// TODO(bassosimone): it would be cool to write unit tests. However, to do that
+// we need to ~redesign the engine package for unit-testability.
+
+func TestOONIRunV2Link(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		descriptor := &v2Descriptor{
+			Name:        "",
+			Description: "",
+			Author:      "",
+			Nettests: []v2Nettest{{
+				Inputs: []string{},
+				Options: map[string]any{
+					"SleepTime": int64(10 * time.Millisecond),
+				},
+				TestName: "example",
+			}},
+		}
+		data, err := json.Marshal(descriptor)
+		runtimex.PanicOnError(err, "json.Marshal failed")
+		w.Write(data)
+	}))
+	defer server.Close()
+	ctx := context.Background()
+	config := &LinkConfig{
+		AcceptChanges: true, // avoid "oonirun: need to accept changes" error
+		Annotations: map[string]string{
+			"platform": "linux",
+		},
+		KVStore:     &kvstore.Memory{},
+		MaxRuntime:  0,
+		NoCollector: true,
+		NoJSON:      true,
+		Random:      false,
+		ReportFile:  "",
+		Session:     newSession(ctx, t),
+	}
+	r := NewLinkRunner(config, server.URL)
+	if err := r.Run(ctx); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This diff adds support for OONIRun v2 links. Documentation regarding
how to use these links will follow soon.

Part of https://github.com/ooni/probe/issues/2184.
