### PR TITLE
feat(shellx): support incremental command construction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,8 +68,8 @@ run `go mod tidy` to minimize such changes.
 
 ## Implementation requirements
 
-- consider using `./internal/shellx` instead of `os/exec` if `shellx`
-implements the functionality you need
+- always use `x/sys/execabs` or `./internal/shellx` instead of
+using the `os/exec` package directly
 
 - use `./internal/fsx.OpenFile` when you need to open a file
 

--- a/internal/shellx/shellx.go
+++ b/internal/shellx/shellx.go
@@ -138,7 +138,7 @@ func cmd(config *Config, argv *Argv, envp *Envp) *execabs.Cmd {
 		cmd.Env = append(cmd.Env, entry)
 	}
 	if config.Logger != nil {
-		cmdline := quotedCommandLine(argv.P, argv.V...)
+		cmdline := quotedCommandLineUnsafe(argv.P, argv.V...)
 		config.Logger.Infof("+ %s", cmdline)
 	}
 	return cmd
@@ -204,8 +204,7 @@ func run(logger model.Logger, flags int64, command string, args ...string) error
 	return RunEx(config, argv, envp)
 }
 
-// RunQuiet runs the given command without emitting any output and
-// using the environment variables in the current [Envp].
+// RunQuiet runs the given command without emitting any output.
 func RunQuiet(command string, args ...string) error {
 	return run(nil, 0, command, args...)
 }
@@ -272,18 +271,20 @@ func OutputCommandLine(logger model.Logger, cmdline string) ([]byte, error) {
 // ErrNoCommandToExecute means that the command line is empty.
 var ErrNoCommandToExecute = errors.New("shellx: no command to execute")
 
-// quotedCommandLine returns a quoted command line.
-func quotedCommandLine(command string, args ...string) string {
+// quotedCommandLineUnsafe returns a quoted command line. This function is unsafe
+// and SHOULD only be used to produce a nice output.
+func quotedCommandLineUnsafe(command string, args ...string) string {
 	v := []string{}
-	v = append(v, maybeQuoteArg(command))
+	v = append(v, maybeQuoteArgUnsafe(command))
 	for _, a := range args {
-		v = append(v, maybeQuoteArg(a))
+		v = append(v, maybeQuoteArgUnsafe(a))
 	}
 	return strings.Join(v, " ")
 }
 
-// maybeQuoteArg quotes a command line argument if needed.
-func maybeQuoteArg(a string) string {
+// maybeQuoteArgUnsafe quotes a command line argument if needed. This function is unsafe
+// and SHOULD only be used to produce a nice output.
+func maybeQuoteArgUnsafe(a string) string {
 	if strings.Contains(a, "\"") {
 		a = strings.ReplaceAll(a, "\"", "\\\"")
 	}

--- a/internal/shellx/shellx.go
+++ b/internal/shellx/shellx.go
@@ -117,8 +117,9 @@ type Config struct {
 
 // cmd creates a new [execabs.Cmd] instance.
 func cmd(config *Config, argv *Argv, envp *Envp) *execabs.Cmd {
-	// Implementation note: since Go 1.19 we don't need to use the execabs
-	// package anymore. See <https://tip.golang.org/doc/go1.19>.
+	// Implementation note: in go1.19, os/exec does not use "." for searching
+	// the path except for Windows (IIUC). Because of that, let's keep using
+	// x/sys/execabs everywhere. See <https://tip.golang.org/doc/go1.19>.
 	cmd := execabs.Command(argv.P, argv.V...)
 	cmd.Env = os.Environ()
 	for _, entry := range envp.V {

--- a/internal/shellx/shellx.go
+++ b/internal/shellx/shellx.go
@@ -117,9 +117,18 @@ type Config struct {
 
 // cmd creates a new [execabs.Cmd] instance.
 func cmd(config *Config, argv *Argv, envp *Envp) *execabs.Cmd {
-	// Implementation note: in go1.19, os/exec does not use "." for searching
-	// the path except for Windows (IIUC). Because of that, let's keep using
-	// x/sys/execabs everywhere. See <https://tip.golang.org/doc/go1.19>.
+	// Implementation note: go1.19 release notes says about os/exec:
+	//
+	//	[...]
+	//
+	//	On Windows, Command and LookPath now respect the NoDefaultCurrentDirectoryInExePath
+	//	environment variable, making it possible to disable the default implicit search
+	//	of “.” in PATH lookups on Windows systems.
+	//
+	// I would rather not use "." for search paths on Windows as well,
+	// hence the choice to keep using x/sys/execabs everywhere.
+	//
+	// See <https://tip.golang.org/doc/go1.19> for more information.
 	cmd := execabs.Command(argv.P, argv.V...)
 	cmd.Env = os.Environ()
 	for _, entry := range envp.V {

--- a/internal/shellx/shellx.go
+++ b/internal/shellx/shellx.go
@@ -7,24 +7,24 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/google/shlex"
 	"github.com/ooni/probe-cli/v3/internal/fsx"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
+	"golang.org/x/sys/execabs"
 )
 
 // Dependencies is the library on which this package depends.
 type Dependencies interface {
 	// CmdOutput is equivalent to calling c.Output.
-	CmdOutput(c *exec.Cmd) ([]byte, error)
+	CmdOutput(c *execabs.Cmd) ([]byte, error)
 
 	// CmdRun is equivalent to calling c.Run.
-	CmdRun(c *exec.Cmd) error
+	CmdRun(c *execabs.Cmd) error
 
-	// LookPath is equivalent to calling exec.LookPath.
+	// LookPath is equivalent to calling execabs.LookPath.
 	LookPath(file string) (string, error)
 }
 
@@ -35,18 +35,18 @@ var Library Dependencies = &StdlibDependencies{}
 type StdlibDependencies struct{}
 
 // CmdOutput implements [Dependencies].
-func (*StdlibDependencies) CmdOutput(c *exec.Cmd) ([]byte, error) {
+func (*StdlibDependencies) CmdOutput(c *execabs.Cmd) ([]byte, error) {
 	return c.Output()
 }
 
 // CmdRun implements [Dependencies].
-func (*StdlibDependencies) CmdRun(c *exec.Cmd) error {
+func (*StdlibDependencies) CmdRun(c *execabs.Cmd) error {
 	return c.Run()
 }
 
 // LookPath implements [Dependencies].
 func (*StdlibDependencies) LookPath(file string) (string, error) {
-	return exec.LookPath(file)
+	return execabs.LookPath(file)
 }
 
 // Envp is the environment in which we execute commands.
@@ -115,11 +115,11 @@ type Config struct {
 	Flags int64
 }
 
-// cmd creates a new [exec.Cmd] instance.
-func cmd(config *Config, argv *Argv, envp *Envp) *exec.Cmd {
+// cmd creates a new [execabs.Cmd] instance.
+func cmd(config *Config, argv *Argv, envp *Envp) *execabs.Cmd {
 	// Implementation note: since Go 1.19 we don't need to use the execabs
 	// package anymore. See <https://tip.golang.org/doc/go1.19>.
-	cmd := exec.Command(argv.P, argv.V...)
+	cmd := execabs.Command(argv.P, argv.V...)
 	cmd.Env = os.Environ()
 	for _, entry := range envp.V {
 		if config.Logger != nil {

--- a/internal/shellx/shellx_test.go
+++ b/internal/shellx/shellx_test.go
@@ -1,15 +1,22 @@
 package shellx
 
 import (
+	"context"
 	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/probe-cli/v3/internal/fsx"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/model/mocks"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
 // testGolangExe is the golang exe to use in this test suite
@@ -48,10 +55,131 @@ func testLogger() (model.Logger, *atomic.Int64) {
 	return log, n
 }
 
+func TestVerifyWeCanAppendToArgv(t *testing.T) {
+	argv1, err := NewArgv(testGolangExe, "run", "./testdata/checkenv.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	argv2, err := NewArgv(testGolangExe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	argv2.Append("run")
+	argv2.Append("./testdata/checkenv.go")
+	if diff := cmp.Diff(argv1, argv2); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestVerifyWeAddEnvironmentVariables(t *testing.T) {
+	env := &Envp{}
+
+	// Add the expected environment variables. The command we're
+	// going to run will exit(1) if it cannot find them.
+	env.Append("ANTANI", "antani")
+	env.Append("MASCETTI", "mascetti")
+	env.Append("STUZZICA", "stuzzica")
+
+	argv, err := NewArgv(testGolangExe, "run", "./testdata/checkenv.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := &Config{
+		Logger: model.DiscardLogger,
+		Flags:  FlagShowStdoutStderr,
+	}
+
+	t.Run("for OutputEx", func(t *testing.T) {
+		out, err := OutputEx(config, argv, env)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(out) > 0 {
+			t.Fatal("expected no output")
+		}
+	})
+
+	t.Run("for RunEx", func(t *testing.T) {
+		if err := RunEx(config, argv, env); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestOutput(t *testing.T) {
+	t.Run("with a valid command", func(t *testing.T) {
+		log, count := testLogger()
+		output, err := Output(log, testGolangExe, "env")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(output) <= 0 {
+			t.Fatal("expected to see output")
+		}
+		if n := count.Load(); n != 1 {
+			t.Fatal("expected one log message, got", n)
+		}
+	})
+
+	t.Run("with an invalid command", func(t *testing.T) {
+		log, count := testLogger()
+		output, err := Output(log, "nonexistent", "env")
+		if !testErrorIsExecutableNotFound(err) {
+			t.Fatal("unexpected error", err)
+		}
+		if len(output) > 0 {
+			t.Fatal("expected to see no output")
+		}
+		if n := count.Load(); n != 0 {
+			t.Fatal("expected zero log messages, got", n)
+		}
+	})
+}
+
+func TestOutputQuiet(t *testing.T) {
+	t.Run("with a valid command", func(t *testing.T) {
+		output, err := OutputQuiet(testGolangExe, "env")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(output) <= 0 {
+			t.Fatal("expected to see output")
+		}
+	})
+
+	t.Run("with an invalid command", func(t *testing.T) {
+		output, err := OutputQuiet("nonexistent", "env")
+		if !testErrorIsExecutableNotFound(err) {
+			t.Fatal("unexpected error", err)
+		}
+		if len(output) > 0 {
+			t.Fatal("expected to see no output")
+		}
+	})
+}
+
+func TestRunQuiet(t *testing.T) {
+	t.Run("with a valid command", func(t *testing.T) {
+		err := RunQuiet(testGolangExe, "env")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("with an invalid command", func(t *testing.T) {
+		err := RunQuiet("nonexistent", "env")
+		if !testErrorIsExecutableNotFound(err) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+}
+
 func TestRun(t *testing.T) {
 	t.Run("with a valid command", func(t *testing.T) {
 		log, count := testLogger()
-		if err := Run(log, testGolangExe, "version"); err != nil {
+		err := Run(log, testGolangExe, "env")
+		if err != nil {
 			t.Fatal(err)
 		}
 		if n := count.Load(); n != 1 {
@@ -61,7 +189,7 @@ func TestRun(t *testing.T) {
 
 	t.Run("with an invalid command", func(t *testing.T) {
 		log, count := testLogger()
-		err := Run(log, "nonexistent", "version")
+		err := Run(log, "nonexistent", "env")
 		if !testErrorIsExecutableNotFound(err) {
 			t.Fatal("unexpected error", err)
 		}
@@ -71,26 +199,22 @@ func TestRun(t *testing.T) {
 	})
 }
 
-func TestRunQuiet(t *testing.T) {
+func TestRunCommandLine(t *testing.T) {
 	t.Run("with a valid command", func(t *testing.T) {
-		if err := RunQuiet(testGolangExe, "version"); err != nil {
+		log, count := testLogger()
+		err := RunCommandLine(log, testGolangExe+" env")
+		if err != nil {
 			t.Fatal(err)
+		}
+		if n := count.Load(); n != 1 {
+			t.Fatal("expected one log message, got", n)
 		}
 	})
 
 	t.Run("with an invalid command", func(t *testing.T) {
-		err := RunQuiet("nonexistent", "version")
-		if !testErrorIsExecutableNotFound(err) {
-			t.Fatal("unexpected error", err)
-		}
-	})
-}
-
-func TestRunCommandline(t *testing.T) {
-	t.Run("when the command does not parse", func(t *testing.T) {
 		log, count := testLogger()
-		err := RunCommandLine(log, `"foobar`)
-		if !testErrorIsCannotParseCmdLine(err) {
+		err := RunCommandLine(log, "nonexistent env")
+		if !testErrorIsExecutableNotFound(err) {
 			t.Fatal("unexpected error", err)
 		}
 		if n := count.Load(); n != 0 {
@@ -98,7 +222,7 @@ func TestRunCommandline(t *testing.T) {
 		}
 	})
 
-	t.Run("when we have no arguments", func(t *testing.T) {
+	t.Run("with empty command line", func(t *testing.T) {
 		log, count := testLogger()
 		err := RunCommandLine(log, "")
 		if !errors.Is(err, ErrNoCommandToExecute) {
@@ -109,377 +233,111 @@ func TestRunCommandline(t *testing.T) {
 		}
 	})
 
-	t.Run("when we have arguments", func(t *testing.T) {
+	t.Run("with invalid command line", func(t *testing.T) {
 		log, count := testLogger()
-		if err := RunCommandLine(log, testGolangExe+" version"); err != nil {
+		err := RunCommandLine(log, "\"foobar")
+		if !testErrorIsCannotParseCmdLine(err) {
+			t.Fatal("unexpected error", err)
+		}
+		if n := count.Load(); n != 0 {
+			t.Fatal("expected zero log messages, got", n)
+		}
+	})
+}
+
+func TestRunCommandLineQuiet(t *testing.T) {
+	t.Run("with a valid command", func(t *testing.T) {
+		err := RunCommandLineQuiet(testGolangExe + " env")
+		if err != nil {
 			t.Fatal(err)
+		}
+	})
+
+	t.Run("with an invalid command", func(t *testing.T) {
+		err := RunCommandLineQuiet("nonexistent env")
+		if !testErrorIsExecutableNotFound(err) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+}
+
+func TestOutputCommandLine(t *testing.T) {
+	t.Run("with a valid command", func(t *testing.T) {
+		log, count := testLogger()
+		output, err := OutputCommandLine(log, testGolangExe+" env")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(output) <= 0 {
+			t.Fatal("expected to see output")
 		}
 		if n := count.Load(); n != 1 {
 			t.Fatal("expected one log message, got", n)
 		}
 	})
-}
 
-func TestRunCommandlineQuiet(t *testing.T) {
-	t.Run("when the command does not parse", func(t *testing.T) {
-		err := RunCommandLineQuiet(`"foobar`)
-		if !testErrorIsCannotParseCmdLine(err) {
+	t.Run("with an invalid command", func(t *testing.T) {
+		log, count := testLogger()
+		output, err := OutputCommandLine(log, "nonexistent env")
+		if !testErrorIsExecutableNotFound(err) {
 			t.Fatal("unexpected error", err)
+		}
+		if len(output) > 0 {
+			t.Fatal("expected to see no output")
+		}
+		if n := count.Load(); n != 0 {
+			t.Fatal("expected zero log messages, got", n)
 		}
 	})
 
-	t.Run("when we have no arguments", func(t *testing.T) {
-		err := RunCommandLineQuiet("")
+	t.Run("with empty command line", func(t *testing.T) {
+		log, count := testLogger()
+		output, err := OutputCommandLine(log, "")
 		if !errors.Is(err, ErrNoCommandToExecute) {
 			t.Fatal("unexpected error", err)
 		}
+		if len(output) > 0 {
+			t.Fatal("expected to see no output")
+		}
+		if n := count.Load(); n != 0 {
+			t.Fatal("expected zero log messages, got", n)
+		}
 	})
 
-	t.Run("when we have arguments", func(t *testing.T) {
-		if err := RunCommandLineQuiet(testGolangExe + " version"); err != nil {
-			t.Fatal(err)
+	t.Run("with a command line that does not parse", func(t *testing.T) {
+		log, count := testLogger()
+		output, err := OutputCommandLine(log, "\"foobar")
+		if !testErrorIsCannotParseCmdLine(err) {
+			t.Fatal("unexpected error", err)
+		}
+		if len(output) > 0 {
+			t.Fatal("expected to see no output")
+		}
+		if n := count.Load(); n != 0 {
+			t.Fatal("expected zero log messages, got", n)
 		}
 	})
 }
 
-func TestEnv(t *testing.T) {
-
-	t.Run("we verify we can add environment variables", func(t *testing.T) {
-		env := &Env{}
-
-		// Add the expected environment variables. The command we're
-		// going to run will exit(1) if it cannot find them.
-		env.Append("ANTANI", "antani")
-		env.Append("MASCETTI", "mascetti")
-		env.Append("STUZZICA", "stuzzica")
-
-		t.Run("for OutputQuiet", func(t *testing.T) {
-			_, err := env.OutputQuiet(testGolangExe, "run", "./testdata/checkenv.go")
-			if err != nil {
-				t.Fatal(err)
-			}
-		})
-
-		t.Run("for Output", func(t *testing.T) {
-			_, err := env.Output(model.DiscardLogger, testGolangExe, "run", "./testdata/checkenv.go")
-			if err != nil {
-				t.Fatal(err)
-			}
-		})
-
-		t.Run("for RunQuiet", func(t *testing.T) {
-			t.Log(env.Vars)
-			err := env.RunQuiet(testGolangExe, "run", "./testdata/checkenv.go")
-			if err != nil {
-				t.Fatal(err)
-			}
-		})
-
-		t.Run("for Run", func(t *testing.T) {
-			err := env.Run(model.DiscardLogger, testGolangExe, "run", "./testdata/checkenv.go")
-			if err != nil {
-				t.Fatal(err)
-			}
-		})
-
-		t.Run("for RunCommandLineQuiet", func(t *testing.T) {
-			err := env.RunCommandLineQuiet(testGolangExe + " run ./testdata/checkenv.go")
-			if err != nil {
-				t.Fatal(err)
-			}
-		})
-
-		t.Run("for RunCommandLine", func(t *testing.T) {
-			err := env.RunCommandLine(model.DiscardLogger, testGolangExe+" run ./testdata/checkenv.go")
-			if err != nil {
-				t.Fatal(err)
-			}
-		})
+func TestOutputCommandLineQuiet(t *testing.T) {
+	t.Run("with a valid command", func(t *testing.T) {
+		output, err := OutputCommandLineQuiet(testGolangExe + " env")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(output) <= 0 {
+			t.Fatal("expected to see output")
+		}
 	})
 
-	t.Run("Output", func(t *testing.T) {
-		t.Run("with a valid command", func(t *testing.T) {
-			log, count := testLogger()
-			env := &Env{}
-			output, err := env.Output(log, testGolangExe, "env")
-			if err != nil {
-				t.Fatal(err)
-			}
-			if len(output) <= 0 {
-				t.Fatal("expected to see output")
-			}
-			if n := count.Load(); n != 1 {
-				t.Fatal("expected one log message, got", n)
-			}
-		})
-
-		t.Run("with an invalid command", func(t *testing.T) {
-			log, count := testLogger()
-			env := &Env{}
-			output, err := env.Output(log, "nonexistent", "env")
-			if !testErrorIsExecutableNotFound(err) {
-				t.Fatal("unexpected error", err)
-			}
-			if len(output) > 0 {
-				t.Fatal("expected to see no output")
-			}
-			if n := count.Load(); n != 0 {
-				t.Fatal("expected zero log messages, got", n)
-			}
-		})
-	})
-
-	t.Run("OutputQuiet", func(t *testing.T) {
-		t.Run("with a valid command", func(t *testing.T) {
-			env := &Env{}
-			output, err := env.OutputQuiet(testGolangExe, "env")
-			if err != nil {
-				t.Fatal(err)
-			}
-			if len(output) <= 0 {
-				t.Fatal("expected to see output")
-			}
-		})
-
-		t.Run("with an invalid command", func(t *testing.T) {
-			env := &Env{}
-			output, err := env.OutputQuiet("nonexistent", "env")
-			if !testErrorIsExecutableNotFound(err) {
-				t.Fatal("unexpected error", err)
-			}
-			if len(output) > 0 {
-				t.Fatal("expected to see no output")
-			}
-		})
-	})
-
-	t.Run("RunQuiet", func(t *testing.T) {
-		t.Run("with a valid command", func(t *testing.T) {
-			env := &Env{}
-			err := env.RunQuiet(testGolangExe, "env")
-			if err != nil {
-				t.Fatal(err)
-			}
-		})
-
-		t.Run("with an invalid command", func(t *testing.T) {
-			env := &Env{}
-			err := env.RunQuiet("nonexistent", "env")
-			if !testErrorIsExecutableNotFound(err) {
-				t.Fatal("unexpected error", err)
-			}
-		})
-	})
-
-	t.Run("Run", func(t *testing.T) {
-		t.Run("with a valid command", func(t *testing.T) {
-			env := &Env{}
-			log, count := testLogger()
-			err := env.Run(log, testGolangExe, "env")
-			if err != nil {
-				t.Fatal(err)
-			}
-			if n := count.Load(); n != 1 {
-				t.Fatal("expected one log message, got", n)
-			}
-		})
-
-		t.Run("with an invalid command", func(t *testing.T) {
-			env := &Env{}
-			log, count := testLogger()
-			err := env.Run(log, "nonexistent", "env")
-			if !testErrorIsExecutableNotFound(err) {
-				t.Fatal("unexpected error", err)
-			}
-			if n := count.Load(); n != 0 {
-				t.Fatal("expected zero log messages, got", n)
-			}
-		})
-	})
-
-	t.Run("RunCommandLine", func(t *testing.T) {
-		t.Run("with a valid command", func(t *testing.T) {
-			env := &Env{}
-			log, count := testLogger()
-			err := env.RunCommandLine(log, testGolangExe+" env")
-			if err != nil {
-				t.Fatal(err)
-			}
-			if n := count.Load(); n != 1 {
-				t.Fatal("expected one log message, got", n)
-			}
-		})
-
-		t.Run("with an invalid command", func(t *testing.T) {
-			env := &Env{}
-			log, count := testLogger()
-			err := env.RunCommandLine(log, "nonexistent env")
-			if !testErrorIsExecutableNotFound(err) {
-				t.Fatal("unexpected error", err)
-			}
-			if n := count.Load(); n != 0 {
-				t.Fatal("expected zero log messages, got", n)
-			}
-		})
-
-		t.Run("with empty command line", func(t *testing.T) {
-			env := &Env{}
-			log, count := testLogger()
-			err := env.RunCommandLine(log, "")
-			if !errors.Is(err, ErrNoCommandToExecute) {
-				t.Fatal("unexpected error", err)
-			}
-			if n := count.Load(); n != 0 {
-				t.Fatal("expected zero log messages, got", n)
-			}
-		})
-
-		t.Run("with invalid command line", func(t *testing.T) {
-			env := &Env{}
-			log, count := testLogger()
-			err := env.RunCommandLine(log, "\"foobar")
-			if !testErrorIsCannotParseCmdLine(err) {
-				t.Fatal("unexpected error", err)
-			}
-			if n := count.Load(); n != 0 {
-				t.Fatal("expected zero log messages, got", n)
-			}
-		})
-	})
-
-	t.Run("RunCommandLineQuiet", func(t *testing.T) {
-		t.Run("with a valid command", func(t *testing.T) {
-			env := &Env{}
-			err := env.RunCommandLineQuiet(testGolangExe + " env")
-			if err != nil {
-				t.Fatal(err)
-			}
-		})
-
-		t.Run("with an invalid command", func(t *testing.T) {
-			env := &Env{}
-			err := env.RunCommandLineQuiet("nonexistent env")
-			if !testErrorIsExecutableNotFound(err) {
-				t.Fatal("unexpected error", err)
-			}
-		})
-	})
-
-	t.Run("OutputCommandLine", func(t *testing.T) {
-		t.Run("with a valid command", func(t *testing.T) {
-			env := &Env{}
-			log, count := testLogger()
-			output, err := env.OutputCommandLine(log, testGolangExe+" env")
-			if err != nil {
-				t.Fatal(err)
-			}
-			if len(output) <= 0 {
-				t.Fatal("expected to see output")
-			}
-			if n := count.Load(); n != 1 {
-				t.Fatal("expected one log message, got", n)
-			}
-		})
-
-		t.Run("with an invalid command", func(t *testing.T) {
-			env := &Env{}
-			log, count := testLogger()
-			output, err := env.OutputCommandLine(log, "nonexistent env")
-			if !testErrorIsExecutableNotFound(err) {
-				t.Fatal("unexpected error", err)
-			}
-			if len(output) > 0 {
-				t.Fatal("expected to see no output")
-			}
-			if n := count.Load(); n != 0 {
-				t.Fatal("expected zero log messages, got", n)
-			}
-		})
-
-		t.Run("with empty command line", func(t *testing.T) {
-			env := &Env{}
-			log, count := testLogger()
-			output, err := env.OutputCommandLine(log, "")
-			if !errors.Is(err, ErrNoCommandToExecute) {
-				t.Fatal("unexpected error", err)
-			}
-			if len(output) > 0 {
-				t.Fatal("expected to see no output")
-			}
-			if n := count.Load(); n != 0 {
-				t.Fatal("expected zero log messages, got", n)
-			}
-		})
-
-		t.Run("with a command line that does not parse", func(t *testing.T) {
-			env := &Env{}
-			log, count := testLogger()
-			output, err := env.OutputCommandLine(log, "\"foobar")
-			if !testErrorIsCannotParseCmdLine(err) {
-				t.Fatal("unexpected error", err)
-			}
-			if len(output) > 0 {
-				t.Fatal("expected to see no output")
-			}
-			if n := count.Load(); n != 0 {
-				t.Fatal("expected zero log messages, got", n)
-			}
-		})
-
-		t.Run("with environment variables", func(t *testing.T) {
-			env := &Env{}
-			log, count := testLogger()
-			env.Append("GOCACHE", "/foobar")
-			env.Append("FOO", "/foobar")
-			output, err := env.OutputCommandLine(log, "go env GOCACHE")
-			if err != nil {
-				t.Fatal(err)
-			}
-			expected := []byte("/foobar\n")
-			if diff := cmp.Diff(expected, output); diff != "" {
-				t.Fatal(diff)
-			}
-			if n := count.Load(); n != 3 {
-				t.Fatal("expected three log messages, got", n)
-			}
-		})
-	})
-
-	t.Run("OutputCommandLineQuiet", func(t *testing.T) {
-		t.Run("with a valid command", func(t *testing.T) {
-			env := &Env{}
-			output, err := env.OutputCommandLineQuiet(testGolangExe + " env")
-			if err != nil {
-				t.Fatal(err)
-			}
-			if len(output) <= 0 {
-				t.Fatal("expected to see output")
-			}
-		})
-
-		t.Run("with an invalid command", func(t *testing.T) {
-			env := &Env{}
-			output, err := env.OutputCommandLineQuiet("nonexistent env")
-			if !testErrorIsExecutableNotFound(err) {
-				t.Fatal("unexpected error", err)
-			}
-			if len(output) > 0 {
-				t.Fatal("expected to see no output")
-			}
-		})
-
-		t.Run("with environment variables", func(t *testing.T) {
-			env := &Env{}
-			env.Append("GOCACHE", "/foobar")
-			output, err := env.OutputCommandLineQuiet("go env GOCACHE")
-			if err != nil {
-				t.Fatal(err)
-			}
-			expected := []byte("/foobar\n")
-			if diff := cmp.Diff(expected, output); diff != "" {
-				t.Fatal(diff)
-			}
-		})
+	t.Run("with an invalid command", func(t *testing.T) {
+		output, err := OutputCommandLineQuiet("nonexistent env")
+		if !testErrorIsExecutableNotFound(err) {
+			t.Fatal("unexpected error", err)
+		}
+		if len(output) > 0 {
+			t.Fatal("expected to see no output")
+		}
 	})
 }
 
@@ -527,4 +385,74 @@ func Test_maybeQuoteArg(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCopyFile(t *testing.T) {
+	t.Run("in case of success", func(t *testing.T) {
+		source := filepath.Join("testdata", "checkenv.go")
+		expected, err := os.ReadFile(source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dest := filepath.Join("testdata", "copy.txt")
+		defer os.Remove(dest)
+		if err := CopyFile(source, dest, 0600); err != nil {
+			t.Fatal(err)
+		}
+		got, err := os.ReadFile(dest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(expected, got); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
+	t.Run("if we cannot open the source file", func(t *testing.T) {
+		source := filepath.Join("testdata", "checkenv.go")
+		dest := filepath.Join("testdata", "copy.txt")
+		defer os.Remove(dest)
+		expected := errors.New("mocked error")
+		fsxOpenFile = func(pathname string) (fs.File, error) {
+			return nil, expected
+		}
+		defer func() {
+			fsxOpenFile = fsx.OpenFile
+		}()
+		if err := CopyFile(source, dest, 0600); !errors.Is(err, expected) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("if we cannot open the dest file", func(t *testing.T) {
+		source := filepath.Join("testdata", "checkenv.go")
+		dest := filepath.Join("testdata", "copy.txt")
+		defer os.Remove(dest)
+		expected := errors.New("mocked error")
+		osOpenFile = func(name string, flag int, perm os.FileMode) (*os.File, error) {
+			return nil, expected
+		}
+		defer func() {
+			osOpenFile = os.OpenFile
+		}()
+		if err := CopyFile(source, dest, 0600); !errors.Is(err, expected) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("if we cannot copy", func(t *testing.T) {
+		source := filepath.Join("testdata", "checkenv.go")
+		dest := filepath.Join("testdata", "copy.txt")
+		defer os.Remove(dest)
+		expected := errors.New("mocked error")
+		netxliteCopyContext = func(ctx context.Context, dst io.Writer, src io.Reader) (int64, error) {
+			return 0, expected
+		}
+		defer func() {
+			netxliteCopyContext = netxlite.CopyContext
+		}()
+		if err := CopyFile(source, dest, 0600); !errors.Is(err, expected) {
+			t.Fatal("unexpected error", err)
+		}
+	})
 }

--- a/internal/shellx/shellx_test.go
+++ b/internal/shellx/shellx_test.go
@@ -75,7 +75,7 @@ func TestVerifyWeAddEnvironmentVariables(t *testing.T) {
 	env := &Envp{}
 
 	// Add the expected environment variables. The command we're
-	// going to run will exit(1) if it cannot find them.
+	// going to run will exit with nonzero exit code if it cannot find them.
 	env.Append("ANTANI", "antani")
 	env.Append("MASCETTI", "mascetti")
 	env.Append("STUZZICA", "stuzzica")
@@ -200,7 +200,7 @@ func TestRun(t *testing.T) {
 }
 
 func TestRunCommandLine(t *testing.T) {
-	t.Run("with a valid command", func(t *testing.T) {
+	t.Run("with a valid command line", func(t *testing.T) {
 		log, count := testLogger()
 		err := RunCommandLine(log, testGolangExe+" env")
 		if err != nil {
@@ -211,7 +211,7 @@ func TestRunCommandLine(t *testing.T) {
 		}
 	})
 
-	t.Run("with an invalid command", func(t *testing.T) {
+	t.Run("with an invalid command line", func(t *testing.T) {
 		log, count := testLogger()
 		err := RunCommandLine(log, "nonexistent env")
 		if !testErrorIsExecutableNotFound(err) {
@@ -233,7 +233,7 @@ func TestRunCommandLine(t *testing.T) {
 		}
 	})
 
-	t.Run("with invalid command line", func(t *testing.T) {
+	t.Run("with a command line that does not parse", func(t *testing.T) {
 		log, count := testLogger()
 		err := RunCommandLine(log, "\"foobar")
 		if !testErrorIsCannotParseCmdLine(err) {
@@ -246,23 +246,37 @@ func TestRunCommandLine(t *testing.T) {
 }
 
 func TestRunCommandLineQuiet(t *testing.T) {
-	t.Run("with a valid command", func(t *testing.T) {
+	t.Run("with a valid command line", func(t *testing.T) {
 		err := RunCommandLineQuiet(testGolangExe + " env")
 		if err != nil {
 			t.Fatal(err)
 		}
 	})
 
-	t.Run("with an invalid command", func(t *testing.T) {
+	t.Run("with an invalid command line", func(t *testing.T) {
 		err := RunCommandLineQuiet("nonexistent env")
 		if !testErrorIsExecutableNotFound(err) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("with empty command line", func(t *testing.T) {
+		err := RunCommandLineQuiet("")
+		if !errors.Is(err, ErrNoCommandToExecute) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("with a command line that does not parse", func(t *testing.T) {
+		err := RunCommandLineQuiet("\"foobar")
+		if !testErrorIsCannotParseCmdLine(err) {
 			t.Fatal("unexpected error", err)
 		}
 	})
 }
 
 func TestOutputCommandLine(t *testing.T) {
-	t.Run("with a valid command", func(t *testing.T) {
+	t.Run("with a valid command line", func(t *testing.T) {
 		log, count := testLogger()
 		output, err := OutputCommandLine(log, testGolangExe+" env")
 		if err != nil {
@@ -276,7 +290,7 @@ func TestOutputCommandLine(t *testing.T) {
 		}
 	})
 
-	t.Run("with an invalid command", func(t *testing.T) {
+	t.Run("with an invalid command line", func(t *testing.T) {
 		log, count := testLogger()
 		output, err := OutputCommandLine(log, "nonexistent env")
 		if !testErrorIsExecutableNotFound(err) {
@@ -339,9 +353,29 @@ func TestOutputCommandLineQuiet(t *testing.T) {
 			t.Fatal("expected to see no output")
 		}
 	})
+
+	t.Run("with empty command line", func(t *testing.T) {
+		output, err := OutputCommandLineQuiet("")
+		if !errors.Is(err, ErrNoCommandToExecute) {
+			t.Fatal("unexpected error", err)
+		}
+		if len(output) > 0 {
+			t.Fatal("expected to see no output")
+		}
+	})
+
+	t.Run("with a command line that does not parse", func(t *testing.T) {
+		output, err := OutputCommandLineQuiet("\"foobar")
+		if !testErrorIsCannotParseCmdLine(err) {
+			t.Fatal("unexpected error", err)
+		}
+		if len(output) > 0 {
+			t.Fatal("expected to see no output")
+		}
+	})
 }
 
-func Test_maybeQuoteArg(t *testing.T) {
+func Test_maybeQuoteArgUnsafe(t *testing.T) {
 	type args struct {
 		a string
 	}
@@ -380,7 +414,7 @@ func Test_maybeQuoteArg(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := maybeQuoteArg(tt.args.a); got != tt.want {
+			if got := maybeQuoteArgUnsafe(tt.args.a); got != tt.want {
 				t.Errorf("maybeQuoteArg() = %v, want %v", got, tt.want)
 			}
 		})

--- a/internal/shellx/shellxtesting/shellxtesting.go
+++ b/internal/shellx/shellxtesting/shellxtesting.go
@@ -3,17 +3,17 @@ package shellxtesting
 
 import (
 	"os"
-	"os/exec"
 
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 	"github.com/ooni/probe-cli/v3/internal/shellx"
+	"golang.org/x/sys/execabs"
 )
 
 // Library implements shellx.Dependencies.
 type Library struct {
-	MockCmdOutput func(c *exec.Cmd) ([]byte, error)
+	MockCmdOutput func(c *execabs.Cmd) ([]byte, error)
 
-	MockCmdRun func(c *exec.Cmd) error
+	MockCmdRun func(c *execabs.Cmd) error
 
 	MockLookPath func(file string) (string, error)
 }
@@ -21,12 +21,12 @@ type Library struct {
 var _ shellx.Dependencies = &Library{}
 
 // CmdOutput implements shellx.Dependencies
-func (lib *Library) CmdOutput(c *exec.Cmd) ([]byte, error) {
+func (lib *Library) CmdOutput(c *execabs.Cmd) ([]byte, error) {
 	return lib.MockCmdOutput(c)
 }
 
 // CmdRun implements shellx.Dependencies
-func (lib *Library) CmdRun(c *exec.Cmd) error {
+func (lib *Library) CmdRun(c *execabs.Cmd) error {
 	return lib.MockCmdRun(c)
 }
 
@@ -35,17 +35,17 @@ func (lib *Library) LookPath(file string) (string, error) {
 	return lib.MockLookPath(file)
 }
 
-// MustArgv returns the [exec.Cmd]'s Argv or panics.
-func MustArgv(c *exec.Cmd) []string {
+// MustArgv returns the [execabs.Cmd]'s Argv or panics.
+func MustArgv(c *execabs.Cmd) []string {
 	runtimex.Assert(len(c.Args) >= 1, "too few arguments")
 	out := []string{c.Path}
 	out = append(out, c.Args[1:]...)
 	return out
 }
 
-// RemoveCommonEnvironmentVariables returns the given [exec.Cmd]
+// RemoveCommonEnvironmentVariables returns the given [execabs.Cmd]
 // environment variables minus the ones of the current process.
-func RemoveCommonEnvironmentVariables(c *exec.Cmd) []string {
+func RemoveCommonEnvironmentVariables(c *execabs.Cmd) []string {
 	const (
 		us = 1 << iota
 		them

--- a/internal/shellx/shellxtesting/shellxtesting.go
+++ b/internal/shellx/shellxtesting/shellxtesting.go
@@ -1,4 +1,4 @@
-// Package shellxtesting contains mocks for shellx.
+// Package shellxtesting supports shellx testing.
 package shellxtesting
 
 import (
@@ -43,23 +43,26 @@ func MustArgv(c *execabs.Cmd) []string {
 	return out
 }
 
-// RemoveCommonEnvironmentVariables returns the given [execabs.Cmd]
-// environment variables minus the ones of the current process.
-func RemoveCommonEnvironmentVariables(c *execabs.Cmd) []string {
+// CmdEnvironMinusOsEnviron removes the environment variables in
+// [os.Environ] from the ones inside the given command. Note that
+// the variables in os.Environ and in the command are like name=value,
+// therefore, if you have HOME=/home/sbs in os.Environ and have
+// HOME=/tmp in the command, you'll get HOME=/tmp in output.
+func CmdEnvironMinusOsEnviron(c *execabs.Cmd) []string {
 	const (
-		us = 1 << iota
-		them
+		inCmd = 1 << iota
+		inEnviron
 	)
 	m := make(map[string]int)
 	for _, env := range os.Environ() {
-		m[env] |= us
+		m[env] |= inEnviron
 	}
 	for _, env := range c.Env {
-		m[env] |= them
+		m[env] |= inCmd
 	}
 	out := []string{}
 	for key, value := range m {
-		if (value & us) == 0 {
+		if value == inCmd {
 			out = append(out, key)
 		}
 	}

--- a/internal/shellx/shellxtesting/shellxtesting.go
+++ b/internal/shellx/shellxtesting/shellxtesting.go
@@ -1,0 +1,77 @@
+// Package shellxtesting contains mocks for shellx.
+package shellxtesting
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
+	"github.com/ooni/probe-cli/v3/internal/shellx"
+)
+
+// Library implements shellx.Dependencies.
+type Library struct {
+	MockCmdOutput func(c *exec.Cmd) ([]byte, error)
+
+	MockCmdRun func(c *exec.Cmd) error
+
+	MockLookPath func(file string) (string, error)
+}
+
+var _ shellx.Dependencies = &Library{}
+
+// CmdOutput implements shellx.Dependencies
+func (lib *Library) CmdOutput(c *exec.Cmd) ([]byte, error) {
+	return lib.MockCmdOutput(c)
+}
+
+// CmdRun implements shellx.Dependencies
+func (lib *Library) CmdRun(c *exec.Cmd) error {
+	return lib.MockCmdRun(c)
+}
+
+// LookPath implements shellx.Dependencies
+func (lib *Library) LookPath(file string) (string, error) {
+	return lib.MockLookPath(file)
+}
+
+// MustArgv returns the [exec.Cmd]'s Argv or panics.
+func MustArgv(c *exec.Cmd) []string {
+	runtimex.Assert(len(c.Args) >= 1, "too few arguments")
+	out := []string{c.Path}
+	out = append(out, c.Args[1:]...)
+	return out
+}
+
+// RemoveCommonEnvironmentVariables returns the given [exec.Cmd]
+// environment variables minus the ones of the current process.
+func RemoveCommonEnvironmentVariables(c *exec.Cmd) []string {
+	const (
+		us = 1 << iota
+		them
+	)
+	m := make(map[string]int)
+	for _, env := range os.Environ() {
+		m[env] |= us
+	}
+	for _, env := range c.Env {
+		m[env] |= them
+	}
+	out := []string{}
+	for key, value := range m {
+		if (value & us) == 0 {
+			out = append(out, key)
+		}
+	}
+	return out
+}
+
+// WithCustomLibrary executes the given function with a custom shellx.Library.
+func WithCustomLibrary(library shellx.Dependencies, fn func()) {
+	prev := shellx.Library
+	defer func() {
+		shellx.Library = prev
+	}()
+	shellx.Library = library
+	fn()
+}

--- a/internal/shellx/shellxtesting/shellxtesting_test.go
+++ b/internal/shellx/shellxtesting/shellxtesting_test.go
@@ -1,0 +1,111 @@
+package shellxtesting
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/probe-cli/v3/internal/shellx"
+)
+
+func TestCmdOutput(t *testing.T) {
+	expected := errors.New("mocked error")
+	lib := &Library{
+		MockCmdOutput: func(c *exec.Cmd) ([]byte, error) {
+			return nil, expected
+		},
+	}
+	data, err := lib.CmdOutput(&exec.Cmd{})
+	if !errors.Is(err, expected) {
+		t.Fatal("unexpected error", err)
+	}
+	if len(data) != 0 {
+		t.Fatal("expected zero-length data")
+	}
+}
+
+func TestCmdRun(t *testing.T) {
+	expected := errors.New("mocked error")
+	lib := &Library{
+		MockCmdRun: func(c *exec.Cmd) error {
+			return expected
+		},
+	}
+	err := lib.CmdRun(&exec.Cmd{})
+	if !errors.Is(err, expected) {
+		t.Fatal("unexpected error", err)
+	}
+}
+
+func TestLookPath(t *testing.T) {
+	expected := errors.New("mocked error")
+	lib := &Library{
+		MockLookPath: func(file string) (string, error) {
+			return "", expected
+		},
+	}
+	binary, err := lib.LookPath("go")
+	if !errors.Is(err, expected) {
+		t.Fatal("unexpected error", err)
+	}
+	if len(binary) != 0 {
+		t.Fatal("expected zero-length string")
+	}
+}
+
+func TestMustArgv(t *testing.T) {
+	cmd := &exec.Cmd{
+		Path: "/usr/bin/go",
+		Args: []string{"go", "env", "GOPATH"},
+	}
+	argv := MustArgv(cmd)
+	expected := []string{"/usr/bin/go", "env", "GOPATH"}
+	if diff := cmp.Diff(expected, argv); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestWithCustomLibrary(t *testing.T) {
+	expected := errors.New("mocked error")
+	library := &Library{
+		MockCmdRun: func(c *exec.Cmd) error {
+			return expected
+		},
+		MockLookPath: func(file string) (string, error) {
+			return "go", nil
+		},
+	}
+	var err error
+	WithCustomLibrary(library, func() {
+		err = shellx.RunQuiet("go", "version")
+	})
+	if !errors.Is(err, expected) {
+		t.Fatal("unexpected error", err)
+	}
+}
+
+func TestRemoveCommonEnvironmentVariables(t *testing.T) {
+	cmd := &exec.Cmd{
+		Env: os.Environ(),
+	}
+	expected := map[string]bool{
+		"ANTANI=1":        true,
+		"MASCETTI=10":     true,
+		"FOO=55":          true,
+		"PATH=/bin":       true,
+		"HOME=/var/empty": true,
+	}
+	for key := range expected {
+		cmd.Env = append(cmd.Env, key)
+	}
+	got := RemoveCommonEnvironmentVariables(cmd)
+	m := map[string]bool{}
+	for _, entry := range got {
+		m[entry] = true
+	}
+	if diff := cmp.Diff(expected, m); diff != "" {
+		t.Fatal(diff)
+	}
+}

--- a/internal/shellx/shellxtesting/shellxtesting_test.go
+++ b/internal/shellx/shellxtesting/shellxtesting_test.go
@@ -86,7 +86,7 @@ func TestWithCustomLibrary(t *testing.T) {
 	}
 }
 
-func TestRemoveCommonEnvironmentVariables(t *testing.T) {
+func TestCmdEnvironMinusOsEnviron(t *testing.T) {
 	cmd := &execabs.Cmd{
 		Env: os.Environ(),
 	}
@@ -100,7 +100,7 @@ func TestRemoveCommonEnvironmentVariables(t *testing.T) {
 	for key := range expected {
 		cmd.Env = append(cmd.Env, key)
 	}
-	got := RemoveCommonEnvironmentVariables(cmd)
+	got := CmdEnvironMinusOsEnviron(cmd)
 	m := map[string]bool{}
 	for _, entry := range got {
 		m[entry] = true

--- a/internal/shellx/shellxtesting/shellxtesting_test.go
+++ b/internal/shellx/shellxtesting/shellxtesting_test.go
@@ -3,21 +3,21 @@ package shellxtesting
 import (
 	"errors"
 	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/ooni/probe-cli/v3/internal/shellx"
+	"golang.org/x/sys/execabs"
 )
 
 func TestCmdOutput(t *testing.T) {
 	expected := errors.New("mocked error")
 	lib := &Library{
-		MockCmdOutput: func(c *exec.Cmd) ([]byte, error) {
+		MockCmdOutput: func(c *execabs.Cmd) ([]byte, error) {
 			return nil, expected
 		},
 	}
-	data, err := lib.CmdOutput(&exec.Cmd{})
+	data, err := lib.CmdOutput(&execabs.Cmd{})
 	if !errors.Is(err, expected) {
 		t.Fatal("unexpected error", err)
 	}
@@ -29,11 +29,11 @@ func TestCmdOutput(t *testing.T) {
 func TestCmdRun(t *testing.T) {
 	expected := errors.New("mocked error")
 	lib := &Library{
-		MockCmdRun: func(c *exec.Cmd) error {
+		MockCmdRun: func(c *execabs.Cmd) error {
 			return expected
 		},
 	}
-	err := lib.CmdRun(&exec.Cmd{})
+	err := lib.CmdRun(&execabs.Cmd{})
 	if !errors.Is(err, expected) {
 		t.Fatal("unexpected error", err)
 	}
@@ -56,7 +56,7 @@ func TestLookPath(t *testing.T) {
 }
 
 func TestMustArgv(t *testing.T) {
-	cmd := &exec.Cmd{
+	cmd := &execabs.Cmd{
 		Path: "/usr/bin/go",
 		Args: []string{"go", "env", "GOPATH"},
 	}
@@ -70,7 +70,7 @@ func TestMustArgv(t *testing.T) {
 func TestWithCustomLibrary(t *testing.T) {
 	expected := errors.New("mocked error")
 	library := &Library{
-		MockCmdRun: func(c *exec.Cmd) error {
+		MockCmdRun: func(c *execabs.Cmd) error {
 			return expected
 		},
 		MockLookPath: func(file string) (string, error) {
@@ -87,7 +87,7 @@ func TestWithCustomLibrary(t *testing.T) {
 }
 
 func TestRemoveCommonEnvironmentVariables(t *testing.T) {
-	cmd := &exec.Cmd{
+	cmd := &execabs.Cmd{
 		Env: os.Environ(),
 	}
 	expected := map[string]bool{


### PR DESCRIPTION
Recent changes in https://github.com/ooni/probe-cli/pull/1042 made `shellx` better in terms of pretending we're running commands in tests. However, the work done there is not enough for https://github.com/ooni/probe/issues/2401. It turns out I also need a mechanism to incrementally construct commands. So, while keeping unchanged the external `shellx` API used by existing packages, let's try to use a better underlying API that meets these new needs.

While there, re-read Go 1.19 release notes and realize that I want to keep using `x/sys/execabs` everywhere. See the informative comment in the diff below explaining why I want to do that.