### PR TITLE
chore: bump web_connectivity version to 0.5.5

### DIFF
--- a/internal/experiment/webconnectivity/measurer.go
+++ b/internal/experiment/webconnectivity/measurer.go
@@ -36,7 +36,7 @@ func (m *Measurer) ExperimentName() string {
 
 // ExperimentVersion implements model.ExperimentMeasurer.
 func (m *Measurer) ExperimentVersion() string {
-	return "0.5.4"
+	return "0.5.5"
 }
 
 // Run implements model.ExperimentMeasurer.


### PR DESCRIPTION
We're bumping the version number to reflect recent improvements in the data format implemented in these pull requests:

- https://github.com/ooni/probe-cli/pull/942

- https://github.com/ooni/probe-cli/pull/943

- https://github.com/ooni/probe-cli/pull/944

Reference issue: https://github.com/ooni/probe/issues/2238
