### PR TITLE
fix(webconnectivity@v0.5): include http transaction start/done

### DIFF
--- a/internal/experiment/webconnectivity/cleartextflow.go
+++ b/internal/experiment/webconnectivity/cleartextflow.go
@@ -224,6 +224,9 @@ func (t *CleartextFlow) httpTransaction(ctx context.Context, network, address, a
 	txp model.HTTPTransport, req *http.Request, trace *measurexlite.Trace) (*http.Response, []byte, error) {
 	const maxbody = 1 << 19
 	started := trace.TimeSince(trace.ZeroTime)
+	t.TestKeys.AppendNetworkEvents(measurexlite.NewAnnotationArchivalNetworkEvent(
+		trace.Index, started, "http_transaction_start",
+	))
 	resp, err := txp.RoundTrip(req)
 	var body []byte
 	if err == nil {
@@ -235,6 +238,9 @@ func (t *CleartextFlow) httpTransaction(ctx context.Context, network, address, a
 		body, err = netxlite.ReadAllContext(ctx, reader)
 	}
 	finished := trace.TimeSince(trace.ZeroTime)
+	t.TestKeys.AppendNetworkEvents(measurexlite.NewAnnotationArchivalNetworkEvent(
+		trace.Index, finished, "http_transaction_done",
+	))
 	ev := measurexlite.NewArchivalHTTPRequestResult(
 		trace.Index,
 		started,

--- a/internal/experiment/webconnectivity/secureflow.go
+++ b/internal/experiment/webconnectivity/secureflow.go
@@ -276,6 +276,9 @@ func (t *SecureFlow) httpTransaction(ctx context.Context, network, address, alpn
 	txp model.HTTPTransport, req *http.Request, trace *measurexlite.Trace) (*http.Response, []byte, error) {
 	const maxbody = 1 << 19
 	started := trace.TimeSince(trace.ZeroTime)
+	t.TestKeys.AppendNetworkEvents(measurexlite.NewAnnotationArchivalNetworkEvent(
+		trace.Index, started, "http_transaction_start",
+	))
 	resp, err := txp.RoundTrip(req)
 	var body []byte
 	if err == nil {
@@ -287,6 +290,9 @@ func (t *SecureFlow) httpTransaction(ctx context.Context, network, address, alpn
 		body, err = netxlite.ReadAllContext(ctx, reader)
 	}
 	finished := trace.TimeSince(trace.ZeroTime)
+	t.TestKeys.AppendNetworkEvents(measurexlite.NewAnnotationArchivalNetworkEvent(
+		trace.Index, finished, "http_transaction_done",
+	))
 	ev := measurexlite.NewArchivalHTTPRequestResult(
 		trace.Index,
 		started,

--- a/internal/experiment/webconnectivity/testkeys.go
+++ b/internal/experiment/webconnectivity/testkeys.go
@@ -8,6 +8,7 @@ package webconnectivity
 //
 
 import (
+	"sort"
 	"sync"
 
 	"github.com/ooni/probe-cli/v3/internal/engine/experiment/webconnectivity"
@@ -328,4 +329,9 @@ func NewTestKeys() *TestKeys {
 // must be called from the measurer after all the tasks have completed.
 func (tk *TestKeys) Finalize(logger model.Logger) {
 	tk.analysisToplevel(logger)
+	// Note: sort.SliceStable is WAI when the input slice is nil
+	// as demonstrated by https://go.dev/play/p/znA4MyGFVHC
+	sort.SliceStable(tk.NetworkEvents, func(i, j int) bool {
+		return tk.NetworkEvents[i].T < tk.NetworkEvents[j].T
+	})
 }


### PR DESCRIPTION
Code based on urlgetter had this event and we would like to have this event with step-by-step code as well.

Because there's no tracing for HTTP when using step-by-step, we will need to include emitting these events inside the boilerplate.

By doing that, we emit events out of order, so make sure we sort them by T, which is "the moment when the event was collected".

Part of https://github.com/ooni/probe/issues/2238
