### PR TITLE
fix: attempt to make android builds faster

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,7 +10,8 @@ on:
       - "v*"
 
 jobs:
-  build_and_publish:
+
+  build_and_publish_mobile:
     runs-on: ubuntu-20.04
     permissions: # See https://github.com/ooni/probe/issues/2154
       contents: write
@@ -36,21 +37,156 @@ jobs:
           PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
 
       - run: make MOBILE/android
-      - run: make CLI/android
 
       - run: |
           tag=$(echo $GITHUB_REF | sed 's|refs/tags/||g')
           gh release create -p $tag --target $GITHUB_SHA || true
           gh release upload $tag --clobber ./MOBILE/android/oonimkall.aar \
                                            ./MOBILE/android/oonimkall-sources.jar \
-                                           ./MOBILE/android/oonimkall.pom \
-                                           ./CLI/miniooni-android-386 \
-                                           ./CLI/miniooni-android-amd64 \
-                                           ./CLI/miniooni-android-arm \
-                                           ./CLI/miniooni-android-arm64 \
-                                           ./CLI/ooniprobe-android-386 \
-                                           ./CLI/ooniprobe-android-amd64 \
-                                           ./CLI/ooniprobe-android-arm \
+                                           ./MOBILE/android/oonimkall.pom
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build_and_publish_cli_386:
+    runs-on: ubuntu-20.04
+    permissions: # See https://github.com/ooni/probe/issues/2154
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get GOVERSION content
+        id: goversion
+        run: echo ::set-output name=version::$(cat GOVERSION)
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "${{ steps.goversion.outputs.version }}"
+
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+
+      - run: make CLI/android-386
+
+      - run: |
+          tag=$(echo $GITHUB_REF | sed 's|refs/tags/||g')
+          gh release create -p $tag --target $GITHUB_SHA || true
+          gh release upload $tag --clobber ./CLI/miniooni-android-386 \
+                                           ./CLI/ooniprobe-android-386
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build_and_publish_cli_amd64:
+    runs-on: ubuntu-20.04
+    permissions: # See https://github.com/ooni/probe/issues/2154
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get GOVERSION content
+        id: goversion
+        run: echo ::set-output name=version::$(cat GOVERSION)
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "${{ steps.goversion.outputs.version }}"
+
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+
+      - run: make CLI/android-amd64
+
+      - run: |
+          tag=$(echo $GITHUB_REF | sed 's|refs/tags/||g')
+          gh release create -p $tag --target $GITHUB_SHA || true
+          gh release upload $tag --clobber ./CLI/miniooni-android-amd64 \
+                                           ./CLI/ooniprobe-android-amd64
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build_and_publish_cli_arm:
+    runs-on: ubuntu-20.04
+    permissions: # See https://github.com/ooni/probe/issues/2154
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get GOVERSION content
+        id: goversion
+        run: echo ::set-output name=version::$(cat GOVERSION)
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "${{ steps.goversion.outputs.version }}"
+
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+
+      - run: make CLI/android-arm
+
+      - run: |
+          tag=$(echo $GITHUB_REF | sed 's|refs/tags/||g')
+          gh release create -p $tag --target $GITHUB_SHA || true
+          gh release upload $tag --clobber ./CLI/miniooni-android-arm \
+                                           ./CLI/ooniprobe-android-arm
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build_and_publish_cli_arm64:
+    runs-on: ubuntu-20.04
+    permissions: # See https://github.com/ooni/probe/issues/2154
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get GOVERSION content
+        id: goversion
+        run: echo ::set-output name=version::$(cat GOVERSION)
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "${{ steps.goversion.outputs.version }}"
+
+      - run: |
+          echo -n $PSIPHON_CONFIG_KEY > ./internal/engine/psiphon-config.key
+          echo $PSIPHON_CONFIG_JSON_AGE_BASE64 | base64 -d > ./internal/engine/psiphon-config.json.age
+        env:
+          PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
+          PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+
+      - run: make CLI/android-arm64
+
+      - run: |
+          tag=$(echo $GITHUB_REF | sed 's|refs/tags/||g')
+          gh release create -p $tag --target $GITHUB_SHA || true
+          gh release upload $tag --clobber ./CLI/miniooni-android-arm64 \
                                            ./CLI/ooniprobe-android-arm64
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         env:

--- a/Makefile
+++ b/Makefile
@@ -50,16 +50,30 @@ show-config:
 	@echo "OONI_PSIPHON_TAGS=$(OONI_PSIPHON_TAGS)"
 
 #help:
-#help: The `make CLI/android` command builds miniooni and ooniprobe for
-#help: all the supported Android architectures.
-.PHONY: CLI/android
-CLI/android: search/for/go search/for/android/sdk maybe/copypsiphon
+#help: The `make CLI/android-386` command builds miniooni and ooniprobe for android/386.
+.PHONY: CLI/android-386
+CLI/android-386: search/for/go search/for/android/sdk maybe/copypsiphon
 	./CLI/go-build-android 386 ./internal/cmd/miniooni
 	./CLI/go-build-android 386 ./cmd/ooniprobe
+
+#help:
+#help: The `make CLI/android-amd64` command builds miniooni and ooniprobe for android/amd64.
+.PHONY: CLI/android-amd64
+CLI/android-amd64: search/for/go search/for/android/sdk maybe/copypsiphon
 	./CLI/go-build-android amd64 ./internal/cmd/miniooni
 	./CLI/go-build-android amd64 ./cmd/ooniprobe
+
+#help:
+#help: The `make CLI/android-arm` command builds miniooni and ooniprobe for android/arm.
+.PHONY: CLI/android-arm
+CLI/android-arm: search/for/go search/for/android/sdk maybe/copypsiphon
 	./CLI/go-build-android arm ./internal/cmd/miniooni
 	./CLI/go-build-android arm ./cmd/ooniprobe
+
+#help:
+#help: The `make CLI/android-arm64` command builds miniooni and ooniprobe for android/arm64.
+.PHONY: CLI/android-arm64
+CLI/android-arm64: search/for/go search/for/android/sdk maybe/copypsiphon
 	./CLI/go-build-android arm64 ./internal/cmd/miniooni
 	./CLI/go-build-android arm64 ./cmd/ooniprobe
 


### PR DESCRIPTION
After https://github.com/ooni/probe-cli/pull/908, the Android
build has become super slow, because we build serially.

Attempt to make it faster by building in parallel.

Still part of https://github.com/ooni/probe/issues/2119, because
I don't feel happy with a super slow build.

