### PR TITLE
refactor(oohelperd): make performing additional measurements easier

### DIFF
--- a/internal/cmd/oohelperd/measure.go
+++ b/internal/cmd/oohelperd/measure.go
@@ -89,9 +89,14 @@ func measure(ctx context.Context, config *handler, creq *ctrlRequest) (*ctrlResp
 	// continue assembling the response
 	cresp.HTTPRequest = <-httpch
 	cresp.TCPConnect = make(map[string]ctrlTCPResult)
-	for len(cresp.TCPConnect) < len(creq.TCPConnect) {
-		tcpconn := <-tcpconnch
-		cresp.TCPConnect[tcpconn.Endpoint] = tcpconn.Result
+Loop:
+	for {
+		select {
+		case tcpconn := <-tcpconnch:
+			cresp.TCPConnect[tcpconn.Endpoint] = tcpconn.Result
+		default:
+			break Loop
+		}
 	}
 
 	return cresp, nil


### PR DESCRIPTION
This diff refactors oohelperd to make performing additional measurements easier. We need:

1. to run the DNS task _before_ other tasks such that we can measure both IP addresses returned by the TH and the ones returned by the probe. When we'll introduce TLS measurements, this will allow us to validate probe-provided IP addresses inside the TH call. If probe-provided addresses work with TLS, they are legitimate for the domain.

2. to tie the number of TCP measurements to a list of endpoints collected by the probe _or_ the TH rather than just to the one provided by the probe. Anticipating this change, let us refactor how we read the results of the TCP task to make it independent of the number of addresses provided by the probe.

This work is part of https://github.com/ooni/probe/issues/2237