### PR TITLE
feat: collect system resolver results using context

### DIFF
--- a/internal/netxlite/resolverparallel_test.go
+++ b/internal/netxlite/resolverparallel_test.go
@@ -6,10 +6,13 @@ import (
 	"errors"
 	"net"
 	"testing"
+	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/miekg/dns"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/model/mocks"
+	"github.com/ooni/probe-cli/v3/internal/testingx"
 )
 
 func TestParallelResolver(t *testing.T) {
@@ -269,6 +272,213 @@ func TestParallelResolver(t *testing.T) {
 			}
 			if https != nil {
 				t.Fatal("unexpected result")
+			}
+		})
+	})
+
+	t.Run("uses a context-injected custom trace (success case)", func(t *testing.T) {
+		var (
+			onLookupACalled        bool
+			onLookupAAAACalled     bool
+			goodQueryTypeA         bool
+			goodQueryTypeAAAA      bool
+			goodLookupAddrsA       bool
+			goodLookupAddrsAAAA    bool
+			goodLookupErrorA       bool
+			goodLookupErrorAAAA    bool
+			goodLookupResolverA    bool
+			goodLookupResolverAAAA bool
+		)
+		expectedA := []string{"1.1.1.1"}
+		expectedAAAA := []string{"::1"}
+		txp := &mocks.DNSTransport{
+			MockRoundTrip: func(ctx context.Context, query model.DNSQuery) (model.DNSResponse, error) {
+				if query.Type() == dns.TypeA {
+					return &mocks.DNSResponse{
+						MockDecodeLookupHost: func() ([]string, error) {
+							return expectedA, nil
+						},
+					}, nil
+				}
+				if query.Type() == dns.TypeAAAA {
+					return &mocks.DNSResponse{
+						MockDecodeLookupHost: func() ([]string, error) {
+							return expectedAAAA, nil
+						},
+					}, nil
+				}
+				return nil, errors.New("unexpected query type")
+			},
+			MockNetwork: func() string {
+				return "mocked"
+			},
+			MockRequiresPadding: func() bool {
+				return false
+			},
+		}
+		r := NewUnwrappedParallelResolver(txp)
+		zeroTime := time.Now()
+		deteterministicTime := testingx.NewTimeDeterministic(zeroTime)
+		tx := &mocks.Trace{
+			MockTimeNow: deteterministicTime.Now,
+			MockOnDNSRoundTripForLookupHost: func(started time.Time, reso model.Resolver, query model.DNSQuery,
+				response model.DNSResponse, addrs []string, err error, finished time.Time) {
+				if query.Type() == dns.TypeA {
+					onLookupACalled = true
+					goodQueryTypeA = (query.Type() == dns.TypeA)
+					goodLookupAddrsA = (cmp.Diff(expectedA, addrs) == "")
+					goodLookupErrorA = (err == nil)
+					goodLookupResolverA = (reso.Network() == "mocked")
+				}
+				if query.Type() == dns.TypeAAAA {
+					onLookupAAAACalled = true
+					goodQueryTypeAAAA = (query.Type() == dns.TypeAAAA)
+					goodLookupAddrsAAAA = (cmp.Diff(expectedAAAA, addrs) == "")
+					goodLookupErrorAAAA = (err == nil)
+					goodLookupResolverAAAA = (reso.Network() == "mocked")
+				}
+			},
+		}
+		want := []string{"1.1.1.1", "::1"}
+		ctx := ContextWithTrace(context.Background(), tx)
+		addrs, err := r.LookupHost(ctx, "example.com")
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+		if diff := cmp.Diff(want, addrs); diff != "" {
+			t.Fatal("unexpected addresses")
+		}
+
+		t.Run("with A reply", func(t *testing.T) {
+			if !onLookupACalled {
+				t.Fatal("onLookupACalled not called")
+			}
+			if !goodQueryTypeA {
+				t.Fatal("unexpected query type in system resolver")
+			}
+			if !goodLookupAddrsA {
+				t.Fatal("unexpected addresses in LookupHost")
+			}
+			if !goodLookupErrorA {
+				t.Fatal("unexpected error in trace")
+			}
+			if !goodLookupResolverA {
+				t.Fatal("unexpected resolver network encountered")
+			}
+		})
+
+		t.Run("with AAAA reply", func(t *testing.T) {
+			if !onLookupAAAACalled {
+				t.Fatal("onLookupAAAACalled not called")
+			}
+			if !goodQueryTypeAAAA {
+				t.Fatal("unexpected query type in system resolver")
+			}
+			if !goodLookupAddrsAAAA {
+				t.Fatal("unexpected addresses in LookupHost")
+			}
+			if !goodLookupErrorAAAA {
+				t.Fatal("unexpected error in trace")
+			}
+			if !goodLookupResolverAAAA {
+				t.Fatal("unexpected resolver network encountered")
+			}
+		})
+	})
+
+	t.Run("uses a context-injected custom trace (failure case)", func(t *testing.T) {
+		var (
+			onLookupACalled        bool
+			onLookupAAAACalled     bool
+			goodQueryTypeA         bool
+			goodQueryTypeAAAA      bool
+			goodLookupAddrsA       bool
+			goodLookupAddrsAAAA    bool
+			goodLookupErrorA       bool
+			goodLookupErrorAAAA    bool
+			goodLookupResolverA    bool
+			goodLookupResolverAAAA bool
+		)
+		expected := errors.New("mocked")
+		txp := &mocks.DNSTransport{
+			MockRoundTrip: func(ctx context.Context, query model.DNSQuery) (model.DNSResponse, error) {
+				if query.Type() == dns.TypeAAAA || query.Type() == dns.TypeA {
+					return nil, expected
+				}
+				return nil, errors.New("unexpected query type")
+			},
+			MockNetwork: func() string {
+				return "mocked"
+			},
+			MockRequiresPadding: func() bool {
+				return false
+			},
+		}
+		r := NewUnwrappedParallelResolver(txp)
+		zeroTime := time.Now()
+		deteterministicTime := testingx.NewTimeDeterministic(zeroTime)
+		tx := &mocks.Trace{
+			MockTimeNow: deteterministicTime.Now,
+			MockOnDNSRoundTripForLookupHost: func(started time.Time, reso model.Resolver, query model.DNSQuery,
+				response model.DNSResponse, addrs []string, err error, finished time.Time) {
+				if query.Type() == dns.TypeA {
+					onLookupACalled = true
+					goodQueryTypeA = (query.Type() == dns.TypeA)
+					goodLookupAddrsA = (len(addrs) == 0)
+					goodLookupErrorA = errors.Is(expected, err)
+					goodLookupResolverA = (reso.Network() == "mocked")
+				}
+				if query.Type() == dns.TypeAAAA {
+					onLookupAAAACalled = true
+					goodQueryTypeAAAA = (query.Type() == dns.TypeAAAA)
+					goodLookupAddrsAAAA = (len(addrs) == 0)
+					goodLookupErrorAAAA = errors.Is(expected, err)
+					goodLookupResolverAAAA = (reso.Network() == "mocked")
+				}
+			},
+		}
+		ctx := ContextWithTrace(context.Background(), tx)
+		addrs, err := r.LookupHost(ctx, "example.com")
+		if !errors.Is(expected, err) {
+			t.Fatal("unexpected error", err)
+		}
+		if len(addrs) != 0 {
+			t.Fatal("unexpected addresses")
+		}
+
+		t.Run("with A reply", func(t *testing.T) {
+			if !onLookupACalled {
+				t.Fatal("onLookupACalled not called")
+			}
+			if !goodQueryTypeA {
+				t.Fatal("unexpected query type in system resolver")
+			}
+			if !goodLookupAddrsA {
+				t.Fatal("unexpected addresses in LookupHost")
+			}
+			if !goodLookupErrorA {
+				t.Fatal("unexpected error in trace")
+			}
+			if !goodLookupResolverA {
+				t.Fatal("unexpected resolver network encountered")
+			}
+		})
+
+		t.Run("with AAAA reply", func(t *testing.T) {
+			if !onLookupAAAACalled {
+				t.Fatal("onLookupAAAACalled not called")
+			}
+			if !goodQueryTypeAAAA {
+				t.Fatal("unexpected query type in system resolver")
+			}
+			if !goodLookupAddrsAAAA {
+				t.Fatal("unexpected addresses in LookupHost")
+			}
+			if !goodLookupErrorAAAA {
+				t.Fatal("unexpected error in trace")
+			}
+			if !goodLookupResolverAAAA {
+				t.Fatal("unexpected resolver network encountered")
 			}
 		})
 	})

--- a/internal/netxlite/resolverparallel_test.go
+++ b/internal/netxlite/resolverparallel_test.go
@@ -345,6 +345,7 @@ func TestParallelResolver(t *testing.T) {
 		if err != nil {
 			t.Fatal("unexpected error", err)
 		}
+		// Note: the implementation always puts IPv4 addrs before IPv6 addrs
 		if diff := cmp.Diff(want, addrs); diff != "" {
 			t.Fatal("unexpected addresses")
 		}
@@ -354,7 +355,7 @@ func TestParallelResolver(t *testing.T) {
 				t.Fatal("onLookupACalled not called")
 			}
 			if !goodQueryTypeA {
-				t.Fatal("unexpected query type in system resolver")
+				t.Fatal("unexpected query type in parallel resolver")
 			}
 			if !goodLookupAddrsA {
 				t.Fatal("unexpected addresses in LookupHost")
@@ -372,7 +373,7 @@ func TestParallelResolver(t *testing.T) {
 				t.Fatal("onLookupAAAACalled not called")
 			}
 			if !goodQueryTypeAAAA {
-				t.Fatal("unexpected query type in system resolver")
+				t.Fatal("unexpected query type in parallel resolver")
 			}
 			if !goodLookupAddrsAAAA {
 				t.Fatal("unexpected addresses in LookupHost")
@@ -427,6 +428,7 @@ func TestParallelResolver(t *testing.T) {
 					goodLookupAddrsA = (len(addrs) == 0)
 					goodLookupErrorA = errors.Is(expected, err)
 					goodLookupResolverA = (reso.Network() == "mocked")
+					return
 				}
 				if query.Type() == dns.TypeAAAA {
 					onLookupAAAACalled = true
@@ -434,6 +436,7 @@ func TestParallelResolver(t *testing.T) {
 					goodLookupAddrsAAAA = (len(addrs) == 0)
 					goodLookupErrorAAAA = errors.Is(expected, err)
 					goodLookupResolverAAAA = (reso.Network() == "mocked")
+					return
 				}
 			},
 		}
@@ -451,7 +454,7 @@ func TestParallelResolver(t *testing.T) {
 				t.Fatal("onLookupACalled not called")
 			}
 			if !goodQueryTypeA {
-				t.Fatal("unexpected query type in system resolver")
+				t.Fatal("unexpected query type in parallel resolver")
 			}
 			if !goodLookupAddrsA {
 				t.Fatal("unexpected addresses in LookupHost")
@@ -469,7 +472,7 @@ func TestParallelResolver(t *testing.T) {
 				t.Fatal("onLookupAAAACalled not called")
 			}
 			if !goodQueryTypeAAAA {
-				t.Fatal("unexpected query type in system resolver")
+				t.Fatal("unexpected query type in parallel resolver")
 			}
 			if !goodLookupAddrsAAAA {
 				t.Fatal("unexpected addresses in LookupHost")


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2207
- [ ] if you changed anything related how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description
This introduces context-based tracing to the system resolver in netxlite
