### PR TITLE
refactor(buildtool): unify C deps with other deps

### DIFF
--- a/internal/cmd/buildtool/builddeps.go
+++ b/internal/cmd/buildtool/builddeps.go
@@ -12,6 +12,11 @@ type buildDeps struct{}
 
 var _ buildtoolmodel.Dependencies = &buildDeps{}
 
+// AbsoluteCurDir implements buildtoolmodel.Dependencies
+func (*buildDeps) AbsoluteCurDir() string {
+	return cdepsMustAbsoluteCurdir()
+}
+
 // AndroidNDKCheck implements buildtoolmodel.Dependencies
 func (*buildDeps) AndroidNDKCheck(androidHome string) string {
 	return androidNDKCheck(androidHome)
@@ -42,6 +47,11 @@ func (*buildDeps) LinuxWriteDockerfile(filename string, content []byte, mode fs.
 	must.WriteFile(filename, content, mode)
 }
 
+// MustChdir implements buildtoolmodel.Dependencies
+func (*buildDeps) MustChdir(dirname string) func() {
+	return cdepsMustChdir(dirname)
+}
+
 // PsiphonFilesExist implements buildtoolmodel.Dependencies
 func (*buildDeps) PsiphonFilesExist() bool {
 	return psiphonFilesExist()
@@ -55,4 +65,9 @@ func (*buildDeps) PsiphonMaybeCopyConfigFiles() {
 // WindowsMingwCheck implements buildtoolmodel.Dependencies
 func (*buildDeps) WindowsMingwCheck() {
 	windowsMingwCheck()
+}
+
+// VerifySHA256 implements buildtoolmodel.Dependencies
+func (*buildDeps) VerifySHA256(expectedSHA256 string, tarball string) {
+	cdepsMustVerifySHA256(expectedSHA256, tarball)
 }

--- a/internal/cmd/buildtool/cdeps.go
+++ b/internal/cmd/buildtool/cdeps.go
@@ -37,39 +37,6 @@ type cdepsEnv struct {
 	openSSLCompiler string
 }
 
-// cdepsDependencies groups dependencies used when building cdeps.
-type cdepsDependencies interface {
-	// mustChdir changes the current working directory and returns the
-	// function to return to the original working directory.
-	mustChdir(dirname string) func()
-
-	// absoluteCurDir returns the absolute current directory.
-	absoluteCurDir() string
-
-	// verifySHA256 verifies that the tarball has the given checksum.
-	verifySHA256(expectedSHA256, tarball string)
-}
-
-// cdepsDependenciesStdlib are the [cdepsDependencies] used by default.
-type cdepsDependenciesStdlib struct{}
-
-var _ cdepsDependencies = &cdepsDependenciesStdlib{}
-
-// absoluteCurDir implements cdepsDependencies
-func (c *cdepsDependenciesStdlib) absoluteCurDir() string {
-	return cdepsMustAbsoluteCurdir()
-}
-
-// verifySHA256 implements cdepsDependencies
-func (c *cdepsDependenciesStdlib) verifySHA256(expectedSHA256, tarball string) {
-	cdepsMustVerifySHA256(expectedSHA256, tarball)
-}
-
-// mustChdir implements cdepsDependencies
-func (c *cdepsDependenciesStdlib) mustChdir(dirname string) func() {
-	return cdepsMustChdir(dirname)
-}
-
 // cdepsAddCflags merges this struct's cflags with the extra cflags and
 // then stores the merged cflags into the given envp.
 func cdepsAddCflags(envp *shellx.Envp, c *cdepsEnv, extraCflags ...string) {

--- a/internal/cmd/buildtool/cdepslibevent.go
+++ b/internal/cmd/buildtool/cdepslibevent.go
@@ -12,26 +12,27 @@ import (
 	"strconv"
 
 	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/cmd/buildtool/internal/buildtoolmodel"
 	"github.com/ooni/probe-cli/v3/internal/must"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 	"github.com/ooni/probe-cli/v3/internal/shellx"
 )
 
 // cdepsLibeventBuildMain is the script that builds libevent.
-func cdepsLibeventBuildMain(cdenv *cdepsEnv, deps cdepsDependencies) {
-	topdir := deps.absoluteCurDir() // must be mockable
+func cdepsLibeventBuildMain(cdenv *cdepsEnv, deps buildtoolmodel.Dependencies) {
+	topdir := deps.AbsoluteCurDir() // must be mockable
 	work := cdepsMustMkdirTemp()
 	restore := cdepsMustChdir(work)
 	defer restore()
 
 	// See https://github.com/Homebrew/homebrew-core/blob/master/Formula/libevent.rb
 	cdepsMustFetch("https://github.com/libevent/libevent/archive/release-2.1.12-stable.tar.gz")
-	deps.verifySHA256( // must be mockable
+	deps.VerifySHA256( // must be mockable
 		"7180a979aaa7000e1264da484f712d403fcf7679b1e9212c4e3d09f5c93efc24",
 		"release-2.1.12-stable.tar.gz",
 	)
 	must.Run(log.Log, "tar", "-xf", "release-2.1.12-stable.tar.gz")
-	_ = deps.mustChdir("libevent-release-2.1.12-stable") // must be mockable
+	_ = deps.MustChdir("libevent-release-2.1.12-stable") // must be mockable
 
 	mydir := filepath.Join(topdir, "CDEPS", "libevent")
 	for _, patch := range cdepsMustListPatches(mydir) {

--- a/internal/cmd/buildtool/cdepsopenssl.go
+++ b/internal/cmd/buildtool/cdepsopenssl.go
@@ -12,26 +12,27 @@ import (
 	"strconv"
 
 	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/cmd/buildtool/internal/buildtoolmodel"
 	"github.com/ooni/probe-cli/v3/internal/must"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 	"github.com/ooni/probe-cli/v3/internal/shellx"
 )
 
 // cdepsOpenSSLBuildMain is the script that builds OpenSSL.
-func cdepsOpenSSLBuildMain(cdenv *cdepsEnv, deps cdepsDependencies) {
-	topdir := deps.absoluteCurDir() // must be mockable
+func cdepsOpenSSLBuildMain(cdenv *cdepsEnv, deps buildtoolmodel.Dependencies) {
+	topdir := deps.AbsoluteCurDir() // must be mockable
 	work := cdepsMustMkdirTemp()
 	restore := cdepsMustChdir(work)
 	defer restore()
 
 	// See https://github.com/Homebrew/homebrew-core/blob/master/Formula/openssl@1.1.rb
 	cdepsMustFetch("https://www.openssl.org/source/openssl-1.1.1s.tar.gz")
-	deps.verifySHA256( // must be mockable
+	deps.VerifySHA256( // must be mockable
 		"c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa",
 		"openssl-1.1.1s.tar.gz",
 	)
 	must.Run(log.Log, "tar", "-xf", "openssl-1.1.1s.tar.gz")
-	_ = deps.mustChdir("openssl-1.1.1s") // must be mockable
+	_ = deps.MustChdir("openssl-1.1.1s") // must be mockable
 
 	mydir := filepath.Join(topdir, "CDEPS", "openssl")
 	for _, patch := range cdepsMustListPatches(mydir) {

--- a/internal/cmd/buildtool/cdepstor.go
+++ b/internal/cmd/buildtool/cdepstor.go
@@ -12,26 +12,27 @@ import (
 	"strconv"
 
 	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/cmd/buildtool/internal/buildtoolmodel"
 	"github.com/ooni/probe-cli/v3/internal/must"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 	"github.com/ooni/probe-cli/v3/internal/shellx"
 )
 
 // cdepsTorBuildMain is the script that builds tor.
-func cdepsTorBuildMain(cdenv *cdepsEnv, deps cdepsDependencies) {
-	topdir := deps.absoluteCurDir() // must be mockable
+func cdepsTorBuildMain(cdenv *cdepsEnv, deps buildtoolmodel.Dependencies) {
+	topdir := deps.AbsoluteCurDir() // must be mockable
 	work := cdepsMustMkdirTemp()
 	restore := cdepsMustChdir(work)
 	defer restore()
 
 	// See https://github.com/Homebrew/homebrew-core/blob/master/Formula/tor.rb
 	cdepsMustFetch("https://www.torproject.org/dist/tor-0.4.7.12.tar.gz")
-	deps.verifySHA256( // must be mockable
+	deps.VerifySHA256( // must be mockable
 		"3b5d969712c467851bd028f314343ef15a97ea457191e93ffa97310b05b9e395",
 		"tor-0.4.7.12.tar.gz",
 	)
 	must.Run(log.Log, "tar", "-xf", "tor-0.4.7.12.tar.gz")
-	_ = deps.mustChdir("tor-0.4.7.12") // must be mockable
+	_ = deps.MustChdir("tor-0.4.7.12") // must be mockable
 
 	mydir := filepath.Join(topdir, "CDEPS", "tor")
 	for _, patch := range cdepsMustListPatches(mydir) {

--- a/internal/cmd/buildtool/cdepszlib.go
+++ b/internal/cmd/buildtool/cdepszlib.go
@@ -12,25 +12,26 @@ import (
 	"strconv"
 
 	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/cmd/buildtool/internal/buildtoolmodel"
 	"github.com/ooni/probe-cli/v3/internal/must"
 	"github.com/ooni/probe-cli/v3/internal/shellx"
 )
 
 // cdepsZlibBuildMain is the script that builds zlib.
-func cdepsZlibBuildMain(cdenv *cdepsEnv, deps cdepsDependencies) {
-	topdir := deps.absoluteCurDir() // must be mockable
+func cdepsZlibBuildMain(cdenv *cdepsEnv, deps buildtoolmodel.Dependencies) {
+	topdir := deps.AbsoluteCurDir() // must be mockable
 	work := cdepsMustMkdirTemp()
 	restore := cdepsMustChdir(work)
 	defer restore()
 
 	// See https://github.com/Homebrew/homebrew-core/blob/master/Formula/zlib.rb
 	cdepsMustFetch("https://zlib.net/zlib-1.2.13.tar.gz")
-	deps.verifySHA256( // must be mockable
+	deps.VerifySHA256( // must be mockable
 		"b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
 		"zlib-1.2.13.tar.gz",
 	)
 	must.Run(log.Log, "tar", "-xf", "zlib-1.2.13.tar.gz")
-	_ = deps.mustChdir("zlib-1.2.13") // must be mockable
+	_ = deps.MustChdir("zlib-1.2.13") // must be mockable
 
 	mydir := filepath.Join(topdir, "CDEPS", "zlib")
 	for _, patch := range cdepsMustListPatches(mydir) {

--- a/internal/cmd/buildtool/internal/buildtoolmodel/buildtoolmodel.go
+++ b/internal/cmd/buildtool/internal/buildtoolmodel/buildtoolmodel.go
@@ -6,6 +6,9 @@ import "io/fs"
 // Dependencies abstracts the commands and checks required
 // to perform all the builds in this package.
 type Dependencies interface {
+	// AbsoluteCurDir returns the absolute current directory.
+	AbsoluteCurDir() string
+
 	// AndroidNDKCheck checks we have the right NDK
 	// inside the SDK and returns its dir.
 	AndroidNDKCheck(androidHome string) string
@@ -28,6 +31,10 @@ type Dependencies interface {
 	// LinuxReadGOVERSION reads the GOVERSION file for linux.
 	LinuxReadGOVERSION(filename string) []byte
 
+	// MustChdir changes the current working directory and returns the
+	// function to return to the original working directory.
+	MustChdir(dirname string) func()
+
 	// PsiphonFilesExist returns true if the psiphon
 	// config files are in the correct location.
 	PsiphonFilesExist() bool
@@ -35,6 +42,9 @@ type Dependencies interface {
 	// PsiphonMaybeCopyConfigFiles copies psiphon
 	// config files if possible
 	PsiphonMaybeCopyConfigFiles()
+
+	// VerifySHA256 verifies that the tarball has the given checksum.
+	VerifySHA256(expectedSHA256, tarball string)
 
 	// WindowsMingwCheck makes sure we're using the
 	// expected version of mingw-w64.

--- a/internal/cmd/buildtool/internal/buildtooltest/buildtooltest.go
+++ b/internal/cmd/buildtool/internal/buildtooltest/buildtooltest.go
@@ -135,14 +135,17 @@ const CanonicalGolangVersion = "1.14.17"
 
 // Constants describing the dependent functions we can call when building.
 const (
+	TagAbsoluteCurDir              = "absoluteCurDir"
 	TagAndroidNDKCheck             = "androidNDK"
 	TagAndroidSDKCheck             = "androidSDK"
 	TagGOPATH                      = "GOPATH"
 	TagGolangCheck                 = "golangCheck"
 	TagLinuxReadGOVERSION          = "linuxReadGOVERSION"
 	TagLinuxWriteDockerfile        = "linuxWriteDockerfile"
+	TagMustChdir                   = "mustChdir"
 	TagPsiphonFilesExist           = "psiphonFilesExist"
 	TagPsiphonMaybeCopyConfigFiles = "maybeCopyPsiphonFiles"
+	TagVerifySHA256                = "verifySHA256"
 	TagWindowsMingwCheck           = "windowsMingwCheck"
 )
 
@@ -157,6 +160,12 @@ var _ buildtoolmodel.Dependencies = &DependenciesCallCounter{}
 
 // CanonicalNDKVersion is the canonical NDK version used in tests.
 const CanonicalNDKVersion = "25.1.7654321"
+
+// AbsoluteCurDir implements buildtoolmodel.Dependencies
+func (cc *DependenciesCallCounter) AbsoluteCurDir() string {
+	cc.increment(TagAbsoluteCurDir)
+	return runtimex.Try1(filepath.Abs("../../../")) // pretend we're in the real topdir
+}
 
 // AndroidNDKCheck implements buildtoolmodel.Dependencies
 func (cc *DependenciesCallCounter) AndroidNDKCheck(androidHome string) string {
@@ -194,6 +203,12 @@ func (cc *DependenciesCallCounter) LinuxWriteDockerfile(
 	cc.increment(TagLinuxWriteDockerfile)
 }
 
+// MustChdir implements buildtoolmodel.Dependencies
+func (cc *DependenciesCallCounter) MustChdir(dirname string) func() {
+	cc.increment(TagMustChdir)
+	return func() {} // nothing
+}
+
 // psiphonFilesExist implements buildtoolmodel.Dependencies
 func (cc *DependenciesCallCounter) PsiphonFilesExist() bool {
 	cc.increment(TagPsiphonFilesExist)
@@ -203,6 +218,11 @@ func (cc *DependenciesCallCounter) PsiphonFilesExist() bool {
 // psiphonMaybeCopyConfigFiles implements buildtoolmodel.Dependencies
 func (cc *DependenciesCallCounter) PsiphonMaybeCopyConfigFiles() {
 	cc.increment(TagPsiphonMaybeCopyConfigFiles)
+}
+
+// VerifySHA256 implements buildtoolmodel.Dependencies
+func (cc *DependenciesCallCounter) VerifySHA256(expectedSHA256 string, tarball string) {
+	cc.increment(TagVerifySHA256)
 }
 
 // windowsMingwCheck implements buildtoolmodel.Dependencies

--- a/internal/cmd/buildtool/internal/buildtooltest/buildtooltest_test.go
+++ b/internal/cmd/buildtool/internal/buildtooltest/buildtooltest_test.go
@@ -1,8 +1,10 @@
 package buildtooltest
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/ooni/probe-cli/v3/internal/fsx"
 	"golang.org/x/sys/execabs"
 )
 
@@ -149,7 +151,57 @@ func TestSimpleCommandCollector(t *testing.T) {
 }
 
 func TestDependenciesCallCounter(t *testing.T) {
-	t.Run("golangCheck", func(t *testing.T) {
+	t.Run("AbsoluteCurDir", func(t *testing.T) {
+		cc := &DependenciesCallCounter{}
+		dir := cc.AbsoluteCurDir()
+		if cc.Counter[TagAbsoluteCurDir] != 1 {
+			t.Fatal("did not increment")
+		}
+		// Note: adding two ".." to offset for the fact that we're two
+		// more directories deep with respect to when we run tests
+		cdepsDir := filepath.Join(dir, "..", "..", "CDEPS")
+		if !fsx.DirectoryExists(cdepsDir) {
+			t.Fatal("directory does not exist", cdepsDir)
+		}
+	})
+
+	t.Run("AndroidNDKCheck", func(t *testing.T) {
+		cc := &DependenciesCallCounter{}
+		dir := cc.AndroidNDKCheck("xo")
+		if cc.Counter[TagAndroidNDKCheck] != 1 {
+			t.Fatal("did not increment")
+		}
+		expect := filepath.Join("xo", "ndk", CanonicalNDKVersion)
+		if dir != expect {
+			t.Fatal("expected", expect, "but got", dir)
+		}
+	})
+
+	t.Run("AndroidSDKCheck", func(t *testing.T) {
+		cc := &DependenciesCallCounter{}
+		dir := cc.AndroidSDKCheck()
+		if cc.Counter[TagAndroidSDKCheck] != 1 {
+			t.Fatal("did not increment")
+		}
+		expect := filepath.Join("Android", "sdk")
+		if dir != expect {
+			t.Fatal("expected", expect, "but got", dir)
+		}
+	})
+
+	t.Run("GOPATH", func(t *testing.T) {
+		cc := &DependenciesCallCounter{}
+		dir := cc.GOPATH()
+		if cc.Counter[TagGOPATH] != 1 {
+			t.Fatal("did not increment")
+		}
+		expect := "/go/gopath"
+		if dir != expect {
+			t.Fatal("expected", expect, "but got", dir)
+		}
+	})
+
+	t.Run("GolangCheck", func(t *testing.T) {
 		cc := &DependenciesCallCounter{}
 		cc.GolangCheck()
 		if cc.Counter[TagGolangCheck] != 1 {
@@ -157,7 +209,7 @@ func TestDependenciesCallCounter(t *testing.T) {
 		}
 	})
 
-	t.Run("linuxReadGOVERSION", func(t *testing.T) {
+	t.Run("LinuxReadGOVERSION", func(t *testing.T) {
 		cc := &DependenciesCallCounter{}
 		cc.LinuxReadGOVERSION("xo")
 		if cc.Counter[TagLinuxReadGOVERSION] != 1 {
@@ -165,7 +217,7 @@ func TestDependenciesCallCounter(t *testing.T) {
 		}
 	})
 
-	t.Run("linuxWriteDOCKEFILE", func(t *testing.T) {
+	t.Run("LinuxWriteDOCKEFILE", func(t *testing.T) {
 		cc := &DependenciesCallCounter{}
 		cc.LinuxWriteDockerfile("xo", nil, 0600)
 		if cc.Counter[TagLinuxWriteDockerfile] != 1 {
@@ -173,7 +225,15 @@ func TestDependenciesCallCounter(t *testing.T) {
 		}
 	})
 
-	t.Run("psiphonFileExists", func(t *testing.T) {
+	t.Run("MustChdir", func(t *testing.T) {
+		cc := &DependenciesCallCounter{}
+		cc.MustChdir("xo")
+		if cc.Counter[TagMustChdir] != 1 {
+			t.Fatal("did not increment")
+		}
+	})
+
+	t.Run("PsiphonFileExists", func(t *testing.T) {
 		t.Run("if false", func(t *testing.T) {
 			cc := &DependenciesCallCounter{}
 			got := cc.PsiphonFilesExist()
@@ -199,7 +259,7 @@ func TestDependenciesCallCounter(t *testing.T) {
 		})
 	})
 
-	t.Run("psiphonMaybeCopyConfigFiles", func(t *testing.T) {
+	t.Run("PsiphonMaybeCopyConfigFiles", func(t *testing.T) {
 		cc := &DependenciesCallCounter{}
 		cc.PsiphonMaybeCopyConfigFiles()
 		if cc.Counter[TagPsiphonMaybeCopyConfigFiles] != 1 {
@@ -207,7 +267,15 @@ func TestDependenciesCallCounter(t *testing.T) {
 		}
 	})
 
-	t.Run("windowsMingwCheck", func(t *testing.T) {
+	t.Run("VerifySHA256", func(t *testing.T) {
+		cc := &DependenciesCallCounter{}
+		cc.VerifySHA256("xo", "xo")
+		if cc.Counter[TagVerifySHA256] != 1 {
+			t.Fatal("did not increment")
+		}
+	})
+
+	t.Run("WindowsMingwCheck", func(t *testing.T) {
 		cc := &DependenciesCallCounter{}
 		cc.WindowsMingwCheck()
 		if cc.Counter[TagWindowsMingwCheck] != 1 {

--- a/internal/cmd/buildtool/linuxcdeps.go
+++ b/internal/cmd/buildtool/linuxcdeps.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/ooni/probe-cli/v3/internal/cmd/buildtool/internal/buildtoolmodel"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 	"github.com/spf13/cobra"
 )
@@ -20,7 +21,7 @@ func linuxCdepsSubcommand() *cobra.Command {
 		Short: "Builds C dependencies on Linux systems (experimental)",
 		Run: func(cmd *cobra.Command, args []string) {
 			for _, arg := range args {
-				linuxCdepsBuildMain(arg, &cdepsDependenciesStdlib{})
+				linuxCdepsBuildMain(arg, &buildDeps{})
 			}
 		},
 		Args: cobra.MinimumNArgs(1),
@@ -28,7 +29,7 @@ func linuxCdepsSubcommand() *cobra.Command {
 }
 
 // linuxCdepsBuildMain is the main of the linuxCdeps build.
-func linuxCdepsBuildMain(name string, deps cdepsDependencies) {
+func linuxCdepsBuildMain(name string, deps buildtoolmodel.Dependencies) {
 	runtimex.Assert(
 		runtime.GOOS == "linux" && runtime.GOARCH == "amd64",
 		"this command requires linux/amd64",


### PR DESCRIPTION
It was a bit of annoying two have two structs to represent build dependencies when just one of them is good enough.

Part of https://github.com/ooni/probe/issues/2401
