### PR TITLE
feat(oohelperd): log messages at info level

### DIFF
--- a/internal/cmd/oohelperd/dns_test.go
+++ b/internal/cmd/oohelperd/dns_test.go
@@ -68,7 +68,8 @@ func TestDNSDo(t *testing.T) {
 		ctx := context.Background()
 		config := &dnsConfig{
 			Domain: "antani.ooni.org",
-			NewResolver: func() model.Resolver {
+			Logger: model.DiscardLogger,
+			NewResolver: func(model.Logger) model.Resolver {
 				return &mocks.Resolver{
 					MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
 						return nil, netxlite.ErrOODNSNoSuchHost

--- a/internal/cmd/oohelperd/handler.go
+++ b/internal/cmd/oohelperd/handler.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/ooni/probe-cli/v3/internal/atomicx"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
@@ -18,20 +19,26 @@ import (
 
 // handler implements the Web Connectivity test helper HTTP API.
 type handler struct {
+	// BaseLogger is the MANDATORY logger to use.
+	BaseLogger model.Logger
+
+	// Indexer is the MANDATORY atomic integer used to assign an index to requests.
+	Indexer *atomicx.Int64
+
 	// MaxAcceptableBody is the MANDATORY maximum acceptable response body.
 	MaxAcceptableBody int64
 
 	// NewClient is the MANDATORY factory to create a new HTTPClient.
-	NewClient func() model.HTTPClient
+	NewClient func(model.Logger) model.HTTPClient
 
 	// NewDialer is the MANDATORY factory to create a new Dialer.
-	NewDialer func() model.Dialer
+	NewDialer func(model.Logger) model.Dialer
 
 	// NewResolver is the MANDATORY factory for creating a new resolver.
-	NewResolver func() model.Resolver
+	NewResolver func(model.Logger) model.Resolver
 
 	// NewTLSHandshaker is the MANDATORY factory for creating a new TLS handshaker.
-	NewTLSHandshaker func() model.TLSHandshaker
+	NewTLSHandshaker func(model.Logger) model.TLSHandshaker
 }
 
 var _ http.Handler = &handler{}

--- a/internal/cmd/oohelperd/handler_test.go
+++ b/internal/cmd/oohelperd/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ooni/probe-cli/v3/internal/atomicx"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/model/mocks"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
@@ -53,17 +54,19 @@ const requestWithoutDomainName = `{
 
 func TestHandlerWorkingAsIntended(t *testing.T) {
 	handler := &handler{
+		BaseLogger:        model.DiscardLogger,
+		Indexer:           &atomicx.Int64{},
 		MaxAcceptableBody: 1 << 24,
-		NewClient: func() model.HTTPClient {
+		NewClient: func(model.Logger) model.HTTPClient {
 			return http.DefaultClient
 		},
-		NewDialer: func() model.Dialer {
+		NewDialer: func(model.Logger) model.Dialer {
 			return netxlite.NewDialerWithStdlibResolver(model.DiscardLogger)
 		},
-		NewResolver: func() model.Resolver {
+		NewResolver: func(model.Logger) model.Resolver {
 			return netxlite.NewUnwrappedStdlibResolver()
 		},
-		NewTLSHandshaker: func() model.TLSHandshaker {
+		NewTLSHandshaker: func(model.Logger) model.TLSHandshaker {
 			return netxlite.NewTLSHandshakerStdlib(model.DiscardLogger)
 		},
 	}

--- a/internal/cmd/oohelperd/http_test.go
+++ b/internal/cmd/oohelperd/http_test.go
@@ -20,8 +20,9 @@ func TestHTTPDoWithInvalidURL(t *testing.T) {
 	wg.Add(1)
 	go httpDo(ctx, &httpConfig{
 		Headers:           nil,
+		Logger:            model.DiscardLogger,
 		MaxAcceptableBody: 1 << 24,
-		NewClient: func() model.HTTPClient {
+		NewClient: func(model.Logger) model.HTTPClient {
 			return http.DefaultClient
 		},
 		Out: httpch,
@@ -44,8 +45,9 @@ func TestHTTPDoWithHTTPTransportFailure(t *testing.T) {
 	wg.Add(1)
 	go httpDo(ctx, &httpConfig{
 		Headers:           nil,
+		Logger:            model.DiscardLogger,
 		MaxAcceptableBody: 1 << 24,
-		NewClient: func() model.HTTPClient {
+		NewClient: func(model.Logger) model.HTTPClient {
 			return &http.Client{
 				Transport: &mocks.HTTPTransport{
 					MockRoundTrip: func(req *http.Request) (*http.Response, error) {

--- a/internal/cmd/oohelperd/logging.go
+++ b/internal/cmd/oohelperd/logging.go
@@ -1,0 +1,41 @@
+package main
+
+import "github.com/ooni/probe-cli/v3/internal/model"
+
+// indexLogger is a logger with an index.
+type indexLogger struct {
+	indexstr string
+	logger   model.Logger
+}
+
+var _ model.Logger = &indexLogger{}
+
+// Debug implements DebugLogger.Debug
+func (p *indexLogger) Debug(msg string) {
+	p.logger.Debug(p.indexstr + msg)
+}
+
+// Debugf implements DebugLogger.Debugf
+func (p *indexLogger) Debugf(format string, v ...interface{}) {
+	p.logger.Debugf(p.indexstr+format, v...)
+}
+
+// Info implements InfoLogger.Info
+func (p *indexLogger) Info(msg string) {
+	p.logger.Info(p.indexstr + msg)
+}
+
+// Infov implements InfoLogger.Infov
+func (p *indexLogger) Infof(format string, v ...interface{}) {
+	p.logger.Infof(p.indexstr+format, v...)
+}
+
+// Warn implements Logger.Warn
+func (p *indexLogger) Warn(msg string) {
+	p.logger.Warn(p.indexstr + msg)
+}
+
+// Warnf implements Logger.Warnf
+func (p *indexLogger) Warnf(format string, v ...interface{}) {
+	p.logger.Warnf(p.indexstr+format, v...)
+}

--- a/internal/cmd/oohelperd/logging_test.go
+++ b/internal/cmd/oohelperd/logging_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/ooni/probe-cli/v3/internal/model/mocks"
+)
+
+func TestIndexLogger(t *testing.T) {
+	t.Run("Debug", func(t *testing.T) {
+		expected := "<0>antani"
+		base := &mocks.Logger{
+			MockDebug: func(message string) {
+				if message != expected {
+					t.Fatal("unexpected message")
+				}
+			},
+		}
+		logger := &indexLogger{
+			indexstr: "<0>",
+			logger:   base,
+		}
+		logger.Debug("antani")
+	})
+
+	t.Run("Info", func(t *testing.T) {
+		expected := "<0>antani"
+		base := &mocks.Logger{
+			MockInfo: func(message string) {
+				if message != expected {
+					t.Fatal("unexpected message")
+				}
+			},
+		}
+		logger := &indexLogger{
+			indexstr: "<0>",
+			logger:   base,
+		}
+		logger.Info("antani")
+	})
+
+	t.Run("Warn", func(t *testing.T) {
+		expected := "<0>antani"
+		base := &mocks.Logger{
+			MockWarn: func(message string) {
+				if message != expected {
+					t.Fatal("unexpected message")
+				}
+			},
+		}
+		logger := &indexLogger{
+			indexstr: "<0>",
+			logger:   base,
+		}
+		logger.Warn("antani")
+	})
+
+	t.Run("Debugf", func(t *testing.T) {
+		expected := "<0>antani%d"
+		base := &mocks.Logger{
+			MockDebugf: func(format string, v ...any) {
+				if format != expected {
+					t.Fatal("unexpected message")
+				}
+			},
+		}
+		logger := &indexLogger{
+			indexstr: "<0>",
+			logger:   base,
+		}
+		logger.Debugf("antani%d", 11)
+	})
+
+	t.Run("Infof", func(t *testing.T) {
+		expected := "<0>antani%d"
+		base := &mocks.Logger{
+			MockInfof: func(format string, v ...any) {
+				if format != expected {
+					t.Fatal("unexpected message")
+				}
+			},
+		}
+		logger := &indexLogger{
+			indexstr: "<0>",
+			logger:   base,
+		}
+		logger.Infof("antani%d", 11)
+	})
+
+	t.Run("Warnf", func(t *testing.T) {
+		expected := "<0>antani%d"
+		base := &mocks.Logger{
+			MockWarnf: func(format string, v ...any) {
+				if format != expected {
+					t.Fatal("unexpected message")
+				}
+			},
+		}
+		logger := &indexLogger{
+			indexstr: "<0>",
+			logger:   base,
+		}
+		logger.Warnf("antani%d", 11)
+	})
+}


### PR DESCRIPTION
We're using a request-specific logger where we also print the ID
of the request. This design helps to observe logs produced by
concurrent requests.

Part of https://github.com/ooni/probe/issues/2183

While there, fix https://github.com/ooni/probe/issues/2241
