### PR TITLE
cli: add support for passing proxy command line parameter

### DIFF
--- a/CLI/go-build-generic
+++ b/CLI/go-build-generic
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+	echo "" 1>&2
+	echo "Compiler for a Go PACKAGE producing GOOS/GOARCH binaries in the" 1>&2
+	echo "top-level directory (should not be used for releasing)." 1>&2
+	echo "" 1>&2
+	echo "usage: $0 PACKAGE..." 1>&2
+	echo "" 1>&2
+	echo "Features:" 1>&2
+	echo "" 1>&2
+	echo "* automatically sets -tags=ooni_psiphon_config when possible;" 1>&2
+	echo "" 1>&2
+	echo "* if GOLANG_EXTRA_FLAGS is set, pass it to the Go compiler." 1>&2
+	echo "" 1>&2
+	echo "Example:" 1>&2
+	echo "" 1>&2
+	echo "  ./CLI/go-build-generic ./internal/cmd/miniooni" 1>&2
+	echo "" 1>&2
+	exit 1
+fi
+
+if [[ -f ./internal/engine/psiphon-config.json.age &&
+	-f ./internal/engine/psiphon-config.key ]]; then
+	OONI_PSIPHON_TAGS=ooni_psiphon_config
+else
+	OONI_PSIPHON_TAGS=""
+fi
+
+set -x
+for pkg in "$@"; do
+	go build -tags=$OONI_PSIPHON_TAGS -ldflags="-s -w" ${GOLANG_EXTRA_FLAGS:-} $pkg
+done

--- a/Makefile
+++ b/Makefile
@@ -130,14 +130,14 @@ CLI/linux-static-arm64: search/for/docker maybe/copypsiphon
 	./CLI/go-build-linux-static $(OONI_GO_DOCKER_GOCACHE) arm64 ./cmd/ooniprobe ./internal/cmd/miniooni
 
 #help:
-#help: The `make CLI/miniooni` creates a build of miniooni, for the current
+#help: The `make CLI/miniooni` command creates a build of miniooni, for the current
 #help: system, putting the binary in the top-level directory.
 .PHONY: CLI/miniooni
 CLI/miniooni: maybe/copypsiphon search/for/go
 	./CLI/go-build-generic ./internal/cmd/miniooni
 
 #help:
-#help: The `make CLI/ooniprobe` creates a build of ooniprobe, for the current
+#help: The `make CLI/ooniprobe` command creates a build of ooniprobe, for the current
 #help: system, putting the binary in the top-level directory.
 .PHONY: CLI/ooniprobe
 CLI/ooniprobe: maybe/copypsiphon search/for/go

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,20 @@ CLI/linux-static-arm64: search/for/docker maybe/copypsiphon
 	./CLI/go-build-linux-static $(OONI_GO_DOCKER_GOCACHE) arm64 ./cmd/ooniprobe ./internal/cmd/miniooni
 
 #help:
+#help: The `make CLI/miniooni` creates a build of miniooni, for the current
+#help: system, putting the binary in the top-level directory.
+.PHONY: CLI/miniooni
+CLI/miniooni: maybe/copypsiphon search/for/go
+	./CLI/go-build-generic ./internal/cmd/miniooni
+
+#help:
+#help: The `make CLI/ooniprobe` creates a build of ooniprobe, for the current
+#help: system, putting the binary in the top-level directory.
+.PHONY: CLI/ooniprobe
+CLI/ooniprobe: maybe/copypsiphon search/for/go
+	./CLI/go-build-generic ./cmd/ooniprobe
+
+#help:
 #help: The `make CLI/windows` command builds the ooniprobe and miniooni
 #help: command line clients for windows/386 and windows/amd64.
 .PHONY: CLI/windows

--- a/cmd/ooniprobe/internal/cli/root/root.go
+++ b/cmd/ooniprobe/internal/cli/root/root.go
@@ -44,6 +44,9 @@ func init() {
 	softwareVersion := Cmd.Flag(
 		"software-version", "Override the application version",
 	).Default(version.Version).String()
+	proxy := Cmd.Flag(
+		"proxy", "specify a proxy address for speaking to the OONI Probe backend (use: --proxy=psiphon:/// for psiphon)",
+	).String()
 
 	Cmd.PreAction(func(ctx *kingpin.ParseContext) error {
 		// TODO(bassosimone): we need to properly deprecate --batch
@@ -78,7 +81,7 @@ func init() {
 			}
 
 			probe := ooni.NewProbe(*configPath, homePath)
-			err = probe.Init(*softwareName, *softwareVersion)
+			err = probe.Init(*softwareName, *softwareVersion, *proxy)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/ooniprobe/internal/nettests/nettests_test.go
+++ b/cmd/ooniprobe/internal/nettests/nettests_test.go
@@ -33,7 +33,7 @@ func newOONIProbe(t *testing.T) *ooni.Probe {
 	probe := ooni.NewProbe(configPath, homePath)
 	swName := "ooniprobe-cli-tests"
 	swVersion := "3.0.0-alpha"
-	err = probe.Init(swName, swVersion)
+	err = probe.Init(swName, swVersion, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/ooniprobe/internal/ooni/ooni.go
+++ b/cmd/ooniprobe/internal/ooni/ooni.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed" // because we embed a file
 	"io/ioutil"
+	"net/url"
 	"os"
 	"os/signal"
 	"syscall"
@@ -62,6 +63,7 @@ type Probe struct {
 
 	softwareName    string
 	softwareVersion string
+	proxyURL        *url.URL
 }
 
 // SetIsBatch sets the value of isBatch.
@@ -124,7 +126,7 @@ func (p *Probe) ListenForSignals() {
 // MaybeListenForStdinClosed will treat any error on stdin just
 // like SIGTERM if and only if
 //
-//     os.Getenv("OONI_STDIN_EOF_IMPLIES_SIGTERM") == "true"
+//	os.Getenv("OONI_STDIN_EOF_IMPLIES_SIGTERM") == "true"
 //
 // When this feature is enabled, a collateral effect is that we swallow
 // whatever is passed to us on the standard input.
@@ -151,7 +153,7 @@ func (p *Probe) MaybeListenForStdinClosed() {
 }
 
 // Init the OONI manager
-func (p *Probe) Init(softwareName, softwareVersion string) error {
+func (p *Probe) Init(softwareName, softwareVersion, proxy string) error {
 	var err error
 
 	if err = MaybeInitializeHome(p.home); err != nil {
@@ -197,6 +199,12 @@ func (p *Probe) Init(softwareName, softwareVersion string) error {
 
 	p.softwareName = softwareName
 	p.softwareVersion = softwareVersion
+	if proxy != "" {
+		p.proxyURL, err = url.Parse(proxy)
+		if err != nil {
+			return errors.Wrap(err, "invalid proxy URL")
+		}
+	}
 	return nil
 }
 
@@ -228,6 +236,7 @@ func (p *Probe) NewSession(ctx context.Context, runType model.RunType) (*engine.
 		SoftwareVersion: p.softwareVersion,
 		TempDir:         p.tempDir,
 		TunnelDir:       p.tunnelDir,
+		ProxyURL:        p.proxyURL,
 	})
 }
 

--- a/cmd/ooniprobe/internal/ooni/ooni_test.go
+++ b/cmd/ooniprobe/internal/ooni/ooni_test.go
@@ -17,7 +17,7 @@ func TestInit(t *testing.T) {
 	probe := NewProbe("", ooniHome)
 	swName := "ooniprobe-cli-tests"
 	swVersion := "3.0.0-alpha"
-	if err := probe.Init(swName, swVersion); err != nil {
+	if err := probe.Init(swName, swVersion, ""); err != nil {
 		t.Error(err)
 		t.Fatal("failed to init the context")
 	}


### PR DESCRIPTION
This implements the bare minimum needed to have circumvention proxy support in OONI Probe CLI.

The reference issue is https://github.com/ooni/probe/issues/1955. (Most of that issue is implemented, save for the fact that currently we do not have support for `http` and `https` proxies.)

While there, add to `Makefile` a rule for correctly building `ooniprobe` and `miniooni` for "this system" (i.e., the default `GOOS` and `GOARCH` on a system), because we needed this for testing this patch and we needed to figure out the commands instead.