### PR TITLE
refactor(probeservices): use internal testing

### DIFF
--- a/internal/engine/mockable/mockable.go
+++ b/internal/engine/mockable/mockable.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/ooni/probe-cli/v3/internal/engine/probeservices"
 	"github.com/ooni/probe-cli/v3/internal/kvstore"
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
@@ -150,4 +149,3 @@ func (sess *Session) UserAgent() string {
 }
 
 var _ model.ExperimentSession = &Session{}
-var _ probeservices.Session = &Session{}

--- a/internal/engine/probeservices/bouncer_test.go
+++ b/internal/engine/probeservices/bouncer_test.go
@@ -1,4 +1,4 @@
-package probeservices_test
+package probeservices
 
 import (
 	"context"

--- a/internal/engine/probeservices/checkin_test.go
+++ b/internal/engine/probeservices/checkin_test.go
@@ -1,4 +1,4 @@
-package probeservices_test
+package probeservices
 
 import (
 	"context"

--- a/internal/engine/probeservices/checkreportid_test.go
+++ b/internal/engine/probeservices/checkreportid_test.go
@@ -1,4 +1,4 @@
-package probeservices_test
+package probeservices
 
 import (
 	"context"
@@ -8,7 +8,6 @@ import (
 
 	"github.com/apex/log"
 	"github.com/ooni/probe-cli/v3/internal/atomicx"
-	"github.com/ooni/probe-cli/v3/internal/engine/probeservices"
 	"github.com/ooni/probe-cli/v3/internal/httpx"
 	"github.com/ooni/probe-cli/v3/internal/kvstore"
 )
@@ -17,7 +16,7 @@ func TestCheckReportIDWorkingAsIntended(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip test in short mode")
 	}
-	client := probeservices.Client{
+	client := Client{
 		APIClientTemplate: httpx.APIClientTemplate{
 			BaseURL:    "https://api.ooni.io/",
 			HTTPClient: http.DefaultClient,
@@ -26,7 +25,7 @@ func TestCheckReportIDWorkingAsIntended(t *testing.T) {
 		},
 		LoginCalls:    &atomicx.Int64{},
 		RegisterCalls: &atomicx.Int64{},
-		StateFile:     probeservices.NewStateFile(&kvstore.Memory{}),
+		StateFile:     NewStateFile(&kvstore.Memory{}),
 	}
 	reportID := `20201209T052225Z_urlgetter_IT_30722_n1_E1VUhMz08SEkgYFU`
 	ctx := context.Background()
@@ -40,7 +39,7 @@ func TestCheckReportIDWorkingAsIntended(t *testing.T) {
 }
 
 func TestCheckReportIDWorkingWithCancelledContext(t *testing.T) {
-	client := probeservices.Client{
+	client := Client{
 		APIClientTemplate: httpx.APIClientTemplate{
 			BaseURL:    "https://api.ooni.io/",
 			HTTPClient: http.DefaultClient,
@@ -49,7 +48,7 @@ func TestCheckReportIDWorkingWithCancelledContext(t *testing.T) {
 		},
 		LoginCalls:    &atomicx.Int64{},
 		RegisterCalls: &atomicx.Int64{},
-		StateFile:     probeservices.NewStateFile(&kvstore.Memory{}),
+		StateFile:     NewStateFile(&kvstore.Memory{}),
 	}
 	reportID := `20201209T052225Z_urlgetter_IT_30722_n1_E1VUhMz08SEkgYFU`
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/engine/probeservices/collector_test.go
+++ b/internal/engine/probeservices/collector_test.go
@@ -1,4 +1,4 @@
-package probeservices_test
+package probeservices
 
 import (
 	"context"
@@ -13,7 +13,6 @@ import (
 
 	"github.com/apex/log"
 	"github.com/google/go-cmp/cmp"
-	"github.com/ooni/probe-cli/v3/internal/engine/probeservices"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
@@ -22,9 +21,9 @@ type fakeTestKeys struct {
 	Failure *string `json:"failure"`
 }
 
-func makeMeasurement(rt probeservices.ReportTemplate, ID string) model.Measurement {
+func makeMeasurement(rt ReportTemplate, ID string) model.Measurement {
 	return model.Measurement{
-		DataFormatVersion:    probeservices.DefaultDataFormatVersion,
+		DataFormatVersion:    DefaultDataFormatVersion,
 		ID:                   "bdd20d7a-bba5-40dd-a111-9863d7908572",
 		MeasurementRuntime:   5.0565230846405,
 		MeasurementStartTime: "2018-11-01 15:33:20",
@@ -54,10 +53,10 @@ func TestNewReportTemplate(t *testing.T) {
 		TestStartTime:   "2019-10-28 12:51:06",
 		TestVersion:     "0.1.0",
 	}
-	rt := probeservices.NewReportTemplate(m)
-	expect := probeservices.ReportTemplate{
-		DataFormatVersion: probeservices.DefaultDataFormatVersion,
-		Format:            probeservices.DefaultFormat,
+	rt := NewReportTemplate(m)
+	expect := ReportTemplate{
+		DataFormatVersion: DefaultDataFormatVersion,
+		Format:            DefaultFormat,
 		ProbeASN:          "AS117",
 		ProbeCC:           "IT",
 		SoftwareName:      "ooniprobe-engine",
@@ -73,9 +72,9 @@ func TestNewReportTemplate(t *testing.T) {
 
 func TestReportLifecycle(t *testing.T) {
 	ctx := context.Background()
-	template := probeservices.ReportTemplate{
-		DataFormatVersion: probeservices.DefaultDataFormatVersion,
-		Format:            probeservices.DefaultFormat,
+	template := ReportTemplate{
+		DataFormatVersion: DefaultDataFormatVersion,
+		Format:            DefaultFormat,
 		ProbeASN:          "AS0",
 		ProbeCC:           "ZZ",
 		SoftwareName:      "ooniprobe-engine",
@@ -103,9 +102,9 @@ func TestReportLifecycle(t *testing.T) {
 
 func TestReportLifecycleWrongExperiment(t *testing.T) {
 	ctx := context.Background()
-	template := probeservices.ReportTemplate{
-		DataFormatVersion: probeservices.DefaultDataFormatVersion,
-		Format:            probeservices.DefaultFormat,
+	template := ReportTemplate{
+		DataFormatVersion: DefaultDataFormatVersion,
+		Format:            DefaultFormat,
 		ProbeASN:          "AS0",
 		ProbeCC:           "ZZ",
 		SoftwareName:      "ooniprobe-engine",
@@ -128,9 +127,9 @@ func TestReportLifecycleWrongExperiment(t *testing.T) {
 
 func TestOpenReportInvalidDataFormatVersion(t *testing.T) {
 	ctx := context.Background()
-	template := probeservices.ReportTemplate{
+	template := ReportTemplate{
 		DataFormatVersion: "0.1.0",
-		Format:            probeservices.DefaultFormat,
+		Format:            DefaultFormat,
 		ProbeASN:          "AS0",
 		ProbeCC:           "ZZ",
 		SoftwareName:      "ooniprobe-engine",
@@ -141,7 +140,7 @@ func TestOpenReportInvalidDataFormatVersion(t *testing.T) {
 	}
 	client := newclient()
 	report, err := client.OpenReport(ctx, template)
-	if !errors.Is(err, probeservices.ErrUnsupportedDataFormatVersion) {
+	if !errors.Is(err, ErrUnsupportedDataFormatVersion) {
 		t.Fatal("not the error we expected")
 	}
 	if report != nil {
@@ -151,8 +150,8 @@ func TestOpenReportInvalidDataFormatVersion(t *testing.T) {
 
 func TestOpenReportInvalidFormat(t *testing.T) {
 	ctx := context.Background()
-	template := probeservices.ReportTemplate{
-		DataFormatVersion: probeservices.DefaultDataFormatVersion,
+	template := ReportTemplate{
+		DataFormatVersion: DefaultDataFormatVersion,
 		Format:            "yaml",
 		ProbeASN:          "AS0",
 		ProbeCC:           "ZZ",
@@ -164,7 +163,7 @@ func TestOpenReportInvalidFormat(t *testing.T) {
 	}
 	client := newclient()
 	report, err := client.OpenReport(ctx, template)
-	if !errors.Is(err, probeservices.ErrUnsupportedFormat) {
+	if !errors.Is(err, ErrUnsupportedFormat) {
 		t.Fatal("not the error we expected")
 	}
 	if report != nil {
@@ -174,9 +173,9 @@ func TestOpenReportInvalidFormat(t *testing.T) {
 
 func TestJSONAPIClientCreateFailure(t *testing.T) {
 	ctx := context.Background()
-	template := probeservices.ReportTemplate{
-		DataFormatVersion: probeservices.DefaultDataFormatVersion,
-		Format:            probeservices.DefaultFormat,
+	template := ReportTemplate{
+		DataFormatVersion: DefaultDataFormatVersion,
+		Format:            DefaultFormat,
 		ProbeASN:          "AS0",
 		ProbeCC:           "ZZ",
 		SoftwareName:      "ooniprobe-engine",
@@ -204,9 +203,9 @@ func TestOpenResponseNoJSONSupport(t *testing.T) {
 	)
 	defer server.Close()
 	ctx := context.Background()
-	template := probeservices.ReportTemplate{
-		DataFormatVersion: probeservices.DefaultDataFormatVersion,
-		Format:            probeservices.DefaultFormat,
+	template := ReportTemplate{
+		DataFormatVersion: DefaultDataFormatVersion,
+		Format:            DefaultFormat,
 		ProbeASN:          "AS0",
 		ProbeCC:           "ZZ",
 		SoftwareName:      "ooniprobe-engine",
@@ -218,7 +217,7 @@ func TestOpenResponseNoJSONSupport(t *testing.T) {
 	client := newclient()
 	client.BaseURL = server.URL
 	report, err := client.OpenReport(ctx, template)
-	if !errors.Is(err, probeservices.ErrJSONFormatNotSupported) {
+	if !errors.Is(err, ErrJSONFormatNotSupported) {
 		t.Fatal("expected an error here")
 	}
 	if report != nil {
@@ -257,9 +256,9 @@ func TestEndToEnd(t *testing.T) {
 	)
 	defer server.Close()
 	ctx := context.Background()
-	template := probeservices.ReportTemplate{
-		DataFormatVersion: probeservices.DefaultDataFormatVersion,
-		Format:            probeservices.DefaultFormat,
+	template := ReportTemplate{
+		DataFormatVersion: DefaultDataFormatVersion,
+		Format:            DefaultFormat,
 		ProbeASN:          "AS0",
 		ProbeCC:           "ZZ",
 		SoftwareName:      "ooniprobe-engine",
@@ -281,13 +280,13 @@ func TestEndToEnd(t *testing.T) {
 }
 
 type RecordingReportChannel struct {
-	tmpl probeservices.ReportTemplate
+	tmpl ReportTemplate
 	m    []*model.Measurement
 	mu   sync.Mutex
 }
 
 func (rrc *RecordingReportChannel) CanSubmit(m *model.Measurement) bool {
-	return reflect.DeepEqual(probeservices.NewReportTemplate(m), rrc.tmpl)
+	return reflect.DeepEqual(NewReportTemplate(m), rrc.tmpl)
 }
 
 func (rrc *RecordingReportChannel) SubmitMeasurement(ctx context.Context, m *model.Measurement) error {
@@ -319,8 +318,8 @@ type RecordingReportOpener struct {
 }
 
 func (rro *RecordingReportOpener) OpenReport(
-	ctx context.Context, rt probeservices.ReportTemplate,
-) (probeservices.ReportChannel, error) {
+	ctx context.Context, rt ReportTemplate,
+) (ReportChannel, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
@@ -334,9 +333,9 @@ func (rro *RecordingReportOpener) OpenReport(
 func TestOpenReportCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately abort
-	template := probeservices.ReportTemplate{
-		DataFormatVersion: probeservices.DefaultDataFormatVersion,
-		Format:            probeservices.DefaultFormat,
+	template := ReportTemplate{
+		DataFormatVersion: DefaultDataFormatVersion,
+		Format:            DefaultFormat,
 		ProbeASN:          "AS0",
 		ProbeCC:           "ZZ",
 		SoftwareName:      "ooniprobe-engine",
@@ -358,9 +357,9 @@ func TestOpenReportCancelledContext(t *testing.T) {
 func TestSubmitMeasurementCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	template := probeservices.ReportTemplate{
-		DataFormatVersion: probeservices.DefaultDataFormatVersion,
-		Format:            probeservices.DefaultFormat,
+	template := ReportTemplate{
+		DataFormatVersion: DefaultDataFormatVersion,
+		Format:            DefaultFormat,
 		ProbeASN:          "AS0",
 		ProbeCC:           "ZZ",
 		SoftwareName:      "ooniprobe-engine",
@@ -390,7 +389,7 @@ func TestSubmitMeasurementCancelledContext(t *testing.T) {
 
 func makeMeasurementWithoutTemplate(failure, testName string) *model.Measurement {
 	return &model.Measurement{
-		DataFormatVersion:    probeservices.DefaultDataFormatVersion,
+		DataFormatVersion:    DefaultDataFormatVersion,
 		ID:                   "bdd20d7a-bba5-40dd-a111-9863d7908572",
 		MeasurementRuntime:   5.0565230846405,
 		MeasurementStartTime: "2018-11-01 15:33:20",
@@ -412,7 +411,7 @@ func makeMeasurementWithoutTemplate(failure, testName string) *model.Measurement
 
 func TestSubmitterLifecyle(t *testing.T) {
 	rro := &RecordingReportOpener{}
-	submitter := probeservices.NewSubmitter(rro, log.Log)
+	submitter := NewSubmitter(rro, log.Log)
 	ctx := context.Background()
 	m1 := makeMeasurementWithoutTemplate("antani", "example")
 	if err := submitter.Submit(ctx, m1); err != nil {
@@ -439,7 +438,7 @@ func TestSubmitterLifecyle(t *testing.T) {
 
 func TestSubmitterCannotOpenNewChannel(t *testing.T) {
 	rro := &RecordingReportOpener{}
-	submitter := probeservices.NewSubmitter(rro, log.Log)
+	submitter := NewSubmitter(rro, log.Log)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // fail immediately
 	m1 := makeMeasurementWithoutTemplate("antani", "example")

--- a/internal/engine/probeservices/login_test.go
+++ b/internal/engine/probeservices/login_test.go
@@ -1,17 +1,15 @@
-package probeservices_test
+package probeservices
 
 import (
 	"context"
 	"testing"
 	"time"
-
-	"github.com/ooni/probe-cli/v3/internal/engine/probeservices"
 )
 
 func TestMaybeLogin(t *testing.T) {
 	t.Run("when we already have a token", func(t *testing.T) {
 		clnt := newclient()
-		state := probeservices.State{
+		state := State{
 			Expire: time.Now().Add(time.Hour),
 			Token:  "xx-xxx-x-xxxx",
 		}
@@ -25,7 +23,7 @@ func TestMaybeLogin(t *testing.T) {
 	})
 	t.Run("when we have already registered", func(t *testing.T) {
 		clnt := newclient()
-		state := probeservices.State{
+		state := State{
 			// Explicitly empty to clarify what this test does
 		}
 		if err := clnt.StateFile.Set(state); err != nil {
@@ -39,7 +37,7 @@ func TestMaybeLogin(t *testing.T) {
 	t.Run("when the API call fails", func(t *testing.T) {
 		clnt := newclient()
 		clnt.BaseURL = "\t\t\t" // causes the code to fail
-		state := probeservices.State{
+		state := State{
 			ClientID: "xx-xxx-x-xxxx",
 			Password: "xx",
 		}

--- a/internal/engine/probeservices/measurementmeta_test.go
+++ b/internal/engine/probeservices/measurementmeta_test.go
@@ -1,4 +1,4 @@
-package probeservices_test
+package probeservices
 
 import (
 	"context"
@@ -9,13 +9,12 @@ import (
 
 	"github.com/apex/log"
 	"github.com/ooni/probe-cli/v3/internal/atomicx"
-	"github.com/ooni/probe-cli/v3/internal/engine/probeservices"
 	"github.com/ooni/probe-cli/v3/internal/httpx"
 	"github.com/ooni/probe-cli/v3/internal/kvstore"
 )
 
 func TestGetMeasurementMetaWorkingAsIntended(t *testing.T) {
-	client := probeservices.Client{
+	client := Client{
 		APIClientTemplate: httpx.APIClientTemplate{
 			BaseURL:    "https://api.ooni.io/",
 			HTTPClient: http.DefaultClient,
@@ -24,9 +23,9 @@ func TestGetMeasurementMetaWorkingAsIntended(t *testing.T) {
 		},
 		LoginCalls:    &atomicx.Int64{},
 		RegisterCalls: &atomicx.Int64{},
-		StateFile:     probeservices.NewStateFile(&kvstore.Memory{}),
+		StateFile:     NewStateFile(&kvstore.Memory{}),
 	}
-	config := probeservices.MeasurementMetaConfig{
+	config := MeasurementMetaConfig{
 		ReportID: `20201209T052225Z_urlgetter_IT_30722_n1_E1VUhMz08SEkgYFU`,
 		Full:     true,
 		Input:    `https://www.example.org`,
@@ -83,7 +82,7 @@ func TestGetMeasurementMetaWorkingAsIntended(t *testing.T) {
 }
 
 func TestGetMeasurementMetaWorkingWithCancelledContext(t *testing.T) {
-	client := probeservices.Client{
+	client := Client{
 		APIClientTemplate: httpx.APIClientTemplate{
 			BaseURL:    "https://api.ooni.io/",
 			HTTPClient: http.DefaultClient,
@@ -92,9 +91,9 @@ func TestGetMeasurementMetaWorkingWithCancelledContext(t *testing.T) {
 		},
 		LoginCalls:    &atomicx.Int64{},
 		RegisterCalls: &atomicx.Int64{},
-		StateFile:     probeservices.NewStateFile(&kvstore.Memory{}),
+		StateFile:     NewStateFile(&kvstore.Memory{}),
 	}
-	config := probeservices.MeasurementMetaConfig{
+	config := MeasurementMetaConfig{
 		ReportID: `20201209T052225Z_urlgetter_IT_30722_n1_E1VUhMz08SEkgYFU`,
 		Full:     true,
 		Input:    `https://www.example.org`,

--- a/internal/engine/probeservices/metadata_test.go
+++ b/internal/engine/probeservices/metadata_test.go
@@ -1,20 +1,16 @@
-package probeservices_test
+package probeservices
 
-import (
-	"testing"
-
-	"github.com/ooni/probe-cli/v3/internal/engine/probeservices"
-)
+import "testing"
 
 func TestValid(t *testing.T) {
 	t.Run("fail on probe_cc", func(t *testing.T) {
-		var m probeservices.Metadata
+		var m Metadata
 		if m.Valid() != false {
 			t.Fatal("expected false here")
 		}
 	})
 	t.Run("fail on probe_asn", func(t *testing.T) {
-		m := probeservices.Metadata{
+		m := Metadata{
 			ProbeCC: "IT",
 		}
 		if m.Valid() != false {
@@ -22,7 +18,7 @@ func TestValid(t *testing.T) {
 		}
 	})
 	t.Run("fail on platform", func(t *testing.T) {
-		m := probeservices.Metadata{
+		m := Metadata{
 			ProbeCC:  "IT",
 			ProbeASN: "AS1234",
 		}
@@ -31,7 +27,7 @@ func TestValid(t *testing.T) {
 		}
 	})
 	t.Run("fail on software_name", func(t *testing.T) {
-		m := probeservices.Metadata{
+		m := Metadata{
 			ProbeCC:  "IT",
 			ProbeASN: "AS1234",
 			Platform: "linux",
@@ -41,7 +37,7 @@ func TestValid(t *testing.T) {
 		}
 	})
 	t.Run("fail on software_version", func(t *testing.T) {
-		m := probeservices.Metadata{
+		m := Metadata{
 			ProbeCC:      "IT",
 			ProbeASN:     "AS1234",
 			Platform:     "linux",
@@ -52,7 +48,7 @@ func TestValid(t *testing.T) {
 		}
 	})
 	t.Run("fail on supported_tests", func(t *testing.T) {
-		m := probeservices.Metadata{
+		m := Metadata{
 			ProbeCC:         "IT",
 			ProbeASN:        "AS1234",
 			Platform:        "linux",
@@ -64,7 +60,7 @@ func TestValid(t *testing.T) {
 		}
 	})
 	t.Run("fail on missing device_token", func(t *testing.T) {
-		m := probeservices.Metadata{
+		m := Metadata{
 			ProbeCC:         "IT",
 			ProbeASN:        "AS1234",
 			Platform:        "ios",
@@ -77,7 +73,7 @@ func TestValid(t *testing.T) {
 		}
 	})
 	t.Run("success for desktop", func(t *testing.T) {
-		m := probeservices.Metadata{
+		m := Metadata{
 			ProbeCC:         "IT",
 			ProbeASN:        "AS1234",
 			Platform:        "linux",
@@ -90,7 +86,7 @@ func TestValid(t *testing.T) {
 		}
 	})
 	t.Run("success for mobile", func(t *testing.T) {
-		m := probeservices.Metadata{
+		m := Metadata{
 			DeviceToken:     "xx-xxx-xx-xxxx",
 			ProbeCC:         "IT",
 			ProbeASN:        "AS1234",

--- a/internal/engine/probeservices/orchestra_test.go
+++ b/internal/engine/probeservices/orchestra_test.go
@@ -1,11 +1,9 @@
-package probeservices_test
-
-import "github.com/ooni/probe-cli/v3/internal/engine/probeservices"
+package probeservices
 
 // MetadataFixture returns a valid metadata struct. This is mostly
 // useful for testing. (We should see if we can make this private.)
-func MetadataFixture() probeservices.Metadata {
-	return probeservices.Metadata{
+func MetadataFixture() Metadata {
+	return Metadata{
 		Platform:        "linux",
 		ProbeASN:        "AS15169",
 		ProbeCC:         "US",

--- a/internal/engine/probeservices/probeservices_test.go
+++ b/internal/engine/probeservices/probeservices_test.go
@@ -1,4 +1,4 @@
-package probeservices_test
+package probeservices
 
 import (
 	"context"
@@ -12,13 +12,12 @@ import (
 	"github.com/apex/log"
 	"github.com/google/go-cmp/cmp"
 	"github.com/ooni/probe-cli/v3/internal/engine/mockable"
-	"github.com/ooni/probe-cli/v3/internal/engine/probeservices"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
-func newclient() *probeservices.Client {
-	client, err := probeservices.NewClient(
+func newclient() *Client {
+	client, err := NewClient(
 		&mockable.Session{
 			MockableHTTPClient: http.DefaultClient,
 			MockableLogger:     log.Log,
@@ -35,7 +34,7 @@ func newclient() *probeservices.Client {
 }
 
 func TestNewClientHTTPS(t *testing.T) {
-	client, err := probeservices.NewClient(
+	client, err := NewClient(
 		&mockable.Session{}, model.OOAPIService{
 			Address: "https://x.org",
 			Type:    "https",
@@ -49,12 +48,12 @@ func TestNewClientHTTPS(t *testing.T) {
 }
 
 func TestNewClientUnsupportedEndpoint(t *testing.T) {
-	client, err := probeservices.NewClient(
+	client, err := NewClient(
 		&mockable.Session{}, model.OOAPIService{
 			Address: "https://x.org",
 			Type:    "onion",
 		})
-	if !errors.Is(err, probeservices.ErrUnsupportedEndpoint) {
+	if !errors.Is(err, ErrUnsupportedEndpoint) {
 		t.Fatal("not the error we expected")
 	}
 	if client != nil {
@@ -63,7 +62,7 @@ func TestNewClientUnsupportedEndpoint(t *testing.T) {
 }
 
 func TestNewClientCloudfrontInvalidURL(t *testing.T) {
-	client, err := probeservices.NewClient(
+	client, err := NewClient(
 		&mockable.Session{}, model.OOAPIService{
 			Address: "\t\t\t",
 			Type:    "cloudfront",
@@ -77,12 +76,12 @@ func TestNewClientCloudfrontInvalidURL(t *testing.T) {
 }
 
 func TestNewClientCloudfrontInvalidURLScheme(t *testing.T) {
-	client, err := probeservices.NewClient(
+	client, err := NewClient(
 		&mockable.Session{}, model.OOAPIService{
 			Address: "http://x.org",
 			Type:    "cloudfront",
 		})
-	if !errors.Is(err, probeservices.ErrUnsupportedCloudFrontAddress) {
+	if !errors.Is(err, ErrUnsupportedCloudFrontAddress) {
 		t.Fatal("not the error we expected")
 	}
 	if client != nil {
@@ -91,12 +90,12 @@ func TestNewClientCloudfrontInvalidURLScheme(t *testing.T) {
 }
 
 func TestNewClientCloudfrontInvalidURLWithPort(t *testing.T) {
-	client, err := probeservices.NewClient(
+	client, err := NewClient(
 		&mockable.Session{}, model.OOAPIService{
 			Address: "https://x.org:54321",
 			Type:    "cloudfront",
 		})
-	if !errors.Is(err, probeservices.ErrUnsupportedCloudFrontAddress) {
+	if !errors.Is(err, ErrUnsupportedCloudFrontAddress) {
 		t.Fatal("not the error we expected")
 	}
 	if client != nil {
@@ -105,7 +104,7 @@ func TestNewClientCloudfrontInvalidURLWithPort(t *testing.T) {
 }
 
 func TestNewClientCloudfrontInvalidFront(t *testing.T) {
-	client, err := probeservices.NewClient(
+	client, err := NewClient(
 		&mockable.Session{}, model.OOAPIService{
 			Address: "https://x.org",
 			Type:    "cloudfront",
@@ -120,7 +119,7 @@ func TestNewClientCloudfrontInvalidFront(t *testing.T) {
 }
 
 func TestNewClientCloudfrontGood(t *testing.T) {
-	client, err := probeservices.NewClient(
+	client, err := NewClient(
 		&mockable.Session{}, model.OOAPIService{
 			Address: "https://x.org",
 			Type:    "cloudfront",
@@ -141,7 +140,7 @@ func TestCloudfront(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip test in short mode")
 	}
-	client, err := probeservices.NewClient(
+	client, err := NewClient(
 		&mockable.Session{}, model.OOAPIService{
 			Address: "https://meek.azureedge.net",
 			Type:    "cloudfront",
@@ -176,8 +175,8 @@ func TestDefaultProbeServicesWorkAsIntended(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip test in short mode")
 	}
-	for _, e := range probeservices.Default() {
-		client, err := probeservices.NewClient(&mockable.Session{
+	for _, e := range Default() {
+		client, err := NewClient(&mockable.Session{
 			MockableHTTPClient: http.DefaultClient,
 			MockableLogger:     log.Log,
 		}, e)
@@ -217,7 +216,7 @@ func TestSortEndpoints(t *testing.T) {
 		Type:    "onion",
 		Address: "httpo://jehhrikjjqrlpufu.onion",
 	}}
-	out := probeservices.SortEndpoints(in)
+	out := SortEndpoints(in)
 	diff := cmp.Diff(out, expect)
 	if diff != "" {
 		t.Fatal(diff)
@@ -252,7 +251,7 @@ func TestOnlyHTTPS(t *testing.T) {
 		Type:    "https",
 		Address: "https://mia-ps-nonexistent.ooni.io",
 	}}
-	out := probeservices.OnlyHTTPS(in)
+	out := OnlyHTTPS(in)
 	diff := cmp.Diff(out, expect)
 	if diff != "" {
 		t.Fatal(diff)
@@ -286,7 +285,7 @@ func TestOnlyFallbacks(t *testing.T) {
 		Type:    "onion",
 		Address: "httpo://jehhrikjjqrlpufu.onion",
 	}}
-	out := probeservices.OnlyFallbacks(in)
+	out := OnlyFallbacks(in)
 	diff := cmp.Diff(out, expect)
 	if diff != "" {
 		t.Fatal(diff)
@@ -318,7 +317,7 @@ func TestTryAllCanceledContext(t *testing.T) {
 		MockableHTTPClient: http.DefaultClient,
 		MockableLogger:     log.Log,
 	}
-	out := probeservices.TryAll(ctx, sess, in)
+	out := TryAll(ctx, sess, in)
 	if len(out) != 5 {
 		t.Fatal("invalid number of entries")
 	}
@@ -382,7 +381,7 @@ func TestTryAllCanceledContext(t *testing.T) {
 	// and so we don't basically do anything. But it also may be nonzero since
 	// we also run tests in the cloud, which is slower than my desktop. So, I
 	// have not written a specific test concerning out[4].Duration.
-	if !errors.Is(out[4].Err, probeservices.ErrUnsupportedEndpoint) {
+	if !errors.Is(out[4].Err, ErrUnsupportedEndpoint) {
 		t.Fatal("invalid error")
 	}
 	if out[4].Endpoint.Type != "onion" {
@@ -413,7 +412,7 @@ func TestTryAllIntegrationWeRaceForFastestHTTPS(t *testing.T) {
 		MockableHTTPClient: http.DefaultClient,
 		MockableLogger:     log.Log,
 	}
-	out := probeservices.TryAll(context.Background(), sess, in)
+	out := TryAll(context.Background(), sess, in)
 	if len(out) != 1 {
 		t.Fatal("invalid number of entries")
 	}
@@ -458,7 +457,7 @@ func TestTryAllIntegrationWeFallback(t *testing.T) {
 		MockableHTTPClient: http.DefaultClient,
 		MockableLogger:     log.Log,
 	}
-	out := probeservices.TryAll(context.Background(), sess, in)
+	out := TryAll(context.Background(), sess, in)
 	if len(out) != 4 {
 		t.Fatal("invalid number of entries")
 	}
@@ -520,23 +519,23 @@ func TestTryAllIntegrationWeFallback(t *testing.T) {
 }
 
 func TestSelectBestEmptyInput(t *testing.T) {
-	if out := probeservices.SelectBest(nil); out != nil {
+	if out := SelectBest(nil); out != nil {
 		t.Fatal("expected nil output here")
 	}
 }
 
 func TestSelectBestOnlyFailures(t *testing.T) {
-	in := []*probeservices.Candidate{{
+	in := []*Candidate{{
 		Duration: 10 * time.Millisecond,
 		Err:      io.EOF,
 	}}
-	if out := probeservices.SelectBest(in); out != nil {
+	if out := SelectBest(in); out != nil {
 		t.Fatal("expected nil output here")
 	}
 }
 
 func TestSelectBestSelectsTheFastest(t *testing.T) {
-	in := []*probeservices.Candidate{{
+	in := []*Candidate{{
 		Duration: 10 * time.Millisecond,
 		Endpoint: model.OOAPIService{
 			Address: "https://ps1.ooni.nonexistent",
@@ -561,14 +560,14 @@ func TestSelectBestSelectsTheFastest(t *testing.T) {
 			Type:    "https",
 		},
 	}}
-	expected := &probeservices.Candidate{
+	expected := &Candidate{
 		Duration: 4 * time.Millisecond,
 		Endpoint: model.OOAPIService{
 			Address: "https://ps2.ooni.nonexistent",
 			Type:    "https",
 		},
 	}
-	out := probeservices.SelectBest(in)
+	out := SelectBest(in)
 	if diff := cmp.Diff(out, expected); diff != "" {
 		t.Fatal(diff)
 	}
@@ -580,7 +579,7 @@ func TestGetCredsAndAuthNotLoggedIn(t *testing.T) {
 		t.Fatal(err)
 	}
 	creds, auth, err := clnt.GetCredsAndAuth()
-	if !errors.Is(err, probeservices.ErrNotLoggedIn) {
+	if !errors.Is(err, ErrNotLoggedIn) {
 		t.Fatal("not the error we expected")
 	}
 	if creds != nil {

--- a/internal/engine/probeservices/psiphon_test.go
+++ b/internal/engine/probeservices/psiphon_test.go
@@ -1,12 +1,10 @@
-package probeservices_test
+package probeservices
 
 import (
 	"context"
 	"encoding/json"
 	"errors"
 	"testing"
-
-	"github.com/ooni/probe-cli/v3/internal/engine/probeservices"
 )
 
 func TestFetchPsiphonConfig(t *testing.T) {
@@ -29,14 +27,14 @@ func TestFetchPsiphonConfig(t *testing.T) {
 
 func TestFetchPsiphonConfigNotRegistered(t *testing.T) {
 	clnt := newclient()
-	state := probeservices.State{
+	state := State{
 		// Explicitly empty so the test is more clear
 	}
 	if err := clnt.StateFile.Set(state); err != nil {
 		t.Fatal(err)
 	}
 	data, err := clnt.FetchPsiphonConfig(context.Background())
-	if !errors.Is(err, probeservices.ErrNotRegistered) {
+	if !errors.Is(err, ErrNotRegistered) {
 		t.Fatal("expected an error here")
 	}
 	if data != nil {

--- a/internal/engine/probeservices/register_test.go
+++ b/internal/engine/probeservices/register_test.go
@@ -1,27 +1,25 @@
-package probeservices_test
+package probeservices
 
 import (
 	"context"
 	"errors"
 	"strings"
 	"testing"
-
-	"github.com/ooni/probe-cli/v3/internal/engine/probeservices"
 )
 
 func TestMaybeRegister(t *testing.T) {
 	t.Run("when metadata is not valid", func(t *testing.T) {
 		clnt := newclient()
 		ctx := context.Background()
-		var metadata probeservices.Metadata
+		var metadata Metadata
 		err := clnt.MaybeRegister(ctx, metadata)
-		if !errors.Is(err, probeservices.ErrInvalidMetadata) {
+		if !errors.Is(err, ErrInvalidMetadata) {
 			t.Fatal("expected an error here")
 		}
 	})
 	t.Run("when we have already registered", func(t *testing.T) {
 		clnt := newclient()
-		state := probeservices.State{
+		state := State{
 			ClientID: "xx-xxx-x-xxxx",
 			Password: "xx",
 		}

--- a/internal/engine/probeservices/statefile_test.go
+++ b/internal/engine/probeservices/statefile_test.go
@@ -1,4 +1,4 @@
-package probeservices_test
+package probeservices
 
 import (
 	"encoding/json"
@@ -7,19 +7,18 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/ooni/probe-cli/v3/internal/engine/probeservices"
 	"github.com/ooni/probe-cli/v3/internal/kvstore"
 )
 
 func TestStateAuth(t *testing.T) {
 	t.Run("with no Token", func(t *testing.T) {
-		state := probeservices.State{Expire: time.Now().Add(10 * time.Hour)}
+		state := State{Expire: time.Now().Add(10 * time.Hour)}
 		if state.Auth() != nil {
 			t.Fatal("expected nil here")
 		}
 	})
 	t.Run("with expired Token", func(t *testing.T) {
-		state := probeservices.State{
+		state := State{
 			Expire: time.Now().Add(-1 * time.Hour),
 			Token:  "xx-x-xxx-xx",
 		}
@@ -28,7 +27,7 @@ func TestStateAuth(t *testing.T) {
 		}
 	})
 	t.Run("with good Token", func(t *testing.T) {
-		state := probeservices.State{
+		state := State{
 			Expire: time.Now().Add(10 * time.Hour),
 			Token:  "xx-x-xxx-xx",
 		}
@@ -40,13 +39,13 @@ func TestStateAuth(t *testing.T) {
 
 func TestStateCredentials(t *testing.T) {
 	t.Run("with no ClientID", func(t *testing.T) {
-		state := probeservices.State{}
+		state := State{}
 		if state.Credentials() != nil {
 			t.Fatal("expected nil here")
 		}
 	})
 	t.Run("with no Password", func(t *testing.T) {
-		state := probeservices.State{
+		state := State{
 			ClientID: "xx-x-xxx-xx",
 		}
 		if state.Credentials() != nil {
@@ -54,7 +53,7 @@ func TestStateCredentials(t *testing.T) {
 		}
 	})
 	t.Run("with all good", func(t *testing.T) {
-		state := probeservices.State{
+		state := State{
 			ClientID: "xx-x-xxx-xx",
 			Password: "xx",
 		}
@@ -67,8 +66,8 @@ func TestStateCredentials(t *testing.T) {
 func TestStateFileMemoryIntegration(t *testing.T) {
 	// Does the StateFile have the property that we can write
 	// values into it and then read again the same files?
-	sf := probeservices.NewStateFile(&kvstore.Memory{})
-	s := probeservices.State{
+	sf := NewStateFile(&kvstore.Memory{})
+	s := State{
 		Expire:   time.Now(),
 		Password: "xy",
 		Token:    "abc",
@@ -85,8 +84,8 @@ func TestStateFileMemoryIntegration(t *testing.T) {
 }
 
 func TestStateFileSetMarshalError(t *testing.T) {
-	sf := probeservices.NewStateFile(&kvstore.Memory{})
-	s := probeservices.State{
+	sf := NewStateFile(&kvstore.Memory{})
+	s := State{
 		Expire:   time.Now(),
 		Password: "xy",
 		Token:    "abc",
@@ -102,7 +101,7 @@ func TestStateFileSetMarshalError(t *testing.T) {
 }
 
 func TestStateFileGetKVStoreGetError(t *testing.T) {
-	sf := probeservices.NewStateFile(&kvstore.Memory{})
+	sf := NewStateFile(&kvstore.Memory{})
 	expected := errors.New("mocked error")
 	failingfunc := func(string) ([]byte, error) {
 		return nil, expected
@@ -126,8 +125,8 @@ func TestStateFileGetKVStoreGetError(t *testing.T) {
 }
 
 func TestStateFileGetUnmarshalError(t *testing.T) {
-	sf := probeservices.NewStateFile(&kvstore.Memory{})
-	if err := sf.Set(probeservices.State{}); err != nil {
+	sf := NewStateFile(&kvstore.Memory{})
+	if err := sf.Set(State{}); err != nil {
 		t.Fatal(err)
 	}
 	expected := errors.New("mocked error")

--- a/internal/engine/probeservices/tor_test.go
+++ b/internal/engine/probeservices/tor_test.go
@@ -1,11 +1,9 @@
-package probeservices_test
+package probeservices
 
 import (
 	"context"
 	"net/http"
 	"testing"
-
-	"github.com/ooni/probe-cli/v3/internal/engine/probeservices"
 )
 
 func TestFetchTorTargets(t *testing.T) {
@@ -30,7 +28,7 @@ func TestFetchTorTargets(t *testing.T) {
 
 func TestFetchTorTargetsNotRegistered(t *testing.T) {
 	clnt := newclient()
-	state := probeservices.State{
+	state := State{
 		// Explicitly empty so the test is more clear
 	}
 	if err := clnt.StateFile.Set(state); err != nil {

--- a/internal/engine/probeservices/urls_test.go
+++ b/internal/engine/probeservices/urls_test.go
@@ -1,4 +1,4 @@
-package probeservices_test
+package probeservices
 
 import (
 	"context"


### PR DESCRIPTION
I was trying to (1) either move data types definitions inside probeservices to internal/model or (2) make them private to reduce the amount of exported definitions. However, I was severely limited in doing that by the fact that probeservices uses external testing.

To overcome this issue, I'm switching to internal testing first and then I will resume with the two points above, which are in line with my goal for today of moving https://github.com/ooni/probe/issues/2372 forward.

