### PR TITLE
feat(webconnectivity@v0.5): flag case where noone resolved any address

### DIFF
--- a/internal/experiment/webconnectivity/dnsresolvers.go
+++ b/internal/experiment/webconnectivity/dnsresolvers.go
@@ -172,7 +172,7 @@ func (t *DNSResolvers) Run(parentCtx context.Context) {
 	}
 
 	// create priority selector
-	ps := newPrioritySelector(parentCtx, t.ZeroTime, t.TestKeys, t.Logger, t.WaitGroup, addresses)
+	ps := newPrioritySelector(parentCtx, t.ZeroTime, t.TestKeys, t.Logger, addresses)
 
 	// fan out a number of child async tasks to use the IP addrs
 	t.startCleartextFlows(parentCtx, ps, addresses)

--- a/internal/experiment/webconnectivity/measurer.go
+++ b/internal/experiment/webconnectivity/measurer.go
@@ -36,7 +36,7 @@ func (m *Measurer) ExperimentName() string {
 
 // ExperimentVersion implements model.ExperimentMeasurer.
 func (m *Measurer) ExperimentVersion() string {
-	return "0.5.10"
+	return "0.5.11"
 }
 
 // Run implements model.ExperimentMeasurer.

--- a/internal/experiment/webconnectivity/priority.go
+++ b/internal/experiment/webconnectivity/priority.go
@@ -30,7 +30,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"sync"
 	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/model"
@@ -80,7 +79,6 @@ func newPrioritySelector(
 	zeroTime time.Time,
 	tk *TestKeys,
 	logger model.Logger,
-	wg *sync.WaitGroup,
 	addrs []DNSEntry,
 ) *prioritySelector {
 	ps := &prioritySelector{
@@ -107,8 +105,7 @@ func newPrioritySelector(
 			ps.nhttps++
 		}
 	}
-	wg.Add(1)
-	go ps.selector(ctx, wg)
+	go ps.selector(ctx)
 	return ps
 }
 
@@ -151,10 +148,7 @@ func (ps *prioritySelector) permissionToFetch(address string) bool {
 // background goroutine and terminates when [ctx] is done.
 //
 // This function implements https://github.com/ooni/probe/issues/2276.
-func (ps *prioritySelector) selector(ctx context.Context, wg *sync.WaitGroup) {
-	// synchronize with the parent
-	defer wg.Done()
-
+func (ps *prioritySelector) selector(ctx context.Context) {
 	// Implementation note: setting an arbitrary timeout here would
 	// be ~an issue because we want this goroutine to be available in
 	// case the only connections from which we could fetch a webpage

--- a/internal/experiment/webconnectivity/testkeys.go
+++ b/internal/experiment/webconnectivity/testkeys.go
@@ -90,6 +90,11 @@ type TestKeys struct {
 	// BlockingFlags contains blocking flags.
 	BlockingFlags int64 `json:"x_blocking_flags"`
 
+	// NullNullFlags explains why we determined that a measurement is not
+	// failed by detecting specific conditions that would have otherwise
+	// caused .Accessible = nil and .Blocking = nil
+	NullNullFlags int64 `json:"x_null_null_flags"`
+
 	// BodyLength match tells us whether the body length matches.
 	BodyLengthMatch *bool `json:"body_length_match"`
 
@@ -334,6 +339,7 @@ func NewTestKeys() *TestKeys {
 		DNSConsistency:        "",
 		HTTPExperimentFailure: nil,
 		BlockingFlags:         0,
+		NullNullFlags:         0,
 		BodyLengthMatch:       nil,
 		HeadersMatch:          nil,
 		StatusCodeMatch:       nil,


### PR DESCRIPTION
See https://github.com/ooni/probe/issues/2290

While there, notice that in such a case the priority selector would hang because of the WaitGroup, so get rid of the WaitGroup and accept that the priority selector is going to hang around for the whole duration of the measurement in some cases. The cancellable `measurer.go`'s context will cause the priority selector to eventually exit when we return from `measurer.go`'s `Run` method.