### PR TITLE
feat(dash): migrate to locatev2

### DIFF
--- a/internal/experiment/dash/collect.go
+++ b/internal/experiment/dash/collect.go
@@ -17,20 +17,20 @@ type collectDeps interface {
 	Logger() model.Logger
 	NewHTTPRequest(method string, url string, body io.Reader) (*http.Request, error)
 	ReadAllContext(ctx context.Context, r io.Reader) ([]byte, error)
-	Scheme() string
 	UserAgent() string
 }
 
-func collect(ctx context.Context, fqdn, authorization string,
+func collect(ctx context.Context, baseURL, authorization string,
 	results []clientResults, deps collectDeps) error {
 	data, err := deps.JSONMarshal(results)
 	if err != nil {
 		return err
 	}
 	deps.Logger().Debugf("dash: body: %s", string(data))
-	var URL url.URL
-	URL.Scheme = deps.Scheme()
-	URL.Host = fqdn
+	URL, err := url.Parse(baseURL)
+	if err != nil {
+		return err
+	}
 	URL.Path = collectPath
 	req, err := deps.NewHTTPRequest("POST", URL.String(), bytes.NewReader(data))
 	if err != nil {

--- a/internal/experiment/dash/dash_test.go
+++ b/internal/experiment/dash/dash_test.go
@@ -260,7 +260,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "dash" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.13.0" {
+	if measurer.ExperimentVersion() != "0.14.0" {
 		t.Fatal("unexpected version")
 	}
 }

--- a/internal/experiment/dash/locate.go
+++ b/internal/experiment/dash/locate.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/ooni/probe-cli/v3/internal/mlablocate"
+	"github.com/ooni/probe-cli/v3/internal/mlablocatev2"
 	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
 type locateDeps interface {
@@ -14,7 +15,12 @@ type locateDeps interface {
 	UserAgent() string
 }
 
-func locate(ctx context.Context, deps locateDeps) (mlablocate.Result, error) {
-	return mlablocate.NewClient(
-		deps.HTTPClient(), deps.Logger(), deps.UserAgent()).Query(ctx, "neubot")
+func locate(ctx context.Context, deps locateDeps) (*mlablocatev2.DashResult, error) {
+	client := mlablocatev2.NewClient(deps.HTTPClient(), deps.Logger(), deps.UserAgent())
+	result, err := client.QueryDash(ctx)
+	if err != nil {
+		return nil, err
+	}
+	runtimex.Assert(len(result) >= 1, "too few entries")
+	return result[0], nil // ~same as with locate services v1
 }

--- a/internal/experiment/dash/negotiate.go
+++ b/internal/experiment/dash/negotiate.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"net/url"
 
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
@@ -17,23 +16,18 @@ type negotiateDeps interface {
 	Logger() model.Logger
 	NewHTTPRequest(method string, url string, body io.Reader) (*http.Request, error)
 	ReadAllContext(ctx context.Context, r io.Reader) ([]byte, error)
-	Scheme() string
 	UserAgent() string
 }
 
 func negotiate(
-	ctx context.Context, fqdn string, deps negotiateDeps) (negotiateResponse, error) {
+	ctx context.Context, negotiateURL string, deps negotiateDeps) (negotiateResponse, error) {
 	var negotiateResp negotiateResponse
 	data, err := deps.JSONMarshal(negotiateRequest{DASHRates: defaultRates})
 	if err != nil {
 		return negotiateResp, err
 	}
 	deps.Logger().Debugf("dash: body: %s", string(data))
-	var URL url.URL
-	URL.Scheme = deps.Scheme()
-	URL.Host = fqdn
-	URL.Path = negotiatePath
-	req, err := deps.NewHTTPRequest("POST", URL.String(), bytes.NewReader(data))
+	req, err := deps.NewHTTPRequest("POST", negotiateURL, bytes.NewReader(data))
 	if err != nil {
 		return negotiateResp, err
 	}

--- a/internal/experiment/dash/spec.go
+++ b/internal/experiment/dash/spec.go
@@ -1,9 +1,6 @@
 package dash
 
 const (
-	// negotiatePath is the URL path used to negotiate
-	negotiatePath = "/negotiate/dash"
-
 	// downloadPath is the URL path used to request DASH segments. You can
 	// append to this path an integer indicating how many bytes you would like
 	// the server to send you as part of the next chunk.

--- a/internal/mlablocatev2/mlablocatev2.go
+++ b/internal/mlablocatev2/mlablocatev2.go
@@ -191,7 +191,7 @@ type DashResult struct {
 	Site string
 
 	// NegotiateURL is the HTTPS URL to be used for
-	// performing the DASH negotiate operation. Note that the
+	// performing the DASH negotiate operation. Note that this
 	// URL typically includes the required access token.
 	NegotiateURL string
 
@@ -219,9 +219,6 @@ func (c *Client) QueryDash(ctx context.Context) ([]*DashResult, error) {
 		if r.NegotiateURL == "" {
 			continue
 		}
-		// Implementation note: we extract the hostname from the
-		// download URL, under the assumption that the download and
-		// the upload URLs have the same hostname.
 		url, err := url.Parse(r.NegotiateURL)
 		if err != nil {
 			continue


### PR DESCRIPTION
This diff migrates dash to use the locatev2 API. We previously used the locatev1 API for dash. However, this API will be removed by m-lab during 2013, so we'd better start migrating right now.

See https://github.com/ooni/probe/issues/2398
