### PR TITLE
fix: attempt to make all workflows green

### DIFF
--- a/.github/workflows/alltests.yml
+++ b/.github/workflows/alltests.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get GOVERSION content
         id: goversion

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,7 +16,7 @@ jobs:
   build_android:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -98,7 +98,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,5 +13,5 @@ jobs:
       matrix:
         os: [ "ubuntu-20.04" ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: ./script/nocopyreadall.bash

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get GOVERSION content
         id: goversion

--- a/.github/workflows/debianrepo.yml
+++ b/.github/workflows/debianrepo.yml
@@ -11,27 +11,27 @@ jobs:
   test_386:
     runs-on: "ubuntu-20.04"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: sudo ./E2E/debian.bash docker i386
       - run: sudo cat DEBIAN_INSTALLED_PACKAGE.txt
 
   test_amd64:
     runs-on: "ubuntu-20.04"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: sudo ./E2E/debian.bash docker amd64
       - run: sudo cat DEBIAN_INSTALLED_PACKAGE.txt
 
   test_arm:
     runs-on: "ubuntu-20.04"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: sudo ./E2E/debian.bash docker armhf
       - run: sudo cat DEBIAN_INSTALLED_PACKAGE.txt
 
   test_arm64:
     runs-on: "ubuntu-20.04"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: sudo ./E2E/debian.bash docker arm64
       - run: sudo cat DEBIAN_INSTALLED_PACKAGE.txt

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get GOVERSION content
         id: goversion

--- a/.github/workflows/ghpublish.yml
+++ b/.github/workflows/ghpublish.yml
@@ -11,7 +11,7 @@ jobs:
   test_ghpublish_bash:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -14,7 +14,7 @@ jobs:
         GO111MODULE: on
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Get GOVERSION content
       id: goversion

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -16,7 +16,7 @@ jobs:
   build_ios_mobile:
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -53,7 +53,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/jafar.yml
+++ b/.github/workflows/jafar.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get GOVERSION content
         id: goversion

--- a/.github/workflows/libtorlinux.yml
+++ b/.github/workflows/libtorlinux.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get GOVERSION content
         id: goversion

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,7 +16,7 @@ jobs:
   build_linux_cli_386:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -26,6 +26,14 @@ jobs:
         env:
           PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
           PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+
+      - name: Get GOVERSION content
+        id: goversion
+        run: echo ::set-output name=version::$(cat GOVERSION)
+      - uses: magnetikonline/action-golang-cache@v2
+        with:
+          go-version: "${{ steps.goversion.outputs.version }}"
+          cache-key-suffix: "-linux-386-${{ steps.goversion.outputs.version }}"
 
       - uses: actions/cache@v3
         with:
@@ -50,7 +58,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -69,7 +77,7 @@ jobs:
   build_linux_cli_amd64:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -79,6 +87,14 @@ jobs:
         env:
           PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
           PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+
+      - name: Get GOVERSION content
+        id: goversion
+        run: echo ::set-output name=version::$(cat GOVERSION)
+      - uses: magnetikonline/action-golang-cache@v2
+        with:
+          go-version: "${{ steps.goversion.outputs.version }}"
+          cache-key-suffix: "-linux-amd64-${{ steps.goversion.outputs.version }}"
 
       - uses: actions/cache@v3
         with:
@@ -101,7 +117,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: build_linux_cli_amd64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -138,7 +154,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -157,7 +173,7 @@ jobs:
   build_linux_cli_armv6:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -170,6 +186,14 @@ jobs:
         env:
           PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
           PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+
+      - name: Get GOVERSION content
+        id: goversion
+        run: echo ::set-output name=version::$(cat GOVERSION)
+      - uses: magnetikonline/action-golang-cache@v2
+        with:
+          go-version: "${{ steps.goversion.outputs.version }}"
+          cache-key-suffix: "-linux-armv6-${{ steps.goversion.outputs.version }}"
 
       - uses: actions/cache@v3
         with:
@@ -194,7 +218,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -213,7 +237,7 @@ jobs:
   build_linux_cli_armv7:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -226,6 +250,14 @@ jobs:
         env:
           PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
           PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+
+      - name: Get GOVERSION content
+        id: goversion
+        run: echo ::set-output name=version::$(cat GOVERSION)
+      - uses: magnetikonline/action-golang-cache@v2
+        with:
+          go-version: "${{ steps.goversion.outputs.version }}"
+          cache-key-suffix: "-linux-armv7-${{ steps.goversion.outputs.version }}"
 
       - uses: actions/cache@v3
         with:
@@ -250,7 +282,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -269,7 +301,7 @@ jobs:
   build_linux_cli_arm64:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -282,6 +314,14 @@ jobs:
         env:
           PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
           PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
+
+      - name: Get GOVERSION content
+        id: goversion
+        run: echo ::set-output name=version::$(cat GOVERSION)
+      - uses: magnetikonline/action-golang-cache@v2
+        with:
+          go-version: "${{ steps.goversion.outputs.version }}"
+          cache-key-suffix: "-linux-arm64-${{ steps.goversion.outputs.version }}"
 
       - uses: actions/cache@v3
         with:
@@ -306,7 +346,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ jobs:
   build_darwin_cli:
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -61,7 +61,7 @@ jobs:
     runs-on: macos-11
     needs: build_darwin_cli
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -79,7 +79,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/netxlite.yml
+++ b/.github/workflows/netxlite.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ "ubuntu-20.04", "windows-2019", "macos-10.15" ]
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get GOVERSION content
         id: goversion

--- a/.github/workflows/oohelperd.yml
+++ b/.github/workflows/oohelperd.yml
@@ -16,7 +16,7 @@ jobs:
     permissions: # See https://github.com/ooni/probe/issues/2154
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get GOVERSION content
         id: goversion

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -11,5 +11,5 @@ jobs:
   test_webconnectivity:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: ./QA/rundocker.bash "webconnectivity"

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
   build_windows_cli:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -64,7 +64,7 @@ jobs:
     runs-on: windows-2019
     needs: build_windows_cli
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -81,7 +81,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/internal/cmd/buildtool/windows.go
+++ b/internal/cmd/buildtool/windows.go
@@ -100,7 +100,7 @@ func windowsMingwCheckFor(compiler string) {
 	expected := windowsMingwExpectedVersionGetter()
 	firstLine := string(must.FirstLineBytes(must.RunOutputQuiet(compiler, "--version")))
 	v := strings.Split(firstLine, " ")
-	runtimex.Assert(len(v) == 3, "expected to see exactly three tokens")
+	runtimex.Assert(len(v) >= 3, "expected to see three tokens or more")
 	if got := v[2]; got != expected {
 		log.Fatalf("expected mingw %s but got %s", expected, got)
 	}

--- a/internal/cmd/ghgen/linux.go
+++ b/internal/cmd/ghgen/linux.go
@@ -32,6 +32,7 @@ func buildAndPublishCLILinux(w io.Writer, job *Job) {
 			newSetupInstallQemuUserStatic(w)
 		}
 		newStepSetupPsiphon(w)
+		newStepSetupGo(w, fmt.Sprintf("linux-%s", arch))
 		newStepSetupLinuxDockerGoCache(w, arch)
 		newStepMake(w, fmt.Sprintf("CLI/linux-static-%s", arch))
 		newStepUploadArtifacts(w, artifacts)

--- a/internal/cmd/ghgen/utils.go
+++ b/internal/cmd/ghgen/utils.go
@@ -30,7 +30,7 @@ func newJob(w io.Writer, name, runsOn, needs string, permissions map[string]stri
 }
 
 func newStepCheckout(w io.Writer) {
-	mustFprintf(w, "      - uses: actions/checkout@v2\n")
+	mustFprintf(w, "      - uses: actions/checkout@v3\n")
 	mustFprintf(w, "        with:\n")
 	mustFprintf(w, "          fetch-depth: 0\n")
 	mustFprintf(w, "\n")


### PR DESCRIPTION
The check for the number of tokens was failing for Windows so relax the check to say "three or more".

There's a warning related to use the old checkout@v2, so upgrade to using checkout@v3 for all workflows in the repo.

The Linux action didn't set the correct version of Go, so it wasn't possible to start the build.

Everything else was WAI.

Part of https://github.com/ooni/probe/issues/2273.
