### PR TITLE
fix(dnscheck): record whether residual is enabled

### DIFF
--- a/internal/engine/experiment/dnscheck/dnscheck.go
+++ b/internal/engine/experiment/dnscheck/dnscheck.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	testName      = "dnscheck"
-	testVersion   = "0.9.1"
+	testVersion   = "0.9.2"
 	defaultDomain = "example.org"
 )
 
@@ -88,6 +88,7 @@ type TestKeys struct {
 	HTTPHost         string                        `json:"x_http_host,omitempty"`
 	TLSServerName    string                        `json:"x_tls_server_name,omitempty"`
 	TLSVersion       string                        `json:"x_tls_version,omitempty"`
+	Residual         bool                          `json:"x_residual"`
 	Bootstrap        *urlgetter.TestKeys           `json:"bootstrap"`
 	BootstrapFailure *string                       `json:"bootstrap_failure"`
 	Lookups          map[string]urlgetter.TestKeys `json:"lookups"`
@@ -141,6 +142,7 @@ func (m *Measurer) Run(
 	tk.HTTPHost = m.Config.HTTPHost
 	tk.TLSServerName = m.Config.TLSServerName
 	tk.TLSVersion = m.Config.TLSVersion
+	tk.Residual = m.Endpoints != nil
 
 	// 3. parse the input URL describing the resolver to use
 	input := string(measurement.Input)
@@ -309,7 +311,10 @@ func makeResolverURL(URL *url.URL, addr string) string {
 
 // NewExperimentMeasurer creates a new ExperimentMeasurer.
 func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
-	return &Measurer{Config: config}
+	return &Measurer{
+		Config:    config,
+		Endpoints: nil, // disabled by default
+	}
 }
 
 // SummaryKeys contains summary keys for this experiment.

--- a/internal/engine/experiment/dnscheck/dnscheck_test.go
+++ b/internal/engine/experiment/dnscheck/dnscheck_test.go
@@ -49,7 +49,7 @@ func TestExperimentNameAndVersion(t *testing.T) {
 	if measurer.ExperimentName() != "dnscheck" {
 		t.Error("unexpected experiment name")
 	}
-	if measurer.ExperimentVersion() != "0.9.1" {
+	if measurer.ExperimentVersion() != "0.9.2" {
 		t.Error("unexpected experiment version")
 	}
 }


### PR DESCRIPTION
The residual censorship algorithm prevents dnscheck for checking the
same endpoint again in a short time frame under the assumption that a
previous measurement could have caused residual censorship.

In https://github.com/ooni/probe/issues/2234, we mentioned we probably
wanted to disable this algorithm because we didn't want to slow down
dnscheck too much and because we didn't detect this alleged source of
blocking in our previous measurements.

It turns out the algorithm was already disabled. I probably did this
after we published the paper on DNS censorship to make measurements
overall a bit faster.

So, just introduce a new extension field to the measurement telling us
that the residual censorship algorithm is disabled.

It's not super useful except as for the fact that the next time I
read the source code I notice that the algorithm is disabled.
