### PR TITLE
Minor typo fixed in 'ssl_unknown_autority'

### DIFF
--- a/docs/design/dd-002-netx.md
+++ b/docs/design/dd-002-netx.md
@@ -120,7 +120,7 @@ Where `Failure` is one of the errors we care about, i.e.:
 - `eof_error`: unexpected EOF on connection
 - `generic_timeout_error`: some timer has expired
 - `ssl_invalid_hostname`: certificate not valid for SNI
-- `ssl_unknown_autority`: cannot find CA validating certificate
+- `ssl_unknown_authority`: cannot find CA validating certificate
 - `ssl_invalid_certificate`: e.g. certificate expired
 - `unknown_failure <string>`: any other error
 


### PR DESCRIPTION
This is minor typo fix in the documentation. 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [ ] reference issue for this pull request: <!-- add URL here -->
- [ ] if you changed anything related how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

Please, insert here a more detailed description.
