### PR TITLE
webconnectivity@v0.5: handle successful https chains

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
             "-GOCACHE",
             "-GOPATH"
         ]
-    }
+    },
+    "C_Cpp.default.configurationProvider": "ms-vscode.makefile-tools"
 }

--- a/internal/experiment/webconnectivity/iox.go
+++ b/internal/experiment/webconnectivity/iox.go
@@ -19,7 +19,7 @@ import (
 // as [ctx] is done or when [reader] is closed, if applicable.
 //
 // This function transforms an errors.Is(err, io.EOF) to a nil error
-// such as the standard library's io.ReadAll does.
+// such as the standard library's ReadAll does.
 //
 // This function might return a non-zero-length buffer along with
 // an non-nil error in the case in which we could only read a portion

--- a/internal/experiment/webconnectivity/measurer.go
+++ b/internal/experiment/webconnectivity/measurer.go
@@ -36,7 +36,7 @@ func (m *Measurer) ExperimentName() string {
 
 // ExperimentVersion implements model.ExperimentMeasurer.
 func (m *Measurer) ExperimentVersion() string {
-	return "0.5.14"
+	return "0.5.15"
 }
 
 // Run implements model.ExperimentMeasurer.

--- a/internal/experiment/webconnectivity/testkeys.go
+++ b/internal/experiment/webconnectivity/testkeys.go
@@ -90,8 +90,9 @@ type TestKeys struct {
 	// BlockingFlags explains why we think that the website is blocked.
 	BlockingFlags int64 `json:"x_blocking_flags"`
 
-	// WebsiteDownFlags explains why we determined that the website is down.
-	WebsiteDownFlags int64 `json:"x_website_down_flags"`
+	// NullNullFlags describes what the algorithm to avoid emitting
+	// blocking = null, accessible = null measurements did
+	NullNullFlags int64 `json:"x_null_null_flags"`
 
 	// BodyLength match tells us whether the body length matches.
 	BodyLengthMatch *bool `json:"body_length_match"`
@@ -337,7 +338,7 @@ func NewTestKeys() *TestKeys {
 		DNSConsistency:        "",
 		HTTPExperimentFailure: nil,
 		BlockingFlags:         0,
-		WebsiteDownFlags:      0,
+		NullNullFlags:         0,
 		BodyLengthMatch:       nil,
 		HeadersMatch:          nil,
 		StatusCodeMatch:       nil,


### PR DESCRIPTION
This diff includes a rule to recover from the "measurement failed" state that kicks in when we have a chain of successful redirects from the client side leading to a webpage _and_ any URL in the chain uses HTTPS. See https://github.com/ooni/probe/issues/2307.

While there, fix `i/e/w/iox.go` to avoid triggering the `./script/nocopyreadall.bash` script.