### PR TITLE
dnscheck: bump patch version number

### DIFF
--- a/internal/engine/experiment/dnscheck/dnscheck.go
+++ b/internal/engine/experiment/dnscheck/dnscheck.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	testName      = "dnscheck"
-	testVersion   = "0.9.0"
+	testVersion   = "0.9.1"
 	defaultDomain = "example.org"
 )
 

--- a/internal/engine/experiment/dnscheck/dnscheck_test.go
+++ b/internal/engine/experiment/dnscheck/dnscheck_test.go
@@ -49,7 +49,7 @@ func TestExperimentNameAndVersion(t *testing.T) {
 	if measurer.ExperimentName() != "dnscheck" {
 		t.Error("unexpected experiment name")
 	}
-	if measurer.ExperimentVersion() != "0.9.0" {
+	if measurer.ExperimentVersion() != "0.9.1" {
 		t.Error("unexpected experiment version")
 	}
 }


### PR DESCRIPTION
I just changed the timeouts in https://github.com/ooni/probe/issues/2234, so I should also bump patch