### PR TITLE
feat(engine): make netxlite.utlsConn public

### DIFF
--- a/internal/experiment/echcheck/utls.go
+++ b/internal/experiment/echcheck/utls.go
@@ -3,13 +3,16 @@ package echcheck
 import (
 	"context"
 	"crypto/tls"
-	"github.com/ooni/probe-cli/v3/internal/model"
-	utls "gitlab.com/yawning/utls.git"
 	"net"
+
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
+	utls "gitlab.com/yawning/utls.git"
 )
 
 type tlsHandshakerWithExtensions struct {
-	conn       utlsConn
+	conn       *netxlite.UTLSConn
 	extensions []utls.TLSExtension
 	dl         model.DebugLogger
 	id         *utls.ClientHelloID
@@ -31,60 +34,16 @@ func newHandshakerWithExtensions(extensions []utls.TLSExtension) func(dl model.D
 
 func (t *tlsHandshakerWithExtensions) Handshake(ctx context.Context, conn net.Conn, tlsConfig *tls.Config) (
 	net.Conn, tls.ConnectionState, error) {
-	t.conn = newConnUTLSWithHelloID(conn, tlsConfig, t.id)
+	var err error
+	t.conn, err = netxlite.NewUTLSConn(conn, tlsConfig, t.id)
+	runtimex.Assert(err == nil, "unexpected error when creating UTLSConn")
 
 	if t.extensions != nil && len(t.extensions) != 0 {
 		t.conn.BuildHandshakeState()
 		t.conn.Extensions = append(t.conn.Extensions, t.extensions...)
 	}
 
-	err := t.conn.Handshake()
+	err = t.conn.Handshake()
 
 	return t.conn.NetConn(), t.conn.ConnectionState(), err
-}
-
-// TODO remove after https://github.com/ooni/probe/issues/2378
-// utlsConn is a utls connection
-type utlsConn struct {
-	*utls.UConn
-	nc net.Conn
-}
-
-// newConnUTLSWithHelloID creates a new connection with the given client hello ID.
-func newConnUTLSWithHelloID(conn net.Conn, config *tls.Config, cid *utls.ClientHelloID) utlsConn {
-	uConfig := &utls.Config{
-		DynamicRecordSizingDisabled: config.DynamicRecordSizingDisabled,
-		InsecureSkipVerify:          config.InsecureSkipVerify,
-		RootCAs:                     config.RootCAs,
-		NextProtos:                  config.NextProtos,
-		ServerName:                  config.ServerName,
-	}
-	tlsConn := utls.UClient(conn, uConfig, *cid)
-	oconn := utlsConn{
-		UConn: tlsConn,
-		nc:    conn,
-	}
-	return oconn
-}
-
-func (c *utlsConn) ConnectionState() tls.ConnectionState {
-	uState := c.Conn.ConnectionState()
-	return tls.ConnectionState{
-		Version:                     uState.Version,
-		HandshakeComplete:           uState.HandshakeComplete,
-		DidResume:                   uState.DidResume,
-		CipherSuite:                 uState.CipherSuite,
-		NegotiatedProtocol:          uState.NegotiatedProtocol,
-		NegotiatedProtocolIsMutual:  uState.NegotiatedProtocolIsMutual,
-		ServerName:                  uState.ServerName,
-		PeerCertificates:            uState.PeerCertificates,
-		VerifiedChains:              uState.VerifiedChains,
-		SignedCertificateTimestamps: uState.SignedCertificateTimestamps,
-		OCSPResponse:                uState.OCSPResponse,
-		TLSUnique:                   uState.TLSUnique,
-	}
-}
-
-func (c *utlsConn) NetConn() net.Conn {
-	return c.nc
 }

--- a/internal/netxlite/utls_test.go
+++ b/internal/netxlite/utls_test.go
@@ -30,7 +30,7 @@ func TestUTLSConn(t *testing.T) {
 	t.Run("Handshake", func(t *testing.T) {
 		t.Run("not interrupted with success", func(t *testing.T) {
 			ctx := context.Background()
-			conn := &utlsConn{
+			conn := &UTLSConn{
 				testableHandshake: func() error {
 					return nil
 				},
@@ -44,7 +44,7 @@ func TestUTLSConn(t *testing.T) {
 		t.Run("not interrupted with failure", func(t *testing.T) {
 			expected := errors.New("mocked error")
 			ctx := context.Background()
-			conn := &utlsConn{
+			conn := &UTLSConn{
 				testableHandshake: func() error {
 					return expected
 				},
@@ -61,7 +61,7 @@ func TestUTLSConn(t *testing.T) {
 			sigch := make(chan interface{})
 			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 			defer cancel()
-			conn := &utlsConn{
+			conn := &UTLSConn{
 				testableHandshake: func() error {
 					defer wg.Done()
 					<-sigch
@@ -80,7 +80,7 @@ func TestUTLSConn(t *testing.T) {
 			wg := sync.WaitGroup{}
 			wg.Add(1)
 			ctx := context.Background()
-			conn := &utlsConn{
+			conn := &UTLSConn{
 				testableHandshake: func() error {
 					defer wg.Done()
 					panic("mascetti")
@@ -95,7 +95,7 @@ func TestUTLSConn(t *testing.T) {
 	})
 
 	t.Run("NetConn", func(t *testing.T) {
-		factory := newConnUTLS(&utls.HelloChrome_70)
+		factory := newUTLSConnFactory(&utls.HelloChrome_70)
 		conn := &mocks.Conn{}
 		tconn, err := factory(conn, &tls.Config{})
 		if err != nil {
@@ -144,7 +144,7 @@ func Test_newConnUTLSWithHelloID(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer conn.Close()
-			got, err := newConnUTLSWithHelloID(conn, tt.config, tt.cid)
+			got, err := NewUTLSConn(conn, tt.config, tt.cid)
 			if !errors.Is(err, tt.wantErr) {
 				t.Fatal("unexpected err", err)
 			}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2378https://github.com/ooni/probe/issues/2378
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

## Description

This PR exposes the `netxlite.utlsConn` to the experiments by making it public (--> `UTLSConn`) `echcheck` can use `netxlite.UTLSConn` now so we don't need to re-implement utlsConn there any longer.
Note that `NewConnUTLSWithHelloID` returns `*UTLSConn` now, instead of `TLSConn`, to make it more convenient for experiment developers.
