### PR TITLE
feat: expose build information

### DIFF
--- a/internal/engine/experiment.go
+++ b/internal/engine/experiment.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/bytecounter"
 	"github.com/ooni/probe-cli/v3/internal/engine/probeservices"
 	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
 	"github.com/ooni/probe-cli/v3/internal/version"
 )
 
@@ -217,10 +218,15 @@ func (e *experiment) newMeasurement(input string) *model.Measurement {
 		TestStartTime:             e.testStartTime,
 		TestVersion:               e.testVersion,
 	}
+	m.AddAnnotation("architecture", runtime.GOARCH)
 	m.AddAnnotation("engine_name", "ooniprobe-engine")
 	m.AddAnnotation("engine_version", version.Version)
+	m.AddAnnotation("go_version", runtimex.BuildInfo.GoVersion)
 	m.AddAnnotation("platform", e.session.Platform())
-	m.AddAnnotation("architecture", runtime.GOARCH)
+	m.AddAnnotation("vcs_modified", runtimex.BuildInfo.VcsModified)
+	m.AddAnnotation("vcs_revision", runtimex.BuildInfo.VcsRevision)
+	m.AddAnnotation("vcs_time", runtimex.BuildInfo.VcsTime)
+	m.AddAnnotation("vcs_tool", runtimex.BuildInfo.VcsTool)
 	return m
 }
 

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/platform"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
 	"github.com/ooni/probe-cli/v3/internal/tunnel"
 	"github.com/ooni/probe-cli/v3/internal/version"
 )
@@ -159,6 +160,13 @@ func NewSession(ctx context.Context, config SessionConfig) (*Session, error) {
 	if err != nil {
 		return nil, err
 	}
+	config.Logger.Infof(
+		"ooniprobe-engine/v%s %s dirty=%s %s",
+		version.Version,
+		runtimex.BuildInfo.VcsRevision[:10], // short identifier
+		runtimex.BuildInfo.VcsModified,
+		runtimex.BuildInfo.GoVersion,
+	)
 	sess := &Session{
 		availableProbeServices:  config.AvailableProbeServices,
 		byteCounter:             bytecounter.New(),

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -163,7 +163,7 @@ func NewSession(ctx context.Context, config SessionConfig) (*Session, error) {
 	config.Logger.Infof(
 		"ooniprobe-engine/v%s %s dirty=%s %s",
 		version.Version,
-		runtimex.BuildInfo.VcsRevision[:10], // short identifier
+		runtimex.BuildInfo.VcsRevision,
 		runtimex.BuildInfo.VcsModified,
 		runtimex.BuildInfo.GoVersion,
 	)

--- a/internal/runtimex/runtimex.go
+++ b/internal/runtimex/runtimex.go
@@ -27,26 +27,35 @@ type BuildInfoRecord struct {
 	VcsTool string
 }
 
+// setkv is a convenience function to set a [BuildInfoRecord] entry.
+func (bir *BuildInfoRecord) setkv(key, value string) {
+	switch key {
+	case "vcs.revision":
+		bir.VcsRevision = value
+	case "vcs.time":
+		bir.VcsTime = value
+	case "vcs.modified":
+		bir.VcsModified = value
+	case "vcs":
+		bir.VcsTool = value
+	}
+}
+
+// setall sets all the possible settings.
+func (bir *BuildInfoRecord) setall(settings []debug.BuildSetting) {
+	for _, entry := range settings {
+		bir.setkv(entry.Key, entry.Value)
+	}
+}
+
 // BuildInfo is the singleton containing build-time information.
-var BuildInfo BuildInfoRecord
+var BuildInfo = &BuildInfoRecord{}
 
 func init() {
 	info, good := debug.ReadBuildInfo()
-	if !good {
-		return
-	}
-	BuildInfo.GoVersion = info.GoVersion
-	for _, entry := range info.Settings {
-		switch entry.Key {
-		case "vcs.revision":
-			BuildInfo.VcsRevision = entry.Value
-		case "vcs.time":
-			BuildInfo.VcsTime = entry.Value
-		case "vcs.modified":
-			BuildInfo.VcsModified = entry.Value
-		case "vcs":
-			BuildInfo.VcsTool = entry.Value
-		}
+	if good {
+		BuildInfo.GoVersion = info.GoVersion
+		BuildInfo.setall(info.Settings)
 	}
 }
 

--- a/internal/runtimex/runtimex.go
+++ b/internal/runtimex/runtimex.go
@@ -5,7 +5,50 @@ package runtimex
 import (
 	"errors"
 	"fmt"
+	"runtime/debug"
 )
+
+// BuildInfoRecord contains build-time information.
+type BuildInfoRecord struct {
+	// GoVersion is the version of go with which this code
+	// was compiled or an empty string.
+	GoVersion string
+
+	// VcsModified indicates whether the tree was dirty.
+	VcsModified string
+
+	// VcsRevision is the VCS revision we compiled.
+	VcsRevision string
+
+	// VcsTime is the time of the revision we're building.
+	VcsTime string
+
+	// VcsTool is the VCS tool being used.
+	VcsTool string
+}
+
+// BuildInfo is the singleton containing build-time information.
+var BuildInfo BuildInfoRecord
+
+func init() {
+	info, good := debug.ReadBuildInfo()
+	if !good {
+		return
+	}
+	BuildInfo.GoVersion = info.GoVersion
+	for _, entry := range info.Settings {
+		switch entry.Key {
+		case "vcs.revision":
+			BuildInfo.VcsRevision = entry.Value
+		case "vcs.time":
+			BuildInfo.VcsTime = entry.Value
+		case "vcs.modified":
+			BuildInfo.VcsModified = entry.Value
+		case "vcs":
+			BuildInfo.VcsTool = entry.Value
+		}
+	}
+}
 
 // PanicOnError calls panic() if err is not nil. The type passed
 // to panic is an error type wrapping the original error.

--- a/internal/runtimex/runtimex_test.go
+++ b/internal/runtimex/runtimex_test.go
@@ -2,7 +2,10 @@ package runtimex
 
 import (
 	"errors"
+	"runtime/debug"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestPanicOnError(t *testing.T) {
@@ -90,4 +93,56 @@ func TestPanicIfNil(t *testing.T) {
 			t.Fatal("not the error we expected", err)
 		}
 	})
+}
+
+func TestBuildInfoRecord_setall(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+		want  *BuildInfoRecord
+	}{{
+		name:  "for VcsModified",
+		key:   "vcs.modified",
+		value: "ABC",
+		want: &BuildInfoRecord{
+			VcsModified: "ABC",
+		},
+	}, {
+		name:  "for VcsRevision",
+		key:   "vcs.revision",
+		value: "ABC",
+		want: &BuildInfoRecord{
+			VcsRevision: "ABC",
+		},
+	}, {
+		name:  "for VcsTime",
+		key:   "vcs.time",
+		value: "ABC",
+		want: &BuildInfoRecord{
+			VcsTime: "ABC",
+		},
+	}, {
+		name:  "for VcsTool",
+		key:   "vcs",
+		value: "git",
+		want: &BuildInfoRecord{
+			VcsTool: "git",
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bir := &BuildInfoRecord{
+				GoVersion:   "",
+				VcsModified: "",
+				VcsRevision: "",
+				VcsTime:     "",
+				VcsTool:     "",
+			}
+			bir.setall([]debug.BuildSetting{{Key: tt.key, Value: tt.value}})
+			if diff := cmp.Diff(tt.want, bir); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,7 +1,5 @@
-// Package version contains version information
+// Package version contains version information.
 package version
 
-const (
-	// Version is the software version
-	Version = "3.17.0-alpha.1"
-)
+// Version is the ooniprobe version.
+const Version = "3.17.0-alpha.1"


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2273
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: https://github.com/ooni/spec/pull/272
- [ ] if you changed code inside an experiment, make sure you bump its version number

## Description

We expose build information in the logs, when an engine.Session is being created as well as inside the annotations.

Part of https://github.com/ooni/probe/issues/2273

See https://github.com/ooni/spec/pull/272
