### PR TITLE
chore: update to ooni/go-libtor v1.1.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/miekg/dns v1.1.50
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/montanaflynn/stats v0.7.0
-	github.com/ooni/go-libtor v1.1.6
+	github.com/ooni/go-libtor v1.1.7
 	github.com/ooni/oocrypto v0.4.1
 	github.com/ooni/oohttp v0.5.1
 	github.com/ooni/probe-assets v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -626,8 +626,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.24.1 h1:KORJXNNTzJXzu4ScJWssJfJMnJ+2QJqhoQSRwNlze9E=
-github.com/ooni/go-libtor v1.1.6 h1:hf4xq2vS5E5bBC5BdG+D8orrPo81FRLXAVTDIpL4rzY=
-github.com/ooni/go-libtor v1.1.6/go.mod h1:q1YyLwRD9GeMyeerVvwc0vJ2YgwDLTp2bdVcrh/JXyI=
+github.com/ooni/go-libtor v1.1.7 h1:ooVcdEPBqDox5OfeXAfXIeQFCbqMLJVfIpO+Irr7N9A=
+github.com/ooni/go-libtor v1.1.7/go.mod h1:q1YyLwRD9GeMyeerVvwc0vJ2YgwDLTp2bdVcrh/JXyI=
 github.com/ooni/oocrypto v0.4.1 h1:R30TIYJ1Wct9Js6uv1/icVIZJWS+/TqEgRj7kG+WVKo=
 github.com/ooni/oocrypto v0.4.1/go.mod h1:D/yqWldJfw/4LKFJ0+2t0gDQ0cXVsHx2v45ODmna5SY=
 github.com/ooni/oohttp v0.5.1 h1:C2VaxI+NQRLCqPHKu6ihAHU1Cn+Q73snIjHrU8oVRbI=

--- a/internal/cmd/buildtool/android.go
+++ b/internal/cmd/buildtool/android.go
@@ -42,7 +42,7 @@ func androidSubcommand() *cobra.Command {
 	})
 	cmd.AddCommand(&cobra.Command{
 		Use:   "cdeps {zlib|openssl|libevent|tor} [zlib|openssl|libevent|tor...]",
-		Short: "Builds C dependencies on Linux systems (experimental)",
+		Short: "Cross compiles C dependencies for Android",
 		Run: func(cmd *cobra.Command, args []string) {
 			for _, arg := range args {
 				androidCdepsBuildMain(arg, &buildDeps{})
@@ -350,7 +350,6 @@ func androidCdepsBuildMain(name string, deps buildtoolmodel.Dependencies) {
 		runtime.GOOS == "darwin" || runtime.GOOS == "linux",
 		"this command requires darwin or linux",
 	)
-
 	androidHome := deps.AndroidSDKCheck()
 	ndkDir := deps.AndroidNDKCheck(androidHome)
 	archs := []string{"arm", "arm64", "386", "amd64"}

--- a/internal/cmd/buildtool/android_test.go
+++ b/internal/cmd/buildtool/android_test.go
@@ -1644,12 +1644,12 @@ func TestAndroidBuildCdepsTor(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.12.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.7.12.tar.gz",
+				"tar", "-xf", "tor-0.4.7.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -1715,12 +1715,12 @@ func TestAndroidBuildCdepsTor(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.12.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.7.12.tar.gz",
+				"tar", "-xf", "tor-0.4.7.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -1786,12 +1786,12 @@ func TestAndroidBuildCdepsTor(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.12.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.7.12.tar.gz",
+				"tar", "-xf", "tor-0.4.7.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -1857,12 +1857,12 @@ func TestAndroidBuildCdepsTor(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.12.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.7.12.tar.gz",
+				"tar", "-xf", "tor-0.4.7.13.tar.gz",
 			},
 		}, {
 			Env: []string{},

--- a/internal/cmd/buildtool/cdepstor.go
+++ b/internal/cmd/buildtool/cdepstor.go
@@ -26,13 +26,13 @@ func cdepsTorBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependencies) {
 	defer restore()
 
 	// See https://github.com/Homebrew/homebrew-core/blob/master/Formula/tor.rb
-	cdepsMustFetch("https://www.torproject.org/dist/tor-0.4.7.12.tar.gz")
+	cdepsMustFetch("https://www.torproject.org/dist/tor-0.4.7.13.tar.gz")
 	deps.VerifySHA256( // must be mockable
-		"3b5d969712c467851bd028f314343ef15a97ea457191e93ffa97310b05b9e395",
-		"tor-0.4.7.12.tar.gz",
+		"2079172cce034556f110048e26083ce9bea751f3154b0ad2809751815b11ea9d",
+		"tor-0.4.7.13.tar.gz",
 	)
-	must.Run(log.Log, "tar", "-xf", "tor-0.4.7.12.tar.gz")
-	_ = deps.MustChdir("tor-0.4.7.12") // must be mockable
+	must.Run(log.Log, "tar", "-xf", "tor-0.4.7.13.tar.gz")
+	_ = deps.MustChdir("tor-0.4.7.13") // must be mockable
 
 	mydir := filepath.Join(topdir, "CDEPS", "tor")
 	for _, patch := range cdepsMustListPatches(mydir) {

--- a/internal/cmd/buildtool/linuxcdeps_test.go
+++ b/internal/cmd/buildtool/linuxcdeps_test.go
@@ -299,12 +299,12 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.12.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.7.12.tar.gz",
+				"tar", "-xf", "tor-0.4.7.13.tar.gz",
 			},
 		}, {
 			Env: []string{},

--- a/internal/tunnel/tordesktop.go
+++ b/internal/tunnel/tordesktop.go
@@ -2,8 +2,12 @@
 
 package tunnel
 
+//
 // This file implements our strategy for running tor on desktop in most
-// configurations except for experimental ones.
+// configurations except for the ooni_libtor case, where we build tor and
+// its dependencies for Linux. The purpuse of this special case it that
+// of testing the otherwise untested code that would run on Android.
+//
 
 import (
 	"strings"

--- a/internal/tunnel/torembed.go
+++ b/internal/tunnel/torembed.go
@@ -2,7 +2,14 @@
 
 package tunnel
 
-// This file implements an experimental strategy for running tor.
+//
+// This file implements the ooni_libtor strategy of embedding tor. We manually
+// compile tor and its dependencies and link against it. We currently only adopt
+// this technique for Android. We may possibly migrate also iOS in the future,
+// provided that this functionality proves to be stable in the 3.17 cycle.
+//
+// See https://github.com/ooni/probe/issues/2365.
+//
 
 import (
 	"errors"

--- a/internal/tunnel/tormobile.go
+++ b/internal/tunnel/tormobile.go
@@ -2,7 +2,11 @@
 
 package tunnel
 
-// This file implements our strategy for running tor on mobile.
+//
+// This file implements our old strategy for running tor on mobile, which
+// is based on integrating github.com/ooni/go-libtor. We currently only use
+// this stategy on iOS. See https://github.com/ooni/probe/issues/2365.
+//
 
 import (
 	"strings"


### PR DESCRIPTION
While there, improve docs and notice we could upgrade the tor version we're using on Linux. The code builds locally both for Android and iOS. We'll test the changes in the 3.17 cycle.

See https://github.com/ooni/probe/issues/2365
