### PR TITLE
Add new root CA to the signal test

### DIFF
--- a/internal/engine/experiment/signal/signal.go
+++ b/internal/engine/experiment/signal/signal.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	testName    = "signal"
-	testVersion = "0.2.0"
+	testVersion = "0.2.1"
 
 	signalCA = `-----BEGIN CERTIFICATE-----
 MIID7zCCAtegAwIBAgIJAIm6LatK5PNiMA0GCSqGSIb3DQEBBQUAMIGNMQswCQYD
@@ -40,6 +40,34 @@ iOheyv7UzJOefb2pLOc9qsuvI4fnaESh9bhzln+LXxtCrRPGhkxA1IMIo3J/s2WF
 /oF4usY5J7LPkxK3LWzMJnb5EIJDmRvyH8pyRwWg6Qm6qiGFaI4nL8QU4La1x2en
 4DGXRaLMPRwjELNgQPodR38zoCMuA8gHZfZYYoZ7D7Q1wNUiVHcxuFrEeBaYJbLE
 rwLV
+-----END CERTIFICATE-----`
+
+	signalCANew = `-----BEGIN CERTIFICATE-----
+MIIEjDCCAnSgAwIBAgITV+dgmSk1+75Wwn/Mjz8f+gQ9qTANBgkqhkiG9w0BAQsF
+ADB1MQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMN
+TW91bnRhaW4gVmlldzEeMBwGA1UEChMVU2lnbmFsIE1lc3NlbmdlciwgTExDMRkw
+FwYDVQQDExBTaWduYWwgTWVzc2VuZ2VyMB4XDTIyMDgyMzE2NTIxMVoXDTIzMDky
+MzIyNDA1NlowADCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALf8th0A
+N5TFsvvdfaSP1WyCMn5Ql81IF5D0pXrdE9fGDz5AaeAbCazxXU8tnjZiUr4a/BGD
+h3ZxORHXJ2SA3HA2UFG+qHik59QNGkY4Jv4emTM5QLw0fcsGRgJnzb7A60LRoxGs
+17jxD1zyVl/SXn/Ql3cvBrHjxPzJ6NcQG4Pek7YieH2xiMP794QUu0XJYlBx0uvx
+xOI3qpw5c6oNORGY8hlwWzbv+sqvShXhteOlkzluKtIqpL8+NV206JIqLkaKFjB7
+To14TSFF3tYxxsHYwDhRKPatqYpbebx3iCo0H33dL0gjoUtdvRgsdHqnUQXSqoRH
+cUYCIPs3FivKNrcCAwEAAaOBiTCBhjATBgNVHSUEDDAKBggrBgEFBQcDATAMBgNV
+HRMBAf8EAjAAMB0GA1UdDgQWBBSidZq+TLJkcDuNV5j1KbOm/l+dhjAfBgNVHSME
+GDAWgBS180vG5dZL0OWAa4xQw2dbvLHzcTAhBgNVHREBAf8EFzAVghNzZnUudm9p
+cC5zaWduYWwub3JnMA0GCSqGSIb3DQEBCwUAA4ICAQCDchlftHXUm3sFWL86GKUs
+w7nxOiJDZYR+xIVGbsUarBolEsZZkYjTDB427ZjgBS+Nfhhbrw4k2LMarkxf2TQX
+aelPHRa5xNPVfkrN8xw4fv/8TLE9GSjKlrNJm1EoTZL5CYWQU+qe4CuKfAJU6h8l
+xIkcik61aCeNLQoaI1L3V8tPXmmqMWpsnZmFg6YLGeMTLs4skdFqgLOnx9EF2jgO
+7EAJ9HcrgSPirQeuDJKhamaLtQiqIQR8L3H4YG1FDiuOeto6f1LRCIqjH1Mye1BM
+33Qg/VilLQIWp8+C4GJZ0+LO1cfatNh8tkDbrwMzUeA1nLEZHMlgXE05z00euNlQ
+0+evTmJzWRKJHugPnA3vvdzy4lbYvYWaXs8pACrVpESui8I+v6jdH814lOxpDwNH
+bPrxfOxhIxfFiVttCl3AQZBLJM6M0ty6/Q7bYsdNT23jKMl0AmDhj9qn/7dzYcVi
+vI0XKaaJl4ov3IDbuMe0oZWhoLwzPuWxxkWDjTb8ngDnWZT1o5dAR9fltr38m42N
+uA/SkxghiAMmvkC8nhEJ7yT2hme+rozPZSp1SSEDViDkA4KnnQpMcNiotCQpNOe7
+YfA9uSnjHjZloRTPUgtkKQ3u8ZZprFQlS2jDE18BRGdh24V5OsCbMvFPtrEsjG4H
+5xvkiIV0FpbMk4Gj8I4Hbw==
 -----END CERTIFICATE-----`
 )
 
@@ -117,7 +145,15 @@ func (m Measurer) Run(ctx context.Context, sess model.ExperimentSession,
 		signalCABytes = []byte(m.Config.SignalCA)
 	}
 	if !certPool.AppendCertsFromPEM(signalCABytes) {
-		return errors.New("AppendCertsFromPEM failed")
+		return errors.New("AppendCertsFromPEM failed for old CA")
+	}
+
+	signalCANewBytes := []byte(signalCANew)
+	if m.Config.SignalCA != "" {
+		signalCANewBytes = []byte(m.Config.SignalCA)
+	}
+	if !certPool.AppendCertsFromPEM(signalCANewBytes) {
+		return errors.New("AppendCertsFromPEM failed for new CA")
 	}
 
 	inputs := []urlgetter.MultiInput{

--- a/internal/engine/experiment/signal/signal.go
+++ b/internal/engine/experiment/signal/signal.go
@@ -140,20 +140,17 @@ func (m Measurer) Run(ctx context.Context, sess model.ExperimentSession,
 	urlgetter.RegisterExtensions(measurement)
 
 	certPool := netxlite.NewDefaultCertPool()
-	signalCABytes := []byte(signalCA)
+	signalCAByteSlice := [][]byte{
+		[]byte(signalCA),
+		[]byte(signalCANew),
+	}
 	if m.Config.SignalCA != "" {
-		signalCABytes = []byte(m.Config.SignalCA)
+		signalCAByteSlice = [][]byte{[]byte(m.Config.SignalCA)}
 	}
-	if !certPool.AppendCertsFromPEM(signalCABytes) {
-		return errors.New("AppendCertsFromPEM failed for old CA")
-	}
-
-	signalCANewBytes := []byte(signalCANew)
-	if m.Config.SignalCA != "" {
-		signalCANewBytes = []byte(m.Config.SignalCA)
-	}
-	if !certPool.AppendCertsFromPEM(signalCANewBytes) {
-		return errors.New("AppendCertsFromPEM failed for new CA")
+	for _, caBytes := range signalCAByteSlice {
+		if !certPool.AppendCertsFromPEM(caBytes) {
+			return errors.New("AppendCertsFromPEM failed")
+		}
 	}
 
 	inputs := []urlgetter.MultiInput{

--- a/internal/engine/experiment/signal/signal_test.go
+++ b/internal/engine/experiment/signal/signal_test.go
@@ -17,7 +17,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "signal" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.2.0" {
+	if measurer.ExperimentVersion() != "0.2.1" {
 		t.Fatal("unexpected version")
 	}
 }


### PR DESCRIPTION
All measurements collected since 2022-10-19 with previous versions of OONI Probe will wrongly report sfu.voip.signal.org as blocked as it switched to using a different root CA

This fixes: https://github.com/ooni/probe/issues/2344

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2344
- [x] if you changed anything related how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: https://github.com/ooni/spec/pull/265