### PR TITLE
feat(measurexlite): add T0 and TransactionID

### DIFF
--- a/internal/measurexlite/conn.go
+++ b/internal/measurexlite/conn.go
@@ -134,13 +134,15 @@ func addrStringIfNotNil(addr net.Addr) (out string) {
 func NewArchivalNetworkEvent(index int64, started time.Duration, operation string, network string,
 	address string, count int, err error, finished time.Duration) *model.ArchivalNetworkEvent {
 	return &model.ArchivalNetworkEvent{
-		Address:   address,
-		Failure:   tracex.NewFailure(err),
-		NumBytes:  int64(count),
-		Operation: operation,
-		Proto:     network,
-		T:         finished.Seconds(),
-		Tags:      []string{},
+		Address:       address,
+		Failure:       tracex.NewFailure(err),
+		NumBytes:      int64(count),
+		Operation:     operation,
+		Proto:         network,
+		T0:            started.Seconds(),
+		T:             finished.Seconds(),
+		TransactionID: index,
+		Tags:          []string{},
 	}
 }
 

--- a/internal/measurexlite/conn_test.go
+++ b/internal/measurexlite/conn_test.go
@@ -437,13 +437,15 @@ func TestNewAnnotationArchivalNetworkEvent(t *testing.T) {
 		operation       = "tls_handshake_start"
 	)
 	expect := &model.ArchivalNetworkEvent{
-		Address:   "",
-		Failure:   nil,
-		NumBytes:  0,
-		Operation: operation,
-		Proto:     "",
-		T:         duration.Seconds(),
-		Tags:      []string{},
+		Address:       "",
+		Failure:       nil,
+		NumBytes:      0,
+		Operation:     operation,
+		Proto:         "",
+		T0:            duration.Seconds(),
+		T:             duration.Seconds(),
+		TransactionID: index,
+		Tags:          []string{},
 	}
 	got := NewAnnotationArchivalNetworkEvent(
 		index, duration, operation,

--- a/internal/measurexlite/dialer.go
+++ b/internal/measurexlite/dialer.go
@@ -82,7 +82,9 @@ func NewArchivalTCPConnectResult(index int64, started time.Duration, address str
 			Failure: tracex.NewFailure(err),
 			Success: err == nil,
 		},
-		T: finished.Seconds(),
+		T0:            started.Seconds(),
+		T:             finished.Seconds(),
+		TransactionID: index,
 	}
 }
 

--- a/internal/measurexlite/dns.go
+++ b/internal/measurexlite/dns.go
@@ -127,6 +127,7 @@ func NewArchivalDNSLookupResultFromRoundTrip(index int64, started time.Duration,
 		ResolverAddress:  reso.Address(),
 		T0:               started.Seconds(),
 		T:                finished.Seconds(),
+		TransactionID:    index,
 	}
 }
 

--- a/internal/measurexlite/quic_test.go
+++ b/internal/measurexlite/quic_test.go
@@ -184,6 +184,7 @@ func TestNewQUICDialerWithoutResolver(t *testing.T) {
 					NumBytes:  0,
 					Operation: "quic_handshake_done",
 					Proto:     "",
+					T0:        time.Second.Seconds(),
 					T:         time.Second.Seconds(),
 					Tags:      []string{},
 				}

--- a/internal/measurexlite/tls.go
+++ b/internal/measurexlite/tls.go
@@ -86,9 +86,11 @@ func NewArchivalTLSOrQUICHandshakeResult(
 		NoTLSVerify:        config.InsecureSkipVerify,
 		PeerCertificates:   TLSPeerCerts(state, err),
 		ServerName:         config.ServerName,
+		T0:                 started.Seconds(),
 		T:                  finished.Seconds(),
 		Tags:               []string{},
 		TLSVersion:         netxlite.TLSVersionString(state.Version),
+		TransactionID:      index,
 	}
 }
 

--- a/internal/measurexlite/tls_test.go
+++ b/internal/measurexlite/tls_test.go
@@ -167,6 +167,7 @@ func TestNewTLSHandshakerStdlib(t *testing.T) {
 					NumBytes:  0,
 					Operation: "tls_handshake_done",
 					Proto:     "",
+					T0:        time.Second.Seconds(),
 					T:         time.Second.Seconds(),
 					Tags:      []string{},
 				}
@@ -329,6 +330,7 @@ func TestNewTLSHandshakerStdlib(t *testing.T) {
 					NumBytes:  0,
 					Operation: "tls_handshake_done",
 					Proto:     "",
+					T0:        time.Second.Seconds(),
 					T:         time.Second.Seconds(),
 					Tags:      []string{},
 				}

--- a/internal/model/archival.go
+++ b/internal/model/archival.go
@@ -125,6 +125,7 @@ type ArchivalDNSLookupResult struct {
 	ResolverAddress  string              `json:"resolver_address"`
 	T0               float64             `json:"t0"`
 	T                float64             `json:"t"`
+	TransactionID    int64               `json:"transaction_id"`
 }
 
 // ArchivalDNSAnswer is a DNS answer.
@@ -146,10 +147,12 @@ type ArchivalDNSAnswer struct {
 //
 // See https://github.com/ooni/spec/blob/master/data-formats/df-005-tcpconnect.md.
 type ArchivalTCPConnectResult struct {
-	IP     string                   `json:"ip"`
-	Port   int                      `json:"port"`
-	Status ArchivalTCPConnectStatus `json:"status"`
-	T      float64                  `json:"t"`
+	IP            string                   `json:"ip"`
+	Port          int                      `json:"port"`
+	Status        ArchivalTCPConnectStatus `json:"status"`
+	T0            float64                  `json:"t0"`
+	T             float64                  `json:"t"`
+	TransactionID int64                    `json:"transaction_id"`
 }
 
 // ArchivalTCPConnectStatus is the status of ArchivalTCPConnectResult.
@@ -175,9 +178,11 @@ type ArchivalTLSOrQUICHandshakeResult struct {
 	NoTLSVerify        bool                      `json:"no_tls_verify"`
 	PeerCertificates   []ArchivalMaybeBinaryData `json:"peer_certificates"`
 	ServerName         string                    `json:"server_name"`
+	T0                 float64                   `json:"t0"`
 	T                  float64                   `json:"t"`
 	Tags               []string                  `json:"tags"`
 	TLSVersion         string                    `json:"tls_version"`
+	TransactionID      int64                     `json:"transaction_id"`
 }
 
 //
@@ -188,10 +193,12 @@ type ArchivalTLSOrQUICHandshakeResult struct {
 //
 // See https://github.com/ooni/spec/blob/master/data-formats/df-001-httpt.md.
 type ArchivalHTTPRequestResult struct {
-	Failure  *string              `json:"failure"`
-	Request  ArchivalHTTPRequest  `json:"request"`
-	Response ArchivalHTTPResponse `json:"response"`
-	T        float64              `json:"t"`
+	Failure       *string              `json:"failure"`
+	Request       ArchivalHTTPRequest  `json:"request"`
+	Response      ArchivalHTTPResponse `json:"response"`
+	T0            float64              `json:"t0"`
+	T             float64              `json:"t"`
+	TransactionID int64                `json:"transaction_id"`
 }
 
 // ArchivalHTTPRequest contains an HTTP request.
@@ -307,11 +314,13 @@ type ArchivalHTTPTor struct {
 //
 // See https://github.com/ooni/spec/blob/master/data-formats/df-008-netevents.md.
 type ArchivalNetworkEvent struct {
-	Address   string   `json:"address,omitempty"`
-	Failure   *string  `json:"failure"`
-	NumBytes  int64    `json:"num_bytes,omitempty"`
-	Operation string   `json:"operation"`
-	Proto     string   `json:"proto,omitempty"`
-	T         float64  `json:"t"`
-	Tags      []string `json:"tags,omitempty"`
+	Address       string   `json:"address,omitempty"`
+	Failure       *string  `json:"failure"`
+	NumBytes      int64    `json:"num_bytes,omitempty"`
+	Operation     string   `json:"operation"`
+	Proto         string   `json:"proto,omitempty"`
+	T0            float64  `json:"t0"`
+	T             float64  `json:"t"`
+	TransactionID int64    `json:"transaction_id"`
+	Tags          []string `json:"tags,omitempty"`
 }


### PR DESCRIPTION
The T0 field is the moment when we started collecting data, while T
is the moment when we finished collecting data.

The TransactionID field will be repurposed for step-by-step measurements
to indicate related observations collected as part of the same flow
(e.g., TCP+TLS+HTTP).

Note that, for now, this change will only affect measurexlite and we're
not planning on changing other libraries for measuring.

Part of https://github.com/ooni/probe/issues/2137
