### PR TITLE
probeservices: sync up with v3.14.0 ooapi package

### DIFF
--- a/internal/engine/probeservices/checkreportid.go
+++ b/internal/engine/probeservices/checkreportid.go
@@ -5,17 +5,14 @@ import (
 	"net/url"
 
 	"github.com/ooni/probe-cli/v3/internal/httpx"
+	"github.com/ooni/probe-cli/v3/internal/model"
 )
-
-type checkReportIDResponse struct {
-	Found bool `json:"found"`
-}
 
 // CheckReportID checks whether the given ReportID exists.
 func (c Client) CheckReportID(ctx context.Context, reportID string) (bool, error) {
 	query := url.Values{}
 	query.Add("report_id", reportID)
-	var response checkReportIDResponse
+	var response model.OOAPICheckReportIDResponse
 	err := (&httpx.APIClientTemplate{
 		BaseURL:    c.BaseURL,
 		HTTPClient: c.HTTPClient,

--- a/internal/engine/probeservices/statefile.go
+++ b/internal/engine/probeservices/statefile.go
@@ -36,7 +36,7 @@ func (s State) Credentials() *model.OOAPILoginCredentials {
 	if s.Password == "" {
 		return nil
 	}
-	return &model.OOAPILoginCredentials{ClientID: s.ClientID, Password: s.Password}
+	return &model.OOAPILoginCredentials{Username: s.ClientID, Password: s.Password}
 }
 
 // StateFile is the orchestra state file. It is backed by

--- a/internal/engine/probeservices/urls.go
+++ b/internal/engine/probeservices/urls.go
@@ -21,6 +21,8 @@ func (c Client) FetchURLList(ctx context.Context, config model.OOAPIURLListConfi
 		query.Set("limit", fmt.Sprintf("%d", config.Limit))
 	}
 	if len(config.Categories) > 0 {
+		// Note: ooapi (the unused package in v3.14.0 that implemented automatic API
+		// generation) used `category_code` (singular) here, but that's wrong.
 		query.Set("category_codes", strings.Join(config.Categories, ","))
 	}
 	var response model.OOAPIURLListResult

--- a/internal/engine/probeservices/urls.go
+++ b/internal/engine/probeservices/urls.go
@@ -22,7 +22,8 @@ func (c Client) FetchURLList(ctx context.Context, config model.OOAPIURLListConfi
 	}
 	if len(config.Categories) > 0 {
 		// Note: ooapi (the unused package in v3.14.0 that implemented automatic API
-		// generation) used `category_code` (singular) here, but that's wrong.
+		// generation) used `category_code` (singular) here, but that's wrong. The plural
+		// name is the correct name as I've just verified -- 2022-11-30.
 		query.Set("category_codes", strings.Join(config.Categories, ","))
 	}
 	var response model.OOAPIURLListResult

--- a/internal/model/ooapi.go
+++ b/internal/model/ooapi.go
@@ -63,11 +63,24 @@ type OOAPICheckInNettests struct {
 
 // OOAPICheckInResult is the result returned by the checkin API.
 type OOAPICheckInResult struct {
+	// ProbeASN contains the probe's ASN.
+	ProbeASN string `json:"probe_asn"`
+
+	// ProbeCC contains the probe's CC.
+	ProbeCC string `json:"probe_cc"`
+
 	// Tests contains information about nettests.
 	Tests OOAPICheckInNettests `json:"tests"`
 
 	// V is the version.
-	V int `json:"v"`
+	V int64 `json:"v"`
+}
+
+// OOAPICheckReportIDResponse is the check-report-id API response.
+type OOAPICheckReportIDResponse struct {
+	Error string `json:"error"`
+	Found bool   `json:"found"`
+	V     int64  `json:"v"`
 }
 
 // OOAPIService describes a backend service.
@@ -174,6 +187,9 @@ type OOAPIReportTemplate struct {
 
 // OOAPICollectorOpenResponse is the response returned by the open report API.
 type OOAPICollectorOpenResponse struct {
+	// BackendVersion is the backend version.
+	BackendVersion string `json:"backend_version"`
+
 	// ReportID is the report ID.
 	ReportID string `json:"report_id"`
 
@@ -198,7 +214,7 @@ type OOAPICollectorUpdateResponse struct {
 
 // OOAPILoginCredentials contains the login credentials
 type OOAPILoginCredentials struct {
-	ClientID string `json:"username"`
+	Username string `json:"username"`
 	Password string `json:"password"`
 }
 
@@ -306,5 +322,12 @@ type OOAPIRegisterResponse struct {
 
 // OOAPIURLListResult is the result of the /api/v1/test-list/urls API call.
 type OOAPIURLListResult struct {
-	Results []OOAPIURLInfo `json:"results"`
+	Metadata OOAPIURLListMetadata `json:"metadata"`
+	Results  []OOAPIURLInfo       `json:"results"`
+}
+
+// OONIAPIURLListMetadata contains metadata included
+// inside the OOAPIURLListResult struct.
+type OOAPIURLListMetadata struct {
+	Count int64 `json:"count"`
 }


### PR DESCRIPTION
This diff ensures that the definitions we're using are in sync with the model used by [v3.14.0's ooapi package](
https://github.com/ooni/probe-cli/tree/v3.14.0/internal/ooapi/apimodel), which was an experiment at autogenerating APIs and cross checking with ooni/api's swagger JSON file.

The only difference that remains pertains the name of the query string parameter for /api/v1/test-list/urls, which must be plural (as it is in the probeservices package) rather than singular (as it is in the ooapi/apimodel package).

So, after merging this diff, we can say we have done part of the work specified by https://github.com/ooni/probe/issues/2372. However, we want to also check with the _current_ swagger.

(Because we already had a model that was consistent with the swagger _at the time we wrote ooapi_, it seems reasonable for us to start syncing up with that model, which is easy, and then focus on importing the swagger and comparing with it.)
