### PR TITLE
fix(miniooni): handle panics with --repeat-every

### DIFF
--- a/internal/cmd/miniooni/consent.go
+++ b/internal/cmd/miniooni/consent.go
@@ -17,7 +17,10 @@ func acquireUserConsent(miniooniDir string, currentOptions *Options) {
 	consentFile := path.Join(miniooniDir, "informed")
 	err := maybeWriteConsentFile(currentOptions.Yes, consentFile)
 	runtimex.PanicOnError(err, "cannot write informed consent file")
-	runtimex.PanicIfFalse(regularFileExists(consentFile), riskOfRunningOONI)
+	runtimex.PanicIfFalse(
+		regularFileExists(consentFile),
+		riskOfRunningOONI,
+	)
 }
 
 // maybeWriteConsentFile writes the consent file iff the yes argument is true
@@ -30,6 +33,7 @@ func maybeWriteConsentFile(yes bool, filepath string) (err error) {
 
 // riskOfRunningOONI is miniooni's informed consent text.
 const riskOfRunningOONI = `
+
 Do you consent to OONI Probe data collection?
 
 OONI Probe collects evidence of internet censorship and measures

--- a/internal/cmd/miniooni/main.go
+++ b/internal/cmd/miniooni/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -287,6 +288,17 @@ func MainWithConfiguration(experimentName string, currentOptions *Options) {
 // mainSingleIteration runs a single iteration. There may be multiple iterations
 // when the user specifies the --repeat-every command line flag.
 func mainSingleIteration(logger model.Logger, experimentName string, currentOptions *Options) {
+
+	// We allow the inner code to fail but we stop propagating the panic here
+	// such that --repeat-every works as intended anyway
+	if currentOptions.RepeatEvery > 0 {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Warnf("recovered from panic: %+v\n%s\n", r, debug.Stack())
+			}
+		}()
+	}
+
 	extraOptions := mustMakeMapStringAny(currentOptions.ExtraOptions)
 	annotations := mustMakeMapStringString(currentOptions.Annotations)
 


### PR DESCRIPTION
Most of miniooni panics on errors. We should not panic on error with
--repeat-every, rather we should try the next measurement.

See https://github.com/ooni/probe/issues/2250
