### PR TITLE
fix(httpapi): don't return nil, nil with null JSON input

### DIFF
--- a/internal/httpapi/call_test.go
+++ b/internal/httpapi/call_test.go
@@ -1015,6 +1015,11 @@ func TestCallWithJSON(t *testing.T) {
 		want:         nil,
 		wantErr:      errors.New("unexpected end of JSON input"),
 	}, {
+		name:         "with literal null response",
+		bodyToReturn: []byte(`null`),
+		want:         &CallStructResponse{},
+		wantErr:      nil,
+	}, {
 		name:         "with good response",
 		bodyToReturn: []byte(`{"Name": "sbs", "AgeSquared": 1156}`),
 		want: &CallStructResponse{
@@ -1053,7 +1058,7 @@ func TestCallWithJSON(t *testing.T) {
 				Request: &RequestDescriptor[*CallStructRequest]{
 					Body: []byte(`{"Name": "sbs", "Age": 34}`),
 				},
-				Response: &JSONResponseDescriptor[*CallStructResponse]{},
+				Response: &JSONResponseDescriptor[CallStructResponse]{},
 				Timeout:  0,
 				URLPath:  "/",
 				URLQuery: nil,

--- a/internal/httpapi/descriptor.go
+++ b/internal/httpapi/descriptor.go
@@ -52,6 +52,13 @@ func (r *JSONResponseDescriptor[T]) Unmarshal(resp *http.Response, data []byte) 
 	// returned pointer also being nil, but they just need to worry about
 	// whether any field inside the returned struct is the zero value.
 	//
+	// (Of course, the above reasoning breaks if the caller asks for a T
+	// equal to `*Foo`, which causes the return value to be `**Foo`. That
+	// said, in all cases in OONI we have T equal to `Foo` and we return
+	// a `*Foo` type. This scenario is, in fact, the only one making sense
+	// when you're reading a JSON from a server. So, while the problem is
+	// only solved for a sub-problem, this sub-problem is the one that matters.)
+	//
 	// Because this safety property is important, there is also a test that
 	// makes sure we don't return `nil`, `nil` with `null` input.
 	var value T

--- a/internal/ooapi/checkin.go
+++ b/internal/ooapi/checkin.go
@@ -31,7 +31,7 @@ func NewDescriptorCheckIn(
 		Request: &httpapi.RequestDescriptor[*model.OOAPICheckInConfig]{
 			Body: rawRequest,
 		},
-		Response: &httpapi.JSONResponseDescriptor[*model.OOAPICheckInResult]{},
+		Response: &httpapi.JSONResponseDescriptor[model.OOAPICheckInResult]{},
 		Timeout:  0,
 		URLPath:  "/api/v1/check-in",
 		URLQuery: nil,

--- a/internal/ooapi/th.go
+++ b/internal/ooapi/th.go
@@ -31,7 +31,7 @@ func NewDescriptorTH(
 		Request: &httpapi.RequestDescriptor[*model.THRequest]{
 			Body: rawRequest,
 		},
-		Response: &httpapi.JSONResponseDescriptor[*model.THResponse]{},
+		Response: &httpapi.JSONResponseDescriptor[model.THResponse]{},
 		Timeout:  0,
 		URLPath:  "/",
 		URLQuery: nil,


### PR DESCRIPTION
While working on https://github.com/ooni/probe/issues/2396, I noticed
that the httpapi code could return nil, nil when the input from the
server was the `null` UTF-8 string. In such a case, golang translates
the `null` string into a `nil` pointer. However, if we pass the
pointer to a struct rather than the pointer to a pointer, the code
returns an empty struct, which is much safer.

This reasoning works as long as we assume the caller wants to get
a struct by pointer or nil on error. If the caller for some reason
wants the code to return a `**T` type, we're back in the case where
the code can return `nil`, `nil`. But all our code always wants
a `*T` back and this seems the only case that makes sense.