### PR TITLE
fix: ooporthelper connection_refused

### DIFF
--- a/internal/cmd/ooporthelper/main.go
+++ b/internal/cmd/ooporthelper/main.go
@@ -31,7 +31,7 @@ func shutdown(ctx context.Context, l net.Listener) {
 }
 
 // TODO(DecFox): Add the ability of an echo service to generate some traffic
-func handleConnetion(ctx context.Context, conn net.Conn) {
+func handleConnection(ctx context.Context, conn net.Conn) {
 	defer conn.Close()
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -48,10 +48,10 @@ func listenTCP(ctx context.Context, port string) {
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
-			log.Infof("listener unable to accept connections on port%s", port)
+			log.Infof("listener unable to accept connections on port: %s", port)
 			return
 		}
-		go handleConnetion(ctx, conn)
+		go handleConnection(ctx, conn)
 	}
 }
 

--- a/internal/cmd/ooporthelper/main_test.go
+++ b/internal/cmd/ooporthelper/main_test.go
@@ -9,13 +9,19 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
+var (
+	portsMap = make(map[string]bool)
+)
+
 func TestMainWorkingAsIntended(t *testing.T) {
-	t.Skip("// TODO(https://github.com/ooni/probe/issues/2338)")
 	srvTest = true // toggle to imply that we are running in test mode
+	for _, port := range TestPorts {
+		portsMap[port] = false
+	}
 	go main()
 	dialer := netxlite.NewDialerWithoutResolver(model.DiscardLogger)
-	for _, port := range TestPorts {
-		<-srvTestChan
+	for i := 0; i < len(TestPorts); i++ {
+		port := <-srvTestChan
 		addr := net.JoinHostPort("127.0.0.1", port)
 		ctx := context.Background()
 		conn, err := dialer.DialContext(ctx, "tcp", addr)
@@ -26,7 +32,14 @@ func TestMainWorkingAsIntended(t *testing.T) {
 			t.Fatal("expected non-nil conn")
 		}
 		conn.Close()
+		portsMap[port] = true
 	}
 	srvCancel()  // shutdown server
 	srvWg.Wait() // wait for listeners on all ports to close
+	// check if all ports were covered
+	for _, port := range TestPorts {
+		if !portsMap[port] {
+			t.Fatal("missed port in test", port)
+		}
+	}
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2338
- [ ] if you changed anything related how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff fixes the `connection_refused` error we face with go1.19 for `ooporthelper`
