### PR TITLE
fix(oohelperd): enforce timeout for each measurement step

### DIFF
--- a/internal/cmd/oohelperd/dns.go
+++ b/internal/cmd/oohelperd/dns.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/webconnectivity"
 	"github.com/ooni/probe-cli/v3/internal/model"
@@ -38,6 +39,9 @@ type dnsConfig struct {
 
 // dnsDo performs the DNS check.
 func dnsDo(ctx context.Context, config *dnsConfig) {
+	const timeout = 4 * time.Second
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 	defer config.Wg.Done()
 	reso := config.NewResolver()
 	defer reso.CloseIdleConnections()

--- a/internal/cmd/oohelperd/http.go
+++ b/internal/cmd/oohelperd/http.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/webconnectivity"
 	"github.com/ooni/probe-cli/v3/internal/model"
@@ -44,6 +45,9 @@ type httpConfig struct {
 
 // httpDo performs the HTTP check.
 func httpDo(ctx context.Context, config *httpConfig) {
+	const timeout = 15 * time.Second
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 	defer config.Wg.Done()
 	req, err := http.NewRequestWithContext(ctx, "GET", config.URL, nil)
 	if err != nil {

--- a/internal/cmd/oohelperd/tcpconnect.go
+++ b/internal/cmd/oohelperd/tcpconnect.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/webconnectivity"
 	"github.com/ooni/probe-cli/v3/internal/model"
@@ -42,6 +43,9 @@ type tcpConfig struct {
 
 // tcpDo performs the TCP check.
 func tcpDo(ctx context.Context, config *tcpConfig) {
+	const timeout = 10 * time.Second
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 	defer config.Wg.Done()
 	dialer := config.NewDialer()
 	defer dialer.CloseIdleConnections()


### PR DESCRIPTION
While working on https://github.com/ooni/probe/issues/2237, I noticed
there's no enforced timeout for measurement tasks.

So, this diff introduces the following timeouts:

1. use a 4 seconds timeout for the DNS lookup;

2. use a 10 seconds timeout for TCP;

3. use a 15 seconds timeout for HTTP.

They are a bit stricter than what we have on the probe because the TH
should supposedly have better bandwidth and connectivity.
