### PR TITLE
refactor(buildtool): use naming reminding of bash variables

### DIFF
--- a/internal/cmd/buildtool/android.go
+++ b/internal/cmd/buildtool/android.go
@@ -150,12 +150,12 @@ func androidBuildCLIProductArch(
 
 	envp := &shellx.Envp{}
 	envp.Append("CGO_ENABLED", "1")
-	envp.Append("CC", cgo.cc)
-	envp.Append("CXX", cgo.cxx)
+	envp.Append("CC", cgo.CC)
+	envp.Append("CXX", cgo.CXX)
 	envp.Append("GOOS", "android")
-	envp.Append("GOARCH", cgo.goarch)
-	if cgo.goarm != "" {
-		envp.Append("GOARM", cgo.goarm)
+	envp.Append("GOARCH", cgo.GOARCH)
+	if cgo.GOARM != "" {
+		envp.Append("GOARM", cgo.GOARM)
 	}
 
 	// [2023-01-26] Adding the following flags produces these warnings for android/arm
@@ -177,35 +177,35 @@ func androidBuildCLIProductArch(
 // given ooniArch ("arm", "arm64", "386", "amd64").
 func newAndroidCBuildEnv(ndkDir string, ooniArch string) *cBuildEnv {
 	out := &cBuildEnv{
-		binpath:  androidNDKBinPath(ndkDir),
-		cc:       "",
-		cflags:   androidCflags(ooniArch),
-		cxx:      "",
-		cxxflags: androidCflags(ooniArch),
-		goarch:   "",
-		goarm:    "",
+		BINPATH:  androidNDKBinPath(ndkDir),
+		CC:       "",
+		CFLAGS:   androidCflags(ooniArch),
+		CXX:      "",
+		CXXFLAGS: androidCflags(ooniArch),
+		GOARCH:   "",
+		GOARM:    "",
 	}
 	switch ooniArch {
 	case "arm":
-		out.cc = filepath.Join(out.binpath, "armv7a-linux-androideabi21-clang")
-		out.cxx = filepath.Join(out.binpath, "armv7a-linux-androideabi21-clang++")
-		out.goarch = ooniArch
-		out.goarm = "7"
+		out.CC = filepath.Join(out.BINPATH, "armv7a-linux-androideabi21-clang")
+		out.CXX = filepath.Join(out.BINPATH, "armv7a-linux-androideabi21-clang++")
+		out.GOARCH = ooniArch
+		out.GOARM = "7"
 	case "arm64":
-		out.cc = filepath.Join(out.binpath, "aarch64-linux-android21-clang")
-		out.cxx = filepath.Join(out.binpath, "aarch64-linux-android21-clang++")
-		out.goarch = ooniArch
-		out.goarm = ""
+		out.CC = filepath.Join(out.BINPATH, "aarch64-linux-android21-clang")
+		out.CXX = filepath.Join(out.BINPATH, "aarch64-linux-android21-clang++")
+		out.GOARCH = ooniArch
+		out.GOARM = ""
 	case "386":
-		out.cc = filepath.Join(out.binpath, "i686-linux-android21-clang")
-		out.cxx = filepath.Join(out.binpath, "i686-linux-android21-clang++")
-		out.goarch = ooniArch
-		out.goarm = ""
+		out.CC = filepath.Join(out.BINPATH, "i686-linux-android21-clang")
+		out.CXX = filepath.Join(out.BINPATH, "i686-linux-android21-clang++")
+		out.GOARCH = ooniArch
+		out.GOARM = ""
 	case "amd64":
-		out.cc = filepath.Join(out.binpath, "x86_64-linux-android21-clang")
-		out.cxx = filepath.Join(out.binpath, "x86_64-linux-android21-clang++")
-		out.goarch = ooniArch
-		out.goarm = ""
+		out.CC = filepath.Join(out.BINPATH, "x86_64-linux-android21-clang")
+		out.CXX = filepath.Join(out.BINPATH, "x86_64-linux-android21-clang++")
+		out.GOARCH = ooniArch
+		out.GOARM = ""
 	default:
 		panic(errors.New("unsupported ooniArch"))
 	}

--- a/internal/cmd/buildtool/cbuildenv.go
+++ b/internal/cmd/buildtool/cbuildenv.go
@@ -11,44 +11,46 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/shellx"
 )
 
-// cBuildEnv describes the C build environment. We use
-// this structure for more complex C and CGO builds.
+// cBuildEnv describes the C build environment. We use this structure
+// for more complex C and CGO builds. You should think at fields inside
+// this structure as the enviroment variables you would use and export
+// in a bash script (hence the all uppercase naming).
 type cBuildEnv struct {
-	// binpath is the path containing the C and C++ compilers.
-	binpath string
+	// BINPATH is the path containing the C and C++ compilers.
+	BINPATH string
 
-	// cc is the full path to the C compiler.
-	cc string
+	// CC is the full path to the C compiler.
+	CC string
 
-	// cflags contains the extra CFLAGS to set.
-	cflags []string
+	// CFLAGS contains the extra CFLAGS to set.
+	CFLAGS []string
 
-	// configureHost is the value to pass to ./configure's --host option.
-	configureHost string
+	// CONFIGURE_HOST is the value to pass to ./configure's --host option.
+	CONFIGURE_HOST string
 
-	// destdir is the directory where to install.
-	destdir string
+	// DESTDIR is the directory where to install.
+	DESTDIR string
 
-	// cxx is the full path to the CXX compiler.
-	cxx string
+	// CXX is the full path to the CXX compiler.
+	CXX string
 
-	// cxxflags contains the extra CXXFLAGS to set.
-	cxxflags []string
+	// CXXFLAGS contains the extra CXXFLAGS to set.
+	CXXFLAGS []string
 
-	// goarch is the GOARCH we're building for.
-	goarch string
+	// GOARCH is the GOARCH we're building for.
+	GOARCH string
 
-	// goarm is the GOARM subarchitecture.
-	goarm string
+	// GOARM is the GOARM subarchitecture.
+	GOARM string
 
 	// lfdlags contains the LDFLAGS to use when compiling.
-	ldflags []string
+	LDFLAGS []string
 
-	// openSSLAPIDefine is an extra define we need to add on Android.
-	openSSLAPIDefine string
+	// OPENSSL_API_DEFINE is an extra define we need to add on Android.
+	OPENSSL_API_DEFINE string
 
-	// openSSLCompiler is the compiler name for OpenSSL.
-	openSSLCompiler string
+	// OPENSSL_COMPILER is the compiler name for OpenSSL.
+	OPENSSL_COMPILER string
 }
 
 // cBuildExportEnviron merges the gloval and the local c build environment
@@ -58,20 +60,20 @@ type cBuildEnv struct {
 func cBuildExportEnviron(global, local *cBuildEnv) *shellx.Envp {
 	envp := &shellx.Envp{}
 
-	cflags := append([]string{}, global.cflags...)
-	cflags = append(cflags, local.cflags...)
+	cflags := append([]string{}, global.CFLAGS...)
+	cflags = append(cflags, local.CFLAGS...)
 	if len(cflags) > 0 {
 		envp.Append("CFLAGS", strings.Join(cflags, " "))
 	}
 
-	cxxflags := append([]string{}, global.cxxflags...)
-	cxxflags = append(cxxflags, local.cxxflags...)
+	cxxflags := append([]string{}, global.CXXFLAGS...)
+	cxxflags = append(cxxflags, local.CXXFLAGS...)
 	if len(cxxflags) > 0 {
 		envp.Append("CXXFLAGS", strings.Join(cxxflags, " "))
 	}
 
-	ldflags := append([]string{}, global.ldflags...)
-	ldflags = append(ldflags, local.ldflags...)
+	ldflags := append([]string{}, global.LDFLAGS...)
+	ldflags = append(ldflags, local.LDFLAGS...)
 	if len(ldflags) > 0 {
 		envp.Append("LDFLAGS", strings.Join(ldflags, " "))
 	}

--- a/internal/cmd/buildtool/cbuildenv_test.go
+++ b/internal/cmd/buildtool/cbuildenv_test.go
@@ -9,14 +9,14 @@ import (
 func TestCBuildEnv(t *testing.T) {
 	t.Run("we can correctly merge build flags", func(t *testing.T) {
 		global := &cBuildEnv{
-			cflags:   []string{"a", "b", "c"},
-			cxxflags: []string{"A", "B", "C"},
-			ldflags:  []string{"1", "2", "3"},
+			CFLAGS:   []string{"a", "b", "c"},
+			CXXFLAGS: []string{"A", "B", "C"},
+			LDFLAGS:  []string{"1", "2", "3"},
 		}
 		local := &cBuildEnv{
-			cflags:   []string{"d", "e"},
-			cxxflags: []string{"D", "E"},
-			ldflags:  []string{"4", "5"},
+			CFLAGS:   []string{"d", "e"},
+			CXXFLAGS: []string{"D", "E"},
+			LDFLAGS:  []string{"4", "5"},
 		}
 		envp := cBuildExportEnviron(global, local)
 		expected := []string{
@@ -31,14 +31,14 @@ func TestCBuildEnv(t *testing.T) {
 
 	t.Run("we do nothing with empty variables", func(t *testing.T) {
 		global := &cBuildEnv{
-			cflags:   []string{},
-			cxxflags: []string{},
-			ldflags:  []string{},
+			CFLAGS:   []string{},
+			CXXFLAGS: []string{},
+			LDFLAGS:  []string{},
 		}
 		local := &cBuildEnv{
-			cflags:   []string{},
-			cxxflags: []string{},
-			ldflags:  []string{},
+			CFLAGS:   []string{},
+			CXXFLAGS: []string{},
+			LDFLAGS:  []string{},
 		}
 		envp := cBuildExportEnviron(global, local)
 		var expected []string

--- a/internal/cmd/buildtool/cdepslibevent.go
+++ b/internal/cmd/buildtool/cdepslibevent.go
@@ -42,32 +42,32 @@ func cdepsLibeventBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependenci
 	must.Run(log.Log, "./autogen.sh")
 
 	localEnv := &cBuildEnv{
-		cflags:   []string{"-I" + globalEnv.destdir + "/include"},
-		cxxflags: []string{"-I" + globalEnv.destdir + "/include"},
-		ldflags:  []string{"-L" + globalEnv.destdir + "/lib"},
+		CFLAGS:   []string{"-I" + globalEnv.DESTDIR + "/include"},
+		CXXFLAGS: []string{"-I" + globalEnv.DESTDIR + "/include"},
+		LDFLAGS:  []string{"-L" + globalEnv.DESTDIR + "/lib"},
 	}
 	envp := cBuildExportEnviron(globalEnv, localEnv)
 
 	argv := runtimex.Try1(shellx.NewArgv("./configure"))
-	if globalEnv.configureHost != "" {
-		argv.Append("--host=" + globalEnv.configureHost)
+	if globalEnv.CONFIGURE_HOST != "" {
+		argv.Append("--host=" + globalEnv.CONFIGURE_HOST)
 	}
 	argv.Append("--disable-libevent-regress", "--disable-samples", "--disable-shared", "--prefix=/")
 	runtimex.Try0(shellx.RunEx(defaultShellxConfig(), argv, envp))
 
 	must.Run(log.Log, "make", "V=1", "-j", strconv.Itoa(runtime.NumCPU()))
-	must.Run(log.Log, "make", "DESTDIR="+globalEnv.destdir, "install")
-	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.destdir, "bin"))
-	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.destdir, "lib", "pkgconfig"))
+	must.Run(log.Log, "make", "DESTDIR="+globalEnv.DESTDIR, "install")
+	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.DESTDIR, "bin"))
+	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.DESTDIR, "lib", "pkgconfig"))
 
 	// we just need libevent.a
-	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.destdir, "lib", "libevent.la"))
-	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.destdir, "lib", "libevent_core.a"))
-	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.destdir, "lib", "libevent_core.la"))
-	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.destdir, "lib", "libevent_extra.a"))
-	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.destdir, "lib", "libevent_extra.la"))
-	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.destdir, "lib", "libevent_openssl.a"))
-	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.destdir, "lib", "libevent_openssl.la"))
-	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.destdir, "lib", "libevent_pthreads.a"))
-	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.destdir, "lib", "libevent_pthreads.la"))
+	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.DESTDIR, "lib", "libevent.la"))
+	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.DESTDIR, "lib", "libevent_core.a"))
+	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.DESTDIR, "lib", "libevent_core.la"))
+	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.DESTDIR, "lib", "libevent_extra.a"))
+	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.DESTDIR, "lib", "libevent_extra.la"))
+	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.DESTDIR, "lib", "libevent_openssl.a"))
+	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.DESTDIR, "lib", "libevent_openssl.la"))
+	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.DESTDIR, "lib", "libevent_pthreads.a"))
+	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.DESTDIR, "lib", "libevent_pthreads.la"))
 }

--- a/internal/cmd/buildtool/cdepsopenssl.go
+++ b/internal/cmd/buildtool/cdepsopenssl.go
@@ -40,8 +40,8 @@ func cdepsOpenSSLBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependencie
 	}
 
 	localEnv := &cBuildEnv{
-		cflags:   []string{"-Wno-macro-redefined"},
-		cxxflags: []string{"-Wno-macro-redefined"},
+		CFLAGS:   []string{"-Wno-macro-redefined"},
+		CXXFLAGS: []string{"-Wno-macro-redefined"},
 	}
 	envp := cBuildExportEnviron(globalEnv, localEnv)
 
@@ -50,15 +50,15 @@ func cdepsOpenSSLBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependencie
 		"no-ssl2", "no-ssl3", "no-camellia", "no-idea", "no-md2", "no-md4",
 		"no-mdc2", "no-rc2", "no-rc4", "no-rc5", "no-rmd160", "no-whirlpool",
 		"no-dso", "no-hw", "no-ui-console", "no-shared", "no-unit-test",
-		globalEnv.openSSLCompiler,
+		globalEnv.OPENSSL_COMPILER,
 	))
-	if globalEnv.openSSLAPIDefine != "" {
-		argv.Append(globalEnv.openSSLAPIDefine)
+	if globalEnv.OPENSSL_API_DEFINE != "" {
+		argv.Append(globalEnv.OPENSSL_API_DEFINE)
 	}
 	argv.Append("--libdir=lib", "--prefix=/", "--openssldir=/")
 	runtimex.Try0(shellx.RunEx(defaultShellxConfig(), argv, envp))
 
 	must.Run(log.Log, "make", "-j", strconv.Itoa(runtime.NumCPU()))
-	must.Run(log.Log, "make", "DESTDIR="+globalEnv.destdir, "install_dev")
-	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.destdir, "lib", "pkgconfig"))
+	must.Run(log.Log, "make", "DESTDIR="+globalEnv.DESTDIR, "install_dev")
+	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.DESTDIR, "lib", "pkgconfig"))
 }

--- a/internal/cmd/buildtool/cdepstor.go
+++ b/internal/cmd/buildtool/cdepstor.go
@@ -43,14 +43,14 @@ func cdepsTorBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependencies) {
 	envp := cBuildExportEnviron(globalEnv, localEnv)
 
 	argv := runtimex.Try1(shellx.NewArgv("./configure"))
-	if globalEnv.configureHost != "" {
-		argv.Append("--host=" + globalEnv.configureHost)
+	if globalEnv.CONFIGURE_HOST != "" {
+		argv.Append("--host=" + globalEnv.CONFIGURE_HOST)
 	}
 	argv.Append(
 		"--enable-pic",
-		"--enable-static-libevent", "--with-libevent-dir="+globalEnv.destdir,
-		"--enable-static-openssl", "--with-openssl-dir="+globalEnv.destdir,
-		"--enable-static-zlib", "--with-zlib-dir="+globalEnv.destdir,
+		"--enable-static-libevent", "--with-libevent-dir="+globalEnv.DESTDIR,
+		"--enable-static-openssl", "--with-openssl-dir="+globalEnv.DESTDIR,
+		"--enable-static-zlib", "--with-zlib-dir="+globalEnv.DESTDIR,
 		"--disable-module-dirauth",
 		"--disable-zstd", "--disable-lzma",
 		"--disable-tool-name-check",
@@ -61,6 +61,6 @@ func cdepsTorBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependencies) {
 
 	must.Run(log.Log, "make", "V=1", "-j", strconv.Itoa(runtime.NumCPU()))
 
-	must.Run(log.Log, "install", "-m644", "src/feature/api/tor_api.h", globalEnv.destdir+"/include")
-	must.Run(log.Log, "install", "-m644", "libtor.a", globalEnv.destdir+"/lib")
+	must.Run(log.Log, "install", "-m644", "src/feature/api/tor_api.h", globalEnv.DESTDIR+"/include")
+	must.Run(log.Log, "install", "-m644", "libtor.a", globalEnv.DESTDIR+"/lib")
 }

--- a/internal/cmd/buildtool/cdepszlib.go
+++ b/internal/cmd/buildtool/cdepszlib.go
@@ -38,13 +38,13 @@ func cdepsZlibBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependencies) 
 	}
 
 	envp := cBuildExportEnviron(globalEnv, &cBuildEnv{})
-	if globalEnv.configureHost != "" {
-		envp.Append("CHOST", globalEnv.configureHost) // zlib's configure otherwise uses Apple's libtool
+	if globalEnv.CONFIGURE_HOST != "" {
+		envp.Append("CHOST", globalEnv.CONFIGURE_HOST) // zlib's configure otherwise uses Apple's libtool
 	}
 	cdepsMustRunWithDefaultConfig(envp, "./configure", "--prefix=/", "--static")
 
 	must.Run(log.Log, "make", "-j", strconv.Itoa(runtime.NumCPU()))
-	must.Run(log.Log, "make", "DESTDIR="+globalEnv.destdir, "install")
-	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.destdir, "lib", "pkgconfig"))
-	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.destdir, "share"))
+	must.Run(log.Log, "make", "DESTDIR="+globalEnv.DESTDIR, "install")
+	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.DESTDIR, "lib", "pkgconfig"))
+	must.Run(log.Log, "rm", "-rf", filepath.Join(globalEnv.DESTDIR, "share"))
 }

--- a/internal/cmd/buildtool/linuxcdeps.go
+++ b/internal/cmd/buildtool/linuxcdeps.go
@@ -47,12 +47,12 @@ func linuxCdepsBuildMain(name string, deps buildtoolmodel.Dependencies) {
 		"-O2",
 	}
 	globalEnv := &cBuildEnv{
-		cflags:   cflags,
-		cxxflags: cflags,
-		destdir: runtimex.Try1(filepath.Abs(filepath.Join( // must be absolute
+		CFLAGS:   cflags,
+		CXXFLAGS: cflags,
+		DESTDIR: runtimex.Try1(filepath.Abs(filepath.Join( // must be absolute
 			"internal", "libtor", "linux", runtime.GOARCH,
 		))),
-		openSSLCompiler: "linux-x86_64",
+		OPENSSL_COMPILER: "linux-x86_64",
 	}
 	switch name {
 	case "libevent":


### PR DESCRIPTION
I know this is a bit weird in the Go convention but using this naming helps me to read the code in this case.

See https://github.com/ooni/probe/issues/2401
