### PR TITLE
fix(registry): ensure we can run telegram and webconnectivity

### DIFF
--- a/internal/cmd/miniooni/main.go
+++ b/internal/cmd/miniooni/main.go
@@ -6,16 +6,6 @@ package main
 // Main function
 //
 
-import (
-	"fmt"
-	"os"
-)
-
 func main() {
-	defer func() {
-		if s := recover(); s != nil {
-			fmt.Fprintf(os.Stderr, "FATAL: %s\n", s)
-		}
-	}()
 	Main()
 }

--- a/internal/registry/telegram.go
+++ b/internal/registry/telegram.go
@@ -16,7 +16,7 @@ func init() {
 				config.(telegram.Config),
 			)
 		},
-		config:        &telegram.Config{},
+		config:        telegram.Config{},
 		interruptible: false,
 		inputPolicy:   model.InputNone,
 	}

--- a/internal/registry/webconnectivity.go
+++ b/internal/registry/webconnectivity.go
@@ -16,7 +16,7 @@ func init() {
 				config.(webconnectivity.Config),
 			)
 		},
-		config:        &webconnectivity.Config{},
+		config:        webconnectivity.Config{},
 		interruptible: false,
 		inputPolicy:   model.InputOrQueryBackend,
 	}


### PR DESCRIPTION
I made a mistake while adapting code from an experimental branch thus
breaking these two experiments because of interface conversion.

This diff fixes it.

While there, remove the panic trap for miniooni. Because miniooni is
an experimental tool, we want to see the full panic text, which definitely
leads to a more pleasant and effective debugging experience.

See https://github.com/ooni/probe/issues/2216 for context on why we
were trying to change how we register experiments.

The broken commit is https://github.com/ooni/probe-cli/commit/6a0ae5c70b68a72206ff7ffb530c758661545cc4.
