### PR TITLE
Feat/dnsscan

### DIFF
--- a/internal/engine/allexperiments.go
+++ b/internal/engine/allexperiments.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/dash"
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/dnscheck"
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/dnsping"
+	"github.com/ooni/probe-cli/v3/internal/engine/experiment/dnsscan"
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/example"
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/fbmessenger"
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/hhfm"
@@ -71,6 +72,18 @@ var experimentsByName = map[string]func(*Session) *experimentBuilder{
 			},
 			config:      &dnsping.Config{},
 			inputPolicy: InputOrStaticDefault,
+		}
+	},
+
+	"dnsscan": func(session *Session) *experimentBuilder {
+		return &experimentBuilder{
+			build: func(config interface{}) *experiment {
+				return newExperiment(session, dnsscan.NewExperimentMeasurer(
+					*config.(*dnsscan.Config),
+				))
+			},
+			config:      &dnsscan.Config{},
+			inputPolicy: InputStrictlyRequired,
 		}
 	},
 

--- a/internal/engine/experiment/dnsscan/dnsscan.go
+++ b/internal/engine/experiment/dnsscan/dnsscan.go
@@ -1,0 +1,151 @@
+// Package dnsscan is the experimental dnsscan experiment.
+package dnsscan
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/ooni/probe-cli/v3/internal/measurexlite"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+)
+
+const (
+	testName    = "dnsscan"
+	testVersion = "0.1.0"
+)
+
+// TestKeys contains the experiment results.
+type TestKeys struct {
+	Queries        []*model.ArchivalDNSLookupResult `json:"queries"`
+	TargetResolver string                           `json:"target_resolver"`
+}
+
+// Config contains the experiment configuration.
+type Config struct {
+	// Address of the DNS resolver to be used for testing
+	Resolver string `ooni:"address of the DNS resolver to use"`
+}
+
+func (c Config) resolver() string {
+	if c.Resolver != "" {
+		return c.Resolver
+	}
+	return "udp://8.8.8.8:53"
+}
+
+// Measurer performs the measurement.
+type Measurer struct {
+	config Config
+}
+
+// ExperimentName implements ExperimentMeasurer.ExperiExperimentName.
+func (m *Measurer) ExperimentName() string {
+	return testName
+}
+
+// ExperimentVersion implements ExperimentMeasurer.ExperimentVersion.
+func (m *Measurer) ExperimentVersion() string {
+	return testVersion
+}
+
+var (
+	// errNoInputProvided indicates you didn't provide any input
+	errNoInputProvided = errors.New("not input provided")
+
+	// errInputFormatInvalid means that the input format is not valid
+	errInputFormatInvalid = errors.New("input is not a domain or URL")
+
+	// errNoInputProvided indicates that the chosen DNS resolver is not currently supported
+	errResolverNotSupported = errors.New("resolver not supported")
+
+	// errInvalidResolver indicates that the chosen DNS resolver is invalid
+	errInvalidResolver = errors.New("resolver address is invalid")
+
+	// errMissingPort indicates that there is no port.
+	errMissingPort = errors.New("the URL must include a port")
+)
+
+// Run implements ExperimentMeasurer.Run.
+func (m *Measurer) Run(
+	ctx context.Context,
+	sess model.ExperimentSession,
+	measurement *model.Measurement,
+	callbacks model.ExperimentCallbacks,
+) error {
+	if measurement.Input == "" {
+		return errNoInputProvided
+	}
+
+	// XXX do we also care to support URLs as inputs?
+	domain := string(measurement.Input)
+
+	tk := new(TestKeys)
+	tk.TargetResolver = m.config.resolver()
+	measurement.TestKeys = tk
+
+	resolver := m.config.resolver()
+	parsedResolver, err := url.Parse(string(resolver))
+	if err != nil {
+		return fmt.Errorf("%w: %s", errInvalidResolver, err.Error())
+	}
+	if parsedResolver.Scheme != "udp" {
+		return errResolverNotSupported
+	}
+	if parsedResolver.Port() == "" {
+		return errMissingPort
+	}
+	resolverIP := net.ParseIP(parsedResolver.Hostname())
+	if resolverIP == nil {
+		return fmt.Errorf("%w: invalid IP address", errInvalidResolver)
+	}
+	resolverAddress := fmt.Sprintf("%s:%s", resolverIP, parsedResolver.Port())
+	// is an IPv6 address
+	if resolverIP.To4() == nil {
+		resolverAddress = fmt.Sprintf("[%s]:%s", resolverIP, parsedResolver.Port())
+	}
+	m.dnsRoundTrip(ctx, measurement.MeasurementStartTimeSaved, sess.Logger(), resolverAddress, domain, tk)
+	return nil // return nil so we always submit the measurement
+}
+
+// dnsRoundTrip performs a round trip and returns the results to the caller.
+func (m *Measurer) dnsRoundTrip(ctx context.Context, zeroTime time.Time,
+	logger model.Logger, address string, domain string, tk *TestKeys) {
+	fmt.Printf("Measuing %s %s", domain, address)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	trace := measurexlite.NewTrace(0, zeroTime)
+	ol := measurexlite.NewOperationLogger(logger, "DNSScan %s %s", address, domain)
+
+	dialer := netxlite.NewDialerWithStdlibResolver(logger)
+	resolver := trace.NewParallelUDPResolver(logger, dialer, address)
+	_, err := resolver.LookupHost(ctx, domain)
+	ol.Stop(err)
+	// Add the dns.TypeA query
+	tk.Queries = append(tk.Queries, <-trace.DNSLookup[dns.TypeA])
+	// Add the dns.TypeAAAA query
+	tk.Queries = append(tk.Queries, <-trace.DNSLookup[dns.TypeAAAA])
+}
+
+// NewExperimentMeasurer creates a new ExperimentMeasurer.
+func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
+	return &Measurer{config: config}
+}
+
+// SummaryKeys contains summary keys for this experiment.
+//
+// Note that this structure is part of the ABI contract with ooniprobe
+// therefore we should be careful when changing it.
+type SummaryKeys struct {
+	IsAnomaly bool `json:"-"`
+}
+
+// GetSummaryKeys implements model.ExperimentMeasurer.GetSummaryKeys.
+func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
+	return SummaryKeys{IsAnomaly: false}, nil
+}

--- a/internal/engine/experiment/dnsscan/dnsscan_test.go
+++ b/internal/engine/experiment/dnsscan/dnsscan_test.go
@@ -1,0 +1,60 @@
+package dnsscan
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ooni/probe-cli/v3/internal/engine/mockable"
+	"github.com/ooni/probe-cli/v3/internal/model"
+)
+
+func TestConfig_resolver(t *testing.T) {
+	c := Config{}
+	if c.resolver() != "8.8.8.8:53" {
+		t.Fatal("invalid default domains list")
+	}
+}
+
+func TestMeasurer_run(t *testing.T) {
+	// runHelper is an helper function to run this set of tests.
+	runHelper := func(input string) (*model.Measurement, model.ExperimentMeasurer, error) {
+		m := NewExperimentMeasurer(Config{
+			Resolver: "udp://8.8.8.8:53",
+		})
+		if m.ExperimentName() != "dnsscan" {
+			t.Fatal("invalid experiment name")
+		}
+		if m.ExperimentVersion() != "0.1.0" {
+			t.Fatal("invalid experiment version")
+		}
+		ctx := context.Background()
+		meas := &model.Measurement{
+			Input: model.MeasurementTarget(input),
+		}
+		sess := &mockable.Session{
+			MockableLogger: model.DiscardLogger,
+		}
+		callbacks := model.NewPrinterCallbacks(model.DiscardLogger)
+		err := m.Run(ctx, sess, meas, callbacks)
+		return meas, m, err
+	}
+
+	t.Run("with valid input", func(t *testing.T) {
+		meas, m, err := runHelper("example.com")
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+		tk := meas.TestKeys.(*TestKeys)
+		if len(tk.Queries) != 2 {
+			t.Fatal("unexpected number of queries", len(tk.Queries))
+		}
+		ask, err := m.GetSummaryKeys(meas)
+		if err != nil {
+			t.Fatal("cannot obtain summary")
+		}
+		summary := ask.(SummaryKeys)
+		if summary.IsAnomaly {
+			t.Fatal("expected no anomaly")
+		}
+	})
+}


### PR DESCRIPTION
Added an experiment for scanning open DNS resolvers to detect blocking.

Currently experimental and as such doesn't have a spec for it yet.

Here is a sample of the output of a test run:
```
{
  "annotations": {
    "architecture": "amd64",
    "engine_name": "ooniprobe-engine",
Add dnsscan to allexperiments
    "engine_version": "3.16.0-alpha",
    "platform": "macos"
  },
  "data_format_version": "0.2.0",
  "input": "ooni.org",
  "measurement_start_time": "2022-08-02 11:22:37",
  "options": [
    "Resolver=udp://9.9.9.9:53"
  ],
  "probe_asn": "AS30722",
  "probe_cc": "IT",
  "probe_ip": "127.0.0.1",
  "probe_network_name": "Vodafone Italia S.p.A.",
  "report_id": "",
  "resolver_asn": "AS30722",
  "resolver_ip": "91.81.132.35",
  "resolver_network_name": "Vodafone Italia S.p.A.",
  "software_name": "miniooni",
  "software_version": "3.16.0-alpha",
  "test_keys": {
    "queries": [
      {
        "answers": [
          {
            "asn": 16509,
            "as_org_name": "Amazon.com, Inc.",
            "answer_type": "A",
            "ipv4": "75.2.60.5",
            "ttl": null
          },
          {
            "asn": 16509,
            "as_org_name": "Amazon.com, Inc.",
            "answer_type": "A",
            "ipv4": "99.83.231.61",
            "ttl": null
          }
        ],
        "engine": "udp",
        "failure": null,
        "hostname": "ooni.org",
        "query_type": "A",
        "resolver_hostname": null,
        "resolver_port": null,
        "resolver_address": "9.9.9.9:53",
        "t": 0.132053
      },
      {
        "answers": null,
        "engine": "udp",
        "failure": "dns_no_answer",
        "hostname": "ooni.org",
        "query_type": "AAAA",
        "resolver_hostname": null,
        "resolver_port": null,
        "resolver_address": "9.9.9.9:53",
        "t": 0.102853
      }
    ],
    "target_resolver": "udp://9.9.9.9:53"
  },
  "test_name": "dnsscan",
  "test_runtime": 0.132149438,
  "test_start_time": "2022-08-02 11:22:37",
  "test_version": "0.1.0"
}
```