### PR TITLE
chore: set version to 3.17.0-alpha

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,5 +3,5 @@ package version
 
 const (
 	// Version is the software version
-	Version = "3.16.0-alpha.3"
+	Version = "3.17.0-alpha"
 )


### PR DESCRIPTION
I've just branched off the `release/3.16` branch since we're really looking good for release modulo minor changes.

Hence, it's time to update `master`'s version.
