### PR TITLE
feat(jafar): add -tls-proxy-outbound-port flag

### DIFF
--- a/internal/cmd/jafar/README.md
+++ b/internal/cmd/jafar/README.md
@@ -165,7 +165,7 @@ on their SNI value. It is controlled by the following flags:
   -tls-proxy-block value
         Register SNI header keyword triggering TLS censorship
   -tls-proxy-outbound-port
-        Define the outbound port requests are proxied to (default "443 for HTTPS)
+        Define the outbound port requests are proxied to (default "443" for HTTPS)
 ```
 
 The `-tls-proxy-address` flags has the same semantics it has for the DNS

--- a/internal/cmd/jafar/README.md
+++ b/internal/cmd/jafar/README.md
@@ -156,14 +156,16 @@ response for every request whose `Host` contains the specified string.
 
 ### tls-proxy
 
-TLS proxy is a proxy that routes traffic to specific servers depending
+TLS proxy is a TCP proxy that routes traffic to specific servers depending
 on their SNI value. It is controlled by the following flags:
 
 ```bash
   -tls-proxy-address string
-        Address where the HTTP proxy should listen (default "127.0.0.1:443")
+        Address where the TCP+TLS proxy should listen (default "127.0.0.1:443")
   -tls-proxy-block value
-        Register keyword triggering TLS censorship
+        Register SNI header keyword triggering TLS censorship
+  -tls-proxy-outbound-port
+        Define the outbound port requests are proxied to (default "443 for HTTPS)
 ```
 
 The `-tls-proxy-address` flags has the same semantics it has for the DNS

--- a/internal/cmd/jafar/main.go
+++ b/internal/cmd/jafar/main.go
@@ -232,7 +232,7 @@ func iptablesStart() *iptables.CensoringPolicy {
 }
 
 func tlsProxyStart(uncensored *uncensored.Client) net.Listener {
-	proxy := tlsproxy.NewCensoringProxy(tlsProxyBlock, uncensored, tlsProxyOutboundPort)
+	proxy := tlsproxy.NewCensoringProxy(tlsProxyBlock, uncensored, *tlsProxyOutboundPort)
 	listener, err := proxy.Start(*tlsProxyAddress)
 	runtimex.PanicOnError(err, "proxy.Start failed")
 	return listener

--- a/internal/cmd/jafar/main.go
+++ b/internal/cmd/jafar/main.go
@@ -58,8 +58,9 @@ var (
 
 	tag *string
 
-	tlsProxyAddress *string
-	tlsProxyBlock   flagx.StringArray
+	tlsProxyAddress      *string
+	tlsProxyBlock        flagx.StringArray
+	tlsProxyOutboundPort *string
 
 	uncensoredResolverDoH *string
 )
@@ -159,11 +160,15 @@ func init() {
 	// tlsProxy
 	tlsProxyAddress = flag.String(
 		"tls-proxy-address", "127.0.0.1:443",
-		"Address where the HTTP proxy should listen",
+		"Address where the TCP+TLS proxy should listen",
 	)
 	flag.Var(
 		&tlsProxyBlock, "tls-proxy-block",
 		"Register keyword triggering TLS censorship",
+	)
+	tlsProxyOutboundPort = flag.String(
+		"tls-proxy-outbound-port", "443",
+		"The outbound port where requests should be proxied",
 	)
 
 	// uncensored
@@ -227,7 +232,7 @@ func iptablesStart() *iptables.CensoringPolicy {
 }
 
 func tlsProxyStart(uncensored *uncensored.Client) net.Listener {
-	proxy := tlsproxy.NewCensoringProxy(tlsProxyBlock, uncensored)
+	proxy := tlsproxy.NewCensoringProxy(tlsProxyBlock, uncensored, tlsProxyOutboundPort)
 	listener, err := proxy.Start(*tlsProxyAddress)
 	runtimex.PanicOnError(err, "proxy.Start failed")
 	return listener

--- a/internal/cmd/jafar/tlsproxy/tlsproxy.go
+++ b/internal/cmd/jafar/tlsproxy/tlsproxy.go
@@ -29,21 +29,17 @@ type CensoringProxy struct {
 // NewCensoringProxy creates a new CensoringProxy instance using
 // the specified list of keywords to censor. keywords is the list
 // of keywords that trigger censorship if any of them appears in
-// the SNII record of a ClientHello. dnsNetwork and dnsAddress are
+// the SNI record of a ClientHello. dnsNetwork and dnsAddress are
 // settings to configure the upstream, non censored DNS.
 func NewCensoringProxy(
-	keywords []string, uncensored Dialer, outboundPort *string,
+	keywords []string, uncensored Dialer, outboundPort string,
 ) *CensoringProxy {
-	defaultPort := "443"
-	if outboundPort == nil {
-		outboundPort = &defaultPort
-	}
 	return &CensoringProxy{
 		keywords: keywords,
 		dial: func(network, address string) (net.Conn, error) {
 			return uncensored.DialContext(context.Background(), network, address)
 		},
-		outboundPort: *outboundPort,
+		outboundPort: outboundPort,
 	}
 }
 

--- a/internal/cmd/jafar/tlsproxy/tlsproxy_test.go
+++ b/internal/cmd/jafar/tlsproxy/tlsproxy_test.go
@@ -94,7 +94,7 @@ func TestFailWriteAfterConnect(t *testing.T) {
 
 func TestListenError(t *testing.T) {
 	proxy := NewCensoringProxy(
-		[]string{""}, uncensored.NewClient("https://1.1.1.1/dns-query"), nil,
+		[]string{""}, uncensored.NewClient("https://1.1.1.1/dns-query"), "443",
 	)
 	listener, err := proxy.Start("8.8.8.8:80")
 	if err == nil {
@@ -107,7 +107,7 @@ func TestListenError(t *testing.T) {
 
 func newproxy(t *testing.T, blocked string) net.Listener {
 	proxy := NewCensoringProxy(
-		[]string{blocked}, uncensored.NewClient("https://1.1.1.1/dns-query"), nil,
+		[]string{blocked}, uncensored.NewClient("https://1.1.1.1/dns-query"), "443",
 	)
 	listener, err := proxy.Start("127.0.0.1:0")
 	if err != nil {

--- a/internal/cmd/jafar/tlsproxy/tlsproxy_test.go
+++ b/internal/cmd/jafar/tlsproxy/tlsproxy_test.go
@@ -94,7 +94,7 @@ func TestFailWriteAfterConnect(t *testing.T) {
 
 func TestListenError(t *testing.T) {
 	proxy := NewCensoringProxy(
-		[]string{""}, uncensored.NewClient("https://1.1.1.1/dns-query"),
+		[]string{""}, uncensored.NewClient("https://1.1.1.1/dns-query"), nil,
 	)
 	listener, err := proxy.Start("8.8.8.8:80")
 	if err == nil {
@@ -107,7 +107,7 @@ func TestListenError(t *testing.T) {
 
 func newproxy(t *testing.T, blocked string) net.Listener {
 	proxy := NewCensoringProxy(
-		[]string{blocked}, uncensored.NewClient("https://1.1.1.1/dns-query"),
+		[]string{blocked}, uncensored.NewClient("https://1.1.1.1/dns-query"), nil,
 	)
 	listener, err := proxy.Start("127.0.0.1:0")
 	if err != nil {


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: none
- [x] if you changed anything related how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: no experiment change
- [x] if you change code inside an experiment, make sure you bump its version number: no experiment change

## Description

While developing a SMTP/IMAP probe, it proved useful to use Jafar's evil TLS proxying features. However, outbound port 443 was hardcoded into it. In this PR, i introduce a tls-proxy-outbound-port flag for jafar to control which port requests are proxied to. It defaults to 443 as it did previously for usage as HTTPS mitm.

## Usage

Example:
<code>jafar -tls-proxy-address "127.0.0.1:465" -tls-proxy-block "smtp" -tls-proxy-outbound-port "465"</code>

This will accept requests on localhost:465 and proxy those to whatever hostname is in the TLS SNI header on port 465... except when SNI contains "smtp" of course.

## Test results

<details><pre><code>
go test -race ./...
?   	github.com/ooni/probe-cli/v3/GHGEN	[no test files]
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe	[no test files]
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/autorun	[no test files]
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/cli/app	[no test files]
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/cli/autorun	[no test files]
ok  	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/cli/geoip	0.091s
ok  	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/cli/info	0.105s
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/cli/list	[no test files]
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/cli/onboard	[no test files]
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/cli/reset	[no test files]
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/cli/rm	[no test files]
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/cli/root	[no test files]
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/cli/run	[no test files]
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/cli/show	[no test files]
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/cli/upload	[no test files]
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/cli/version	[no test files]
ok  	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/config	(cached)
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/log/handlers/batch	[no test files]
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/log/handlers/cli	[no test files]
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/log/handlers/cli/progress	[no test files]
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/log/handlers/syslog	[no test files]
ok  	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/nettests	5.803s
ok  	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/ooni	0.090s
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/oonitest	[no test files]
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/output	[no test files]
ok  	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/utils	(cached)
?   	github.com/ooni/probe-cli/v3/cmd/ooniprobe/internal/utils/homedir	[no test files]
ok  	github.com/ooni/probe-cli/v3/internal/atomicx	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/bytecounter	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/cmd/apitool	(cached)
?   	github.com/ooni/probe-cli/v3/internal/cmd/e2epostprocess	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/cmd/getresources	[no test files]
ok  	github.com/ooni/probe-cli/v3/internal/cmd/jafar	3.032s
ok  	github.com/ooni/probe-cli/v3/internal/cmd/jafar/badproxy	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/cmd/jafar/flagx	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/cmd/jafar/httpproxy	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/cmd/jafar/iptables	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/cmd/jafar/resolver	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/cmd/jafar/tlsproxy	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/cmd/jafar/uncensored	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/cmd/miniooni	1.657s
ok  	github.com/ooni/probe-cli/v3/internal/cmd/oohelper	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/cmd/oohelper/internal	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/cmd/oohelperd	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/cmd/oonireport	1.263s
ok  	github.com/ooni/probe-cli/v3/internal/cmd/ooporthelper	(cached)
?   	github.com/ooni/probe-cli/v3/internal/cmd/printversion	[no test files]
ok  	github.com/ooni/probe-cli/v3/internal/database	0.679s
ok  	github.com/ooni/probe-cli/v3/internal/engine	80.484s
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/dash	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/dnscheck	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/dnsping	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/example	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/fbmessenger	0.451s
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/hhfm	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/hirl	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/httphostheader	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/ndt7	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/portfiltering	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/psiphon	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/quicping	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/riseupvpn	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/run	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/signal	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/simplequicping	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/sniblocking	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/stunreachability	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/tcpping	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/telegram	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/tlsmiddlebox	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/tlsping	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/tlstool	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/tlstool/internal	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/tor	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/torsf	18.921s
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/urlgetter	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/vanillator	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/webconnectivity	10.969s
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/webconnectivity/internal	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/experiment/whatsapp	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/geolocate	(cached)
?   	github.com/ooni/probe-cli/v3/internal/engine/mockable	[no test files]
ok  	github.com/ooni/probe-cli/v3/internal/engine/netx	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/engine/probeservices	(cached)
?   	github.com/ooni/probe-cli/v3/internal/engine/probeservices/testorchestra	[no test files]
ok  	github.com/ooni/probe-cli/v3/internal/engine/sessionresolver	(cached)
?   	github.com/ooni/probe-cli/v3/internal/experiment/webconnectivity	[no test files]
ok  	github.com/ooni/probe-cli/v3/internal/fsx	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/geoipx	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/httpapi	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/httpx	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/humanize	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/kvstore	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/legacy/assetsdir	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/logx	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/measurex	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/measurexlite	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/mlablocate	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/mlablocatev2	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/model	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/model/mocks	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/multierror	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/netxlite	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/netxlite/filtering	(cached)
?   	github.com/ooni/probe-cli/v3/internal/netxlite/internal/gencertifi	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/netxlite/internal/generrno	[no test files]
ok  	github.com/ooni/probe-cli/v3/internal/netxlite/mocks	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/netxlite/quictesting	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/oonirun	0.083s
ok  	github.com/ooni/probe-cli/v3/internal/platform	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/ptx	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/randx	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/registry	0.063s
ok  	github.com/ooni/probe-cli/v3/internal/runtimex	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/scrubber	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/shellx	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/stuninput	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/testingx	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/torlogs	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/tracex	(cached)
ok  	github.com/ooni/probe-cli/v3/internal/tunnel	5.870s
ok  	github.com/ooni/probe-cli/v3/internal/tunnel/mocks	(cached)
?   	github.com/ooni/probe-cli/v3/internal/tutorial/experiment/torsf/chapter01	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/experiment/torsf/chapter02	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/experiment/torsf/chapter03	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/experiment/torsf/chapter04	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/generator	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/measurex/chapter01	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/measurex/chapter02	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/measurex/chapter03	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/measurex/chapter04	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/measurex/chapter05	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/measurex/chapter06	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/measurex/chapter07	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/measurex/chapter08	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/measurex/chapter09	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/measurex/chapter10	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/measurex/chapter11	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/measurex/chapter12	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/measurex/chapter13	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/measurex/chapter14	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/netxlite/chapter01	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/netxlite/chapter02	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/netxlite/chapter03	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/netxlite/chapter04	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/netxlite/chapter05	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/netxlite/chapter06	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/netxlite/chapter07	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/tutorial/netxlite/chapter08	[no test files]
?   	github.com/ooni/probe-cli/v3/internal/version	[no test files]
ok  	github.com/ooni/probe-cli/v3/pkg/oonimkall	21.182s
</code></pre></details>