### PR TITLE
feat(httpapi): annotate Descriptor with ResponseType

### DIFF
--- a/internal/engine/experiment/webconnectivity/control.go
+++ b/internal/engine/experiment/webconnectivity/control.go
@@ -29,8 +29,7 @@ func Control(
 		httpapi.NewEndpointList(sess.DefaultHTTPClient(), sess.Logger(), sess.UserAgent(), testhelpers...)...,
 	)
 	sess.Logger().Infof("control for %s...", creq.HTTPRequest)
-	var out ControlResponse
-	idx, err := seqCaller.CallWithJSONResponse(ctx, &out)
+	out, idx, err := seqCaller.Call(ctx)
 	sess.Logger().Infof("control for %s... %+v", creq.HTTPRequest, model.ErrorToStringOrOK(err))
 	if err != nil {
 		// make sure error is wrapped
@@ -39,7 +38,8 @@ func Control(
 	}
 	fillASNs(&out.DNS)
 	runtimex.Assert(idx >= 0 && idx < len(testhelpers), "idx out of bounds")
-	return out, &testhelpers[idx], nil
+	runtimex.Assert(out != nil, "out is nil")
+	return *out, &testhelpers[idx], nil
 }
 
 // fillASNs fills the ASNs array of ControlDNSResult. For each Addr inside

--- a/internal/engine/probeservices/checkin.go
+++ b/internal/engine/probeservices/checkin.go
@@ -16,9 +16,9 @@ func (c Client) CheckIn(
 	ctx context.Context, config model.OOAPICheckInConfig) (*model.OOAPICheckInNettests, error) {
 	epnt := c.newHTTPAPIEndpoint()
 	desc := ooapi.NewDescriptorCheckIn(&config)
-	var response model.OOAPICheckInResult
-	if err := httpapi.CallWithJSONResponse(ctx, desc, epnt, &response); err != nil {
+	resp, err := httpapi.Call(ctx, desc, epnt)
+	if err != nil {
 		return nil, err
 	}
-	return &response.Tests, nil
+	return &resp.Tests, nil
 }

--- a/internal/experiment/webconnectivity/control.go
+++ b/internal/experiment/webconnectivity/control.go
@@ -116,8 +116,7 @@ func (c *Control) Run(parentCtx context.Context) {
 	)
 
 	// issue the control request and wait for the response
-	var cresp webconnectivity.ControlResponse
-	idx, err := seqCaller.CallWithJSONResponse(opCtx, &cresp)
+	cresp, idx, err := seqCaller.Call(opCtx)
 	if err != nil {
 		// make sure error is wrapped
 		err = netxlite.NewTopLevelGenericErrWrapper(err)
@@ -125,9 +124,10 @@ func (c *Control) Run(parentCtx context.Context) {
 		ol.Stop(err)
 		return
 	}
+	runtimex.Assert(cresp != nil, "cresp is nil")
 
 	// on success, save the control response
-	c.TestKeys.SetControl(&cresp)
+	c.TestKeys.SetControl(cresp)
 	ol.Stop(nil)
 
 	// record the specific TH that worked

--- a/internal/httpapi/sequence.go
+++ b/internal/httpapi/sequence.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 
 	"github.com/ooni/probe-cli/v3/internal/multierror"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
 // SequenceCaller calls the API specified by [Descriptor] once for each of
@@ -20,20 +21,20 @@ import (
 //
 // CAVEAT: this code will ONLY retry API calls with subsequent endpoints when
 // the error originates in the HTTP round trip or while reading the body.
-type SequenceCaller[RequestType any] struct {
+type SequenceCaller[RequestType, ResponseType any] struct {
 	// Descriptor is the API [Descriptor].
-	Descriptor *Descriptor[RequestType]
+	Descriptor *Descriptor[RequestType, ResponseType]
 
 	// Endpoints is the list of [Endpoint] to use.
 	Endpoints []*Endpoint
 }
 
 // NewSequenceCaller is a factory for creating a [SequenceCaller].
-func NewSequenceCaller[RequestType any](
-	desc *Descriptor[RequestType],
+func NewSequenceCaller[RequestType, ResponseType any](
+	desc *Descriptor[RequestType, ResponseType],
 	endpoints ...*Endpoint,
-) *SequenceCaller[RequestType] {
-	return &SequenceCaller[RequestType]{
+) *SequenceCaller[RequestType, ResponseType] {
+	return &SequenceCaller[RequestType, ResponseType]{
 		Descriptor: desc,
 		Endpoints:  endpoints,
 	}
@@ -55,7 +56,8 @@ func sequenceCallerShouldRetry(err error) bool {
 //
 // CAVEAT: this code will ONLY retry API calls with subsequent endpoints when
 // the error originates in the HTTP round trip or while reading the body.
-func (sc *SequenceCaller[RequestType]) Call(ctx context.Context) ([]byte, int, error) {
+func (sc *SequenceCaller[RequestType, ResponseType]) Call(ctx context.Context) (ResponseType, int, error) {
+	runtimex.Assert(sc.Descriptor.Response != nil, "sc.Descriptor.Response is nil")
 	var selected int
 	merr := multierror.New(ErrAllEndpointsFailed)
 	for _, epnt := range sc.Endpoints {
@@ -69,28 +71,5 @@ func (sc *SequenceCaller[RequestType]) Call(ctx context.Context) ([]byte, int, e
 		// early as documented for this method
 		return respBody, selected, err
 	}
-	return nil, -1, merr
-}
-
-// CallWithJSONResponse is like [SequenceCaller.Call] except that it invokes the
-// underlying [CallWithJSONResponse] rather than invoking [Call].
-//
-// CAVEAT: this code will ONLY retry API calls with subsequent endpoints when
-// the error originates in the HTTP round trip or while reading the body.
-func (sc *SequenceCaller[RequestType]) CallWithJSONResponse(
-	ctx context.Context, response any) (int, error) {
-	var selected int
-	merr := multierror.New(ErrAllEndpointsFailed)
-	for _, epnt := range sc.Endpoints {
-		err := CallWithJSONResponse(ctx, sc.Descriptor, epnt, response)
-		if sequenceCallerShouldRetry(err) {
-			merr.Add(err)
-			selected++
-			continue
-		}
-		// Note: some errors will lead us to return
-		// early as documented for this method
-		return selected, err
-	}
-	return -1, merr
+	return *new(ResponseType), -1, merr
 }

--- a/internal/ooapi/checkin.go
+++ b/internal/ooapi/checkin.go
@@ -17,10 +17,10 @@ import (
 // to issue an HTTP call to the CheckIn API.
 func NewDescriptorCheckIn(
 	config *model.OOAPICheckInConfig,
-) *httpapi.Descriptor[*model.OOAPICheckInConfig] {
+) *httpapi.Descriptor[*model.OOAPICheckInConfig, *model.OOAPICheckInResult] {
 	rawRequest, err := json.Marshal(config)
 	runtimex.PanicOnError(err, "json.Marshal failed unexpectedly")
-	return &httpapi.Descriptor[*model.OOAPICheckInConfig]{
+	return &httpapi.Descriptor[*model.OOAPICheckInConfig, *model.OOAPICheckInResult]{
 		Accept:             httpapi.ApplicationJSON,
 		AcceptEncodingGzip: true, // we want a small response
 		Authorization:      "",
@@ -31,6 +31,7 @@ func NewDescriptorCheckIn(
 		Request: &httpapi.RequestDescriptor[*model.OOAPICheckInConfig]{
 			Body: rawRequest,
 		},
+		Response: &httpapi.JSONResponseDescriptor[*model.OOAPICheckInResult]{},
 		Timeout:  0,
 		URLPath:  "/api/v1/check-in",
 		URLQuery: nil,

--- a/internal/ooapi/checkin_test.go
+++ b/internal/ooapi/checkin_test.go
@@ -52,9 +52,13 @@ func TestNewDescriptorCheckIn(t *testing.T) {
 				t.Fatalf("unexpected desc.%s", name)
 			}
 		case "Request":
-			reqBody := field.Interface().(*httpapi.RequestDescriptor[*model.OOAPICheckInConfig])
-			if len(reqBody.Body) <= 2 {
+			req := field.Interface().(*httpapi.RequestDescriptor[*model.OOAPICheckInConfig])
+			if len(req.Body) <= 2 {
 				t.Fatalf("unexpected desc.%s length", name)
+			}
+		case "Response":
+			if field.IsZero() {
+				t.Fatalf("unexpected desc.%s", name)
 			}
 		case "Timeout":
 			if !field.IsZero() {

--- a/internal/ooapi/th.go
+++ b/internal/ooapi/th.go
@@ -17,10 +17,10 @@ import (
 // to issue an HTTP call to the Web Connectivity Test Helper (TH).
 func NewDescriptorTH(
 	creq *model.THRequest,
-) *httpapi.Descriptor[*model.THRequest] {
+) *httpapi.Descriptor[*model.THRequest, *model.THResponse] {
 	rawRequest, err := json.Marshal(creq)
 	runtimex.PanicOnError(err, "json.Marshal failed unexpectedly")
-	return &httpapi.Descriptor[*model.THRequest]{
+	return &httpapi.Descriptor[*model.THRequest, *model.THResponse]{
 		Accept:             httpapi.ApplicationJSON,
 		AcceptEncodingGzip: false,
 		Authorization:      "",
@@ -31,6 +31,7 @@ func NewDescriptorTH(
 		Request: &httpapi.RequestDescriptor[*model.THRequest]{
 			Body: rawRequest,
 		},
+		Response: &httpapi.JSONResponseDescriptor[*model.THResponse]{},
 		Timeout:  0,
 		URLPath:  "/",
 		URLQuery: nil,

--- a/internal/ooapi/th_test.go
+++ b/internal/ooapi/th_test.go
@@ -52,9 +52,13 @@ func TestNewDescriptorTH(t *testing.T) {
 				t.Fatalf("unexpected desc.%s", name)
 			}
 		case "Request":
-			reqBody := field.Interface().(*httpapi.RequestDescriptor[*model.THRequest])
-			if len(reqBody.Body) <= 2 {
+			req := field.Interface().(*httpapi.RequestDescriptor[*model.THRequest])
+			if len(req.Body) <= 2 {
 				t.Fatalf("unexpected desc.%s length", name)
+			}
+		case "Response":
+			if field.IsZero() {
+				t.Fatalf("unexpected desc.%s", name)
 			}
 		case "Timeout":
 			if !field.IsZero() {


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2372
- [ ] if you changed anything related how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [ ] if you changed code inside an experiment, make sure you bump its version number

## Description

This diff modifies httpapi to annotate the descriptor with the ResponseType, which also allows us to write code where we naturally call an API as follows:

```Go
resp, err := httpapi.Call(ctx, desc, epnt)
```

and where `resp` is of the correct response type and where `desc` has been configured to unmarshal using the JSON format.

In addition to this syntactic-sugar change, this diff matters because knowing the type of the request and of the response allows us to generate a swagger to compare to the server's swagger.

Part of https://github.com/ooni/probe/issues/2372.

