### PR TITLE
refactor(buildtool): merge cdeps and android build envs

### DIFF
--- a/internal/cmd/buildtool/android.go
+++ b/internal/cmd/buildtool/android.go
@@ -136,7 +136,7 @@ func androidBuildCLIProductArch(
 	ooniArch string,
 	ndkDir string,
 ) {
-	cgo := newAndroidConfigCGO(ndkDir, ooniArch)
+	cgo := newAndroidCBuildEnv(ndkDir, ooniArch)
 
 	log.Infof("building %s for android/%s", product.Pkg, ooniArch)
 
@@ -173,35 +173,10 @@ func androidBuildCLIProductArch(
 	runtimex.Try0(shellx.RunEx(defaultShellxConfig(), argv, envp))
 }
 
-// androidConfigCGO contains the settings required
-// to compile for Android using a C compiler.
-type androidConfigCGO struct {
-	// binpath is the path containing the C and C++ compilers.
-	binpath string
-
-	// cc is the full path to the C compiler.
-	cc string
-
-	// cflags contains the extra CFLAGS to set.
-	cflags []string
-
-	// cxx is the full path to the CXX compiler.
-	cxx string
-
-	// cxxflags contains the extra CXXFLAGS to set.
-	cxxflags []string
-
-	// goarch is the GOARCH we're building for.
-	goarch string
-
-	// goarm is the GOARM subarchitecture.
-	goarm string
-}
-
-// newAndroidConfigCGO creates a new androidConfigCGO for the
+// newAndroidCBuildEnv creates a new [cBuildEnv] for the
 // given ooniArch ("arm", "arm64", "386", "amd64").
-func newAndroidConfigCGO(ndkDir string, ooniArch string) *androidConfigCGO {
-	out := &androidConfigCGO{
+func newAndroidCBuildEnv(ndkDir string, ooniArch string) *cBuildEnv {
+	out := &cBuildEnv{
 		binpath:  androidNDKBinPath(ndkDir),
 		cc:       "",
 		cflags:   androidCflags(ooniArch),

--- a/internal/cmd/buildtool/cbuildenv.go
+++ b/internal/cmd/buildtool/cbuildenv.go
@@ -1,5 +1,10 @@
 package main
 
+//
+// Common build environment for builds using C (which applies
+// to both CGO builds and to pure C builds).
+//
+
 import (
 	"strings"
 
@@ -55,15 +60,21 @@ func cBuildExportEnviron(global, local *cBuildEnv) *shellx.Envp {
 
 	cflags := append([]string{}, global.cflags...)
 	cflags = append(cflags, local.cflags...)
-	envp.Append("CFLAGS", strings.Join(cflags, " "))
+	if len(cflags) > 0 {
+		envp.Append("CFLAGS", strings.Join(cflags, " "))
+	}
 
 	cxxflags := append([]string{}, global.cxxflags...)
 	cxxflags = append(cxxflags, local.cxxflags...)
-	envp.Append("CXXFLAGS", strings.Join(cxxflags, " "))
+	if len(cxxflags) > 0 {
+		envp.Append("CXXFLAGS", strings.Join(cxxflags, " "))
+	}
 
 	ldflags := append([]string{}, global.ldflags...)
 	ldflags = append(ldflags, local.ldflags...)
-	envp.Append("LDFLAGS", strings.Join(ldflags, " "))
+	if len(ldflags) > 0 {
+		envp.Append("LDFLAGS", strings.Join(ldflags, " "))
+	}
 
 	return envp
 }

--- a/internal/cmd/buildtool/cbuildenv.go
+++ b/internal/cmd/buildtool/cbuildenv.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/ooni/probe-cli/v3/internal/shellx"
+)
+
+// cBuildEnv describes the C build environment. We use
+// this structure for more complex C and CGO builds.
+type cBuildEnv struct {
+	// binpath is the path containing the C and C++ compilers.
+	binpath string
+
+	// cc is the full path to the C compiler.
+	cc string
+
+	// cflags contains the extra CFLAGS to set.
+	cflags []string
+
+	// configureHost is the value to pass to ./configure's --host option.
+	configureHost string
+
+	// destdir is the directory where to install.
+	destdir string
+
+	// cxx is the full path to the CXX compiler.
+	cxx string
+
+	// cxxflags contains the extra CXXFLAGS to set.
+	cxxflags []string
+
+	// goarch is the GOARCH we're building for.
+	goarch string
+
+	// goarm is the GOARM subarchitecture.
+	goarm string
+
+	// lfdlags contains the LDFLAGS to use when compiling.
+	ldflags []string
+
+	// openSSLAPIDefine is an extra define we need to add on Android.
+	openSSLAPIDefine string
+
+	// openSSLCompiler is the compiler name for OpenSSL.
+	openSSLCompiler string
+}
+
+// cBuildExportEnviron merges the gloval and the local c build environment
+// to produce the environment variables to export for the build. More specifically,
+// this appends the local variables to the remote variables for any string slice
+// type inside [cBuildEnv]. We ignore all the other variables.
+func cBuildExportEnviron(global, local *cBuildEnv) *shellx.Envp {
+	envp := &shellx.Envp{}
+
+	cflags := append([]string{}, global.cflags...)
+	cflags = append(cflags, local.cflags...)
+	envp.Append("CFLAGS", strings.Join(cflags, " "))
+
+	cxxflags := append([]string{}, global.cxxflags...)
+	cxxflags = append(cxxflags, local.cxxflags...)
+	envp.Append("CXXFLAGS", strings.Join(cxxflags, " "))
+
+	ldflags := append([]string{}, global.ldflags...)
+	ldflags = append(ldflags, local.ldflags...)
+	envp.Append("LDFLAGS", strings.Join(ldflags, " "))
+
+	return envp
+}

--- a/internal/cmd/buildtool/cbuildenv_test.go
+++ b/internal/cmd/buildtool/cbuildenv_test.go
@@ -28,4 +28,22 @@ func TestCBuildEnv(t *testing.T) {
 			t.Fatal(diff)
 		}
 	})
+
+	t.Run("we do nothing with empty variables", func(t *testing.T) {
+		global := &cBuildEnv{
+			cflags:   []string{},
+			cxxflags: []string{},
+			ldflags:  []string{},
+		}
+		local := &cBuildEnv{
+			cflags:   []string{},
+			cxxflags: []string{},
+			ldflags:  []string{},
+		}
+		envp := cBuildExportEnviron(global, local)
+		var expected []string
+		if diff := cmp.Diff(expected, envp.V); diff != "" {
+			t.Fatal(diff)
+		}
+	})
 }

--- a/internal/cmd/buildtool/cbuildenv_test.go
+++ b/internal/cmd/buildtool/cbuildenv_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCBuildEnv(t *testing.T) {
+	t.Run("we can correctly merge build flags", func(t *testing.T) {
+		global := &cBuildEnv{
+			cflags:   []string{"a", "b", "c"},
+			cxxflags: []string{"A", "B", "C"},
+			ldflags:  []string{"1", "2", "3"},
+		}
+		local := &cBuildEnv{
+			cflags:   []string{"d", "e"},
+			cxxflags: []string{"D", "E"},
+			ldflags:  []string{"4", "5"},
+		}
+		envp := cBuildExportEnviron(global, local)
+		expected := []string{
+			"CFLAGS=a b c d e",
+			"CXXFLAGS=A B C D E",
+			"LDFLAGS=1 2 3 4 5",
+		}
+		if diff := cmp.Diff(expected, envp.V); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+}

--- a/internal/cmd/buildtool/cdeps.go
+++ b/internal/cmd/buildtool/cdeps.go
@@ -16,43 +16,6 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/shellx"
 )
 
-// cdepsEnv contains the environment for compiling a C dependency.
-type cdepsEnv struct {
-	// cflags contains the CFLAGS to use when compiling.
-	cflags []string
-
-	// configureHost is the value to pass to ./configure's --host option.
-	configureHost string
-
-	// destdir is the directory where to install.
-	destdir string
-
-	// lfdlags contains the LDFLAGS to use when compiling.
-	ldflags []string
-
-	// openSSLAPIDefine is an extra define we need to add on Android.
-	openSSLAPIDefine string
-
-	// openSSLCompiler is the compiler name for OpenSSL.
-	openSSLCompiler string
-}
-
-// cdepsAddCflags merges this struct's cflags with the extra cflags and
-// then stores the merged cflags into the given envp.
-func cdepsAddCflags(envp *shellx.Envp, c *cdepsEnv, extraCflags ...string) {
-	mergedCflags := append([]string{}, c.cflags...)
-	mergedCflags = append(mergedCflags, extraCflags...)
-	envp.Append("CFLAGS", strings.Join(mergedCflags, " "))
-}
-
-// cdepsAddLdflags merges this struct's ldflags with the extra ldflags and
-// then stores the merged ldflags into the given envp.
-func cdepsAddLdflags(envp *shellx.Envp, c *cdepsEnv, extraLdflags ...string) {
-	mergedLdflags := append([]string{}, c.ldflags...)
-	mergedLdflags = append(mergedLdflags, extraLdflags...)
-	envp.Append("LDFLAGS", strings.Join(mergedLdflags, " "))
-}
-
 // cdepsMustMkdirTemp creates a temporary directory.
 func cdepsMustMkdirTemp() string {
 	return runtimex.Try1(os.MkdirTemp("", ""))

--- a/internal/cmd/buildtool/cdepstor.go
+++ b/internal/cmd/buildtool/cdepstor.go
@@ -19,7 +19,7 @@ import (
 )
 
 // cdepsTorBuildMain is the script that builds tor.
-func cdepsTorBuildMain(cdenv *cdepsEnv, deps buildtoolmodel.Dependencies) {
+func cdepsTorBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependencies) {
 	topdir := deps.AbsoluteCurDir() // must be mockable
 	work := cdepsMustMkdirTemp()
 	restore := cdepsMustChdir(work)
@@ -39,19 +39,18 @@ func cdepsTorBuildMain(cdenv *cdepsEnv, deps buildtoolmodel.Dependencies) {
 		must.Run(log.Log, "git", "apply", patch)
 	}
 
-	envp := &shellx.Envp{}
-	cdepsAddCflags(envp, cdenv)
-	cdepsAddLdflags(envp, cdenv)
+	localEnv := &cBuildEnv{}
+	envp := cBuildExportEnviron(globalEnv, localEnv)
 
 	argv := runtimex.Try1(shellx.NewArgv("./configure"))
-	if cdenv.configureHost != "" {
-		argv.Append("--host=" + cdenv.configureHost)
+	if globalEnv.configureHost != "" {
+		argv.Append("--host=" + globalEnv.configureHost)
 	}
 	argv.Append(
 		"--enable-pic",
-		"--enable-static-libevent", "--with-libevent-dir="+cdenv.destdir,
-		"--enable-static-openssl", "--with-openssl-dir="+cdenv.destdir,
-		"--enable-static-zlib", "--with-zlib-dir="+cdenv.destdir,
+		"--enable-static-libevent", "--with-libevent-dir="+globalEnv.destdir,
+		"--enable-static-openssl", "--with-openssl-dir="+globalEnv.destdir,
+		"--enable-static-zlib", "--with-zlib-dir="+globalEnv.destdir,
 		"--disable-module-dirauth",
 		"--disable-zstd", "--disable-lzma",
 		"--disable-tool-name-check",
@@ -62,6 +61,6 @@ func cdepsTorBuildMain(cdenv *cdepsEnv, deps buildtoolmodel.Dependencies) {
 
 	must.Run(log.Log, "make", "V=1", "-j", strconv.Itoa(runtime.NumCPU()))
 
-	must.Run(log.Log, "install", "-m644", "src/feature/api/tor_api.h", cdenv.destdir+"/include")
-	must.Run(log.Log, "install", "-m644", "libtor.a", cdenv.destdir+"/lib")
+	must.Run(log.Log, "install", "-m644", "src/feature/api/tor_api.h", globalEnv.destdir+"/include")
+	must.Run(log.Log, "install", "-m644", "libtor.a", globalEnv.destdir+"/lib")
 }

--- a/internal/cmd/buildtool/cdepszlib.go
+++ b/internal/cmd/buildtool/cdepszlib.go
@@ -14,11 +14,10 @@ import (
 	"github.com/apex/log"
 	"github.com/ooni/probe-cli/v3/internal/cmd/buildtool/internal/buildtoolmodel"
 	"github.com/ooni/probe-cli/v3/internal/must"
-	"github.com/ooni/probe-cli/v3/internal/shellx"
 )
 
 // cdepsZlibBuildMain is the script that builds zlib.
-func cdepsZlibBuildMain(cdenv *cdepsEnv, deps buildtoolmodel.Dependencies) {
+func cdepsZlibBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependencies) {
 	topdir := deps.AbsoluteCurDir() // must be mockable
 	work := cdepsMustMkdirTemp()
 	restore := cdepsMustChdir(work)
@@ -38,15 +37,14 @@ func cdepsZlibBuildMain(cdenv *cdepsEnv, deps buildtoolmodel.Dependencies) {
 		must.Run(log.Log, "git", "apply", patch)
 	}
 
-	envp := &shellx.Envp{}
-	if cdenv.configureHost != "" {
-		envp.Append("CHOST", cdenv.configureHost) // zlib's configure otherwise uses Apple's libtool
+	envp := cBuildExportEnviron(globalEnv, &cBuildEnv{})
+	if globalEnv.configureHost != "" {
+		envp.Append("CHOST", globalEnv.configureHost) // zlib's configure otherwise uses Apple's libtool
 	}
-	cdepsAddCflags(envp, cdenv)
 	cdepsMustRunWithDefaultConfig(envp, "./configure", "--prefix=/", "--static")
 
 	must.Run(log.Log, "make", "-j", strconv.Itoa(runtime.NumCPU()))
-	must.Run(log.Log, "make", "DESTDIR="+cdenv.destdir, "install")
-	must.Run(log.Log, "rm", "-rf", filepath.Join(cdenv.destdir, "lib", "pkgconfig"))
-	must.Run(log.Log, "rm", "-rf", filepath.Join(cdenv.destdir, "share"))
+	must.Run(log.Log, "make", "DESTDIR="+globalEnv.destdir, "install")
+	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.destdir, "lib", "pkgconfig"))
+	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.destdir, "share"))
 }

--- a/internal/cmd/buildtool/internal/buildtooltest/buildtooltest.go
+++ b/internal/cmd/buildtool/internal/buildtooltest/buildtooltest.go
@@ -40,7 +40,7 @@ func CompareArgv(expected, got []string) error {
 	}
 	for idx := 1; idx < len(got); idx++ {
 		if got[idx] != expected[idx] {
-			return fmt.Errorf("entry %d: expected %s, but got %s", idx, expected[idx], got[idx])
+			return fmt.Errorf("entry %d of %+v: expected %s, but got %s", idx, expected, expected[idx], got[idx])
 		}
 	}
 	return nil

--- a/internal/cmd/buildtool/linuxcdeps.go
+++ b/internal/cmd/buildtool/linuxcdeps.go
@@ -34,7 +34,7 @@ func linuxCdepsBuildMain(name string, deps buildtoolmodel.Dependencies) {
 		runtime.GOOS == "linux" && runtime.GOARCH == "amd64",
 		"this command requires linux/amd64",
 	)
-	cdenv := &cdepsEnv{
+	globalEnv := &cBuildEnv{
 		cflags: []string{
 			// See https://airbus-seclab.github.io/c-compiler-security/
 			"-D_FORTIFY_SOURCE=2",
@@ -52,13 +52,13 @@ func linuxCdepsBuildMain(name string, deps buildtoolmodel.Dependencies) {
 	}
 	switch name {
 	case "libevent":
-		cdepsLibeventBuildMain(cdenv, deps)
+		cdepsLibeventBuildMain(globalEnv, deps)
 	case "openssl":
-		cdepsOpenSSLBuildMain(cdenv, deps)
+		cdepsOpenSSLBuildMain(globalEnv, deps)
 	case "tor":
-		cdepsTorBuildMain(cdenv, deps)
+		cdepsTorBuildMain(globalEnv, deps)
 	case "zlib":
-		cdepsZlibBuildMain(cdenv, deps)
+		cdepsZlibBuildMain(globalEnv, deps)
 	default:
 		panic(fmt.Errorf("unknown dependency: %s", name))
 	}

--- a/internal/cmd/buildtool/linuxcdeps.go
+++ b/internal/cmd/buildtool/linuxcdeps.go
@@ -34,17 +34,19 @@ func linuxCdepsBuildMain(name string, deps buildtoolmodel.Dependencies) {
 		runtime.GOOS == "linux" && runtime.GOARCH == "amd64",
 		"this command requires linux/amd64",
 	)
+	cflags := []string{
+		// See https://airbus-seclab.github.io/c-compiler-security/
+		"-D_FORTIFY_SOURCE=2",
+		"-fstack-protector-strong",
+		"-fstack-clash-protection",
+		"-fPIC", // makes more sense than -fPIE given that we're building a library
+		"-fsanitize=bounds",
+		"-fsanitize-undefined-trap-on-error",
+		"-O2",
+	}
 	globalEnv := &cBuildEnv{
-		cflags: []string{
-			// See https://airbus-seclab.github.io/c-compiler-security/
-			"-D_FORTIFY_SOURCE=2",
-			"-fstack-protector-strong",
-			"-fstack-clash-protection",
-			"-fPIC", // makes more sense than -fPIE given that we're building a library
-			"-fsanitize=bounds",
-			"-fsanitize-undefined-trap-on-error",
-			"-O2",
-		},
+		cflags:   cflags,
+		cxxflags: cflags,
 		destdir: runtimex.Try1(filepath.Abs(filepath.Join( // must be absolute
 			"internal", "libtor", "linux", runtime.GOARCH,
 		))),

--- a/internal/cmd/buildtool/linuxcdeps.go
+++ b/internal/cmd/buildtool/linuxcdeps.go
@@ -20,6 +20,12 @@ func linuxCdepsSubcommand() *cobra.Command {
 		Use:   "cdeps {zlib|openssl|libevent|tor} [zlib|openssl|libevent|tor...]",
 		Short: "Builds C dependencies on Linux systems (experimental)",
 		Run: func(cmd *cobra.Command, args []string) {
+			// Implementation note: perform the check here such that we can
+			// run unit test for the building code from any system
+			runtimex.Assert(
+				runtime.GOOS == "linux" && runtime.GOARCH == "amd64",
+				"this command requires linux/amd64",
+			)
 			for _, arg := range args {
 				linuxCdepsBuildMain(arg, &buildDeps{})
 			}
@@ -30,10 +36,6 @@ func linuxCdepsSubcommand() *cobra.Command {
 
 // linuxCdepsBuildMain is the main of the linuxCdeps build.
 func linuxCdepsBuildMain(name string, deps buildtoolmodel.Dependencies) {
-	runtimex.Assert(
-		runtime.GOOS == "linux" && runtime.GOARCH == "amd64",
-		"this command requires linux/amd64",
-	)
 	cflags := []string{
 		// See https://airbus-seclab.github.io/c-compiler-security/
 		"-D_FORTIFY_SOURCE=2",

--- a/internal/cmd/buildtool/linuxcdeps_test.go
+++ b/internal/cmd/buildtool/linuxcdeps_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"testing"
@@ -24,6 +25,14 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 		// expectations contains the commands we expect to see
 		expect []buildtooltest.ExecExpectations
 	}
+
+	// Note: even if the build only runs on Linux, we want to run unit tests
+	// from everywhere otherwise we cannot catch errors. This means we need
+	// to do some gymnastics here to fake out the correct GOARCH.
+	sysDepDestDir := filepath.Join(
+		"internal", "cmd", "buildtool", "internal", "libtor",
+		"linux", runtime.GOARCH,
+	)
 
 	var testcases = []testspec{{
 		name:   "we can build zlib",
@@ -60,21 +69,21 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 			Env: []string{},
 			Argv: []string{
 				"make",
-				"DESTDIR=" + faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64",
+				"DESTDIR=" + faketopdir + "/" + sysDepDestDir,
 				"install",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
 				"rm", "-rf",
-				faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64/lib/pkgconfig",
+				faketopdir + "/" + sysDepDestDir + "/lib/pkgconfig",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
 				"rm",
 				"-rf",
-				faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64/share",
+				faketopdir + "/" + sysDepDestDir + "/share",
 			},
 		}},
 	}, {
@@ -121,14 +130,14 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 			Env: []string{},
 			Argv: []string{
 				"make",
-				"DESTDIR=" + faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64",
+				"DESTDIR=" + faketopdir + "/" + sysDepDestDir,
 				"install_dev",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
 				"rm", "-rf",
-				faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64/lib/pkgconfig",
+				faketopdir + "/" + sysDepDestDir + "/lib/pkgconfig",
 			},
 		}},
 	}, {
@@ -169,16 +178,19 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 		}, {
 			Env: []string{
 				fmt.Sprintf(
-					"CFLAGS=-D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection -fPIC -fsanitize=bounds -fsanitize-undefined-trap-on-error -O2 -I%s/internal/cmd/buildtool/internal/libtor/linux/amd64/include",
+					"CFLAGS=-D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection -fPIC -fsanitize=bounds -fsanitize-undefined-trap-on-error -O2 -I%s/%s/include",
 					faketopdir,
+					sysDepDestDir,
 				),
 				fmt.Sprintf(
-					"CXXFLAGS=-D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection -fPIC -fsanitize=bounds -fsanitize-undefined-trap-on-error -O2 -I%s/internal/cmd/buildtool/internal/libtor/linux/amd64/include",
+					"CXXFLAGS=-D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection -fPIC -fsanitize=bounds -fsanitize-undefined-trap-on-error -O2 -I%s/%s/include",
 					faketopdir,
+					sysDepDestDir,
 				),
 				fmt.Sprintf(
-					"LDFLAGS=-L%s/internal/cmd/buildtool/internal/libtor/linux/amd64/lib",
+					"LDFLAGS=-L%s/%s/lib",
 					faketopdir,
+					sysDepDestDir,
 				),
 			},
 			Argv: []string{
@@ -197,7 +209,7 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 			Env: []string{},
 			Argv: []string{
 				"make",
-				"DESTDIR=" + faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64",
+				"DESTDIR=" + faketopdir + "/" + sysDepDestDir,
 				"install",
 			},
 		}, {
@@ -205,77 +217,77 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 			Argv: []string{
 				"rm",
 				"-rf",
-				faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64/bin",
+				faketopdir + "/" + sysDepDestDir + "/bin",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
 				"rm",
 				"-rf",
-				faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64/lib/pkgconfig",
+				faketopdir + "/" + sysDepDestDir + "/lib/pkgconfig",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
 				"rm",
 				"-rf",
-				faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64/lib/libevent.la",
+				faketopdir + "/" + sysDepDestDir + "/lib/libevent.la",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
 				"rm",
 				"-rf",
-				faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64/lib/libevent_core.a",
+				faketopdir + "/" + sysDepDestDir + "/lib/libevent_core.a",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
 				"rm",
 				"-rf",
-				faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64/lib/libevent_core.la",
+				faketopdir + "/" + sysDepDestDir + "/lib/libevent_core.la",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
 				"rm",
 				"-rf",
-				faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64/lib/libevent_extra.a",
+				faketopdir + "/" + sysDepDestDir + "/lib/libevent_extra.a",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
 				"rm",
 				"-rf",
-				faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64/lib/libevent_extra.la",
+				faketopdir + "/" + sysDepDestDir + "/lib/libevent_extra.la",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
 				"rm",
 				"-rf",
-				faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64/lib/libevent_openssl.a",
+				faketopdir + "/" + sysDepDestDir + "/lib/libevent_openssl.a",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
 				"rm",
 				"-rf",
-				faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64/lib/libevent_openssl.la",
+				faketopdir + "/" + sysDepDestDir + "/lib/libevent_openssl.la",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
 				"rm",
 				"-rf",
-				faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64/lib/libevent_pthreads.a",
+				faketopdir + "/" + sysDepDestDir + "/lib/libevent_pthreads.a",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
 				"rm",
 				"-rf",
-				faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64/lib/libevent_pthreads.la",
+				faketopdir + "/" + sysDepDestDir + "/lib/libevent_pthreads.la",
 			},
 		}},
 	}, {
@@ -315,11 +327,11 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 				"./configure",
 				"--enable-pic",
 				"--enable-static-libevent",
-				"--with-libevent-dir=" + faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64",
+				"--with-libevent-dir=" + faketopdir + "/" + sysDepDestDir,
 				"--enable-static-openssl",
-				"--with-openssl-dir=" + faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64",
+				"--with-openssl-dir=" + faketopdir + "/" + sysDepDestDir,
 				"--enable-static-zlib",
-				"--with-zlib-dir=" + faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64",
+				"--with-zlib-dir=" + faketopdir + "/" + sysDepDestDir,
 				"--disable-module-dirauth",
 				"--disable-zstd",
 				"--disable-lzma",
@@ -336,13 +348,13 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 			Env: []string{},
 			Argv: []string{
 				"install", "-m644", "src/feature/api/tor_api.h",
-				faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64/include",
+				faketopdir + "/" + sysDepDestDir + "/include",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
 				"install", "-m644", "libtor.a",
-				faketopdir + "/internal/cmd/buildtool/internal/libtor/linux/amd64/lib",
+				faketopdir + "/" + sysDepDestDir + "/lib",
 			},
 		}},
 	}}

--- a/internal/cmd/buildtool/linuxcdeps_test.go
+++ b/internal/cmd/buildtool/linuxcdeps_test.go
@@ -11,10 +11,6 @@ import (
 )
 
 func TestLinuxCdepsBuildMain(t *testing.T) {
-	if runtime.GOOS != "linux" && runtime.GOARCH != "amd64" {
-		t.Skip("skip test for GOOS != linux and GOARCH != amd64")
-	}
-
 	faketopdir := (&buildtooltest.DependenciesCallCounter{}).AbsoluteCurDir()
 
 	// testspec specifies a test case for this test
@@ -50,6 +46,7 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 		}, {
 			Env: []string{
 				"CFLAGS=-D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection -fPIC -fsanitize=bounds -fsanitize-undefined-trap-on-error -O2",
+				"CXXFLAGS=-D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection -fPIC -fsanitize=bounds -fsanitize-undefined-trap-on-error -O2",
 			},
 			Argv: []string{
 				"./configure", "--prefix=/", "--static",
@@ -106,6 +103,7 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 		}, {
 			Env: []string{
 				"CFLAGS=-D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection -fPIC -fsanitize=bounds -fsanitize-undefined-trap-on-error -O2 -Wno-macro-redefined",
+				"CXXFLAGS=-D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection -fPIC -fsanitize=bounds -fsanitize-undefined-trap-on-error -O2 -Wno-macro-redefined",
 			},
 			Argv: []string{
 				"./Configure", "no-comp", "no-dtls", "no-ec2m", "no-psk", "no-srp",
@@ -172,6 +170,10 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 			Env: []string{
 				fmt.Sprintf(
 					"CFLAGS=-D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection -fPIC -fsanitize=bounds -fsanitize-undefined-trap-on-error -O2 -I%s/internal/cmd/buildtool/internal/libtor/linux/amd64/include",
+					faketopdir,
+				),
+				fmt.Sprintf(
+					"CXXFLAGS=-D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection -fPIC -fsanitize=bounds -fsanitize-undefined-trap-on-error -O2 -I%s/internal/cmd/buildtool/internal/libtor/linux/amd64/include",
 					faketopdir,
 				),
 				fmt.Sprintf(
@@ -307,7 +309,7 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 		}, {
 			Env: []string{
 				"CFLAGS=-D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection -fPIC -fsanitize=bounds -fsanitize-undefined-trap-on-error -O2",
-				"LDFLAGS=",
+				"CXXFLAGS=-D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection -fPIC -fsanitize=bounds -fsanitize-undefined-trap-on-error -O2",
 			},
 			Argv: []string{
 				"./configure",


### PR DESCRIPTION
At the end of the day, there's just a unique kind of build env that makes sense for both cdeps and android.

While there, write better code for merging global and local environment and make sure we have unit tests for that.

See https://github.com/ooni/probe/issues/2401
