### PR TITLE
fix(webconnectivity@v0.5): fetch HTTP only using system-resolver addrs

### DIFF
--- a/internal/experiment/webconnectivity/dnscache.go
+++ b/internal/experiment/webconnectivity/dnscache.go
@@ -2,6 +2,26 @@ package webconnectivity
 
 import "sync"
 
+// DNSEntry is an entry in the DNS cache.
+type DNSEntry struct {
+	// Addr is the cached address
+	Addr string
+
+	// Flags contains flags
+	Flags int64
+}
+
+const (
+	// DNSAddrFlagSystemResolver means we discovered this addr using the system resolver.
+	DNSAddrFlagSystemResolver = 1 << iota
+
+	// DNSAddrFlagUDP means we discovered this addr using the UDP resolver.
+	DNSAddrFlagUDP
+
+	// DNSAddrFlagHTTPS means we discovered this addr using the DNS-over-HTTPS resolver.
+	DNSAddrFlagHTTPS
+)
+
 // DNSCache wraps a model.Resolver to provide DNS caching.
 //
 // The zero value is invalid; please, use NewDNSCache to construct.
@@ -10,11 +30,11 @@ type DNSCache struct {
 	mu *sync.Mutex
 
 	// values contains already resolved values.
-	values map[string][]string
+	values map[string][]DNSEntry
 }
 
 // Get gets values from the cache
-func (c *DNSCache) Get(domain string) ([]string, bool) {
+func (c *DNSCache) Get(domain string) ([]DNSEntry, bool) {
 	c.mu.Lock()
 	values, found := c.values[domain]
 	c.mu.Unlock()
@@ -22,7 +42,7 @@ func (c *DNSCache) Get(domain string) ([]string, bool) {
 }
 
 // Set inserts into the cache
-func (c *DNSCache) Set(domain string, values []string) {
+func (c *DNSCache) Set(domain string, values []DNSEntry) {
 	c.mu.Lock()
 	c.values[domain] = values
 	c.mu.Unlock()
@@ -32,6 +52,6 @@ func (c *DNSCache) Set(domain string, values []string) {
 func NewDNSCache() *DNSCache {
 	return &DNSCache{
 		mu:     &sync.Mutex{},
-		values: map[string][]string{},
+		values: map[string][]DNSEntry{},
 	}
 }

--- a/internal/experiment/webconnectivity/measurer.go
+++ b/internal/experiment/webconnectivity/measurer.go
@@ -36,7 +36,7 @@ func (m *Measurer) ExperimentName() string {
 
 // ExperimentVersion implements model.ExperimentMeasurer.
 func (m *Measurer) ExperimentVersion() string {
-	return "0.5.3"
+	return "0.5.4"
 }
 
 // Run implements model.ExperimentMeasurer.

--- a/internal/logx/logx.go
+++ b/internal/logx/logx.go
@@ -45,7 +45,7 @@ func (h *Handler) HandleLog(e *log.Entry) (err error) {
 		case log.DebugLevel:
 			level = "🧐"
 		case log.InfoLevel:
-			level = "🗒️"
+			level = "🗒️ "
 		case log.WarnLevel:
 			level = "🔥"
 		default:

--- a/internal/logx/logx.go
+++ b/internal/logx/logx.go
@@ -45,7 +45,7 @@ func (h *Handler) HandleLog(e *log.Entry) (err error) {
 		case log.DebugLevel:
 			level = "🧐"
 		case log.InfoLevel:
-			level = "🗒️ "
+			level = "  "
 		case log.WarnLevel:
 			level = "🔥"
 		default:

--- a/internal/logx/logx_test.go
+++ b/internal/logx/logx_test.go
@@ -74,7 +74,7 @@ func TestLogHandlerHandleLog(t *testing.T) {
 		Name:           "info level with emoji",
 		Emoji:          true,
 		Level:          log.InfoLevel,
-		ExpectSeverity: "🗒️",
+		ExpectSeverity: "  ",
 	}, {
 		Name:           "warn level with emoji",
 		Emoji:          true,


### PR DESCRIPTION
While there, change the emoji logger to emit whitespace on info logs. This makes warnings stand out even more.

Closes https://github.com/ooni/probe/issues/2258
