### PR TITLE
ghpublish: attempt to create a draft release

### DIFF
--- a/script/ghpublish.bash
+++ b/script/ghpublish.bash
@@ -18,8 +18,8 @@ fi
 
 set -x
 
-# 3. create the release as a pre-release unless it already exists
-gh release create -p $__tag --target $GITHUB_SHA || true
+# 3. create the release as a draft pre-release unless it already exists
+gh release create --generate-notes -d -p $__tag --target $GITHUB_SHA || true
 
 # 4. publish all the assets passed as arguments to the target release
 gh release upload $__tag --clobber "$@"


### PR DESCRIPTION
If we don't publish the release using `gh release` and we default to
a pre-release, we're able to manually disable the pre-release flag
when needed without making this script more complex.

