### PR TITLE
cleanup(dash): improve docs and modernize the implementation

### DIFF
--- a/internal/experiment/dash/collect.go
+++ b/internal/experiment/dash/collect.go
@@ -1,5 +1,9 @@
 package dash
 
+//
+// The collect phase of the dash experiment.
+//
+
 import (
 	"bytes"
 	"context"
@@ -11,23 +15,43 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
 
+// collectDeps contains the dependencies for the [collect] function.
 type collectDeps interface {
-	HTTPClient() *http.Client
-	JSONMarshal(v interface{}) ([]byte, error)
+	// HTTPClient returns the HTTP client to use.
+	HTTPClient() model.HTTPClient
+
+	// JSONMarshal allows to mock the [json.Marshal] function.
+	JSONMarshal(v any) ([]byte, error)
+
+	// Logger returns the logger we should use.
 	Logger() model.Logger
+
+	// NewHTTPRequest allows to mock the [http.NewRequest] function.
 	NewHTTPRequest(method string, url string, body io.Reader) (*http.Request, error)
+
+	// RealAllContext allows to mock the [netxlite.ReadAllContext] function.
 	ReadAllContext(ctx context.Context, r io.Reader) ([]byte, error)
+
+	// Scheme returns the scheme we should use.
 	Scheme() string
+
+	// UserAgent returns the user agent we should use.
 	UserAgent() string
 }
 
+// collect implements the collect phase of the dash experiment. We send to
+// the neubot/dash server the results we collected and we get back a response
+// from the server.
 func collect(ctx context.Context, fqdn, authorization string,
 	results []clientResults, deps collectDeps) error {
+	// marshal our results
 	data, err := deps.JSONMarshal(results)
 	if err != nil {
 		return err
 	}
 	deps.Logger().Debugf("dash: body: %s", string(data))
+
+	// prepare the HTTP request
 	var URL url.URL
 	URL.Scheme = deps.Scheme()
 	URL.Host = fqdn
@@ -39,14 +63,22 @@ func collect(ctx context.Context, fqdn, authorization string,
 	req.Header.Set("User-Agent", deps.UserAgent())
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", authorization)
+
+	// send the request and get a response.
 	resp, err := deps.HTTPClient().Do(req.WithContext(ctx))
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
+	// make sure the response is successful.
 	if resp.StatusCode != 200 {
 		return errHTTPRequestFailed
 	}
-	defer resp.Body.Close()
+
+	// read, parse, and ignore the response body. Historically the
+	// most userful data has always been on the server side, therefore,
+	// it doesn't matter much that we're discarding server results.
 	data, err = deps.ReadAllContext(ctx, resp.Body)
 	if err != nil {
 		return err

--- a/internal/experiment/dash/dash.go
+++ b/internal/experiment/dash/dash.go
@@ -1,7 +1,8 @@
-// Package dash implements the DASH network experiment.
-//
-// Spec: https://github.com/ooni/spec/blob/master/nettests/ts-021-dash.md
 package dash
+
+//
+// Top-level experiment implementation
+//
 
 import (
 	"context"
@@ -25,7 +26,7 @@ const (
 	defaultTimeout = 120 * time.Second
 	magicVersion   = "0.008000000"
 	testName       = "dash"
-	testVersion    = "0.13.0"
+	testVersion    = "0.14.0"
 	totalStep      = 15
 )
 
@@ -37,7 +38,7 @@ var (
 // Config contains the experiment config.
 type Config struct{}
 
-// Simple contains the experiment total summary
+// Simple contains the experiment total summary.
 type Simple struct {
 	ConnectLatency  float64 `json:"connect_latency"`
 	MedianBitrate   int64   `json:"median_bitrate"`
@@ -47,13 +48,13 @@ type Simple struct {
 // ServerInfo contains information on the selected server
 //
 // This is currently an extension to the DASH specification
-// until the data format of the new mlab locate is clear.
+// until the data format of mlab locate v2 is fixed.
 type ServerInfo struct {
 	Hostname string `json:"hostname"`
 	Site     string `json:"site,omitempty"`
 }
 
-// TestKeys contains the test keys
+// TestKeys contains the test keys.
 type TestKeys struct {
 	Server       ServerInfo      `json:"server"`
 	Simple       Simple          `json:"simple"`
@@ -69,11 +70,11 @@ type runner struct {
 	tk         *TestKeys
 }
 
-func (r runner) HTTPClient() *http.Client {
+func (r runner) HTTPClient() model.HTTPClient {
 	return r.httpClient
 }
 
-func (r runner) JSONMarshal(v interface{}) ([]byte, error) {
+func (r runner) JSONMarshal(v any) ([]byte, error) {
 	return json.Marshal(v)
 }
 
@@ -305,7 +306,7 @@ type SummaryKeys struct {
 }
 
 // GetSummaryKeys implements model.ExperimentMeasurer.GetSummaryKeys.
-func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
+func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (any, error) {
 	sk := SummaryKeys{IsAnomaly: false}
 	tk, ok := measurement.TestKeys.(*TestKeys)
 	if !ok {

--- a/internal/experiment/dash/dash.go
+++ b/internal/experiment/dash/dash.go
@@ -23,32 +23,48 @@ import (
 )
 
 const (
+	// defaultTimeout is the default timeout for the whole experiment.
 	defaultTimeout = 120 * time.Second
-	magicVersion   = "0.008000000"
-	testName       = "dash"
-	testVersion    = "0.14.0"
-	totalStep      = 15
+
+	// magicVersion encodes the version number of the tool we are
+	// using according to the format originally used by Neubot. We
+	// used "0.007000000" for Measurement Kit, which mapped to Neubot
+	// v0.7.0. OONI pretends to be Neubot v0.8.0.
+	magicVersion = "0.008000000"
+
+	// testName is the name of the experiment.
+	testName = "dash"
+
+	// testVersion is the version of the experiment.
+	testVersion = "0.14.0"
+
+	// totalStep is the total number of steps we should run
+	// during the download experiment.
+	totalStep = 15
 )
 
 var (
-	errServerBusy        = errors.New("dash: server busy; try again later")
+	// errServerBusy is the error returned when the DASH server is busy.
+	errServerBusy = errors.New("dash: server busy; try again later")
+
+	// errHTTPRequest failed is the error returned when an HTTP request fails.
 	errHTTPRequestFailed = errors.New("dash: request failed")
 )
 
 // Config contains the experiment config.
 type Config struct{}
 
-// Simple contains the experiment total summary.
+// Simple contains the experiment summary.
 type Simple struct {
 	ConnectLatency  float64 `json:"connect_latency"`
 	MedianBitrate   int64   `json:"median_bitrate"`
 	MinPlayoutDelay float64 `json:"min_playout_delay"`
 }
 
-// ServerInfo contains information on the selected server
+// ServerInfo contains information on the selected server.
 //
 // This is currently an extension to the DASH specification
-// until the data format of mlab locate v2 is fixed.
+// until the data format of mlab locate v2 is finalized.
 type ServerInfo struct {
 	Hostname string `json:"hostname"`
 	Site     string `json:"site,omitempty"`
@@ -56,49 +72,81 @@ type ServerInfo struct {
 
 // TestKeys contains the test keys.
 type TestKeys struct {
-	Server       ServerInfo      `json:"server"`
-	Simple       Simple          `json:"simple"`
-	Failure      *string         `json:"failure"`
+	// ServerInfo contains information about the server we used.
+	Server ServerInfo `json:"server"`
+
+	// Simple contains simple summary statistics.
+	Simple Simple `json:"simple"`
+
+	// Failure is the failure that occurred.
+	Failure *string `json:"failure"`
+
+	// ReceiverData contains the results.
+	//
+	// WARNING: refactoring this field to become []*clientResults
+	// would be disastrous because the measurement loop relies
+	// on this slice being []clientResults to produce distinct results.
 	ReceiverData []clientResults `json:"receiver_data"`
 }
 
+// runner runs the experiment.
 type runner struct {
-	callbacks  model.ExperimentCallbacks
-	httpClient *http.Client
-	saver      *tracex.Saver
-	sess       model.ExperimentSession
-	tk         *TestKeys
+	// callbacks contains the callbacks for emitting progress.
+	callbacks model.ExperimentCallbacks
+
+	// httpClient is the HTTP client we're using.
+	httpClient model.HTTPClient
+
+	// saver is MUTABLE and is used to save the connect time of connections,
+	// which is part of the DASH measurement results.
+	saver *tracex.Saver
+
+	// sess is the measurement session.
+	sess model.ExperimentSession
+
+	// tk contains the MUTABLE test keys.
+	tk *TestKeys
 }
 
+// HTTPClient returns the configured HTTP client.
 func (r runner) HTTPClient() model.HTTPClient {
 	return r.httpClient
 }
 
+// JSONMarshal allows mocking the [json.Marshal] function.
 func (r runner) JSONMarshal(v any) ([]byte, error) {
 	return json.Marshal(v)
 }
 
+// Logger returns the logger to use.
 func (r runner) Logger() model.Logger {
 	return r.sess.Logger()
 }
 
+// NewHTTPRequest allows mocking the [http.NewRequest] function.
 func (r runner) NewHTTPRequest(meth, url string, body io.Reader) (*http.Request, error) {
 	return http.NewRequest(meth, url, body)
 }
 
+// RealAllContext allows mocking the [netxlite.ReadAllContext] function.
 func (r runner) ReadAllContext(ctx context.Context, reader io.Reader) ([]byte, error) {
 	return netxlite.ReadAllContext(ctx, reader)
 }
 
+// Scheme returns the URL scheme to use.
 func (r runner) Scheme() string {
 	return "https"
 }
 
+// UserAgent returns the user-agent to use.
 func (r runner) UserAgent() string {
 	return r.sess.UserAgent()
 }
 
+// loop (probably a misnomer) is the main function of the experiment, where
+// we perform in sequence all the dash experiment's phases.
 func (r runner) loop(ctx context.Context, numIterations int64) error {
+	// 1. locate the server with which to perform the measurement
 	locateResult, err := locate(ctx, r)
 	if err != nil {
 		return err
@@ -109,42 +157,69 @@ func (r runner) loop(ctx context.Context, numIterations int64) error {
 	}
 	fqdn := locateResult.FQDN
 	r.callbacks.OnProgress(0.0, fmt.Sprintf("streaming: server: %s", fqdn))
+
+	// 2. negotiate with the server and immediately bail in case
+	// there is an error. Historically, the server could choose not
+	// to allow us to perform a measurement and the Neubot client
+	// would loop until given the authorization. Nowadays, the server
+	// always admits us and the queuing is handled centrally by the
+	// m-lab locate API.
 	negotiateResp, err := negotiate(ctx, fqdn, r)
 	if err != nil {
 		return err
 	}
+
+	// 3. perform the measurement loop running for numIterations iterations.
 	if err := r.measure(ctx, fqdn, negotiateResp, numIterations); err != nil {
 		return err
 	}
-	// TODO(bassosimone): it seems we're not saving the server data?
+
+	// 4. [collect] send our measurements to the server and receive
+	// server-side measurements.
+	//
+	// Implementation note: we are not saving server-side measurements
+	// because historically the interesting DASH measurement is the one
+	// performed on the client side.
 	err = collect(ctx, fqdn, negotiateResp.Authorization, r.tk.ReceiverData, r)
 	if err != nil {
 		return err
 	}
+
+	// 5. analyze the measurement results.
 	return r.tk.analyze()
 }
 
+// measure performs DASH measurements with the server. The numIterations
+// parameter controls the total number of iterations we'll make.
 func (r runner) measure(
 	ctx context.Context, fqdn string, negotiateResp negotiateResponse,
 	numIterations int64) error {
+
+	// 1. fill the initial client results.
+	//
 	// Note: according to a comment in MK sources 3000 kbit/s was the
 	// minimum speed recommended by Netflix for SD quality in 2017.
 	//
 	// See: <https://help.netflix.com/en/node/306>.
 	const initialBitrate = 3000
 	current := clientResults{
-		ElapsedTarget: 2,
+		ElapsedTarget: 2, // we expect the download to run for two seconds.
 		Platform:      runtime.GOOS,
 		Rate:          initialBitrate,
 		RealAddress:   negotiateResp.RealAddress,
 		Version:       magicVersion,
 	}
+
 	var (
 		begin       = time.Now()
 		connectTime float64
 		total       int64
 	)
+
+	// 2. perform all the iterations
 	for current.Iteration < numIterations {
+
+		// 2.1. attempt do download a chunk from the server.
 		result, err := download(ctx, downloadConfig{
 			authorization: negotiateResp.Authorization,
 			begin:         begin,
@@ -163,12 +238,20 @@ func (r runner) measure(
 			// again, because that isn't accurate.
 			return err
 		}
+
+		// 2.2. fill the current measurement structure.
+		//
+		// TODO(bassosimone): we should create a new structure in each
+		// loop rather than overwriting the same structure and relying on
+		// copying to produce distinct structures. The current code is a
+		// small refactoring away to produce all equal structures!
 		current.Elapsed = result.elapsed
 		current.Received = result.received
 		current.RequestTicks = result.requestTicks
 		current.Timestamp = result.timestamp
 		current.ServerURL = result.serverURL
-		// Read the events so far and possibly update our measurement
+
+		// 2.3. Read the events so far and possibly update our measurement
 		// of the latest connect time. We should have one sample in most
 		// cases, because the connection should be persistent.
 		for _, ev := range r.saver.Read() {
@@ -177,7 +260,13 @@ func (r runner) measure(
 			}
 		}
 		current.ConnectTime = connectTime
+
+		// 2.4. save the current measurement.
+		//
+		// TODO(bassosimone): see the above comment about refactoring.
 		r.tk.ReceiverData = append(r.tk.ReceiverData, current)
+
+		// 2.5. update the state variables and emit progress.
 		total += current.Received
 		avgspeed := 8 * float64(total) / time.Since(begin).Seconds()
 		percentage := float64(current.Iteration) / float64(numIterations)
@@ -189,9 +278,11 @@ func (r runner) measure(
 		speed /= 1000.0 // to kbit/s
 		current.Rate = int64(speed)
 	}
+
 	return nil
 }
 
+// analyze analyzes the measurement results and fills tk.Simple.
 func (tk *TestKeys) analyze() error {
 	var (
 		rates          []float64
@@ -200,8 +291,10 @@ func (tk *TestKeys) analyze() error {
 	)
 	for _, results := range tk.ReceiverData {
 		rates = append(rates, float64(results.Rate))
+
 		// Same in all samples if we're using a single connection
 		tk.Simple.ConnectLatency = results.ConnectTime
+
 		// Rationale: first segment plays when it arrives. Subsequent segments
 		// would play in ElapsedTarget seconds. However, will play when they
 		// arrive. Stall is the time we need to wait for a frame to arrive with
@@ -217,14 +310,16 @@ func (tk *TestKeys) analyze() error {
 			tk.Simple.MinPlayoutDelay = stall
 		}
 	}
+
 	median, err := stats.Median(rates)
-	tk.Simple.MedianBitrate = int64(median)
+	tk.Simple.MedianBitrate = int64(median) // on error we compute the median of an empty array
 	return err
 }
 
+// do runs the experiment.
 func (r runner) do(ctx context.Context) error {
 	defer r.callbacks.OnProgress(1, "streaming: done")
-	const numIterations = 15
+	const numIterations = totalStep
 	err := r.loop(ctx, numIterations)
 	if err != nil {
 		s := err.Error()
@@ -251,11 +346,16 @@ func (m Measurer) ExperimentVersion() string {
 
 // Run implements model.ExperimentMeasurer.Run.
 func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
+	// unwrap arguments
 	callbacks := args.Callbacks
 	measurement := args.Measurement
 	sess := args.Session
-	tk := new(TestKeys)
+
+	// create and set the test keys
+	tk := &TestKeys{}
 	measurement.TestKeys = tk
+
+	// create a special purpose HTTP client for the measurement.
 	saver := &tracex.Saver{}
 	httpClient := &http.Client{
 		Transport: netx.NewHTTPTransport(netx.Config{
@@ -271,6 +371,12 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 		}),
 	}
 	defer httpClient.CloseIdleConnections()
+
+	// configure the overall timeout for the experiment
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+
+	// create an instance of runner.
 	r := runner{
 		callbacks:  callbacks,
 		httpClient: httpClient,
@@ -278,8 +384,9 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 		sess:       sess,
 		tk:         tk,
 	}
-	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
-	defer cancel()
+
+	// run the experiment.
+	//
 	// Implementation note: we ignore the return value of r.do rather than
 	// returning it to the caller. We do that because returning an error means
 	// the measurement failed for some fundamental reason (e.g., the input

--- a/internal/experiment/dash/dash_test.go
+++ b/internal/experiment/dash/dash_test.go
@@ -260,7 +260,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "dash" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.13.0" {
+	if measurer.ExperimentVersion() != "0.14.0" {
 		t.Fatal("unexpected version")
 	}
 }

--- a/internal/experiment/dash/download.go
+++ b/internal/experiment/dash/download.go
@@ -1,5 +1,9 @@
 package dash
 
+//
+// The download phase of the dash experiment.
+//
+
 import (
 	"context"
 	"fmt"
@@ -7,35 +11,76 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/ooni/probe-cli/v3/internal/model"
 )
 
+// downloadDeps contains dependencies for [download].
 type downloadDeps interface {
-	HTTPClient() *http.Client
+	// HTTPClient returns the HTTP client to use.
+	HTTPClient() model.HTTPClient
+
+	// NewHTTPRequest allows mocking [http.NewRequest].
 	NewHTTPRequest(method string, url string, body io.Reader) (*http.Request, error)
+
+	// ReadAllContext allows mocking [netxlite.ReadAllContext].
 	ReadAllContext(ctx context.Context, r io.Reader) ([]byte, error)
+
+	// Scheme is the scheme we should use.
 	Scheme() string
+
+	// UserAgent is the user-agent we should use.
 	UserAgent() string
 }
 
+// downloadConfig contains configuration for [download].
 type downloadConfig struct {
+	// authorization contains the authorization token to perform the download.
 	authorization string
-	begin         time.Time
-	currentRate   int64
-	deps          downloadDeps
+
+	// begin is the time when we started.
+	begin time.Time
+
+	// currentRate is the bitrate at which we request the next chunk.
+	currentRate int64
+
+	// deps contains the mockable dependencies.
+	deps downloadDeps
+
+	// elapsedTarget is the desired amount of time that the download
+	// of the next chunk should take.
 	elapsedTarget int64
-	fqdn          string
+
+	// fqdn is the domain for the URL.Host
+	fqdn string
 }
 
+// downloadResult is the result returned by [download].
 type downloadResult struct {
-	elapsed      float64
-	received     int64
+	// elapsed is the elapsed time in seconds
+	elapsed float64
+
+	// received is the number of bytes received.
+	received int64
+
+	// requestTicks is the time when we started the request in
+	// seconds relatively to the config's begin time.
 	requestTicks float64
-	serverURL    string
-	timestamp    int64
+
+	// serverURL is the URL we downloaded from.
+	serverURL string
+
+	// timestamp is the timestamp after the download.
+	timestamp int64
 }
 
+// download implements one iteration of download phase of the dash experiment. We request
+// a chunk from the server and return the measured metrics.
 func download(ctx context.Context, config downloadConfig) (downloadResult, error) {
+	// compute the desired number of bytes to download
 	nbytes := (config.currentRate * 1000 * config.elapsedTarget) >> 3
+
+	// prepare the HTTP request
 	var URL url.URL
 	URL.Scheme = config.deps.Scheme()
 	URL.Host = config.fqdn
@@ -48,19 +93,28 @@ func download(ctx context.Context, config downloadConfig) (downloadResult, error
 	result.serverURL = URL.String()
 	req.Header.Set("User-Agent", config.deps.UserAgent())
 	req.Header.Set("Authorization", config.authorization)
+
+	// issue the request and get the response
 	savedTicks := time.Now()
 	resp, err := config.deps.HTTPClient().Do(req.WithContext(ctx))
 	if err != nil {
 		return result, err
 	}
+	defer resp.Body.Close()
+
+	// make sure that the request is successful
 	if resp.StatusCode != 200 {
 		return result, errHTTPRequestFailed
 	}
-	defer resp.Body.Close()
+
+	// read the response body
 	data, err := config.deps.ReadAllContext(ctx, resp.Body)
 	if err != nil {
 		return result, err
 	}
+
+	// compute performance metrics
+	//
 	// Implementation note: MK contains a comment that says that Neubot uses
 	// the elapsed time since when we start receiving the response but it
 	// turns out that Neubot and MK do the same. So, we do what they do. At

--- a/internal/experiment/dash/fake_test.go
+++ b/internal/experiment/dash/fake_test.go
@@ -20,11 +20,11 @@ type FakeDeps struct {
 	readAllResult        []byte
 }
 
-func (d FakeDeps) HTTPClient() *http.Client {
+func (d FakeDeps) HTTPClient() model.HTTPClient {
 	return &http.Client{Transport: d.httpTransport}
 }
 
-func (d FakeDeps) JSONMarshal(v interface{}) ([]byte, error) {
+func (d FakeDeps) JSONMarshal(v any) ([]byte, error) {
 	return d.jsonMarshalResult, d.jsonMarshalErr
 }
 

--- a/internal/experiment/dash/locate.go
+++ b/internal/experiment/dash/locate.go
@@ -1,19 +1,30 @@
 package dash
 
+//
+// Code to invoke m-lab's locate API.
+//
+
 import (
 	"context"
-	"net/http"
 
 	"github.com/ooni/probe-cli/v3/internal/mlablocate"
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
 
+// locateDeps contains the dependencies for [locate].
 type locateDeps interface {
-	HTTPClient() *http.Client
+	// HTTPClient returns the HTTP client we should use.
+	HTTPClient() model.HTTPClient
+
+	// Logger returns the logger we should use.
 	Logger() model.Logger
+
+	// UserAgent returns the user agent we should use.
 	UserAgent() string
 }
 
+// locate issues a query to m-lab's locate services to obtain the
+// m-lab server with which to perform a DASH experiment.
 func locate(ctx context.Context, deps locateDeps) (mlablocate.Result, error) {
 	return mlablocate.NewClient(
 		deps.HTTPClient(), deps.Logger(), deps.UserAgent()).Query(ctx, "neubot")

--- a/internal/experiment/dash/model.go
+++ b/internal/experiment/dash/model.go
@@ -1,5 +1,11 @@
 package dash
 
+//
+// Definition of requests and responses.
+//
+// See the spec: https://github.com/ooni/spec/blob/master/nettests/ts-021-dash.md.
+//
+
 // clientResults contains the results measured by the client. This data
 // structure is sent to the server in the collection phase.
 //

--- a/internal/experiment/dash/negotiate.go
+++ b/internal/experiment/dash/negotiate.go
@@ -1,5 +1,9 @@
 package dash
 
+//
+// The negotiate phase of the DASH experiment.
+//
+
 import (
 	"bytes"
 	"context"
@@ -11,24 +15,46 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
 
+// negotiateDeps contains dependencies for [negotiate].
 type negotiateDeps interface {
-	HTTPClient() *http.Client
-	JSONMarshal(v interface{}) ([]byte, error)
+	// HTTPClient returns the HTTP client to use.
+	HTTPClient() model.HTTPClient
+
+	// JSONMarshal allows mocking the [json.Marshal] function.
+	JSONMarshal(v any) ([]byte, error)
+
+	// Logger returns the logger to use.
 	Logger() model.Logger
+
+	// NewHTTPRequest allows mocking the [http.NewRequest] function.
 	NewHTTPRequest(method string, url string, body io.Reader) (*http.Request, error)
+
+	// ReadAllContext allows mocking the [netxlite.ReadAllContext] function.
 	ReadAllContext(ctx context.Context, r io.Reader) ([]byte, error)
+
+	// Scheme returns the URL scheme to use.
 	Scheme() string
+
+	// UserAgent returns the user-agent to use.
 	UserAgent() string
 }
 
+// negotiate implements one step of the negotiate phase of dash. The original server
+// had a queue to avoid allowing too many clients to run in parallel. During the negotiate
+// loop, clients wait for servers to give them permission to start an experiment. Since
+// ~2023-02-14, we will use negotiate to authenticate using m-lab locate v2 tokens.
 func negotiate(
 	ctx context.Context, fqdn string, deps negotiateDeps) (negotiateResponse, error) {
 	var negotiateResp negotiateResponse
+
+	// marshal the request body
 	data, err := deps.JSONMarshal(negotiateRequest{DASHRates: defaultRates})
 	if err != nil {
 		return negotiateResp, err
 	}
 	deps.Logger().Debugf("dash: body: %s", string(data))
+
+	// prepare the HTTP request
 	var URL url.URL
 	URL.Scheme = deps.Scheme()
 	URL.Host = fqdn
@@ -40,23 +66,34 @@ func negotiate(
 	req.Header.Set("User-Agent", deps.UserAgent())
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "")
+
+	// issue the request and read the response
 	resp, err := deps.HTTPClient().Do(req.WithContext(ctx))
 	if err != nil {
 		return negotiateResp, err
 	}
+	defer resp.Body.Close()
+
+	// make sure we fail if the response indicates a failure
 	if resp.StatusCode != 200 {
 		return negotiateResp, errHTTPRequestFailed
 	}
-	defer resp.Body.Close()
+
+	// read the response body
 	data, err = deps.ReadAllContext(ctx, resp.Body)
 	if err != nil {
 		return negotiateResp, err
 	}
 	deps.Logger().Debugf("dash: body: %s", string(data))
+
+	// unmarshal the response body
 	err = json.Unmarshal(data, &negotiateResp)
 	if err != nil {
 		return negotiateResp, err
 	}
+
+	// check whether we have been authorized
+	//
 	// Implementation oddity: Neubot is using an integer rather than a
 	// boolean for the unchoked, with obvious semantics. I wonder why
 	// I choose an integer over a boolean, given that Python does have

--- a/internal/experiment/dash/negotiate.go
+++ b/internal/experiment/dash/negotiate.go
@@ -41,8 +41,9 @@ type negotiateDeps interface {
 
 // negotiate implements one step of the negotiate phase of dash. The original server
 // had a queue to avoid allowing too many clients to run in parallel. During the negotiate
-// loop, clients wait for servers to give them permission to start an experiment. Since
-// ~2023-02-14, we will use negotiate to authenticate using m-lab locate v2 tokens.
+// loop, clients wait for servers to give them permission to start an experiment. Modern
+// servers always authorize clients to run. Since ~2023-02-14, we will use negotiate to
+// authenticate using m-lab locate v2 tokens.
 func negotiate(
 	ctx context.Context, fqdn string, deps negotiateDeps) (negotiateResponse, error) {
 	var negotiateResp negotiateResponse


### PR DESCRIPTION
Make sure we use model.HTTPClient rather than a bare *http.Client when applicable. Make sure we use `any` rather than using the `interface{}` type. Make sure we document all structs, functions, files, and struct fields, for extra clarity.

We implemented these changes as preliminary yak shaving before working on https://github.com/ooni/probe/issues/2398.

