### PR TITLE
refactor(webconnectivity@v0.5): improve logging clarity

### DIFF
--- a/internal/experiment/webconnectivity/analysiscore.go
+++ b/internal/experiment/webconnectivity/analysiscore.go
@@ -109,7 +109,7 @@ func (tk *TestKeys) analysisToplevel(logger model.Logger) {
 		tk.Blocking = "dns"
 		tk.Accessible = false
 		logger.Warnf(
-			"ANOMALY: flags=%d accessible=%+v, blocking=%+v",
+			"ANOMALY: flags=%d, accessible=%+v, blocking=%+v",
 			tk.BlockingFlags, tk.Accessible, tk.Blocking,
 		)
 
@@ -117,14 +117,14 @@ func (tk *TestKeys) analysisToplevel(logger model.Logger) {
 		tk.Blocking = "tcp_ip"
 		tk.Accessible = false
 		logger.Warnf(
-			"ANOMALY: flags=%d accessible=%+v, blocking=%+v",
+			"ANOMALY: flags=%d, accessible=%+v, blocking=%+v",
 			tk.BlockingFlags, tk.Accessible, tk.Blocking,
 		)
 
 	case (tk.BlockingFlags & (analysisFlagTLSBlocking | analysisFlagHTTPBlocking)) != 0:
 		tk.Blocking = "http-failure"
 		tk.Accessible = false
-		logger.Warnf("ANOMALY: flags=%d accessible=%+v, blocking=%+v",
+		logger.Warnf("ANOMALY: flags=%d, accessible=%+v, blocking=%+v",
 			tk.BlockingFlags, tk.Accessible, tk.Blocking,
 		)
 
@@ -132,7 +132,7 @@ func (tk *TestKeys) analysisToplevel(logger model.Logger) {
 		tk.Blocking = "http-diff"
 		tk.Accessible = false
 		logger.Warnf(
-			"ANOMALY: flags=%d accessible=%+v, blocking=%+v",
+			"ANOMALY: flags=%d, accessible=%+v, blocking=%+v",
 			tk.BlockingFlags, tk.Accessible, tk.Blocking,
 		)
 
@@ -140,7 +140,7 @@ func (tk *TestKeys) analysisToplevel(logger model.Logger) {
 		tk.Blocking = false
 		tk.Accessible = true
 		logger.Infof(
-			"ACCESSIBLE: flags=%d accessible=%+v, blocking=%+v",
+			"ACCESSIBLE: flags=%d, accessible=%+v, blocking=%+v",
 			tk.BlockingFlags, tk.Accessible, tk.Blocking,
 		)
 

--- a/internal/experiment/webconnectivity/analysisdns.go
+++ b/internal/experiment/webconnectivity/analysisdns.go
@@ -117,7 +117,7 @@ func (tk *TestKeys) analysisDNSBogon(logger model.Logger) {
 			case "A":
 				if net.ParseIP(answer.IPv4) != nil && netxlite.IsBogon(answer.IPv4) {
 					logger.Warnf(
-						"DNS: got A BOGON answer %s for domain %s (see #%d)",
+						"DNS: got BOGON answer %s for domain %s (see #%d)",
 						answer.IPv4,
 						query.Hostname,
 						query.TransactionID,
@@ -128,7 +128,7 @@ func (tk *TestKeys) analysisDNSBogon(logger model.Logger) {
 			case "AAAA":
 				if net.ParseIP(answer.IPv6) != nil && netxlite.IsBogon(answer.IPv6) {
 					logger.Warnf(
-						"DNS: got AAAA BOGON answer %s for %s (see #%d)",
+						"DNS: got BOGON answer %s for domain %s (see #%d)",
 						answer.IPv6,
 						query.Hostname,
 						query.TransactionID,

--- a/internal/experiment/webconnectivity/analysishttpcore.go
+++ b/internal/experiment/webconnectivity/analysishttpcore.go
@@ -53,10 +53,10 @@ func (tk *TestKeys) analysisHTTPToplevel(logger model.Logger) {
 			netxlite.FailureEOFError:
 			tk.BlockingFlags |= analysisFlagHTTPBlocking
 			logger.Warnf(
-				"HTTP: endpoint %s is blocked (see #%d): %s",
+				"HTTP: unexpected failure %s for %s (see #%d)",
+				*failure,
 				finalRequest.Address,
 				finalRequest.TransactionID,
-				*failure,
 			)
 		default:
 			// leave this case for ooni/pipeline

--- a/internal/experiment/webconnectivity/analysishttpdiff.go
+++ b/internal/experiment/webconnectivity/analysishttpdiff.go
@@ -62,7 +62,7 @@ func (tk *TestKeys) analysisHTTPDiff(logger model.Logger,
 			tk.BlockingFlags |= analysisFlagSuccess
 			return
 		}
-		logger.Info("HTTP: headers: MISMATCH")
+		logger.Info("HTTP: uncommon headers: MISMATCH")
 		if tk.TitleMatch != nil && *tk.TitleMatch {
 			logger.Infof(
 				"HTTP: statusCodeMatch && titleMatch => #%d is successful",

--- a/internal/experiment/webconnectivity/analysishttpdiff.go
+++ b/internal/experiment/webconnectivity/analysishttpdiff.go
@@ -53,7 +53,7 @@ func (tk *TestKeys) analysisHTTPDiff(logger model.Logger,
 			tk.BlockingFlags |= analysisFlagSuccess
 			return
 		}
-		logger.Info("HTTP: body length: MISMATCH")
+		logger.Infof("HTTP: body length: MISMATCH (see #%d)", probe.TransactionID)
 		if tk.HeadersMatch != nil && *tk.HeadersMatch {
 			logger.Infof(
 				"HTTP: statusCodeMatch && headersMatch => #%d is successful",
@@ -62,7 +62,7 @@ func (tk *TestKeys) analysisHTTPDiff(logger model.Logger,
 			tk.BlockingFlags |= analysisFlagSuccess
 			return
 		}
-		logger.Info("HTTP: uncommon headers: MISMATCH")
+		logger.Infof("HTTP: uncommon headers: MISMATCH (see #%d)", probe.TransactionID)
 		if tk.TitleMatch != nil && *tk.TitleMatch {
 			logger.Infof(
 				"HTTP: statusCodeMatch && titleMatch => #%d is successful",
@@ -71,9 +71,9 @@ func (tk *TestKeys) analysisHTTPDiff(logger model.Logger,
 			tk.BlockingFlags |= analysisFlagSuccess
 			return
 		}
-		logger.Info("HTTP: title: MISMATCH")
+		logger.Infof("HTTP: title: MISMATCH (see #%d)", probe.TransactionID)
 	} else {
-		logger.Infof("HTTP: status code: MISMATCH")
+		logger.Infof("HTTP: status code: MISMATCH (see #%d)", probe.TransactionID)
 	}
 
 	tk.BlockingFlags |= analysisFlagHTTPDiff

--- a/internal/experiment/webconnectivity/analysishttpdiff.go
+++ b/internal/experiment/webconnectivity/analysishttpdiff.go
@@ -53,6 +53,7 @@ func (tk *TestKeys) analysisHTTPDiff(logger model.Logger,
 			tk.BlockingFlags |= analysisFlagSuccess
 			return
 		}
+		logger.Info("HTTP: body length: MISMATCH")
 		if tk.HeadersMatch != nil && *tk.HeadersMatch {
 			logger.Infof(
 				"HTTP: statusCodeMatch && headersMatch => #%d is successful",
@@ -61,6 +62,7 @@ func (tk *TestKeys) analysisHTTPDiff(logger model.Logger,
 			tk.BlockingFlags |= analysisFlagSuccess
 			return
 		}
+		logger.Info("HTTP: headers: MISMATCH")
 		if tk.TitleMatch != nil && *tk.TitleMatch {
 			logger.Infof(
 				"HTTP: statusCodeMatch && titleMatch => #%d is successful",
@@ -69,6 +71,9 @@ func (tk *TestKeys) analysisHTTPDiff(logger model.Logger,
 			tk.BlockingFlags |= analysisFlagSuccess
 			return
 		}
+		logger.Info("HTTP: title: MISMATCH")
+	} else {
+		logger.Infof("HTTP: status code: MISMATCH")
 	}
 
 	tk.BlockingFlags |= analysisFlagHTTPDiff

--- a/internal/experiment/webconnectivity/analysistcpip.go
+++ b/internal/experiment/webconnectivity/analysistcpip.go
@@ -71,10 +71,10 @@ func (tk *TestKeys) analysisTCPIPToplevel(logger model.Logger) {
 			continue
 		}
 		logger.Warnf(
-			"TCP/IP: endpoint %s is blocked (see #%d): %s",
+			"TCP/IP: unexpected failure %s for %s (see #%d)",
+			*failure,
 			epnt,
 			entry.TransactionID,
-			*failure,
 		)
 		entry.Status.Blocked = &istrue
 		tk.BlockingFlags |= analysisFlagTCPIPBlocking

--- a/internal/experiment/webconnectivity/analysistls.go
+++ b/internal/experiment/webconnectivity/analysistls.go
@@ -40,10 +40,10 @@ func (tk *TestKeys) analysisTLSToplevel(logger model.Logger) {
 			continue
 		}
 		logger.Warnf(
-			"TLS: endpoint %s is blocked (see #%d): %s",
+			"TLS: unexpected failure %s for %s (see #%d)",
+			*failure,
 			epnt,
 			entry.TransactionID,
-			*failure,
 		)
 		tk.BlockingFlags |= analysisFlagTLSBlocking
 	}

--- a/internal/experiment/webconnectivity/dnsresolvers.go
+++ b/internal/experiment/webconnectivity/dnsresolvers.go
@@ -268,9 +268,6 @@ func (t *DNSResolvers) waitForLateReplies(parentCtx context.Context, trace *meas
 	defer t.WaitGroup.Done()
 	const lateTimeout = 500 * time.Millisecond
 	events := trace.DelayedDNSResponseWithTimeout(parentCtx, lateTimeout)
-	if length := len(events); length > 0 {
-		t.Logger.Warnf("got %d late DNS replies", length)
-	}
 	t.TestKeys.AppendDNSLateReplies(events...)
 }
 

--- a/internal/experiment/webconnectivity/measurer.go
+++ b/internal/experiment/webconnectivity/measurer.go
@@ -36,7 +36,7 @@ func (m *Measurer) ExperimentName() string {
 
 // ExperimentVersion implements model.ExperimentMeasurer.
 func (m *Measurer) ExperimentVersion() string {
-	return "0.5.16"
+	return "0.5.17"
 }
 
 // Run implements model.ExperimentMeasurer.

--- a/internal/experiment/webconnectivity/testkeys.go
+++ b/internal/experiment/webconnectivity/testkeys.go
@@ -43,9 +43,9 @@ type TestKeys struct {
 	// Do53 contains ancillary observations collected by Do53 resolvers.
 	Do53 *TestKeysDo53 `json:"x_do53"`
 
-	// DNSLateReplies contains late replies we didn't expect to receive from
+	// DNSDuplicateResponses contains late/duplicate responses we didn't expect to receive from
 	// a resolver (which may raise eyebrows if they're different).
-	DNSLateReplies []*model.ArchivalDNSLookupResult `json:"x_dns_late_replies"`
+	DNSDuplicateResponses []*model.ArchivalDNSLookupResult `json:"x_dns_duplicate_responses"`
 
 	// Queries contains DNS queries.
 	Queries []*model.ArchivalDNSLookupResult `json:"queries"`
@@ -202,7 +202,7 @@ func (tk *TestKeys) AppendNetworkEvents(v ...*model.ArchivalNetworkEvent) {
 // AppendDNSLateReplies appends to DNSLateReplies.
 func (tk *TestKeys) AppendDNSLateReplies(v ...*model.ArchivalDNSLookupResult) {
 	tk.mu.Lock()
-	tk.DNSLateReplies = append(tk.DNSLateReplies, v...)
+	tk.DNSDuplicateResponses = append(tk.DNSDuplicateResponses, v...)
 	tk.mu.Unlock()
 }
 
@@ -325,7 +325,7 @@ func NewTestKeys() *TestKeys {
 			NetworkEvents: []*model.ArchivalNetworkEvent{},
 			Queries:       []*model.ArchivalDNSLookupResult{},
 		},
-		DNSLateReplies:        []*model.ArchivalDNSLookupResult{},
+		DNSDuplicateResponses: []*model.ArchivalDNSLookupResult{},
 		Queries:               []*model.ArchivalDNSLookupResult{},
 		Requests:              []*model.ArchivalHTTPRequestResult{},
 		TCPConnect:            []*model.ArchivalTCPConnectResult{},


### PR DESCRIPTION
We're bumping the experiment's version number because we changed the name of the field used to contain late/duplicate DNS responses. We have also changed the algorithm to determine `#dnsDiff`. However, the change should only impact how we log this information. Overall, here the idea is to provide users with a reasonably clear explanation of how the probe maps observations to blocking and accessible using expected/unexpected as the conceptual framework.

Part of https://github.com/ooni/probe/issues/2237
