### PR TITLE
fix(geolocate): always use netxlite functionality

### DIFF
--- a/internal/engine/geolocate/cloudflare.go
+++ b/internal/engine/geolocate/cloudflare.go
@@ -15,6 +15,7 @@ func cloudflareIPLookup(
 	httpClient *http.Client,
 	logger model.Logger,
 	userAgent string,
+	resolver model.Resolver,
 ) (string, error) {
 	data, err := (&httpx.APIClientTemplate{
 		BaseURL:    "https://www.cloudflare.com",

--- a/internal/engine/geolocate/cloudflare_test.go
+++ b/internal/engine/geolocate/cloudflare_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
 func TestIPLookupWorksUsingcloudlflare(t *testing.T) {
@@ -16,6 +17,7 @@ func TestIPLookupWorksUsingcloudlflare(t *testing.T) {
 		http.DefaultClient,
 		log.Log,
 		model.HTTPHeaderUserAgent,
+		netxlite.NewStdlibResolver(model.DiscardLogger),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/engine/geolocate/geolocate.go
+++ b/internal/engine/geolocate/geolocate.go
@@ -90,7 +90,9 @@ func NewTask(config Config) *Task {
 		probeIPLookupper:     ipLookupClient(config),
 		probeASNLookupper:    mmdbLookupper{},
 		resolverASNLookupper: mmdbLookupper{},
-		resolverIPLookupper:  resolverLookupClient{},
+		resolverIPLookupper: resolverLookupClient{
+			Resolver: config.Resolver,
+		},
 	}
 }
 

--- a/internal/engine/geolocate/invalid_test.go
+++ b/internal/engine/geolocate/invalid_test.go
@@ -12,6 +12,7 @@ func invalidIPLookup(
 	httpClient *http.Client,
 	logger model.Logger,
 	userAgent string,
+	resolver model.Resolver,
 ) (string, error) {
 	return "invalid IP", nil
 }

--- a/internal/engine/geolocate/iplookup.go
+++ b/internal/engine/geolocate/iplookup.go
@@ -27,6 +27,7 @@ var (
 type lookupFunc func(
 	ctx context.Context, client *http.Client,
 	logger model.Logger, userAgent string,
+	resolver model.Resolver,
 ) (string, error)
 
 type method struct {
@@ -89,7 +90,7 @@ func (c ipLookupClient) doWithCustomFunc(
 	txp := netxlite.NewHTTPTransportWithResolver(c.Logger, c.Resolver)
 	clnt := &http.Client{Transport: txp}
 	defer clnt.CloseIdleConnections()
-	ip, err := fn(ctx, clnt, c.Logger, c.UserAgent)
+	ip, err := fn(ctx, clnt, c.Logger, c.UserAgent, c.Resolver)
 	if err != nil {
 		return model.DefaultProbeIP, err
 	}

--- a/internal/engine/geolocate/resolverlookup.go
+++ b/internal/engine/geolocate/resolverlookup.go
@@ -3,7 +3,8 @@ package geolocate
 import (
 	"context"
 	"errors"
-	"net"
+
+	"github.com/ooni/probe-cli/v3/internal/model"
 )
 
 var (
@@ -16,7 +17,9 @@ type dnsResolver interface {
 	LookupHost(ctx context.Context, host string) (addrs []string, err error)
 }
 
-type resolverLookupClient struct{}
+type resolverLookupClient struct {
+	Resolver model.Resolver
+}
 
 func (rlc resolverLookupClient) do(ctx context.Context, r dnsResolver) (string, error) {
 	var ips []string
@@ -31,5 +34,5 @@ func (rlc resolverLookupClient) do(ctx context.Context, r dnsResolver) (string, 
 }
 
 func (rlc resolverLookupClient) LookupResolverIP(ctx context.Context) (ip string, err error) {
-	return rlc.do(ctx, &net.Resolver{})
+	return rlc.do(ctx, rlc.Resolver)
 }

--- a/internal/engine/geolocate/resolverlookup_test.go
+++ b/internal/engine/geolocate/resolverlookup_test.go
@@ -4,10 +4,16 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
 func TestLookupResolverIP(t *testing.T) {
-	addr, err := (resolverLookupClient{}).LookupResolverIP(context.Background())
+	rlc := resolverLookupClient{
+		Resolver: netxlite.NewStdlibResolver(model.DiscardLogger),
+	}
+	addr, err := rlc.LookupResolverIP(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -26,7 +32,9 @@ func (bhl brokenHostLookupper) LookupHost(ctx context.Context, host string) ([]s
 
 func TestLookupResolverIPFailure(t *testing.T) {
 	expected := errors.New("mocked error")
-	rlc := resolverLookupClient{}
+	rlc := resolverLookupClient{
+		Resolver: netxlite.NewStdlibResolver(model.DiscardLogger),
+	}
 	addr, err := rlc.do(context.Background(), brokenHostLookupper{
 		err: expected,
 	})
@@ -39,7 +47,9 @@ func TestLookupResolverIPFailure(t *testing.T) {
 }
 
 func TestLookupResolverIPNoAddressReturned(t *testing.T) {
-	rlc := resolverLookupClient{}
+	rlc := resolverLookupClient{
+		Resolver: netxlite.NewStdlibResolver(model.DiscardLogger),
+	}
 	addr, err := rlc.do(context.Background(), brokenHostLookupper{})
 	if !errors.Is(err, ErrNoIPAddressReturned) {
 		t.Fatalf("not the error we expected: %+v", err)

--- a/internal/engine/geolocate/ubuntu.go
+++ b/internal/engine/geolocate/ubuntu.go
@@ -19,6 +19,7 @@ func ubuntuIPLookup(
 	httpClient *http.Client,
 	logger model.Logger,
 	userAgent string,
+	resolver model.Resolver,
 ) (string, error) {
 	data, err := (&httpx.APIClientTemplate{
 		BaseURL:    "https://geoip.ubuntu.com/",

--- a/internal/engine/geolocate/ubuntu_test.go
+++ b/internal/engine/geolocate/ubuntu_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
 func TestUbuntuParseError(t *testing.T) {
@@ -23,6 +24,7 @@ func TestUbuntuParseError(t *testing.T) {
 		}},
 		log.Log,
 		model.HTTPHeaderUserAgent,
+		netxlite.NewStdlibResolver(model.DiscardLogger),
 	)
 	if err == nil || !strings.HasPrefix(err.Error(), "XML syntax error") {
 		t.Fatalf("not the error we expected: %+v", err)
@@ -38,6 +40,7 @@ func TestIPLookupWorksUsingUbuntu(t *testing.T) {
 		http.DefaultClient,
 		log.Log,
 		model.HTTPHeaderUserAgent,
+		netxlite.NewStdlibResolver(model.DiscardLogger),
 	)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This change ensures that, in turn, we're able to "remote" all the traffic generated by the `geolocate` package, rather than missing some bits of it that were still using the standard library and caused _some_ geolocations to geolocate as the local host rather than as the remote host.

Extracted from https://github.com/ooni/probe-cli/pull/969, where we tested this functionality.

Closes https://github.com/ooni/probe/issues/1383 (which was long overdue).

Part of https://github.com/ooni/probe/issues/2340, because it allows us to make progress with that.

