### PR TITLE
cleanup(dash): avoid using mockable.Session

### DIFF
--- a/internal/experiment/dash/measurer_test.go
+++ b/internal/experiment/dash/measurer_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/apex/log"
 	"github.com/montanaflynn/stats"
-	"github.com/ooni/probe-cli/v3/internal/legacy/mockable"
 	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/model/mocks"
 )
 
 func TestTestKeysAnalyzeWithNoData(t *testing.T) {
@@ -87,9 +87,16 @@ func TestMeasureWithCancelledContext(t *testing.T) {
 	args := &model.ExperimentArgs{
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
 		Measurement: measurement,
-		Session: &mockable.Session{
-			MockableHTTPClient: http.DefaultClient,
-			MockableLogger:     log.Log,
+		Session: &mocks.Session{
+			MockDefaultHTTPClient: func() model.HTTPClient {
+				return http.DefaultClient
+			},
+			MockLogger: func() model.Logger {
+				return model.DiscardLogger
+			},
+			MockUserAgent: func() string {
+				return "miniooni/0.1.0-dev"
+			},
 		},
 	}
 	err := m.Run(ctx, args)

--- a/internal/experiment/dash/runner_test.go
+++ b/internal/experiment/dash/runner_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/apex/log"
-	"github.com/ooni/probe-cli/v3/internal/legacy/mockable"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/model/mocks"
 	"github.com/ooni/probe-cli/v3/internal/tracex"
@@ -32,8 +31,13 @@ func TestRunnerLoopLocateFailure(t *testing.T) {
 			},
 		},
 		saver: &tracex.Saver{},
-		sess: &mockable.Session{
-			MockableLogger: log.Log,
+		sess: &mocks.Session{
+			MockLogger: func() model.Logger {
+				return model.DiscardLogger
+			},
+			MockUserAgent: func() string {
+				return "miniooni/0.1.0-dev"
+			},
 		},
 		tk: &TestKeys{},
 	}
@@ -70,8 +74,13 @@ func TestRunnerLoopNegotiateFailure(t *testing.T) {
 		},
 
 		saver: &tracex.Saver{},
-		sess: &mockable.Session{
-			MockableLogger: log.Log,
+		sess: &mocks.Session{
+			MockLogger: func() model.Logger {
+				return model.DiscardLogger
+			},
+			MockUserAgent: func() string {
+				return "miniooni/0.1.0-dev"
+			},
 		},
 		tk: &TestKeys{},
 	}
@@ -115,8 +124,13 @@ func TestRunnerLoopMeasureFailure(t *testing.T) {
 		},
 
 		saver: &tracex.Saver{},
-		sess: &mockable.Session{
-			MockableLogger: log.Log,
+		sess: &mocks.Session{
+			MockLogger: func() model.Logger {
+				return model.DiscardLogger
+			},
+			MockUserAgent: func() string {
+				return "miniooni/0.1.0-dev"
+			},
 		},
 		tk: &TestKeys{},
 	}
@@ -169,8 +183,13 @@ func TestRunnerLoopCollectFailure(t *testing.T) {
 		},
 
 		saver: saver,
-		sess: &mockable.Session{
-			MockableLogger: log.Log,
+		sess: &mocks.Session{
+			MockLogger: func() model.Logger {
+				return model.DiscardLogger
+			},
+			MockUserAgent: func() string {
+				return "miniooni/0.1.0-dev"
+			},
 		},
 		tk: &TestKeys{},
 	}
@@ -229,8 +248,13 @@ func TestRunnerLoopSuccess(t *testing.T) {
 		},
 
 		saver: saver,
-		sess: &mockable.Session{
-			MockableLogger: log.Log,
+		sess: &mocks.Session{
+			MockLogger: func() model.Logger {
+				return model.DiscardLogger
+			},
+			MockUserAgent: func() string {
+				return "miniooni/0.1.0-dev"
+			},
 		},
 		tk: &TestKeys{},
 	}


### PR DESCRIPTION
The mockable.Session struct has been deprecated. Rewrite tests to use the mocks.Session struct instead.

Yak shaving for https://github.com/ooni/probe/issues/2398.
