### PR TITLE
fix(whatsapp): allow registration server to HTTP-fail

### DIFF
--- a/internal/engine/experiment/whatsapp/whatsapp.go
+++ b/internal/engine/experiment/whatsapp/whatsapp.go
@@ -25,7 +25,7 @@ const (
 	WebHTTPSURL = "https://web.whatsapp.com/"
 
 	testName    = "whatsapp"
-	testVersion = "0.10.0"
+	testVersion = "0.11.0"
 )
 
 var endpointPattern = regexp.MustCompile(`^tcpconnect://e[0-9]{1,2}\.whatsapp\.net:[0-9]{3,5}$`)

--- a/internal/engine/experiment/whatsapp/whatsapp.go
+++ b/internal/engine/experiment/whatsapp/whatsapp.go
@@ -155,7 +155,6 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 		}
 	}
 	inputs = append(inputs, urlgetter.MultiInput{
-		Config: urlgetter.Config{FailOnHTTPError: true},
 		Target: RegistrationServiceURL,
 	})
 	inputs = append(inputs, urlgetter.MultiInput{

--- a/internal/engine/experiment/whatsapp/whatsapp_test.go
+++ b/internal/engine/experiment/whatsapp/whatsapp_test.go
@@ -346,7 +346,6 @@ func TestWeConfigureWebChecksCorrectly(t *testing.T) {
 	}
 	called := &atomicx.Int64{}
 	emptyConfig := urlgetter.Config{}
-	configWithFailOnHTTPError := urlgetter.Config{FailOnHTTPError: true}
 	measurer := whatsapp.Measurer{
 		Config: whatsapp.Config{},
 		Getter: func(ctx context.Context, g urlgetter.Getter) (urlgetter.TestKeys, error) {
@@ -358,7 +357,7 @@ func TestWeConfigureWebChecksCorrectly(t *testing.T) {
 				}
 			case whatsapp.RegistrationServiceURL:
 				called.Add(4)
-				if diff := cmp.Diff(g.Config, configWithFailOnHTTPError); diff != "" {
+				if diff := cmp.Diff(g.Config, emptyConfig); diff != "" {
 					panic(diff)
 				}
 			default:

--- a/internal/engine/experiment/whatsapp/whatsapp_test.go
+++ b/internal/engine/experiment/whatsapp/whatsapp_test.go
@@ -20,7 +20,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "whatsapp" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.10.0" {
+	if measurer.ExperimentVersion() != "0.11.0" {
 		t.Fatal("unexpected version")
 	}
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2384
- [x] if you changed anything related how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: _it turns out probe-cli was not compliant with the spec which explicitly said we didn't care about status, so there's no need to change ooni/spec_
- [x] if you change code inside an experiment, make sure you bump its version number

## Description

Like we did for whatsapp web, we care about doing a TLS handshake and getting an HTTP response but we don't care about the content because it may change and that would cause a false positive.

FWIW, it turns out probe-cli was not compliant with the spec which explicitly said we didn't care about status, so this change is a more proper fix than I imagined when I planned doing it.

Closes https://github.com/ooni/probe/issues/2384