### PR TITLE
fix: repair releasing miniooni and ooniprobe-windows

### DIFF
--- a/.github/workflows/miniooni.yml
+++ b/.github/workflows/miniooni.yml
@@ -43,6 +43,16 @@ jobs:
 
       - uses: actions/upload-artifact@v1
         with:
+          name: miniooni-darwin-amd64
+          path: ./CLI/miniooni-darwin-amd64
+
+      - uses: actions/upload-artifact@v1
+        with:
+          name: miniooni-darwin-arm64
+          path: ./CLI/miniooni-darwin-arm64
+
+      - uses: actions/upload-artifact@v1
+        with:
           name: miniooni-linux-386
           path: ./CLI/miniooni-linux-386
 
@@ -50,6 +60,11 @@ jobs:
         with:
           name: miniooni-linux-amd64
           path: ./CLI/miniooni-linux-amd64
+
+      - uses: actions/upload-artifact@v1
+        with:
+          name: miniooni-linux-armv6
+          path: ./CLI/miniooni-linux-armv6
 
       - uses: actions/upload-artifact@v1
         with:
@@ -61,6 +76,16 @@ jobs:
           name: miniooni-linux-arm64
           path: ./CLI/miniooni-linux-arm64
 
+      - uses: actions/upload-artifact@v1
+        with:
+          name: miniooni-windows-386
+          path: ./CLI/miniooni-windows-386
+
+      - uses: actions/upload-artifact@v1
+        with:
+          name: miniooni-windows-amd64
+          path: ./CLI/miniooni-windows-amd64
+
       - run: |
           tag=$(echo $GITHUB_REF | sed 's|refs/tags/||g')
           gh release create -p $tag --target $GITHUB_SHA || true
@@ -68,6 +93,7 @@ jobs:
                                            ./CLI/miniooni-darwin-arm64 \
                                            ./CLI/miniooni-linux-386 \
                                            ./CLI/miniooni-linux-amd64 \
+                                           ./CLI/miniooni-linux-armv6 \
                                            ./CLI/miniooni-linux-armv7 \
                                            ./CLI/miniooni-linux-arm64 \
                                            ./CLI/miniooni-windows-386.exe \

--- a/.github/workflows/miniooni.yml
+++ b/.github/workflows/miniooni.yml
@@ -78,13 +78,13 @@ jobs:
 
       - uses: actions/upload-artifact@v1
         with:
-          name: miniooni-windows-386
-          path: ./CLI/miniooni-windows-386
+          name: miniooni-windows-386.exe
+          path: ./CLI/miniooni-windows-386.exe
 
       - uses: actions/upload-artifact@v1
         with:
-          name: miniooni-windows-amd64
-          path: ./CLI/miniooni-windows-amd64
+          name: miniooni-windows-amd64.exe
+          path: ./CLI/miniooni-windows-amd64.exe
 
       - run: |
           tag=$(echo $GITHUB_REF | sed 's|refs/tags/||g')

--- a/CLI/check-mingw-w64-version
+++ b/CLI/check-mingw-w64-version
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-EXPECTED_MINGW_W64_VERSION=${EXPECTED_MINGW_W64_VERSION:-12.1.0} # Allow overriding
+EXPECTED_MINGW_W64_VERSION=${EXPECTED_MINGW_W64_VERSION:-12.2.0} # Allow overriding
 
 printf "checking for x86_64-w64-mingw32-gcc... "
 command -v x86_64-w64-mingw32-gcc || {

--- a/CLI/go-build-cross
+++ b/CLI/go-build-cross
@@ -47,6 +47,11 @@ else
 	OONI_PSIPHON_TAGS=""
 fi
 
+EXT=
+if [[ $GOOS == "windows" ]]; then
+	EXT=.exe
+fi
+
 PRODUCT=$(basename $PACKAGE)
 
 set -x
@@ -55,5 +60,5 @@ export GOOS=$GOOS
 export GOARCH=$GOARCH
 export GOARM=$GOARM
 go build -tags=$OONI_PSIPHON_TAGS -ldflags="-s -w" \
-	-o ./CLI/$PRODUCT-$GOOS-$OONIARCH ${GOLANG_EXTRA_FLAGS:-} \
+	-o ./CLI/$PRODUCT-$GOOS-$OONIARCH$EXT ${GOLANG_EXTRA_FLAGS:-} \
 	$PACKAGE

--- a/CLI/go-build-windows
+++ b/CLI/go-build-windows
@@ -51,5 +51,5 @@ export CGO_ENABLED=1
 export GOOS=$GOOS
 export GOARCH=$GOARCH
 go build -tags=$OONI_PSIPHON_TAGS -ldflags="-s -w" \
-	-o ./CLI/$PRODUCT-$GOOS-$GOARCH ${GOLANG_EXTRA_FLAGS:-} \
+	-o ./CLI/$PRODUCT-$GOOS-$GOARCH.exe ${GOLANG_EXTRA_FLAGS:-} \
 	$PACKAGE


### PR DESCRIPTION
It seems several CI builds failed for [v3.16.0-alpha](https://github.com/ooni/probe-cli/releases/tag/v3.16.0-alpha). Let's aim to repair miniooni and ooniprobe-windows for now. The other failing builds seem more tricky. (Android fails with an unsupported NDK while Linux fails with issues accessing the git repository from Docker, probably because the  the user running inside Docker is not the user that owns the repository.)