### PR TITLE
fix(webconnectivity@v0.5): avoid confusing log message

### DIFF
--- a/internal/experiment/webconnectivity/control.go
+++ b/internal/experiment/webconnectivity/control.go
@@ -164,7 +164,7 @@ func (c *Control) maybeStartExtraMeasurements(ctx context.Context, thAddrs []str
 		thOnlyAddrs = append(thOnlyAddrs, addr)
 	}
 
-	c.Logger.Infof("measuring additional addrs from TH: %+v", thOnlyAddrs)
+	c.Logger.Infof("additional addrs discovered by the TH: %+v", thOnlyAddrs)
 
 	var thOnly []DNSEntry
 	for _, addr := range thOnlyAddrs {


### PR DESCRIPTION
It's confusing to see

```
measuring additional addrs from TH: []
```

when actually nothing is going to be measured.

So, instead, let us log about the additional addrs discovered by the TH instead, which is less confusing.

Part of https://github.com/ooni/probe/issues/2237
