### PR TITLE
cleanup(oonimkall): remove MaybeUpdateResources stub

### DIFF
--- a/pkg/oonimkall/session.go
+++ b/pkg/oonimkall/session.go
@@ -270,12 +270,6 @@ type GeolocateResults struct {
 	Org string
 }
 
-// MaybeUpdateResources is a legacy stub. It does nothing. We will
-// remove it when we're ready to bump the major number.
-func (sess *Session) MaybeUpdateResources(ctx *Context) error {
-	return nil
-}
-
 // Geolocate performs a geolocate operation and returns the results.
 //
 // This function locks the session until it's done. That is, no other operation


### PR DESCRIPTION
This diff ensures we remove in probe-cli all the functions we have removed in https://github.com/ooni/probe-android/pull/552.

Part of https://github.com/ooni/probe/issues/2273.

Tested by recompiling the AAR and linking it into the Android app.
