### PR TITLE
cleanup: finish moving packages away from engine

### DIFF
--- a/MOBILE/android/template.pom
+++ b/MOBILE/android/template.pom
@@ -21,8 +21,8 @@
   </licenses>
 
   <scm>
-    <url>https://github.com/ooni/probe-engine</url>
-    <connection>https://github.com/ooni/probe-engine.git</connection>
+    <url>https://github.com/ooni/probe-cli</url>
+    <connection>https://github.com/ooni/probe-cli.git</connection>
   </scm>
 
   <developers>

--- a/Readme.md
+++ b/Readme.md
@@ -16,12 +16,7 @@ This repository contains core OONI tools written in Go:
 
 - the OONI Probe engine (inside [internal](internal)).
 
-Every top-level directory in this repository contains an explanatory README file. You
-may also notice that some internal packages live under [internal/engine](internal/engine)
-while most others are top-level. This is part of [a long-standing refactoring](
-https://github.com/ooni/probe/issues/2115) started when we merged
-https://github.com/ooni/probe-engine into this repository. We'll slowly
-ensure that all packages inside `engine` are moved out of it and inside `internal`.
+Every top-level directory in this repository contains an explanatory README file.
 
 ## Semantic versioning policy
 

--- a/internal/experiment/README.md
+++ b/internal/experiment/README.md
@@ -1,4 +1,4 @@
-# Directory github.com/ooni/probe-cli/internal/engine/experiment
+# Directory github.com/ooni/probe-cli/v3/internal/experiment
 
 This directory contains the implementation of all the supported
 experiments, one for each directory. The [OONI spec repository

--- a/internal/experiment/torsf/torsf.go
+++ b/internal/experiment/torsf/torsf.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Implementation note: this file is written with easy diffing with respect
-// to internal/engine/experiment/vanillator/vanillator.go in mind.
+// to internal/experiment/vanillator/vanillator.go in mind.
 //
 // We may want to have a single implementation for both nettests in the future.
 

--- a/internal/experiment/torsf/torsf_test.go
+++ b/internal/experiment/torsf/torsf_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Implementation note: this file is written with easy diffing with respect
-// to internal/engine/experiment/vanillator/vanillator_test.go in mind.
+// to internal/experiment/vanillator/vanillator_test.go in mind.
 //
 // We may want to have a single implementation for both nettests in the future.
 

--- a/internal/experiment/vanillator/vanillator.go
+++ b/internal/experiment/vanillator/vanillator.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Implementation note: this file is written with easy diffing with respect
-// to internal/engine/experiment/torsf/torsf.go in mind.
+// to internal/experiment/torsf/torsf.go in mind.
 //
 // We may want to have a single implementation for both nettests in the future.
 

--- a/internal/experiment/vanillator/vanillator_test.go
+++ b/internal/experiment/vanillator/vanillator_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Implementation note: this file is written with easy diffing with respect
-// to internal/engine/experiment/torsf/torsf_test.go in mind.
+// to internal/experiment/torsf/torsf_test.go in mind.
 //
 // We may want to have a single implementation for both nettests in the future.
 

--- a/internal/model/location.go
+++ b/internal/model/location.go
@@ -1,7 +1,7 @@
 package model
 
 // LocationProvider is an interface that returns the current location. The
-// github.com/ooni/probe-cli/v3/internal/engine/session.Session implements it.
+// [engine.Session] struct implements this interface.
 type LocationProvider interface {
 	ProbeASN() uint
 	ProbeASNString() string

--- a/internal/tutorial/README.md
+++ b/internal/tutorial/README.md
@@ -13,8 +13,7 @@ explains to you how to write a simple experiment. After reading it, you
 will understand the interfaces between an experiment and the OONI
 core. What this tutorial does not teach you, though, is how
 to tell the OONI core about this experiment. To see how to do that,
-you should check how we do that in [internal/engine/allexperiments.go](
-../engine/allexperiments.go).
+you should check how we do that in [internal/registry](../registry).
 
 - [Using the measurex package to write network experiments](measurex): this
 tutorial explains to you how to use the `measurex` library to write networking

--- a/internal/tutorial/experiment/torsf/chapter01/README.md
+++ b/internal/tutorial/experiment/torsf/chapter01/README.md
@@ -55,7 +55,7 @@ The apex/log library is the logging library used by OONI Probe.
 The torsf package contains the implementation of the torsf experiment.
 
 ```Go
-	"github.com/ooni/probe-cli/v3/internal/engine/experiment/torsf"
+	"github.com/ooni/probe-cli/v3/internal/experiment/torsf"
 
 ```
 

--- a/pkg/oonimkall/doc.go
+++ b/pkg/oonimkall/doc.go
@@ -38,7 +38,7 @@
 // See also https://github.com/ooni/probe-engine/pull/347 for the
 // design document describing the task API.
 //
-// See also https://github.com/ooni/probe-cli/v3/internal/engine/blob/master/DESIGN.md,
+// See also https://github.com/ooni/probe-engine/blob/master/DESIGN.md,
 // which explains why we implemented the oonimkall API.
 //
 // # Session API


### PR DESCRIPTION
This diff includes some cleanups while we finish moving packages away from the internal/engine package.

With this diff, we have finally finished merging probe-engine into probe-cli, a process initiated in February 2021.

See https://github.com/ooni/probe/issues/1335.

Closes https://github.com/ooni/probe/issues/2115.
