### PR TITLE
fix(netxlite): allow overriding default cert pool

### DIFF
--- a/internal/netxlite/dialer_test.go
+++ b/internal/netxlite/dialer_test.go
@@ -130,8 +130,8 @@ func TestDialerSystem(t *testing.T) {
 			if conn != nil {
 				t.Fatal("unexpected conn")
 			}
-			if stop.Sub(start) > 100*time.Millisecond {
-				t.Fatal("undable to enforce timeout")
+			if stop.Sub(start) > 500*time.Millisecond {
+				t.Fatal("unable to enforce timeout")
 			}
 		})
 	})

--- a/internal/netxlite/dialer_test.go
+++ b/internal/netxlite/dialer_test.go
@@ -130,7 +130,7 @@ func TestDialerSystem(t *testing.T) {
 			if conn != nil {
 				t.Fatal("unexpected conn")
 			}
-			if stop.Sub(start) > 500*time.Millisecond {
+			if stop.Sub(start) > 100*time.Millisecond {
 				t.Fatal("unable to enforce timeout")
 			}
 		})

--- a/internal/netxlite/quic.go
+++ b/internal/netxlite/quic.go
@@ -166,7 +166,7 @@ func (d *quicDialerQUICGo) dialEarlyContext(ctx context.Context,
 func (d *quicDialerQUICGo) maybeApplyTLSDefaults(config *tls.Config, port int) *tls.Config {
 	config = config.Clone()
 	if config.RootCAs == nil {
-		config.RootCAs = defaultCertPool
+		config.RootCAs = NewDefaultCertPool()
 	}
 	if len(config.NextProtos) <= 0 {
 		switch port {

--- a/internal/netxlite/quic_test.go
+++ b/internal/netxlite/quic_test.go
@@ -248,8 +248,8 @@ func TestQUICDialerQUICGo(t *testing.T) {
 			if tlsConfig.RootCAs != nil {
 				t.Fatal("tlsConfig.RootCAs should not have been changed")
 			}
-			if gotTLSConfig.RootCAs != defaultCertPool {
-				t.Fatal("invalid gotTLSConfig.RootCAs")
+			if gotTLSConfig.RootCAs == nil {
+				t.Fatal("gotTLSConfig.RootCAs should have been set")
 			}
 			if tlsConfig.NextProtos != nil {
 				t.Fatal("tlsConfig.NextProtos should not have been changed")
@@ -289,8 +289,8 @@ func TestQUICDialerQUICGo(t *testing.T) {
 			if tlsConfig.RootCAs != nil {
 				t.Fatal("tlsConfig.RootCAs should not have been changed")
 			}
-			if gotTLSConfig.RootCAs != defaultCertPool {
-				t.Fatal("invalid gotTLSConfig.RootCAs")
+			if gotTLSConfig.RootCAs == nil {
+				t.Fatal("gotTLSConfig.RootCAs should have been set")
 			}
 			if tlsConfig.NextProtos != nil {
 				t.Fatal("tlsConfig.NextProtos should not have been changed")

--- a/internal/netxlite/tls.go
+++ b/internal/netxlite/tls.go
@@ -184,10 +184,6 @@ type tlsHandshakerConfigurable struct {
 
 var _ model.TLSHandshaker = &tlsHandshakerConfigurable{}
 
-// defaultCertPool is the cert pool we use by default. We store this
-// value into a private variable to enable for unit testing.
-var defaultCertPool = NewDefaultCertPool()
-
 // tlsMaybeConnectionState returns the connection state if error is nil
 // and otherwise just returns an empty state to the caller.
 func tlsMaybeConnectionState(conn TLSConn, err error) tls.ConnectionState {
@@ -213,7 +209,7 @@ func (h *tlsHandshakerConfigurable) Handshake(
 	conn.SetDeadline(time.Now().Add(timeout))
 	if config.RootCAs == nil {
 		config = config.Clone()
-		config.RootCAs = defaultCertPool
+		config.RootCAs = NewDefaultCertPool()
 	}
 	tlsconn, err := h.newConn(conn, config)
 	if err != nil {

--- a/internal/netxlite/tls_test.go
+++ b/internal/netxlite/tls_test.go
@@ -269,7 +269,7 @@ func TestTLSHandshakerConfigurable(t *testing.T) {
 			if config.RootCAs != nil {
 				t.Fatal("config.RootCAs should still be nil")
 			}
-			if gotTLSConfig.RootCAs != defaultCertPool {
+			if gotTLSConfig.RootCAs == nil {
 				t.Fatal("gotTLSConfig.RootCAs has not been correctly set")
 			}
 		})


### PR DESCRIPTION
This diff tweaks https://github.com/ooni/probe-cli/pull/1068 to make sure overriding the default cert pool works.

In https://github.com/ooni/probe-cli/pull/1068 we introduced code to add this functionality but we never tested it was working as intended. It turns out it was not!

Because this diff amends the previous diff, we'll consider it part of https://github.com/ooni/probe/issues/2135.
