### PR TITLE
fix(webconnectivity@v0.5): account for broken ipv6 in dnsdiff algorithm

### DIFF
--- a/internal/experiment/webconnectivity/measurer.go
+++ b/internal/experiment/webconnectivity/measurer.go
@@ -36,7 +36,7 @@ func (m *Measurer) ExperimentName() string {
 
 // ExperimentVersion implements model.ExperimentMeasurer.
 func (m *Measurer) ExperimentVersion() string {
-	return "0.5.9"
+	return "0.5.10"
 }
 
 // Run implements model.ExperimentMeasurer.


### PR DESCRIPTION
See https://github.com/ooni/probe/issues/2284
