### PR TITLE
feat: TRR2 resolver 

### DIFF
--- a/internal/measurexlite/dns.go
+++ b/internal/measurexlite/dns.go
@@ -64,6 +64,20 @@ func (r *resolverTrace) LookupNS(ctx context.Context, domain string) ([]*net.NS,
 	return r.r.LookupNS(netxlite.ContextWithTrace(ctx, r.tx), domain)
 }
 
+// NewTrustedRecursiveResolver2 returns a trace-aware TRR2 resolver
+func (tx *Trace) NewTrustedRecursiveResolver2(logger model.Logger, address string) model.Resolver {
+	return tx.newParallelResolverTrace(func() model.Resolver {
+		return NewTrustedRecursiveResolver2(logger, address)
+	})
+}
+
+// NewStdlibResolver returns a trace-aware stdlib resolver
+func (tx *Trace) NewStdlibResolver(logger model.Logger, dialer model.Dialer, address string) model.Resolver {
+	return tx.newParallelResolverTrace(func() model.Resolver {
+		return netxlite.NewStdlibResolver(logger)
+	})
+}
+
 // NewParallelUDPResolver returns a trace-ware parallel UDP resolver
 func (tx *Trace) NewParallelUDPResolver(logger model.Logger, dialer model.Dialer, address string) model.Resolver {
 	return tx.newParallelResolverTrace(func() model.Resolver {

--- a/internal/measurexlite/resolver.go
+++ b/internal/measurexlite/resolver.go
@@ -1,0 +1,106 @@
+package measurexlite
+
+//
+// Trusted Recursive Resolver
+//
+
+import (
+	"context"
+	"net"
+
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+)
+
+// NewTrustedRecursiveResolver2 returns a new trusted recursive resolver
+func NewTrustedRecursiveResolver2(logger model.Logger, URL string) model.Resolver {
+	const mozillaURL = "https://mozilla.cloudflare-dns.com/dns-query"
+	if URL == "" {
+		URL = mozillaURL
+	}
+	return &TrustedRecursiveResolver2{
+		Logger:                            logger,
+		URL:                               URL,
+		NewParallelDNSOverHTTPSResolverFn: nil,
+		ResolverSystem:                    netxlite.NewStdlibResolver(logger),
+	}
+}
+
+// TrustedRecursiveResolver2 emulates Firefox's TRR2 mode
+type TrustedRecursiveResolver2 struct {
+	Logger model.Logger
+	URL    string
+
+	// NewParallelDNSOverHTTPSResolverFn is OPTIONAL and can be used to overide
+	// calls to the netxlite.NewParallelDNSOverHTTPSResolver factory
+	NewParallelDNSOverHTTPSResolverFn func(model.Logger, string) model.Resolver
+
+	// ResolverSystem is MANADATORY and is used as a fallback if the DoH resolver fails
+	ResolverSystem model.Resolver
+}
+
+var _ model.Resolver = &TrustedRecursiveResolver2{}
+
+// Address implements model.Resolver.Address
+// we can't return a decisive address here since we don't know if LookupHost
+// succeeds with the DoH resolver or the system resolver
+func (trr *TrustedRecursiveResolver2) Address() string {
+	return ""
+}
+
+// Network implements model.Resolver.Network
+// we can't return a decisive network here since we don't know if LookupHost
+// succeeds with the DoH resolver or the system resolver
+func (trr *TrustedRecursiveResolver2) Network() string {
+	return ""
+}
+
+// CloseIdleConnections implements model.Resolver.CloseIdleConnections
+// we only check the fallback resolver since DoH resolver is generated on the fly
+func (trr TrustedRecursiveResolver2) CloseIdleConnections() {
+	trr.ResolverSystem.CloseIdleConnections()
+}
+
+// LookupHost implements model.Resolver.LookupHost
+func (trr *TrustedRecursiveResolver2) LookupHost(ctx context.Context, hostname string) ([]string, error) {
+	reso := trr.NewParallelDNSOverHTTPSResolverFn(trr.Logger, trr.URL)
+	if reso == nil {
+		reso = netxlite.NewParallelDNSOverHTTPSResolver(trr.Logger, trr.URL)
+	}
+	addrs, err := reso.LookupHost(ctx, hostname)
+	if err != nil {
+		addrs, err = trr.ResolverSystem.LookupHost(ctx, hostname)
+	}
+	return addrs, err
+}
+
+// LookupHTTPS implements model.Resolver.LookupHTTPS
+func (trr *TrustedRecursiveResolver2) LookupHTTPS(ctx context.Context, domain string) (*model.HTTPSSvc, error) {
+	reso := trr.NewParallelDNSOverHTTPSResolverFn(trr.Logger, trr.URL)
+	if reso == nil {
+		reso = netxlite.NewParallelDNSOverHTTPSResolver(trr.Logger, trr.URL)
+	}
+	out, err := reso.LookupHTTPS(ctx, domain)
+	if err != nil {
+		out, err = trr.ResolverSystem.LookupHTTPS(ctx, domain)
+	}
+	return out, err
+}
+
+// LookupNS implements model.Resolver.LookupNS
+func (trr *TrustedRecursiveResolver2) LookupNS(ctx context.Context, domain string) ([]*net.NS, error) {
+	reso := trr.NewParallelDNSOverHTTPSResolverFn(trr.Logger, trr.URL)
+	if reso == nil {
+		reso = netxlite.NewParallelDNSOverHTTPSResolver(trr.Logger, trr.URL)
+	}
+	out, err := reso.LookupNS(ctx, domain)
+	if err != nil {
+		out, err = trr.ResolverSystem.LookupNS(ctx, domain)
+	}
+	return out, err
+}
+
+// Url returns the configured DoH URL for the TRR2 resolver
+func (trr *TrustedRecursiveResolver2) Url() string {
+	return trr.URL
+}

--- a/internal/measurexlite/resolver_test.go
+++ b/internal/measurexlite/resolver_test.go
@@ -1,0 +1,163 @@
+package measurexlite
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/model/mocks"
+)
+
+func TestNewTrustedRecursiveResolver(t *testing.T) {
+	var called bool
+	newResolver := func(model.Logger, string) model.Resolver {
+		return &mocks.Resolver{
+			MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
+				return []string{"1.1.1.1"}, nil
+			},
+			MockLookupHTTPS: func(ctx context.Context, domain string) (*model.HTTPSSvc, error) {
+				return &model.HTTPSSvc{
+					IPv4: []string{"1.1.1.1"},
+				}, nil
+			},
+			MockLookupNS: func(ctx context.Context, domain string) ([]*net.NS, error) {
+				return []*net.NS{
+					{
+						Host: "1.1.1.1",
+					},
+				}, nil
+			},
+			MockCloseIdleConnections: func() {
+				called = true
+			},
+		}
+	}
+
+	t.Run("default URL", func(t *testing.T) {
+		expected := "https://mozilla.cloudflare-dns.com/dns-query"
+		resolver := NewTrustedRecursiveResolver2(&mocks.Logger{}, "")
+		resolvert := resolver.(*TrustedRecursiveResolver2)
+		if resolvert.Url() != expected {
+			t.Fatal("unexpected default url")
+		}
+	})
+
+	t.Run("custom URL", func(t *testing.T) {
+		expected := "https://dns.google/dns-query"
+		resolver := NewTrustedRecursiveResolver2(&mocks.Logger{}, "https://dns.google/dns-query")
+		resolvert := resolver.(*TrustedRecursiveResolver2)
+		if resolvert.Url() != expected {
+			t.Fatal("unexpected default url")
+		}
+	})
+
+	t.Run("with DoH resolver", func(t *testing.T) {
+		resolver := NewTrustedRecursiveResolver2(&mocks.Logger{}, "")
+		resolvert := resolver.(*TrustedRecursiveResolver2)
+		resolvert.NewParallelDNSOverHTTPSResolverFn = newResolver
+		ctx := context.Background()
+		t.Run("LookupHost", func(t *testing.T) {
+			addrs, err := resolver.LookupHost(ctx, "example.com")
+			if err != nil {
+				t.Fatal("unexpected error", err)
+			}
+			if len(addrs) != 1 || addrs[0] != "1.1.1.1" {
+				t.Fatal("got unexpected addresses")
+			}
+		})
+		t.Run("LookupHTTPS", func(t *testing.T) {
+			want := &model.HTTPSSvc{
+				IPv4: []string{"1.1.1.1"},
+			}
+			got, err := resolver.LookupHTTPS(ctx, "example.com")
+			if err != nil {
+				t.Fatal("unexpected error", err)
+			}
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+		t.Run("LookupNS", func(t *testing.T) {
+			want := &net.NS{
+				Host: "1.1.1.1",
+			}
+			got, err := resolver.LookupNS(ctx, "example.com")
+			if err != nil {
+				t.Fatal("unexpected error", err)
+			}
+			if len(got) != 1 {
+				t.Fatal("got unexpected addresses")
+			}
+			if diff := cmp.Diff(got[0], want); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	})
+	t.Run("with system resolver", func(t *testing.T) {
+		mockedErr := errors.New("mocked")
+		// the DoH resolver must return an error to use the fallback system resolver
+		newDoHResolver := func(model.Logger, string) model.Resolver {
+			return &mocks.Resolver{
+				MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
+					return []string{}, mockedErr
+				},
+				MockLookupHTTPS: func(ctx context.Context, domain string) (*model.HTTPSSvc, error) {
+					return nil, mockedErr
+				},
+				MockLookupNS: func(ctx context.Context, domain string) ([]*net.NS, error) {
+					return nil, mockedErr
+				},
+			}
+		}
+		resolver := NewTrustedRecursiveResolver2(&mocks.Logger{}, "")
+		resolvert := resolver.(*TrustedRecursiveResolver2)
+		resolvert.NewParallelDNSOverHTTPSResolverFn = newDoHResolver
+		resolvert.ResolverSystem = newResolver(&mocks.Logger{}, "")
+		ctx := context.Background()
+		t.Run("LookupHost", func(t *testing.T) {
+			addrs, err := resolver.LookupHost(ctx, "example.com")
+			if err != nil {
+				t.Fatal("unexpected error", err)
+			}
+			if len(addrs) != 1 || addrs[0] != "1.1.1.1" {
+				t.Fatal("got unexpected addresses")
+			}
+		})
+		t.Run("LookupHTTPS", func(t *testing.T) {
+			want := &model.HTTPSSvc{
+				IPv4: []string{"1.1.1.1"},
+			}
+			got, err := resolver.LookupHTTPS(ctx, "example.com")
+			if err != nil {
+				t.Fatal("unexpected error", err)
+			}
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+		t.Run("LookupNS", func(t *testing.T) {
+			want := &net.NS{
+				Host: "1.1.1.1",
+			}
+			got, err := resolver.LookupNS(ctx, "example.com")
+			if err != nil {
+				t.Fatal("unexpected error", err)
+			}
+			if len(got) != 1 {
+				t.Fatal("got unexpected addresses")
+			}
+			if diff := cmp.Diff(got[0], want); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+		t.Run("CloseIdleConnections", func(t *testing.T) {
+			resolver.CloseIdleConnections()
+			if called != true {
+				t.Fatal("unexpected error while calling CloseIdleConnections")
+			}
+		})
+	})
+}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2185
- [ ] if you changed anything related how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This intoduces a TRR2 resolver to measurexlite allowing us to opportunistcally test for DoH and make use of it whenever we can. The resolver uses the system resolver (`getaddrinfo`) as a fallback when DoH fails