### PR TITLE
feat: build ooniprobe for armv6

### DIFF
--- a/.github/workflows/alltests.yml
+++ b/.github/workflows/alltests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "release/**"
+      - "fullbuild"
 
 jobs:
   test:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "release/**"
+      - "fullbuild"
     tags:
       - "v*"
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - "master"
       - "release/**"
+      - "fullbuild"
 
 jobs:
   analyze:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - "master"
       - "release/**"
+      - "fullbuild"
 
 jobs:
   measure_coverage:

--- a/.github/workflows/debianrepo.yml
+++ b/.github/workflows/debianrepo.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "master"
       - "release/**"
+      - "fullbuild"
 
 jobs:
   test_386:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "release/**"
+      - "fullbuild"
 
 jobs:
   test:

--- a/.github/workflows/go1.19.yml
+++ b/.github/workflows/go1.19.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - "master"
       - "release/**"
+      - "fullbuild"
 
 jobs:
   build_and_test:

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "master"
       - "release/**"
+      - "fullbuild"
 
 jobs:
   gosec:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "release/**"
+      - "fullbuild"
     tags:
       - "v*"
 

--- a/.github/workflows/jafar.yml
+++ b/.github/workflows/jafar.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "release/**"
+      - "fullbuild"
 
 jobs:
   test:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "release/**"
+      - "fullbuild"
     tags:
       - "v*"
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -58,6 +58,32 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  build_and_publish_armv6:
+    runs-on: "ubuntu-20.04"
+    permissions: # See https://github.com/ooni/probe/issues/2154
+      contents: write
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: sudo apt-get update -q
+      - run: sudo apt-get install -y qemu-user-static
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+      - run: make ./CLI/ooniprobe-linux-armv6
+      - run: ./E2E/ooniprobe.sh ./CLI/ooniprobe-linux-armv6
+      - run: |
+          tag=$(echo $GITHUB_REF | sed 's|refs/tags/||g')
+          gh release create -p $tag --target $GITHUB_SHA || true
+          gh release upload $tag --clobber ./CLI/ooniprobe-linux-armv6
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build_and_publish_armv7:
     runs-on: "ubuntu-20.04"
     permissions: # See https://github.com/ooni/probe/issues/2154

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "release/**"
+      - "fullbuild"
     tags:
       - "v*"
 

--- a/.github/workflows/miniooni.yml
+++ b/.github/workflows/miniooni.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - "master"
       - "release/**"
+      - "fullbuild"
     tags:
       - "v*"
 

--- a/.github/workflows/netxlite.yml
+++ b/.github/workflows/netxlite.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - "master"
       - "release/**"
+      - "fullbuild"
 
 jobs:
   test_netxlite_package:

--- a/.github/workflows/oohelperd.yml
+++ b/.github/workflows/oohelperd.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "release/**"
+      - "fullbuild"
     tags:
       - "v*"
 

--- a/.github/workflows/qafbmessenger.yml
+++ b/.github/workflows/qafbmessenger.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "release/**"
+      - "fullbuild"
 
 jobs:
   test:

--- a/.github/workflows/qahhfm.yml
+++ b/.github/workflows/qahhfm.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "release/**"
+      - "fullbuild"
 
 jobs:
   test:

--- a/.github/workflows/qahirl.yml
+++ b/.github/workflows/qahirl.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "release/**"
+      - "fullbuild"
 
 jobs:
   test:

--- a/.github/workflows/qatelegram.yml
+++ b/.github/workflows/qatelegram.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "release/**"
+      - "fullbuild"
 
 jobs:
   test:

--- a/.github/workflows/qawebconnectivity.yml
+++ b/.github/workflows/qawebconnectivity.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "release/**"
+      - "fullbuild"
 
 jobs:
   test:

--- a/.github/workflows/qawhatsapp.yml
+++ b/.github/workflows/qawhatsapp.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "release/**"
+      - "fullbuild"
 
 jobs:
   test:

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -2,6 +2,8 @@
 name: tarball
 on:
   push:
+    branches:
+      - "fullbuild"
     tags:
       - "v*"
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "release/**"
+      - "fullbuild"
     tags:
       - "v*"
 

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ show-config:
 ./CLI/ooniprobe-linux: \
 	./CLI/ooniprobe-linux-386 \
 	./CLI/ooniprobe-linux-amd64 \
+	./CLI/ooniprobe-linux-armv6 \
 	./CLI/ooniprobe-linux-armv7 \
 	./CLI/ooniprobe-linux-arm64
 
@@ -163,6 +164,12 @@ show-config:
 .PHONY:     ./CLI/ooniprobe-linux-amd64
 ./CLI/ooniprobe-linux-amd64: search/for/docker maybe/copypsiphon
 	./CLI/go-build-linux-static amd64 ./cmd/ooniprobe
+
+#help:
+#help: * `make ./CLI/ooniprobe-linux-armv6`: linux/arm
+.PHONY:     ./CLI/ooniprobe-linux-armv6
+./CLI/ooniprobe-linux-armv6: search/for/docker maybe/copypsiphon
+	./CLI/go-build-linux-static armv6 ./cmd/ooniprobe
 
 #help:
 #help: * `make ./CLI/ooniprobe-linux-armv7`: linux/arm


### PR DESCRIPTION
Part of https://github.com/ooni/probe/issues/1753.

While there, introduce a rule by which, if the branch is named `fullbuild` we run all possible builds. It helps to test all the builds without creating a release branch. Because release branches are protected, they cannot be deleted easily. On the contrary, the `fullbuild` branch can easily be disposed of.