### PR TITLE
fix: disable psiphon when building with go1.19

### DIFF
--- a/.github/workflows/alltests.yml
+++ b/.github/workflows/alltests.yml
@@ -15,7 +15,7 @@ jobs:
         id: goversion
         run: echo ::set-output name=version::$(cat GOVERSION)
 
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: "${{ steps.goversion.outputs.version }}"
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,7 +22,7 @@ jobs:
         id: goversion
         run: echo ::set-output name=version::$(cat GOVERSION)
 
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: "${{ steps.goversion.outputs.version }}"
 

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -15,7 +15,7 @@ jobs:
         id: goversion
         run: echo ::set-output name=version::$(cat GOVERSION)
 
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: "${{ steps.goversion.outputs.version }}"
 

--- a/.github/workflows/go1.19.yml
+++ b/.github/workflows/go1.19.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: magnetikonline/action-golang-cache@v2
         with:
           go-version: "go1.19"
-          cache-key-suffix: "-coverage-${{ steps.goversion.outputs.version }}"
+          cache-key-suffix: "-coverage-go1.19"
 
       - run: go build -v ./...
 

--- a/.github/workflows/go1.19.yml
+++ b/.github/workflows/go1.19.yml
@@ -1,0 +1,28 @@
+# Interim build script checking for go1.19
+#
+# Psiphon not working with go1.19: TODO(https://github.com/ooni/probe/issues/2222)
+#
+name: go1.19
+on:
+  pull_request:
+  push:
+    branches:
+      - "master"
+      - "release/**"
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: magnetikonline/action-golang-cache@v2
+        with:
+          go-version: "go1.19"
+          cache-key-suffix: "-coverage-${{ steps.goversion.outputs.version }}"
+
+      - run: go build -v ./...
+
+      - run: go test -short -race -tags shaping ./...
+

--- a/.github/workflows/go1.19.yml
+++ b/.github/workflows/go1.19.yml
@@ -17,10 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: magnetikonline/action-golang-cache@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: "go1.19"
-          cache-key-suffix: "-coverage-go1.19"
 
       - run: go build -v ./...
 

--- a/.github/workflows/go1.19.yml
+++ b/.github/workflows/go1.19.yml
@@ -17,11 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: go get golang.org/dl/go1.19
+      - run: go install golang.org/dl/go1.19@latest
 
-      - run: go1.19 download
+      - run: $(go env GOPATH)/bin/go1.19 download
 
-      - run: go1.19 build -v ./...
+      - run: $(go env GOPATH)/bin/go1.19 build -v ./...
 
-      - run: go1.19 test -short -race -tags shaping ./...
+      - run: $(go env GOPATH)/bin/go1.19 test -short -race -tags shaping ./...
 

--- a/.github/workflows/go1.19.yml
+++ b/.github/workflows/go1.19.yml
@@ -17,11 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "go1.19"
+      - run: go get golang.org/dl/go1.19
 
-      - run: go build -v ./...
+      - run: go1.19 download
 
-      - run: go test -short -race -tags shaping ./...
+      - run: go1.19 build -v ./...
+
+      - run: go1.19 test -short -race -tags shaping ./...
 

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -19,7 +19,7 @@ jobs:
       id: goversion
       run: echo ::set-output name=version::$(cat GOVERSION)
 
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v3
       with:
         go-version: "${{ steps.goversion.outputs.version }}"
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -22,7 +22,7 @@ jobs:
         id: goversion
         run: echo ::set-output name=version::$(cat GOVERSION)
 
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: "${{ steps.goversion.outputs.version }}"
 

--- a/.github/workflows/jafar.yml
+++ b/.github/workflows/jafar.yml
@@ -15,7 +15,7 @@ jobs:
         id: goversion
         run: echo ::set-output name=version::$(cat GOVERSION)
 
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: "${{ steps.goversion.outputs.version }}"
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,7 +22,7 @@ jobs:
         id: goversion
         run: echo ::set-output name=version::$(cat GOVERSION)
 
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: "${{ steps.goversion.outputs.version }}"
 

--- a/.github/workflows/miniooni.yml
+++ b/.github/workflows/miniooni.yml
@@ -27,7 +27,7 @@ jobs:
         id: goversion
         run: echo ::set-output name=version::$(cat GOVERSION)
 
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: "${{ steps.goversion.outputs.version }}"
 

--- a/.github/workflows/oohelperd.yml
+++ b/.github/workflows/oohelperd.yml
@@ -19,7 +19,7 @@ jobs:
         id: goversion
         run: echo ::set-output name=version::$(cat GOVERSION)
 
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: "${{ steps.goversion.outputs.version }}"
 

--- a/.github/workflows/qafbmessenger.yml
+++ b/.github/workflows/qafbmessenger.yml
@@ -15,7 +15,7 @@ jobs:
         id: goversion
         run: echo ::set-output name=version::$(cat GOVERSION)
 
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: "${{ steps.goversion.outputs.version }}"
 

--- a/.github/workflows/qahhfm.yml
+++ b/.github/workflows/qahhfm.yml
@@ -15,7 +15,7 @@ jobs:
         id: goversion
         run: echo ::set-output name=version::$(cat GOVERSION)
 
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: "${{ steps.goversion.outputs.version }}"
 

--- a/.github/workflows/qahirl.yml
+++ b/.github/workflows/qahirl.yml
@@ -15,7 +15,7 @@ jobs:
         id: goversion
         run: echo ::set-output name=version::$(cat GOVERSION)
 
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: "${{ steps.goversion.outputs.version }}"
 

--- a/.github/workflows/qatelegram.yml
+++ b/.github/workflows/qatelegram.yml
@@ -15,7 +15,7 @@ jobs:
         id: goversion
         run: echo ::set-output name=version::$(cat GOVERSION)
 
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: "${{ steps.goversion.outputs.version }}"
 

--- a/.github/workflows/qawebconnectivity.yml
+++ b/.github/workflows/qawebconnectivity.yml
@@ -15,7 +15,7 @@ jobs:
         id: goversion
         run: echo ::set-output name=version::$(cat GOVERSION)
 
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: "${{ steps.goversion.outputs.version }}"
 

--- a/.github/workflows/qawhatsapp.yml
+++ b/.github/workflows/qawhatsapp.yml
@@ -15,7 +15,7 @@ jobs:
         id: goversion
         run: echo ::set-output name=version::$(cat GOVERSION)
 
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: "${{ steps.goversion.outputs.version }}"
 

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -21,7 +21,7 @@ jobs:
         id: goversion
         run: echo ::set-output name=version::$(cat GOVERSION)
 
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: "${{ steps.goversion.outputs.version }}"
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ jobs:
         id: goversion
         run: echo ::set-output name=version::$(cat GOVERSION)
 
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: "${{ steps.goversion.outputs.version }}"
 

--- a/Readme.md
+++ b/Readme.md
@@ -59,8 +59,8 @@ Be sure you have:
 
 ### Caveats
 
-As of 2022-08-22, building with go1.19 will omit including [Psiphon](https://psiphon.ca/)
-from the build. Fixing this issue is TODO(https://github.com/ooni/probe/issues/2222).
+As of 2022-08-22, building with go1.19 will not include [Psiphon](https://psiphon.ca/) as
+a dependency. Fixing this issue is TODO(https://github.com/ooni/probe/issues/2222).
 
 ### ooniprobe
 

--- a/Readme.md
+++ b/Readme.md
@@ -57,6 +57,11 @@ Be sure you have:
 
 2. a C compiler (Mingw-w64 for Windows).
 
+### Caveats
+
+As of 2022-08-22, building with go1.19 will omit including [Psiphon](https://psiphon.ca/)
+from the build. Fixing this issue is TODO(https://github.com/ooni/probe/issues/2222).
+
 ### ooniprobe
 
 Ooniprobe is the official CLI client. Compile using:

--- a/internal/engine/experiment/urlgetter/getter_integration_test.go
+++ b/internal/engine/experiment/urlgetter/getter_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -275,6 +276,9 @@ func TestGetterWithCancelledContextNoFollowRedirects(t *testing.T) {
 }
 
 func TestGetterWithCancelledContextCannotStartTunnel(t *testing.T) {
+	if strings.HasPrefix(runtime.Version(), "go1.19") {
+		t.Skip("TODO(https://github.com/ooni/probe/issues/2222)")
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // fail immediately
 	g := urlgetter.Getter{

--- a/internal/tunnel/config.go
+++ b/internal/tunnel/config.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cretz/bine/control"
 	"github.com/cretz/bine/tor"
 	"github.com/ooni/probe-cli/v3/internal/model"
-	"github.com/ooni/psiphon/tunnel-core/ClientLibrary/clientlib"
 	"golang.org/x/sys/execabs"
 )
 
@@ -59,10 +58,6 @@ type Config struct {
 
 	// testSocks5New allows us to mock socks5.New in testing code.
 	testSocks5New func(conf *socks5.Config) (*socks5.Server, error)
-
-	// testStartPsiphon allows us to mock psiphon's clientlib.StartTunnel.
-	testStartPsiphon func(ctx context.Context, config []byte,
-		workdir string) (*clientlib.PsiphonTunnel, error)
 
 	// testTorStart allows us to mock tor.Start.
 	testTorStart func(ctx context.Context, conf *tor.StartConf) (*tor.Tor, error)
@@ -117,16 +112,6 @@ func (c *Config) socks5New(conf *socks5.Config) (*socks5.Server, error) {
 		return c.testSocks5New(conf)
 	}
 	return socks5.New(conf)
-}
-
-// startPsiphon calls either testStartPsiphon or psiphon's clientlib.StartTunnel.
-func (c *Config) startPsiphon(ctx context.Context, config []byte,
-	workdir string) (*clientlib.PsiphonTunnel, error) {
-	if c.testStartPsiphon != nil {
-		return c.testStartPsiphon(ctx, config, workdir)
-	}
-	return clientlib.StartTunnel(ctx, config, "", clientlib.Parameters{
-		DataRootDirectory: &workdir}, nil, nil)
 }
 
 // ooniTorBinaryEnv is the name of the environment variable

--- a/internal/tunnel/psiphon.go
+++ b/internal/tunnel/psiphon.go
@@ -1,4 +1,12 @@
+//go:build !go1.19
+
 package tunnel
+
+//
+// Psiphon not working with go1.19
+//
+// TODO(https://github.com/ooni/probe/issues/2222)
+//
 
 import (
 	"context"
@@ -10,6 +18,13 @@ import (
 
 	"github.com/ooni/psiphon/tunnel-core/ClientLibrary/clientlib"
 )
+
+// mockableStartPsiphon allows us to test for psiphon startup failures.
+var mockableStartPsiphon = func(
+	ctx context.Context, config []byte, workdir string) (*clientlib.PsiphonTunnel, error) {
+	return clientlib.StartTunnel(ctx, config, "", clientlib.Parameters{
+		DataRootDirectory: &workdir}, nil, nil)
+}
 
 // psiphonTunnel is a psiphon tunnel
 type psiphonTunnel struct {
@@ -53,7 +68,7 @@ func psiphonStart(ctx context.Context, config *Config) (Tunnel, DebugInfo, error
 		return nil, debugInfo, err
 	}
 	start := time.Now()
-	tunnel, err := config.startPsiphon(ctx, configJSON, workdir)
+	tunnel, err := mockableStartPsiphon(ctx, configJSON, workdir)
 	if err != nil {
 		return nil, debugInfo, err
 	}

--- a/internal/tunnel/psiphon_go119.go
+++ b/internal/tunnel/psiphon_go119.go
@@ -1,0 +1,19 @@
+//go:build go1.19
+
+package tunnel
+
+//
+// Psiphon not working with go1.19: TODO(https://github.com/ooni/probe/issues/2222)
+//
+
+import (
+	"context"
+	"errors"
+)
+
+// psiphonStart starts the psiphon tunnel.
+func psiphonStart(ctx context.Context, config *Config) (Tunnel, DebugInfo, error) {
+	return nil, DebugInfo{}, errors.New(
+		"psiphon is disabled when building with go1.19: see https://github.com/ooni/probe/issues/2222 for more information",
+	)
+}

--- a/internal/tunnel/psiphon_integration_test.go
+++ b/internal/tunnel/psiphon_integration_test.go
@@ -1,4 +1,10 @@
+//go:build !go1.19
+
 package tunnel_test
+
+//
+// Psiphon not working with go1.19: TODO(https://github.com/ooni/probe/issues/2222)
+//
 
 import (
 	"context"

--- a/internal/tunnel/psiphon_test.go
+++ b/internal/tunnel/psiphon_test.go
@@ -1,4 +1,10 @@
+//go:build !go1.19
+
 package tunnel
+
+//
+// Psiphon not working with go1.19: TODO(https://github.com/ooni/probe/issues/2222)
+//
 
 import (
 	"context"
@@ -82,13 +88,17 @@ func TestPsiphonStartFailure(t *testing.T) {
 	sess := &MockableSession{
 		Result: []byte(`{}`),
 	}
+	oldStartPsiphon := mockableStartPsiphon
+	defer func() {
+		mockableStartPsiphon = oldStartPsiphon
+	}()
+	mockableStartPsiphon = func(ctx context.Context, config []byte,
+		workdir string) (*clientlib.PsiphonTunnel, error) {
+		return nil, expected
+	}
 	tunnel, _, err := psiphonStart(context.Background(), &Config{
 		Session:   sess,
 		TunnelDir: "testdata",
-		testStartPsiphon: func(ctx context.Context, config []byte,
-			workdir string) (*clientlib.PsiphonTunnel, error) {
-			return nil, expected
-		},
 	})
 	if !errors.Is(err, expected) {
 		t.Fatal("not the error we expected")

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -3,6 +3,8 @@ package tunnel_test
 import (
 	"context"
 	"errors"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/ooni/probe-cli/v3/internal/tunnel"
@@ -23,6 +25,9 @@ func TestStartNoTunnel(t *testing.T) {
 }
 
 func TestStartPsiphonWithCancelledContext(t *testing.T) {
+	if strings.HasPrefix(runtime.Version(), "go1.19") {
+		t.Skip("TODO(https://github.com/ooni/probe/issues/2222)")
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // fail immediately
 	tun, _, err := tunnel.Start(ctx, &tunnel.Config{


### PR DESCRIPTION
Part of https://github.com/ooni/probe/issues/2211.

See also https://github.com/ooni/probe/issues/2222, which
describes the issue we have with psiphon and go1.19.