### PR TITLE
fix(webconnectivity@v0.5): DoH failure shouldn't set flags

### DIFF
--- a/internal/experiment/webconnectivity/measurer.go
+++ b/internal/experiment/webconnectivity/measurer.go
@@ -36,7 +36,7 @@ func (m *Measurer) ExperimentName() string {
 
 // ExperimentVersion implements model.ExperimentMeasurer.
 func (m *Measurer) ExperimentVersion() string {
-	return "0.5.5"
+	return "0.5.6"
 }
 
 // Run implements model.ExperimentMeasurer.


### PR DESCRIPTION
See: https://github.com/ooni/probe/issues/2274
