### PR TITLE
cleanup: chmod -x mk && mv mk Makefile

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -33,7 +33,7 @@ jobs:
           PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
           PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
 
-      - run: ./mk ./MOBILE/android
+      - run: make ./MOBILE/android
 
       - run: |
           tag=$(echo $GITHUB_REF | sed 's|refs/tags/||g')

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -33,7 +33,7 @@ jobs:
           PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
           PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
 
-      - run: ./mk EXPECTED_XCODE_VERSION=12.4 ./MOBILE/ios
+      - run: make EXPECTED_XCODE_VERSION=12.4 ./MOBILE/ios
 
       - run: |
           tag=$(echo $GITHUB_REF | sed 's|refs/tags/||g')

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
           PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
-      - run: ./mk ./CLI/ooniprobe-linux-386
+      - run: make ./CLI/ooniprobe-linux-386
       - run: ./E2E/ooniprobe.sh ./CLI/ooniprobe-linux-386
       - run: |
           tag=$(echo $GITHUB_REF | sed 's|refs/tags/||g')
@@ -47,7 +47,7 @@ jobs:
         env:
           PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
           PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
-      - run: ./mk ./CLI/ooniprobe-linux-amd64
+      - run: make ./CLI/ooniprobe-linux-amd64
       - run: ./E2E/ooniprobe.sh ./CLI/ooniprobe-linux-amd64
       - run: |
           tag=$(echo $GITHUB_REF | sed 's|refs/tags/||g')
@@ -73,7 +73,7 @@ jobs:
         env:
           PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
           PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
-      - run: ./mk ./CLI/ooniprobe-linux-armv7
+      - run: make ./CLI/ooniprobe-linux-armv7
       - run: ./E2E/ooniprobe.sh ./CLI/ooniprobe-linux-armv7
       - run: |
           tag=$(echo $GITHUB_REF | sed 's|refs/tags/||g')
@@ -99,7 +99,7 @@ jobs:
         env:
           PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
           PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
-      - run: ./mk ./CLI/ooniprobe-linux-arm64
+      - run: make ./CLI/ooniprobe-linux-arm64
       - run: ./E2E/ooniprobe.sh ./CLI/ooniprobe-linux-arm64
       - run: |
           tag=$(echo $GITHUB_REF | sed 's|refs/tags/||g')

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,7 +33,7 @@ jobs:
           PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
           PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
 
-      - run: ./mk ./CLI/ooniprobe-darwin
+      - run: make ./CLI/ooniprobe-darwin
 
       - run: ./E2E/ooniprobe.sh ./CLI/ooniprobe-darwin-amd64
 

--- a/.github/workflows/miniooni.yml
+++ b/.github/workflows/miniooni.yml
@@ -38,7 +38,7 @@ jobs:
           PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
           PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
 
-      - run: ./mk ./CLI/miniooni
+      - run: make ./CLI/miniooni
       - run: ./E2E/miniooni.bash ./CLI/miniooni-linux-amd64
 
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,7 +31,7 @@ jobs:
           PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
           PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
 
-      - run: ./mk EXPECTED_MINGW_W64_VERSION="9.3-win32" ./CLI/ooniprobe-windows
+      - run: make EXPECTED_MINGW_W64_VERSION="9.3-win32" ./CLI/ooniprobe-windows
 
       - uses: actions/upload-artifact@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,25 @@
-#!/usr/bin/make -f
-
 # Many rules in here break if run in parallel.
 .NOTPARALLEL:
 
-#quickhelp: Usage: ./mk [VARIABLE=VALUE ...] TARGET ...
+#quickhelp: Usage: make [VARIABLE=VALUE ...] TARGET ...
 .PHONY: usage
 usage:
-	@cat mk | grep '^#quickhelp:' | sed -e 's/^#quickhelp://' -e 's/^\ *//'
+	@cat Makefile | grep '^#quickhelp:' | sed -e 's/^#quickhelp://' -e 's/^\ *//'
 
 # Most targets are .PHONY because whether to rebuild is controlled
 # by golang. We expose to the user all the .PHONY targets.
 #quickhelp:
-#quickhelp: The `./mk list-targets` command lists all available targets.
+#quickhelp: The `make list-targets` command lists all available targets.
 .PHONY: list-targets
 list-targets:
-	@cat mk | grep '^\.PHONY:' | sed -e 's/^\.PHONY://' | grep -v '^ search' | grep -v '^ maybe'
+	@cat Makefile | grep '^\.PHONY:' | sed -e 's/^\.PHONY://' | grep -v '^ search' | grep -v '^ maybe'
 
 #quickhelp:
-#quickhelp: The `./mk help` command provides detailed usage instructions. We
-#quickhelp: recommend running `./mk help|less` to page its output.
+#quickhelp: The `make help` command provides detailed usage instructions. We
+#quickhelp: recommend running `make help|less` to page its output.
 .PHONY: help
 help:
-	@cat mk | grep -E '^#(quick)?help:' | sed -E -e 's/^#(quick)?help://' -e s'/^\ //'
+	@cat Makefile | grep -E '^#(quick)?help:' | sed -E -e 's/^#(quick)?help://' -e s'/^\ //'
 
 #help:
 #help: The following variables control the build. You can specify them
@@ -40,11 +38,11 @@ GIT_CLONE_DIR = $(HOME)/.ooniprobe-build/src
 #help:                           repository. If you do not have the permission to
 #help:                           clone it, just clear this variable, e.g.:
 #help:
-#help:                               ./mk OONI_PSIPHON_TAGS="" ./CLI/miniooni
+#help:                               make OONI_PSIPHON_TAGS="" ./CLI/miniooni
 OONI_PSIPHON_TAGS = ooni_psiphon_config
 
 #quickhelp:
-#quickhelp: The `./mk show-config` command shows the current value of the
+#quickhelp: The `make show-config` command shows the current value of the
 #quickhelp: variables controlling the build.
 .PHONY: show-config
 show-config:
@@ -52,7 +50,7 @@ show-config:
 	@echo "OONI_PSIPHON_TAGS=$(OONI_PSIPHON_TAGS)"
 
 #help:
-#help: The `./mk ./CLI/miniooni` command builds the miniooni experimental
+#help: The `make ./CLI/miniooni` command builds the miniooni experimental
 #help: command line client for all the supported GOOS/GOARCH.
 #help:
 #help: You can also build the following subtargets:
@@ -69,61 +67,61 @@ show-config:
 	./CLI/miniooni-windows-amd64.exe
 
 #help:
-#help: * `./mk ./CLI/miniooni-darwin-amd64`: darwin/amd64
+#help: * `make ./CLI/miniooni-darwin-amd64`: darwin/amd64
 .PHONY:   ./CLI/miniooni-darwin-amd64
 ./CLI/miniooni-darwin-amd64: search/for/go maybe/copypsiphon
 	./CLI/go-build-cross darwin amd64 ./internal/cmd/miniooni
 
 #help:
-#help: * `./mk ./CLI/miniooni-darwin-arm64`: darwin/arm64
+#help: * `make ./CLI/miniooni-darwin-arm64`: darwin/arm64
 .PHONY:   ./CLI/miniooni-darwin-arm64
 ./CLI/miniooni-darwin-arm64: search/for/go maybe/copypsiphon
 	./CLI/go-build-cross darwin arm64 ./internal/cmd/miniooni
 
 #help:
-#help: * `./mk ./CLI/miniooni-linux-386`: linux/386
+#help: * `make ./CLI/miniooni-linux-386`: linux/386
 .PHONY:   ./CLI/miniooni-linux-386
 ./CLI/miniooni-linux-386: search/for/go maybe/copypsiphon
 	./CLI/go-build-cross linux 386 ./internal/cmd/miniooni
 
 #help:
-#help: * `./mk ./CLI/miniooni-linux-amd64`: linux/amd64
+#help: * `make ./CLI/miniooni-linux-amd64`: linux/amd64
 .PHONY:   ./CLI/miniooni-linux-amd64
 ./CLI/miniooni-linux-amd64: search/for/go maybe/copypsiphon
 	./CLI/go-build-cross linux amd64 ./internal/cmd/miniooni
 
 #help:
-#help: * `./mk ./CLI/miniooni-linux-armv6`: linux/armv6
+#help: * `make ./CLI/miniooni-linux-armv6`: linux/armv6
 .PHONY:   ./CLI/miniooni-linux-armv6
 ./CLI/miniooni-linux-armv6: search/for/go maybe/copypsiphon
 	./CLI/go-build-cross linux armv6 ./internal/cmd/miniooni
 
 #help:
-#help: * `./mk ./CLI/miniooni-linux-armv7`: linux/armv7
+#help: * `make ./CLI/miniooni-linux-armv7`: linux/armv7
 .PHONY:   ./CLI/miniooni-linux-armv7
 ./CLI/miniooni-linux-armv7: search/for/go maybe/copypsiphon
 	./CLI/go-build-cross linux armv7 ./internal/cmd/miniooni
 
 #help:
-#help: * `./mk ./CLI/miniooni-linux-arm64`: linux/arm64
+#help: * `make ./CLI/miniooni-linux-arm64`: linux/arm64
 .PHONY:   ./CLI/miniooni-linux-arm64
 ./CLI/miniooni-linux-arm64: search/for/go maybe/copypsiphon
 	./CLI/go-build-cross linux arm64 ./internal/cmd/miniooni
 
 #help:
-#help: * `./mk ./CLI/miniooni-windows-386.exe`: windows/386
+#help: * `make ./CLI/miniooni-windows-386.exe`: windows/386
 .PHONY:   ./CLI/miniooni-windows-386.exe
 ./CLI/miniooni-windows-386.exe: search/for/go maybe/copypsiphon
 	./CLI/go-build-cross windows 386 ./internal/cmd/miniooni
 
 #help:
-#help: * `./mk ./CLI/miniooni-windows-amd64.exe`: windows/amd64
+#help: * `make ./CLI/miniooni-windows-amd64.exe`: windows/amd64
 .PHONY:   ./CLI/miniooni-windows-amd64.exe
 ./CLI/miniooni-windows-amd64.exe: search/for/go maybe/copypsiphon
 	./CLI/go-build-cross windows amd64 ./internal/cmd/miniooni
 
 #help:
-#help: The `./mk ./CLI/ooniprobe-darwin` command builds the ooniprobe official
+#help: The `make ./CLI/ooniprobe-darwin` command builds the ooniprobe official
 #help: command line client for darwin/amd64 and darwin/arm64.
 #help:
 #help: You can also build the following subtargets:
@@ -131,19 +129,19 @@ show-config:
 ./CLI/ooniprobe-darwin: ./CLI/ooniprobe-darwin-amd64 ./CLI/ooniprobe-darwin-arm64
 
 #help:
-#help: * `./mk ./CLI/ooniprobe-darwin-amd64`: darwin/amd64
+#help: * `make ./CLI/ooniprobe-darwin-amd64`: darwin/amd64
 .PHONY:     ./CLI/ooniprobe-darwin-amd64
 ./CLI/ooniprobe-darwin-amd64: search/for/go maybe/copypsiphon
 	./CLI/go-build-darwin amd64 ./cmd/ooniprobe
 
 #help:
-#help: * `./mk ./CLI/ooniprobe-darwin-arm64`: darwin/arm64
+#help: * `make ./CLI/ooniprobe-darwin-arm64`: darwin/arm64
 .PHONY:     ./CLI/ooniprobe-darwin-arm64
 ./CLI/ooniprobe-darwin-arm64: search/for/go maybe/copypsiphon
 	./CLI/go-build-darwin arm64 ./cmd/ooniprobe
 
 #help:
-#help: The `./mk ./CLI/ooniprobe-linux` command builds the ooniprobe official command
+#help: The `make ./CLI/ooniprobe-linux` command builds the ooniprobe official command
 #help: line client for amd64, arm64, etc.
 #help:
 #help: You can also build the following subtargets:
@@ -155,31 +153,31 @@ show-config:
 	./CLI/ooniprobe-linux-arm64
 
 #help:
-#help: * `./mk ./CLI/ooniprobe-linux-386`: linux/386
+#help: * `make ./CLI/ooniprobe-linux-386`: linux/386
 .PHONY:     ./CLI/ooniprobe-linux-386
 ./CLI/ooniprobe-linux-386: search/for/docker maybe/copypsiphon
 	./CLI/go-build-linux-static 386 ./cmd/ooniprobe
 
 #help:
-#help: * `./mk ./CLI/ooniprobe-linux-amd64`: linux/amd64
+#help: * `make ./CLI/ooniprobe-linux-amd64`: linux/amd64
 .PHONY:     ./CLI/ooniprobe-linux-amd64
 ./CLI/ooniprobe-linux-amd64: search/for/docker maybe/copypsiphon
 	./CLI/go-build-linux-static amd64 ./cmd/ooniprobe
 
 #help:
-#help: * `./mk ./CLI/ooniprobe-linux-armv7`: linux/arm
+#help: * `make ./CLI/ooniprobe-linux-armv7`: linux/arm
 .PHONY:     ./CLI/ooniprobe-linux-armv7
 ./CLI/ooniprobe-linux-armv7: search/for/docker maybe/copypsiphon
 	./CLI/go-build-linux-static armv7 ./cmd/ooniprobe
 
 #help:
-#help: * `./mk ./CLI/ooniprobe-linux-arm64`: linux/arm64
+#help: * `make ./CLI/ooniprobe-linux-arm64`: linux/arm64
 .PHONY:     ./CLI/ooniprobe-linux-arm64
 ./CLI/ooniprobe-linux-arm64: search/for/docker maybe/copypsiphon
 	./CLI/go-build-linux-static arm64 ./cmd/ooniprobe
 
 #help:
-#help: The `./mk ./CLI/ooniprobe-windows` command builds the ooniprobe official
+#help: The `make ./CLI/ooniprobe-windows` command builds the ooniprobe official
 #help: command line client for windows/386 and windows/amd64.
 #help:
 #help: You can also build the following subtargets:
@@ -189,32 +187,32 @@ show-config:
 	./CLI/ooniprobe-windows-amd64.exe
 
 #help:
-#help: * `./mk ./CLI/ooniprobe-windows-386.exe`: windows/386
+#help: * `make ./CLI/ooniprobe-windows-386.exe`: windows/386
 .PHONY:     ./CLI/ooniprobe-windows-386.exe
 ./CLI/ooniprobe-windows-386.exe: search/for/go search/for/mingw-w64 maybe/copypsiphon
 	./CLI/go-build-windows 386 ./cmd/ooniprobe
 
 #help:
-#help: * `./mk ./CLI/ooniprobe-windows-amd64.exe`: windows/amd64
+#help: * `make ./CLI/ooniprobe-windows-amd64.exe`: windows/amd64
 .PHONY:     ./CLI/ooniprobe-windows-amd64.exe
 ./CLI/ooniprobe-windows-amd64.exe: search/for/go search/for/mingw-w64 maybe/copypsiphon
 	./CLI/go-build-windows amd64 ./cmd/ooniprobe
 
 #help:
-#help: The `./mk ./MOBILE/android` command builds the oonimkall library for Android.
+#help: The `make ./MOBILE/android` command builds the oonimkall library for Android.
 #help:
 #help: You can also build the following subtargets:
 .PHONY: ./MOBILE/android
 ./MOBILE/android: ./MOBILE/android/oonimkall.aar ./MOBILE/android/oonimkall.pom
 
 #help:
-#help: * `./mk ./MOBILE/android/oonimkall.pom`: the POM
+#help: * `make ./MOBILE/android/oonimkall.pom`: the POM
 .PHONY:   ./MOBILE/android/oonimkall.pom
 ./MOBILE/android/oonimkall.pom:
 	./MOBILE/android/createpom
 
 #help:
-#help: * `./mk ./MOBILE/android/oonimkall.aar`: the AAR
+#help: * `make ./MOBILE/android/oonimkall.aar`: the AAR
 .PHONY:   ./MOBILE/android/oonimkall.aar
 ./MOBILE/android/oonimkall.aar: search/for/android/sdk maybe/copypsiphon
 	@echo "Android build disabled - TODO(https://github.com/ooni/probe/issues/2122)"
@@ -222,26 +220,26 @@ show-config:
 	./MOBILE/gomobile android ./pkg/oonimkall
 
 #help:
-#help: The `./mk ./MOBILE/ios` command builds the oonimkall library for iOS.
+#help: The `make ./MOBILE/ios` command builds the oonimkall library for iOS.
 #help:
 #help: You can also build the following subtargets:
 .PHONY: ./MOBILE/ios
 ./MOBILE/ios: ./MOBILE/ios/oonimkall.xcframework.zip ./MOBILE/ios/oonimkall.podspec
 
 #help:
-#help: * `./mk ./MOBILE/ios/oonimkall.xcframework.zip`: zip the xcframework
+#help: * `make ./MOBILE/ios/oonimkall.xcframework.zip`: zip the xcframework
 .PHONY:   ./MOBILE/ios/oonimkall.xcframework.zip
 ./MOBILE/ios/oonimkall.xcframework.zip: search/for/zip ./MOBILE/ios/oonimkall.xcframework
 	./MOBILE/ios/zipframework
 
 #help:
-#help: * `./mk ./MOBILE/ios/xcframework`: the xcframework
+#help: * `make ./MOBILE/ios/xcframework`: the xcframework
 .PHONY:     ./MOBILE/ios/oonimkall.xcframework
 ./MOBILE/ios/oonimkall.xcframework: search/for/go search/for/xcode maybe/copypsiphon
 	./MOBILE/gomobile ios ./pkg/oonimkall
 
 #help:
-#help: * `./mk ./MOBILE/ios/oonimkall.podspec`: the podspec
+#help: * `make ./MOBILE/ios/oonimkall.podspec`: the podspec
 .PHONY:   ./MOBILE/ios/oonimkall.podspec
 ./MOBILE/ios/oonimkall.podspec: ./MOBILE/ios/template.podspec
 	./MOBILE/ios/createpodspec
@@ -279,7 +277,7 @@ search/for/zip:
 	@command -v zip || { echo "not found"; exit 1; }
 
 #help:
-#help: The `./mk maybe/copypsiphon` command checks whether we want
+#help: The `make maybe/copypsiphon` command checks whether we want
 #help: to embed the Psiphon config file into the build. To this end,
 #help: this command checks whether OONI_PSIPHON_TAGS is set. In
 #help: such a case, this command checks whether the required files

--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ This repository contains core OONI tools written in Go:
 
 - the mobile library ([pkg/oonimkall](pkg/oonimkall));
 
-- and all the related support packages (inside [internal](internal)).
+- the OONI Probe engine (inside [internal](internal)).
 
 Every top-level directory in this repository contains an explanatory README file. You
 may also notice that some internal packages live under [internal/engine](internal/engine)
@@ -51,52 +51,25 @@ Please, make sure you add the `ooni/probe-cli` label.
 
 ## Build instructions
 
+Be sure you have the golang version mentioned inside the [GOVERSION](GOVERSION)
+file and a C compiler (Mingw-w64 for Windows).
+
 ### ooniprobe
 
-Be sure you have the golang version mentioned inside the [GOVERSION](GOVERSION)
-file and a C compiler (Mingw-w64 for Windows). You can build using:
+Ooniprobe is the official CLI client. Compile using:
 
 ```bash
-go build -v ./cmd/ooniprobe
+go build -v -ldflags "-s -w" ./cmd/ooniprobe
 ```
 
 This will generate a binary called `ooniprobe` in the current directory.
-
-### Android bindings
-
-Make sure you have GNU make installed, then run:
-
-```bash
-./mk ./MOBILE/android
-```
-
-to build bindings for Android. (Add `OONI_PSIPHON_TAGS=""` if you
-cannot clone private repositories in the https://github.com/ooni namespace.)
-
-The generated bindings are (manually) pushed to the Maven Central package
-repository. The instructions explaining how to integrate these bindings
-are published along with the release notes.
-
-### iOS bindings
-
-Make sure you have GNU make installed, then run:
-
-```bash
-./mk ./MOBILE/ios
-```
-
-to build bindings for iOS. (Add `OONI_PSIPHON_TAGS=""` if you
-cannot clone private repositories in the https://github.com/ooni namespace.)
-
-The generated bindings are (manually) added to GitHub releases. The instructions
-explaining how to integrate these bindings are published along with the release notes.
 
 ### miniooni
 
 Miniooni is the experimental OONI client used for research. Compile using:
 
 ```bash
-go build -v ./internal/cmd/miniooni
+go build -v -ldflags "-s -w" ./internal/cmd/miniooni
 ```
 
 This will generate a binary called `miniooni` in the current directory.
@@ -106,7 +79,7 @@ This will generate a binary called `miniooni` in the current directory.
 Oohelperd is the test helper server. Compile using:
 
 ```bash
-go build -v ./internal/cmd/oohelperd
+go build -v -ldflags "-s -w" ./internal/cmd/oohelperd
 ```
 
 This will generate a binary called `oohelperd` in the current directory.
@@ -132,5 +105,5 @@ Create an issue according to [the routine release template](
 https://github.com/ooni/probe/blob/master/.github/ISSUE_TEMPLATE/routine-sprint-releases.md)
 and perform any item inside the check-list.
 
-We build releases using `./mk`, which requires GNU make. Try
-the `./mk help|less` command for detailed usage.
+We build releases using [Makefile](Makefile), which requires GNU make. Try
+the `make help|less` command for detailed usage.


### PR DESCRIPTION
While there, document what we need to document without mentioning too
many details about release builds, for which we have the Makefile.

See https://github.com/ooni/probe/issues/2218.
