### PR TITLE
refactor: rename check-in nettests results for clarity

### DIFF
--- a/internal/engine/inputloader.go
+++ b/internal/engine/inputloader.go
@@ -28,7 +28,7 @@ var (
 // introduce this abstraction because it helps us with testing.
 type InputLoaderSession interface {
 	CheckIn(ctx context.Context,
-		config *model.OOAPICheckInConfig) (*model.OOAPICheckInNettests, error)
+		config *model.OOAPICheckInConfig) (*model.OOAPICheckInResultNettests, error)
 }
 
 // InputLoaderLogger is the logger according to an InputLoader.
@@ -316,7 +316,7 @@ func (il *InputLoader) loadRemote(ctx context.Context) ([]model.OOAPIURLInfo, er
 // the URLs that are not part of the requested categories. This is done for
 // robustness, just in case we or the API do something wrong.
 func (il *InputLoader) checkIn(
-	ctx context.Context, config *model.OOAPICheckInConfig) (*model.OOAPICheckInNettests, error) {
+	ctx context.Context, config *model.OOAPICheckInConfig) (*model.OOAPICheckInResultNettests, error) {
 	reply, err := il.Session.CheckIn(ctx, config)
 	if err != nil {
 		return nil, err

--- a/internal/engine/inputloader_test.go
+++ b/internal/engine/inputloader_test.go
@@ -446,7 +446,7 @@ func TestInputLoaderReadfileScannerFailure(t *testing.T) {
 type InputLoaderMockableSession struct {
 	// Output contains the output of CheckIn. It should
 	// be nil when Error is not-nil.
-	Output *model.OOAPICheckInNettests
+	Output *model.OOAPICheckInResultNettests
 
 	// Error is the error to be returned by CheckIn. It
 	// should be nil when Output is not-nil.
@@ -455,7 +455,7 @@ type InputLoaderMockableSession struct {
 
 // CheckIn implements InputLoaderSession.CheckIn.
 func (sess *InputLoaderMockableSession) CheckIn(
-	ctx context.Context, config *model.OOAPICheckInConfig) (*model.OOAPICheckInNettests, error) {
+	ctx context.Context, config *model.OOAPICheckInConfig) (*model.OOAPICheckInResultNettests, error) {
 	if sess.Output == nil && sess.Error == nil {
 		return nil, errors.New("both Output and Error are nil")
 	}
@@ -480,7 +480,7 @@ func TestInputLoaderCheckInFailure(t *testing.T) {
 func TestInputLoaderCheckInSuccessWithNilWebConnectivity(t *testing.T) {
 	il := &InputLoader{
 		Session: &InputLoaderMockableSession{
-			Output: &model.OOAPICheckInNettests{},
+			Output: &model.OOAPICheckInResultNettests{},
 		},
 	}
 	out, err := il.loadRemote(context.Background())
@@ -495,7 +495,7 @@ func TestInputLoaderCheckInSuccessWithNilWebConnectivity(t *testing.T) {
 func TestInputLoaderCheckInSuccessWithNoURLs(t *testing.T) {
 	il := &InputLoader{
 		Session: &InputLoaderMockableSession{
-			Output: &model.OOAPICheckInNettests{
+			Output: &model.OOAPICheckInResultNettests{
 				WebConnectivity: &model.OOAPICheckInInfoWebConnectivity{},
 			},
 		},
@@ -521,7 +521,7 @@ func TestInputLoaderCheckInSuccessWithSomeURLs(t *testing.T) {
 	}}
 	il := &InputLoader{
 		Session: &InputLoaderMockableSession{
-			Output: &model.OOAPICheckInNettests{
+			Output: &model.OOAPICheckInResultNettests{
 				WebConnectivity: &model.OOAPICheckInInfoWebConnectivity{
 					URLs: expect,
 				},

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -111,7 +111,7 @@ type Session struct {
 // sessionProbeServicesClientForCheckIn returns the probe services
 // client that we should be using for performing the check-in.
 type sessionProbeServicesClientForCheckIn interface {
-	CheckIn(ctx context.Context, config model.OOAPICheckInConfig) (*model.OOAPICheckInNettests, error)
+	CheckIn(ctx context.Context, config model.OOAPICheckInConfig) (*model.OOAPICheckInResultNettests, error)
 }
 
 // NewSession creates a new session. This factory function will
@@ -264,7 +264,7 @@ func (s *Session) KibiBytesSent() float64 {
 //
 // The return value is either the check-in response or an error.
 func (s *Session) CheckIn(
-	ctx context.Context, config *model.OOAPICheckInConfig) (*model.OOAPICheckInNettests, error) {
+	ctx context.Context, config *model.OOAPICheckInConfig) (*model.OOAPICheckInResultNettests, error) {
 	if err := s.maybeLookupLocationContext(ctx); err != nil {
 		return nil, err
 	}

--- a/internal/engine/session_internal_test.go
+++ b/internal/engine/session_internal_test.go
@@ -33,7 +33,7 @@ type mockableProbeServicesClientForCheckIn struct {
 
 	// Results contains the results of the call. This field MUST be
 	// non-nil if and only if Error is nil.
-	Results *model.OOAPICheckInNettests
+	Results *model.OOAPICheckInResultNettests
 
 	// Error indicates whether the call failed. This field MUST be
 	// non-nil if and only if Error is nil.
@@ -45,7 +45,7 @@ type mockableProbeServicesClientForCheckIn struct {
 
 // CheckIn implements sessionProbeServicesClientForCheckIn.CheckIn.
 func (c *mockableProbeServicesClientForCheckIn) CheckIn(
-	ctx context.Context, config model.OOAPICheckInConfig) (*model.OOAPICheckInNettests, error) {
+	ctx context.Context, config model.OOAPICheckInConfig) (*model.OOAPICheckInResultNettests, error) {
 	defer c.mu.Unlock()
 	c.mu.Lock()
 	if c.Config != nil {
@@ -59,7 +59,7 @@ func (c *mockableProbeServicesClientForCheckIn) CheckIn(
 }
 
 func TestSessionCheckInSuccessful(t *testing.T) {
-	results := &model.OOAPICheckInNettests{
+	results := &model.OOAPICheckInResultNettests{
 		WebConnectivity: &model.OOAPICheckInInfoWebConnectivity{
 			ReportID: "xxx-x-xx",
 			URLs: []model.OOAPIURLInfo{{

--- a/internal/legacy/mockable/mockable.go
+++ b/internal/legacy/mockable/mockable.go
@@ -26,7 +26,7 @@ type Session struct {
 	MockableFetchPsiphonConfigErr    error
 	MockableFetchTorTargetsResult    map[string]model.OOAPITorTarget
 	MockableFetchTorTargetsErr       error
-	MockableCheckInInfo              *model.OOAPICheckInNettests
+	MockableCheckInInfo              *model.OOAPICheckInResultNettests
 	MockableCheckInErr               error
 	MockableResolverIP               string
 	MockableSoftwareName             string

--- a/internal/model/mocks/session.go
+++ b/internal/model/mocks/session.go
@@ -55,7 +55,7 @@ type Session struct {
 	MockNewSubmitter func(ctx context.Context) (model.Submitter, error)
 
 	MockCheckIn func(ctx context.Context,
-		config *model.OOAPICheckInConfig) (*model.OOAPICheckInNettests, error)
+		config *model.OOAPICheckInConfig) (*model.OOAPICheckInResultNettests, error)
 }
 
 func (sess *Session) GetTestHelpersByName(name string) ([]model.OOAPIService, bool) {
@@ -148,6 +148,6 @@ func (sess *Session) NewSubmitter(ctx context.Context) (model.Submitter, error) 
 }
 
 func (sess *Session) CheckIn(ctx context.Context,
-	config *model.OOAPICheckInConfig) (*model.OOAPICheckInNettests, error) {
+	config *model.OOAPICheckInConfig) (*model.OOAPICheckInResultNettests, error) {
 	return sess.MockCheckIn(ctx, config)
 }

--- a/internal/model/mocks/session_test.go
+++ b/internal/model/mocks/session_test.go
@@ -326,7 +326,7 @@ func TestSession(t *testing.T) {
 	t.Run("CheckIn", func(t *testing.T) {
 		expected := errors.New("mocked err")
 		s := &Session{
-			MockCheckIn: func(ctx context.Context, config *model.OOAPICheckInConfig) (*model.OOAPICheckInNettests, error) {
+			MockCheckIn: func(ctx context.Context, config *model.OOAPICheckInConfig) (*model.OOAPICheckInResultNettests, error) {
 				return nil, expected
 			},
 		}

--- a/internal/model/ooapi.go
+++ b/internal/model/ooapi.go
@@ -55,8 +55,9 @@ type OOAPICheckInInfoWebConnectivity struct {
 	URLs []OOAPIURLInfo `json:"urls"`
 }
 
-// OOAPICheckInNettests contains nettest information returned by the checkin API call.
-type OOAPICheckInNettests struct {
+// OOAPICheckInResultNettests contains nettests information
+// returned by the checkin API call.
+type OOAPICheckInResultNettests struct {
 	// WebConnectivity contains WebConnectivity related information.
 	WebConnectivity *OOAPICheckInInfoWebConnectivity `json:"web_connectivity"`
 }
@@ -70,7 +71,7 @@ type OOAPICheckInResult struct {
 	ProbeCC string `json:"probe_cc"`
 
 	// Tests contains information about nettests.
-	Tests OOAPICheckInNettests `json:"tests"`
+	Tests OOAPICheckInResultNettests `json:"tests"`
 
 	// V is the version.
 	V int64 `json:"v"`

--- a/internal/probeservices/checkin.go
+++ b/internal/probeservices/checkin.go
@@ -13,7 +13,7 @@ import (
 // Returns the list of tests to run and the URLs, on success,
 // or an explanatory error, in case of failure.
 func (c Client) CheckIn(
-	ctx context.Context, config model.OOAPICheckInConfig) (*model.OOAPICheckInNettests, error) {
+	ctx context.Context, config model.OOAPICheckInConfig) (*model.OOAPICheckInResultNettests, error) {
 	epnt := c.newHTTPAPIEndpoint()
 	desc := ooapi.NewDescriptorCheckIn(&config)
 	resp, err := httpapi.Call(ctx, desc, epnt)


### PR DESCRIPTION
Specifically, name it ...ResultNettests such that it's clear by inspection that this structure belongs to the results.

Part of https://github.com/ooni/probe/issues/2396

