### PR TITLE
feat(httpapi): annotate Descriptor with RequestType

### DIFF
--- a/internal/httpapi/call_test.go
+++ b/internal/httpapi/call_test.go
@@ -75,7 +75,7 @@ func Test_newRequest(t *testing.T) {
 	type args struct {
 		ctx      context.Context
 		endpoint *Endpoint
-		desc     *Descriptor
+		desc     *Descriptor[RawRequest]
 	}
 	tests := []struct {
 		name    string
@@ -93,14 +93,14 @@ func Test_newRequest(t *testing.T) {
 				Logger:     nil,
 				UserAgent:  "",
 			},
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				Accept:        "",
 				Authorization: "",
 				ContentType:   "",
 				LogBody:       false,
 				MaxBodySize:   0,
 				Method:        "",
-				RequestBody:   nil,
+				Request:       nil,
 				Timeout:       0,
 				URLPath:       "",
 				URLQuery:      nil,
@@ -119,14 +119,14 @@ func Test_newRequest(t *testing.T) {
 				Logger:     nil,
 				UserAgent:  "",
 			},
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				Accept:        "",
 				Authorization: "",
 				ContentType:   "",
 				LogBody:       false,
 				MaxBodySize:   0,
 				Method:        "",
-				RequestBody:   nil,
+				Request:       nil,
 				Timeout:       0,
 				URLPath:       "",
 				URLQuery:      nil,
@@ -145,14 +145,14 @@ func Test_newRequest(t *testing.T) {
 				Logger:     nil,
 				UserAgent:  "",
 			},
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				Accept:        "",
 				Authorization: "",
 				ContentType:   "",
 				LogBody:       false,
 				MaxBodySize:   0,
 				Method:        http.MethodGet,
-				RequestBody:   nil,
+				Request:       nil,
 				Timeout:       0,
 				URLPath:       "",
 				URLQuery:      nil,
@@ -184,14 +184,14 @@ func Test_newRequest(t *testing.T) {
 				Logger:     model.DiscardLogger,
 				UserAgent:  "",
 			},
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				Accept:        "",
 				Authorization: "",
 				ContentType:   "",
 				LogBody:       true, // just to exercise the code path
 				MaxBodySize:   0,
 				Method:        http.MethodPost,
-				RequestBody:   []byte("deadbeef"),
+				Request:       &RequestDescriptor[RawRequest]{Body: []byte("deadbeef")},
 				Timeout:       0,
 				URLPath:       "",
 				URLQuery:      nil,
@@ -227,14 +227,14 @@ func Test_newRequest(t *testing.T) {
 				Logger:     nil,
 				UserAgent:  "httpclient/1.0.1",
 			},
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				Accept:        "application/json",
 				Authorization: "deafbeef",
 				ContentType:   "text/plain",
 				LogBody:       false,
 				MaxBodySize:   0,
 				Method:        http.MethodPut,
-				RequestBody:   nil,
+				Request:       nil,
 				Timeout:       0,
 				URLPath:       "",
 				URLQuery:      nil,
@@ -278,14 +278,14 @@ func Test_newRequest(t *testing.T) {
 				Logger:     nil,
 				UserAgent:  "",
 			},
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				Accept:        "",
 				Authorization: "",
 				ContentType:   "",
 				LogBody:       false,
 				MaxBodySize:   0,
 				Method:        http.MethodGet,
-				RequestBody:   nil,
+				Request:       nil,
 				Timeout:       0,
 				URLPath:       "/test-list/urls",
 				URLQuery:      nil,
@@ -314,14 +314,14 @@ func Test_newRequest(t *testing.T) {
 				Logger:     nil,
 				UserAgent:  "",
 			},
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				Accept:        "",
 				Authorization: "",
 				ContentType:   "",
 				LogBody:       false,
 				MaxBodySize:   0,
 				Method:        http.MethodGet,
-				RequestBody:   nil,
+				Request:       nil,
 				Timeout:       0,
 				URLPath:       "",
 				URLQuery:      nil,
@@ -350,14 +350,14 @@ func Test_newRequest(t *testing.T) {
 				Logger:     nil,
 				UserAgent:  "",
 			},
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				Accept:        "",
 				Authorization: "",
 				ContentType:   "",
 				LogBody:       false,
 				MaxBodySize:   0,
 				Method:        http.MethodGet,
-				RequestBody:   nil,
+				Request:       nil,
 				Timeout:       0,
 				URLPath:       "test-list/urls",
 				URLQuery: map[string][]string{
@@ -384,7 +384,7 @@ func Test_newRequest(t *testing.T) {
 			endpoint: &Endpoint{
 				BaseURL: "https://example.com/",
 			},
-			desc: &Descriptor{},
+			desc: &Descriptor[RawRequest]{},
 		},
 		wantFn: func(t *testing.T, req *http.Request) {
 			if req == nil {
@@ -405,7 +405,7 @@ func Test_newRequest(t *testing.T) {
 			endpoint: &Endpoint{
 				BaseURL: "https://example.com/",
 			},
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				AcceptEncodingGzip: true,
 			},
 		},
@@ -581,7 +581,7 @@ var gzipBombForCall = []byte{
 func Test_docall(t *testing.T) {
 	type args struct {
 		endpoint *Endpoint
-		desc     *Descriptor
+		desc     *Descriptor[RawRequest]
 		request  *http.Request
 	}
 	tests := []struct {
@@ -608,7 +608,7 @@ func Test_docall(t *testing.T) {
 				Logger:    model.DiscardLogger,
 				UserAgent: "",
 			},
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				MaxBodySize: 7,
 				Method:      http.MethodGet,
 				URLPath:     "/",
@@ -640,7 +640,7 @@ func Test_docall(t *testing.T) {
 				Logger:    model.DiscardLogger,
 				UserAgent: "",
 			},
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				MaxBodySize: 0, // we're testing that putting zero here implies default
 				Method:      http.MethodGet,
 				URLPath:     "/",
@@ -680,7 +680,7 @@ func Test_docall(t *testing.T) {
 				Logger:    model.DiscardLogger,
 				UserAgent: "",
 			},
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				Method:  http.MethodGet,
 				URLPath: "/",
 			},
@@ -722,7 +722,7 @@ func Test_docall(t *testing.T) {
 				Logger:    model.DiscardLogger,
 				UserAgent: "",
 			},
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				Method:  http.MethodGet,
 				URLPath: "/",
 			},
@@ -759,7 +759,7 @@ func Test_docall(t *testing.T) {
 				Logger:    model.DiscardLogger,
 				UserAgent: "",
 			},
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				MaxBodySize: 2048, // very small value
 				Method:      http.MethodGet,
 				URLPath:     "/",
@@ -803,7 +803,7 @@ func Test_docall(t *testing.T) {
 func TestCall(t *testing.T) {
 	type args struct {
 		ctx      context.Context
-		desc     *Descriptor
+		desc     *Descriptor[RawRequest]
 		endpoint *Endpoint
 	}
 	tests := []struct {
@@ -816,14 +816,14 @@ func TestCall(t *testing.T) {
 		name: "newRequest fails",
 		args: args{
 			ctx: context.Background(),
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				Accept:        "",
 				Authorization: "",
 				ContentType:   "",
 				LogBody:       false,
 				MaxBodySize:   0,
 				Method:        "",
-				RequestBody:   nil,
+				Request:       nil,
 				Timeout:       0,
 				URLPath:       "",
 				URLQuery:      nil,
@@ -843,7 +843,7 @@ func TestCall(t *testing.T) {
 		name: "endpoint.HTTPClient.Do fails",
 		args: args{
 			ctx: context.Background(),
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				Method: http.MethodGet,
 			},
 			endpoint: &Endpoint{
@@ -868,7 +868,7 @@ func TestCall(t *testing.T) {
 		name: "reading body fails",
 		args: args{
 			ctx: context.Background(),
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				Method: http.MethodGet,
 			},
 			endpoint: &Endpoint{
@@ -900,7 +900,7 @@ func TestCall(t *testing.T) {
 		name: "status code indicates failure",
 		args: args{
 			ctx: context.Background(),
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				Method: http.MethodGet,
 			},
 			endpoint: &Endpoint{
@@ -929,7 +929,7 @@ func TestCall(t *testing.T) {
 		name: "success with log body flag",
 		args: args{
 			ctx: context.Background(),
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				LogBody: true, // as documented by this test's name
 				Method:  http.MethodGet,
 			},
@@ -984,7 +984,7 @@ func TestCallWithJSONResponse(t *testing.T) {
 	}
 	type args struct {
 		ctx      context.Context
-		desc     *Descriptor
+		desc     *Descriptor[RawRequest]
 		endpoint *Endpoint
 	}
 	tests := []struct {
@@ -996,7 +996,7 @@ func TestCallWithJSONResponse(t *testing.T) {
 		name: "call fails",
 		args: args{
 			ctx:  context.Background(),
-			desc: &Descriptor{},
+			desc: &Descriptor[RawRequest]{},
 			endpoint: &Endpoint{
 				BaseURL: "\t\t\t\t", // causes failure
 				Logger:  model.DiscardLogger,
@@ -1008,7 +1008,7 @@ func TestCallWithJSONResponse(t *testing.T) {
 		name: "with error during httpClient.Do",
 		args: args{
 			ctx:  context.Background(),
-			desc: &Descriptor{},
+			desc: &Descriptor[RawRequest]{},
 			endpoint: &Endpoint{
 				BaseURL: "https://www.example.com/a",
 				HTTPClient: &mocks.HTTPClient{
@@ -1030,7 +1030,7 @@ func TestCallWithJSONResponse(t *testing.T) {
 		name: "with error when reading the response body",
 		args: args{
 			ctx:  context.Background(),
-			desc: &Descriptor{},
+			desc: &Descriptor[RawRequest]{},
 			endpoint: &Endpoint{
 				BaseURL: "https://www.example.com/a",
 				HTTPClient: &mocks.HTTPClient{
@@ -1060,7 +1060,7 @@ func TestCallWithJSONResponse(t *testing.T) {
 		name: "with HTTP failure",
 		args: args{
 			ctx:  context.Background(),
-			desc: &Descriptor{},
+			desc: &Descriptor[RawRequest]{},
 			endpoint: &Endpoint{
 				BaseURL: "https://www.example.com/a",
 				HTTPClient: &mocks.HTTPClient{
@@ -1086,7 +1086,7 @@ func TestCallWithJSONResponse(t *testing.T) {
 		name: "with good response and missing header",
 		args: args{
 			ctx:  context.Background(),
-			desc: &Descriptor{},
+			desc: &Descriptor[RawRequest]{},
 			endpoint: &Endpoint{
 				BaseURL: "https://www.example.com/a",
 				HTTPClient: &mocks.HTTPClient{
@@ -1107,7 +1107,7 @@ func TestCallWithJSONResponse(t *testing.T) {
 		name: "with good response and good header",
 		args: args{
 			ctx:  context.Background(),
-			desc: &Descriptor{},
+			desc: &Descriptor[RawRequest]{},
 			endpoint: &Endpoint{
 				BaseURL: "https://www.example.com/a",
 				HTTPClient: &mocks.HTTPClient{
@@ -1131,7 +1131,7 @@ func TestCallWithJSONResponse(t *testing.T) {
 		name: "response is not JSON",
 		args: args{
 			ctx: context.Background(),
-			desc: &Descriptor{
+			desc: &Descriptor[RawRequest]{
 				LogBody: false,
 				Method:  http.MethodGet,
 			},
@@ -1183,7 +1183,7 @@ func TestCallWithJSONResponse(t *testing.T) {
 func TestCallHonoursContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // should fail HTTP request immediately
-	desc := &Descriptor{
+	desc := &Descriptor[RawRequest]{
 		LogBody: false,
 		Method:  http.MethodGet,
 		URLPath: "/robots.txt",
@@ -1206,7 +1206,7 @@ func TestCallHonoursContext(t *testing.T) {
 func TestCallWithJSONResponseHonoursContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // should fail HTTP request immediately
-	desc := &Descriptor{
+	desc := &Descriptor[RawRequest]{
 		LogBody: false,
 		Method:  http.MethodGet,
 		URLPath: "/robots.txt",

--- a/internal/httpapi/descriptor.go
+++ b/internal/httpapi/descriptor.go
@@ -9,12 +9,22 @@ import (
 	"time"
 )
 
+// RawRequest is the type to use with [RequestDescriptor] and
+// [Descriptor] when the request is just raw bytes.
+type RawRequest struct{}
+
+// RequestDescriptor describes the request.
+type RequestDescriptor[T any] struct {
+	// Body is the raw request body.
+	Body []byte
+}
+
 // Descriptor contains the parameters for calling a given HTTP
 // API (e.g., GET /api/v1/test-list/urls).
 //
 // The zero value of this struct is invalid. Please, fill all the
 // fields marked as MANDATORY for correct initialization.
-type Descriptor struct {
+type Descriptor[RequestType any] struct {
 	// Accept contains the OPTIONAL accept header.
 	Accept string
 
@@ -37,8 +47,8 @@ type Descriptor struct {
 	// Method is the MANDATORY request method.
 	Method string
 
-	// RequestBody is the OPTIONAL request body.
-	RequestBody []byte
+	// Request is the OPTIONAL request descriptor.
+	Request *RequestDescriptor[RequestType]
 
 	// Timeout is the OPTIONAL timeout for this call. If no timeout
 	// is specified we will use the [DefaultCallTimeout] const.

--- a/internal/httpapi/sequence_test.go
+++ b/internal/httpapi/sequence_test.go
@@ -17,7 +17,7 @@ func TestSequenceCaller(t *testing.T) {
 	t.Run("Call", func(t *testing.T) {
 		t.Run("first success", func(t *testing.T) {
 			sc := NewSequenceCaller(
-				&Descriptor{
+				&Descriptor[RawRequest]{
 					Method:  http.MethodGet,
 					URLPath: "/",
 				},
@@ -58,7 +58,7 @@ func TestSequenceCaller(t *testing.T) {
 
 		t.Run("first HTTP failure and we immediately stop", func(t *testing.T) {
 			sc := NewSequenceCaller(
-				&Descriptor{
+				&Descriptor[RawRequest]{
 					Method:  http.MethodGet,
 					URLPath: "/",
 				},
@@ -100,7 +100,7 @@ func TestSequenceCaller(t *testing.T) {
 
 		t.Run("first network failure, second success", func(t *testing.T) {
 			sc := NewSequenceCaller(
-				&Descriptor{
+				&Descriptor[RawRequest]{
 					Method:  http.MethodGet,
 					URLPath: "/",
 				},
@@ -141,7 +141,7 @@ func TestSequenceCaller(t *testing.T) {
 
 		t.Run("all network failure", func(t *testing.T) {
 			sc := NewSequenceCaller(
-				&Descriptor{
+				&Descriptor[RawRequest]{
 					Method:  http.MethodGet,
 					URLPath: "/",
 				},
@@ -185,7 +185,7 @@ func TestSequenceCaller(t *testing.T) {
 
 		t.Run("first success", func(t *testing.T) {
 			sc := NewSequenceCaller(
-				&Descriptor{
+				&Descriptor[RawRequest]{
 					Method:  http.MethodGet,
 					URLPath: "/",
 				},
@@ -235,7 +235,7 @@ func TestSequenceCaller(t *testing.T) {
 
 		t.Run("first HTTP failure and we immediately stop", func(t *testing.T) {
 			sc := NewSequenceCaller(
-				&Descriptor{
+				&Descriptor[RawRequest]{
 					Method:  http.MethodGet,
 					URLPath: "/",
 				},
@@ -284,7 +284,7 @@ func TestSequenceCaller(t *testing.T) {
 
 		t.Run("first network failure, second success", func(t *testing.T) {
 			sc := NewSequenceCaller(
-				&Descriptor{
+				&Descriptor[RawRequest]{
 					Method:  http.MethodGet,
 					URLPath: "/",
 				},
@@ -330,7 +330,7 @@ func TestSequenceCaller(t *testing.T) {
 
 		t.Run("all network failure", func(t *testing.T) {
 			sc := NewSequenceCaller(
-				&Descriptor{
+				&Descriptor[RawRequest]{
 					Method:  http.MethodGet,
 					URLPath: "/",
 				},

--- a/internal/ooapi/checkin.go
+++ b/internal/ooapi/checkin.go
@@ -15,10 +15,12 @@ import (
 
 // NewDescriptorCheckIn creates a new [httpapi.Descriptor] describing how
 // to issue an HTTP call to the CheckIn API.
-func NewDescriptorCheckIn(config *model.OOAPICheckInConfig) *httpapi.Descriptor {
+func NewDescriptorCheckIn(
+	config *model.OOAPICheckInConfig,
+) *httpapi.Descriptor[*model.OOAPICheckInConfig] {
 	rawRequest, err := json.Marshal(config)
 	runtimex.PanicOnError(err, "json.Marshal failed unexpectedly")
-	return &httpapi.Descriptor{
+	return &httpapi.Descriptor[*model.OOAPICheckInConfig]{
 		Accept:             httpapi.ApplicationJSON,
 		AcceptEncodingGzip: true, // we want a small response
 		Authorization:      "",
@@ -26,9 +28,11 @@ func NewDescriptorCheckIn(config *model.OOAPICheckInConfig) *httpapi.Descriptor 
 		LogBody:            false, // we don't want to log psiphon config
 		MaxBodySize:        0,
 		Method:             http.MethodPost,
-		RequestBody:        rawRequest,
-		Timeout:            0,
-		URLPath:            "/api/v1/check-in",
-		URLQuery:           nil,
+		Request: &httpapi.RequestDescriptor[*model.OOAPICheckInConfig]{
+			Body: rawRequest,
+		},
+		Timeout:  0,
+		URLPath:  "/api/v1/check-in",
+		URLQuery: nil,
 	}
 }

--- a/internal/ooapi/checkin_test.go
+++ b/internal/ooapi/checkin_test.go
@@ -52,7 +52,8 @@ func TestNewDescriptorCheckIn(t *testing.T) {
 				t.Fatalf("unexpected desc.%s", name)
 			}
 		case "RequestBody":
-			if len(field.Interface().([]byte)) <= 2 {
+			reqBody := field.Interface().(*httpapi.RequestDescriptor[*model.OOAPICheckInConfig])
+			if len(reqBody.Body) <= 2 {
 				t.Fatalf("unexpected desc.%s length", name)
 			}
 		case "Timeout":

--- a/internal/ooapi/th.go
+++ b/internal/ooapi/th.go
@@ -15,10 +15,12 @@ import (
 
 // NewDescriptorTH creates a new [httpapi.Descriptor] describing how
 // to issue an HTTP call to the Web Connectivity Test Helper (TH).
-func NewDescriptorTH(creq *model.THRequest) *httpapi.Descriptor {
+func NewDescriptorTH(
+	creq *model.THRequest,
+) *httpapi.Descriptor[*model.THRequest] {
 	rawRequest, err := json.Marshal(creq)
 	runtimex.PanicOnError(err, "json.Marshal failed unexpectedly")
-	return &httpapi.Descriptor{
+	return &httpapi.Descriptor[*model.THRequest]{
 		Accept:             httpapi.ApplicationJSON,
 		AcceptEncodingGzip: false,
 		Authorization:      "",
@@ -26,9 +28,11 @@ func NewDescriptorTH(creq *model.THRequest) *httpapi.Descriptor {
 		LogBody:            true,
 		MaxBodySize:        0,
 		Method:             http.MethodPost,
-		RequestBody:        rawRequest,
-		Timeout:            0,
-		URLPath:            "/",
-		URLQuery:           nil,
+		Request: &httpapi.RequestDescriptor[*model.THRequest]{
+			Body: rawRequest,
+		},
+		Timeout:  0,
+		URLPath:  "/",
+		URLQuery: nil,
 	}
 }

--- a/internal/ooapi/th_test.go
+++ b/internal/ooapi/th_test.go
@@ -52,7 +52,8 @@ func TestNewDescriptorTH(t *testing.T) {
 				t.Fatalf("unexpected desc.%s", name)
 			}
 		case "RequestBody":
-			if len(field.Interface().([]byte)) <= 2 {
+			reqBody := field.Interface().(*httpapi.RequestDescriptor[*model.THRequest])
+			if len(reqBody.Body) <= 2 {
 				t.Fatalf("unexpected desc.%s length", name)
 			}
 		case "Timeout":


### PR DESCRIPTION
## Checklist

- [ ] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [ ] reference issue for this pull request:  https://github.com/ooni/probe/issues/2372
- [ ] if you changed anything related how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [ ] if you changed code inside an experiment, make sure you bump its version number


## Description

This diff changes the httpapi to annotate a Descriptor with the RequestType. Internally, the descriptor will include a RequestDescriptor that for now only contains the body. Soon, it may contain more fields.

With the Descriptor annotated with a request type, we're now well positioned to generate half of the swagger.

The reference issue is https://github.com/ooni/probe/issues/2372
