### PR TITLE
fix(probeservices): use api.ooni.io

### DIFF
--- a/E2E/miniooni.bash
+++ b/E2E/miniooni.bash
@@ -6,7 +6,7 @@
 #
 set -e
 backends=()
-backends+=( "https://ps1.ooni.io" )
+backends+=( "https://api.ooni.io" )
 backends+=( "https://dvp6h0xblpcqp.cloudfront.net" )
 backends+=( "https://ams-pg-test.ooni.org" )
 miniooni="${1:-./miniooni}"

--- a/QA/webconnectivity.py
+++ b/QA/webconnectivity.py
@@ -51,8 +51,6 @@ def webconnectivity_https_ok_with_control_failure(ooni_exe, outfile):
     """Successful HTTPS measurement but control failure."""
     args = [
         "-iptables-reset-keyword",
-        "wcth.ooni.io",
-        "-iptables-reset-keyword",
         "th.ooni.org",
     ]
     tk = execute_jafar_and_return_validated_test_keys(
@@ -83,8 +81,6 @@ def webconnectivity_https_ok_with_control_failure(ooni_exe, outfile):
 def webconnectivity_http_ok_with_control_failure(ooni_exe, outfile):
     """Successful HTTP measurement but control failure."""
     args = [
-        "-iptables-reset-keyword",
-        "wcth.ooni.io",
         "-iptables-reset-keyword",
         "th.ooni.org",
     ]
@@ -194,8 +190,6 @@ def webconnectivity_control_unreachable_and_using_http(ooni_exe, outfile):
     plaintext HTTP protocol rather than HTTPS"""
     args = []
     args.append("-iptables-reset-keyword")
-    args.append("wcth.ooni.io")
-    args.append("-iptables-reset-keyword")
     args.append("th.ooni.org")
     tk = execute_jafar_and_return_validated_test_keys(
         ooni_exe,
@@ -224,7 +218,7 @@ def webconnectivity_nonexistent_domain(ooni_exe, outfile):
     tk = execute_jafar_and_return_validated_test_keys(
         ooni_exe,
         outfile,
-        "-i http://antani.ooni.io web_connectivity",
+        "-i http://www.ooni.nonexistent web_connectivity",
         "webconnectivity_nonexistent_domain",
         args,
     )

--- a/internal/cmd/apitool/main.go
+++ b/internal/cmd/apitool/main.go
@@ -29,7 +29,7 @@ func newclient() probeservices.Client {
 	ua := fmt.Sprintf("apitool/%s ooniprobe-engine/%s", version.Version, version.Version)
 	return probeservices.Client{
 		APIClientTemplate: httpx.APIClientTemplate{
-			BaseURL:    "https://ams-pg.ooni.org/",
+			BaseURL:    "https://api.ooni.io/",
 			HTTPClient: &http.Client{Transport: txp},
 			Logger:     log.Log,
 			UserAgent:  ua,

--- a/internal/cmd/jafar/httpproxy/httpproxy_test.go
+++ b/internal/cmd/jafar/httpproxy/httpproxy_test.go
@@ -25,7 +25,7 @@ func TestBlock(t *testing.T) {
 	// Here we're filtering any domain containing ooni.io, so we
 	// expect the proxy to send 451 without actually proxing, thus
 	// there should not be any Via header in the output.
-	checkrequest(t, addr.String(), "mia-ps.ooni.io", 451, false)
+	checkrequest(t, addr.String(), "api.ooni.io", 451, false)
 	killproxy(t, server)
 }
 

--- a/internal/cmd/jafar/tlsproxy/tlsproxy_test.go
+++ b/internal/cmd/jafar/tlsproxy/tlsproxy_test.go
@@ -21,7 +21,7 @@ func TestPass(t *testing.T) {
 func TestBlock(t *testing.T) {
 	listener := newproxy(t, "ooni.io")
 	checkdialtls(t, listener.Addr().String(), false, &tls.Config{
-		ServerName: "mia-ps.ooni.io",
+		ServerName: "api.ooni.io",
 	})
 	killproxy(t, listener)
 }

--- a/internal/cmd/oohelper/internal/client_test.go
+++ b/internal/cmd/oohelper/internal/client_test.go
@@ -86,7 +86,7 @@ func TestOOClientDoWithEmptyServerURL(t *testing.T) {
 
 func TestOOClientDoWithInvalidTargetURL(t *testing.T) {
 	ctx := context.Background()
-	config := internal.OOConfig{TargetURL: "\t", ServerURL: "https://wcth.ooni.io"}
+	config := internal.OOConfig{TargetURL: "\t", ServerURL: "https://0.th.ooni.org"}
 	clnt := internal.OOClient{}
 	cresp, err := clnt.Do(ctx, config)
 	if !errors.Is(err, internal.ErrInvalidURL) {
@@ -104,7 +104,7 @@ func TestOOClientDoWithResolverFailure(t *testing.T) {
 	ctx := context.Background()
 	config := internal.OOConfig{
 		TargetURL: "http://www.example.com",
-		ServerURL: "https://wcth.ooni.io",
+		ServerURL: "https://0.th.ooni.org",
 	}
 	clnt := internal.OOClient{
 		HTTPClient: http.DefaultClient,
@@ -114,10 +114,12 @@ func TestOOClientDoWithResolverFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(cresp.TCPConnect) > 0 {
-		// The current implementation of the test helper (the legacy codebase)
-		// only follows the IP addresses returned by the client.
-		t.Fatal("expected empty TCPConnect here")
+	if len(cresp.TCPConnect) <= 0 {
+		// The legacy implementation of the test helper (the legacy codebase)
+		// only follows the IP addresses returned by the client. However, since
+		// https://github.com/ooni/probe-cli/pull/890, the TH is following the
+		// IP addresses from the probe as well as its own addresses.
+		t.Fatal("expected non-empty TCPConnect here")
 	}
 	if cresp.HTTPRequest.StatusCode != 200 {
 		t.Fatal("expected 200 status code here")
@@ -131,7 +133,7 @@ func TestOOClientDoWithUnsupportedExplicitPort(t *testing.T) {
 	ctx := context.Background()
 	config := internal.OOConfig{
 		TargetURL: "http://www.example.com:8080",
-		ServerURL: "https://wcth.ooni.io",
+		ServerURL: "https://0.th.ooni.org",
 	}
 	clnt := internal.OOClient{
 		Resolver: internal.NewFakeResolverWithResult([]string{"1.1.1.1"}),
@@ -168,7 +170,7 @@ func TestOOClientDoWithRoundTripError(t *testing.T) {
 	ctx := context.Background()
 	config := internal.OOConfig{
 		TargetURL: "http://www.example.com",
-		ServerURL: "https://wcth.ooni.io",
+		ServerURL: "https://0.th.ooni.org",
 	}
 	clnt := internal.OOClient{
 		Resolver: internal.NewFakeResolverWithResult([]string{"1.1.1.1"}),
@@ -189,7 +191,7 @@ func TestOOClientDoWithInvalidStatusCode(t *testing.T) {
 	ctx := context.Background()
 	config := internal.OOConfig{
 		TargetURL: "http://www.example.com",
-		ServerURL: "https://wcth.ooni.io",
+		ServerURL: "https://0.th.ooni.org",
 	}
 	clnt := internal.OOClient{
 		Resolver: internal.NewFakeResolverWithResult([]string{"1.1.1.1"}),
@@ -214,7 +216,7 @@ func TestOOClientDoWithBodyReadError(t *testing.T) {
 	ctx := context.Background()
 	config := internal.OOConfig{
 		TargetURL: "http://www.example.com",
-		ServerURL: "https://wcth.ooni.io",
+		ServerURL: "https://0.th.ooni.org",
 	}
 	clnt := internal.OOClient{
 		Resolver: internal.NewFakeResolverWithResult([]string{"1.1.1.1"}),
@@ -240,7 +242,7 @@ func TestOOClientDoWithInvalidJSON(t *testing.T) {
 	ctx := context.Background()
 	config := internal.OOConfig{
 		TargetURL: "http://www.example.com",
-		ServerURL: "https://wcth.ooni.io",
+		ServerURL: "https://0.th.ooni.org",
 	}
 	clnt := internal.OOClient{
 		Resolver: internal.NewFakeResolverWithResult([]string{"1.1.1.1"}),
@@ -290,7 +292,7 @@ func TestOOClientDoWithParseableJSON(t *testing.T) {
 	ctx := context.Background()
 	config := internal.OOConfig{
 		TargetURL: "http://www.example.com",
-		ServerURL: "https://wcth.ooni.io",
+		ServerURL: "https://0.th.ooni.org",
 	}
 	clnt := internal.OOClient{
 		Resolver: internal.NewFakeResolverWithResult([]string{"1.1.1.1"}),

--- a/internal/cmd/oohelper/oohelper.go
+++ b/internal/cmd/oohelper/oohelper.go
@@ -49,7 +49,7 @@ func main() {
 func wcth() interface{} {
 	serverURL := *server
 	if serverURL == "" {
-		serverURL = "https://wcth.ooni.io/"
+		serverURL = "https://0.th.ooni.org/"
 	}
 	clnt := internal.OOClient{HTTPClient: httpClient, Resolver: resolver}
 	config := internal.OOConfig{TargetURL: *target, ServerURL: serverURL}

--- a/internal/cmd/oohelperd/dns_test.go
+++ b/internal/cmd/oohelperd/dns_test.go
@@ -67,7 +67,7 @@ func TestDNSDo(t *testing.T) {
 	t.Run("returns non-nil addresses list on nxdomin", func(t *testing.T) {
 		ctx := context.Background()
 		config := &dnsConfig{
-			Domain: "antani.ooni.org",
+			Domain: "www.ooni.nonexistent",
 			Logger: model.DiscardLogger,
 			NewResolver: func(model.Logger) model.Resolver {
 				return &mocks.Resolver{

--- a/internal/engine/probeservices/benchselect.go
+++ b/internal/engine/probeservices/benchselect.go
@@ -10,10 +10,7 @@ import (
 // Default returns the default probe services
 func Default() []model.OOAPIService {
 	return []model.OOAPIService{{
-		Address: "https://ps1.ooni.io",
-		Type:    "https",
-	}, {
-		Address: "https://ps2.ooni.io",
+		Address: "https://api.ooni.io",
 		Type:    "https",
 	}, {
 		Front:   "dkyhjv0wpi2dk.cloudfront.net",

--- a/internal/engine/probeservices/probeservices_test.go
+++ b/internal/engine/probeservices/probeservices_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -399,31 +398,24 @@ func TestTryAllIntegrationWeRaceForFastestHTTPS(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip test in short mode")
 	}
-	const pattern = "^https://ps[1-4].ooni.io$"
 	// put onion first so we also verify that we sort the endpoints
 	in := []model.OOAPIService{{
 		Type:    "onion",
 		Address: "httpo://jehhrikjjqrlpufu.onion",
 	}, {
 		Type:    "https",
-		Address: "https://ps1.ooni.io",
-	}, {
-		Type:    "https",
-		Address: "https://ps2.ooni.io",
+		Address: "https://api.ooni.io",
 	}, {
 		Front:   "dkyhjv0wpi2dk.cloudfront.net",
 		Type:    "cloudfront",
 		Address: "https://dkyhjv0wpi2dk.cloudfront.net",
-	}, {
-		Type:    "https",
-		Address: "https://ps3.ooni.io",
 	}}
 	sess := &mockable.Session{
 		MockableHTTPClient: http.DefaultClient,
 		MockableLogger:     log.Log,
 	}
 	out := probeservices.TryAll(context.Background(), sess, in)
-	if len(out) != 3 {
+	if len(out) != 1 {
 		t.Fatal("invalid number of entries")
 	}
 	//
@@ -436,34 +428,8 @@ func TestTryAllIntegrationWeRaceForFastestHTTPS(t *testing.T) {
 	if out[0].Endpoint.Type != "https" {
 		t.Fatal("invalid endpoint type")
 	}
-	if ok, _ := regexp.MatchString(pattern, out[0].Endpoint.Address); !ok {
-		t.Fatal("invalid endpoint type")
-	}
-	//
-	if out[1].Duration <= 0 {
-		t.Fatal("invalid duration")
-	}
-	if out[1].Err != nil {
-		t.Fatal("invalid error")
-	}
-	if out[1].Endpoint.Type != "https" {
-		t.Fatal("invalid endpoint type")
-	}
-	if ok, _ := regexp.MatchString(pattern, out[1].Endpoint.Address); !ok {
-		t.Fatal("invalid endpoint type")
-	}
-	//
-	if out[2].Duration <= 0 {
-		t.Fatal("invalid duration")
-	}
-	if out[2].Err != nil {
-		t.Fatal("invalid error")
-	}
-	if out[2].Endpoint.Type != "https" {
-		t.Fatal("invalid endpoint type")
-	}
-	if ok, _ := regexp.MatchString(pattern, out[2].Endpoint.Address); !ok {
-		t.Fatal("invalid endpoint type")
+	if out[0].Endpoint.Address != "https://api.ooni.io" {
+		t.Fatal("invalid endpoint address")
 	}
 }
 
@@ -574,32 +540,32 @@ func TestSelectBestSelectsTheFastest(t *testing.T) {
 	in := []*probeservices.Candidate{{
 		Duration: 10 * time.Millisecond,
 		Endpoint: model.OOAPIService{
-			Address: "https://ps1.ooni.io",
+			Address: "https://ps1.ooni.nonexistent",
 			Type:    "https",
 		},
 	}, {
 		Duration: 4 * time.Millisecond,
 		Endpoint: model.OOAPIService{
-			Address: "https://ps2.ooni.io",
+			Address: "https://ps2.ooni.nonexistent",
 			Type:    "https",
 		},
 	}, {
 		Duration: 7 * time.Millisecond,
 		Endpoint: model.OOAPIService{
-			Address: "https://ps3.ooni.io",
+			Address: "https://ps3.ooni.nonexistent",
 			Type:    "https",
 		},
 	}, {
 		Duration: 11 * time.Millisecond,
 		Endpoint: model.OOAPIService{
-			Address: "https://ps4.ooni.io",
+			Address: "https://ps4.ooni.nonexistent",
 			Type:    "https",
 		},
 	}}
 	expected := &probeservices.Candidate{
 		Duration: 4 * time.Millisecond,
 		Endpoint: model.OOAPIService{
-			Address: "https://ps2.ooni.io",
+			Address: "https://ps2.ooni.nonexistent",
 			Type:    "https",
 		},
 	}

--- a/internal/engine/sessionresolver/resolver_test.go
+++ b/internal/engine/sessionresolver/resolver_test.go
@@ -133,7 +133,7 @@ func TestLittleLLookupHostWithSuccess(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	ri := &resolverinfo{URL: "dot://dns-nonexistent.ooni.org", Score: 0.1}
+	ri := &resolverinfo{URL: "dot://www.ooni.nonexistent", Score: 0.1}
 	addrs, err := reso.lookupHost(ctx, ri, "dns.google")
 	if err != nil {
 		t.Fatal(err)
@@ -159,7 +159,7 @@ func TestLittleLLookupHostWithFailure(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	ri := &resolverinfo{URL: "dot://dns-nonexistent.ooni.org", Score: 0.95}
+	ri := &resolverinfo{URL: "dot://www.ooni.nonexistent", Score: 0.95}
 	addrs, err := reso.lookupHost(ctx, ri, "dns.google")
 	if !errors.Is(err, errMocked) {
 		t.Fatal("not the error we expected", err)

--- a/internal/netxlite/integration_test.go
+++ b/internal/netxlite/integration_test.go
@@ -57,7 +57,7 @@ func TestMeasureWithSystemResolver(t *testing.T) {
 		r := netxlite.NewStdlibResolver(log.Log)
 		defer r.CloseIdleConnections()
 		ctx := context.Background()
-		addrs, err := r.LookupHost(ctx, "antani.ooni.org")
+		addrs, err := r.LookupHost(ctx, "www.ooni.nonexistent")
 		if err == nil || err.Error() != netxlite.FailureDNSNXDOMAINError {
 			t.Fatal("not the error we expected", err)
 		}
@@ -75,7 +75,7 @@ func TestMeasureWithSystemResolver(t *testing.T) {
 		// Implementation note: Windows' resolver has caching so back to back tests
 		// will fail unless we query for something that could bypass the cache itself
 		// e.g. a domain containing a few random letters
-		addrs, err := r.LookupHost(ctx, randx.Letters(7)+".ooni.org")
+		addrs, err := r.LookupHost(ctx, randx.Letters(7)+".ooni.nonexistent")
 		if err == nil || err.Error() != netxlite.FailureGenericTimeoutError {
 			t.Fatal("not the error we expected", err)
 		}


### PR DESCRIPTION
See https://github.com/ooni/probe/issues/2147.

Note that this PR also tries to reduce usage of legacy names inside unit/integration tests.