### PR TITLE
runtimex: always pass to panic an error type

### DIFF
--- a/internal/runtimex/runtimex.go
+++ b/internal/runtimex/runtimex.go
@@ -2,28 +2,35 @@
 // https://pkg.go.dev/github.com/m-lab/go/rtx, except that it's simpler.
 package runtimex
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
-// PanicOnError calls panic() if err is not nil.
+// PanicOnError calls panic() if err is not nil. The type passed
+// to panic is an error type wrapping the original error.
 func PanicOnError(err error, message string) {
 	if err != nil {
 		panic(fmt.Errorf("%s: %w", message, err))
 	}
 }
 
-// Assert calls panic if assertion is false.
+// Assert calls panic if assertion is false. The type passed to
+// panic is an error type wrapping the original error.
 func Assert(assertion bool, message string) {
 	if !assertion {
-		panic(message)
+		panic(errors.New(message))
 	}
 }
 
-// PanicIfTrue calls panic if assertion is true.
+// PanicIfTrue calls panic if assertion is true. The type passed to
+// panic is an error type wrapping the original error.
 func PanicIfTrue(assertion bool, message string) {
 	Assert(!assertion, message)
 }
 
-// PanicIfNil calls panic if the given interface is nil.
-func PanicIfNil(v interface{}, message string) {
+// PanicIfNil calls panic if the given interface is nil. The type passed to
+// panic is an error type wrapping the original error.
+func PanicIfNil(v any, message string) {
 	PanicIfTrue(v == nil, message)
 }

--- a/internal/runtimex/runtimex.go
+++ b/internal/runtimex/runtimex.go
@@ -16,7 +16,7 @@ func PanicOnError(err error, message string) {
 }
 
 // Assert calls panic if assertion is false. The type passed to
-// panic is an error type wrapping the original error.
+// panic is an error constructed using errors.New(message).
 func Assert(assertion bool, message string) {
 	if !assertion {
 		panic(errors.New(message))
@@ -24,13 +24,13 @@ func Assert(assertion bool, message string) {
 }
 
 // PanicIfTrue calls panic if assertion is true. The type passed to
-// panic is an error type wrapping the original error.
+// panic is an error constructed using errors.New(message).
 func PanicIfTrue(assertion bool, message string) {
 	Assert(!assertion, message)
 }
 
 // PanicIfNil calls panic if the given interface is nil. The type passed to
-// panic is an error type wrapping the original error.
+// panic is an error constructed using errors.New(message).
 func PanicIfNil(v any, message string) {
 	PanicIfTrue(v == nil, message)
 }

--- a/internal/runtimex/runtimex_test.go
+++ b/internal/runtimex/runtimex_test.go
@@ -31,7 +31,7 @@ func TestPanicOnError(t *testing.T) {
 func TestAssert(t *testing.T) {
 	badfunc := func(in bool, message string) (out error) {
 		defer func() {
-			out = errors.New(recover().(string))
+			out = recover().(error)
 		}()
 		runtimex.Assert(in, message)
 		return
@@ -53,7 +53,7 @@ func TestAssert(t *testing.T) {
 func TestPanicIfTrue(t *testing.T) {
 	badfunc := func(in bool, message string) (out error) {
 		defer func() {
-			out = errors.New(recover().(string))
+			out = recover().(error)
 		}()
 		runtimex.PanicIfTrue(in, message)
 		return
@@ -75,7 +75,7 @@ func TestPanicIfTrue(t *testing.T) {
 func TestPanicIfNil(t *testing.T) {
 	badfunc := func(in interface{}, message string) (out error) {
 		defer func() {
-			out = errors.New(recover().(string))
+			out = recover().(error)
 		}()
 		runtimex.PanicIfNil(in, message)
 		return


### PR DESCRIPTION
This diff makes the behavior of the functions exported by runtimex slightly more consistent. Now all of them pass to panic an error type. Before, only PanicOnError passed an error type while other functions passed a string. Yet, having an uniform way of throwing error types is better because we also have a better way of catching errors.
