### PR TITLE
feat(netxlite): introduce a generic unknown error

### DIFF
--- a/internal/netxlite/classify.go
+++ b/internal/netxlite/classify.go
@@ -15,6 +15,14 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/scrubber"
 )
 
+// FailureUnknown is the prefix used for unknown failures
+const FailureUnknown = "unknown_failure"
+
+// ErrUnknown is an error you may want to return when you don't
+// known what exactly happened. This error is automatically mapped
+// to FailureUnknown by ClassifyGenericError.
+var ErrUnknown = errors.New(FailureUnknown)
+
 // ClassifyGenericError maps an error occurred during an operation to
 // an OONI failure string. This specific classifier is the most
 // generic one. You usually use it when mapping I/O errors. You should
@@ -63,7 +71,11 @@ func ClassifyGenericError(err error) string {
 		return failure
 	}
 
-	formatted := fmt.Sprintf("unknown_failure: %s", err.Error())
+	if err.Error() == FailureUnknown {
+		return FailureUnknown
+	}
+
+	formatted := fmt.Sprintf("%s: %s", FailureUnknown, err.Error())
 	return scrubber.Scrub(formatted) // scrub IP addresses in the error
 }
 

--- a/internal/netxlite/classify_test.go
+++ b/internal/netxlite/classify_test.go
@@ -104,6 +104,12 @@ func TestClassifyGenericError(t *testing.T) {
 		}
 	})
 
+	t.Run("for the 'unknown_failure' string", func(t *testing.T) {
+		if ClassifyGenericError(ErrUnknown) != FailureUnknown {
+			t.Fatal("unexpected result")
+		}
+	})
+
 	t.Run("for unknown errors", func(t *testing.T) {
 		t.Run("with an IPv4 address", func(t *testing.T) {
 			input := errors.New("read tcp 10.0.2.15:56948->93.184.216.34:443: some error")


### PR DESCRIPTION
This value is a good initial value to initialize errors when failing early needs to cause an error. If we have a canonical value to represent that, we can reduce code duplication.

See bassosimone/oonidsl@9af837a2e7d23fc71477598c494bbace4e42b97d
