### PR TITLE
refactor(dash): avoid using struct method receivers

### DIFF
--- a/internal/experiment/dash/measurer.go
+++ b/internal/experiment/dash/measurer.go
@@ -59,17 +59,17 @@ type Measurer struct {
 }
 
 // ExperimentName implements model.ExperimentMeasurer.ExperimentName.
-func (m Measurer) ExperimentName() string {
+func (m *Measurer) ExperimentName() string {
 	return testName
 }
 
 // ExperimentVersion implements model.ExperimentMeasurer.ExperimentVersion.
-func (m Measurer) ExperimentVersion() string {
+func (m *Measurer) ExperimentVersion() string {
 	return testVersion
 }
 
 // Run implements model.ExperimentMeasurer.Run.
-func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
+func (m *Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	// unwrap arguments
 	callbacks := args.Callbacks
 	measurement := args.Measurement
@@ -101,7 +101,7 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	defer cancel()
 
 	// create an instance of runner.
-	r := runner{
+	r := &runner{
 		callbacks:  callbacks,
 		httpClient: httpClient,
 		saver:      saver,
@@ -116,13 +116,13 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	// the measurement failed for some fundamental reason (e.g., the input
 	// is an URL that you cannot parse). For DASH, this case will never happen
 	// because there is no input, so always returning nil is fine here.
-	_ = r.do(ctx)
+	_ = runnerMain(ctx, r)
 	return nil
 }
 
 // NewExperimentMeasurer creates a new ExperimentMeasurer.
 func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
-	return Measurer{config: config}
+	return &Measurer{config: config}
 }
 
 // SummaryKeys contains summary keys for this experiment.

--- a/internal/experiment/dash/runner.go
+++ b/internal/experiment/dash/runner.go
@@ -166,7 +166,7 @@ func runnerMeasure(
 		// copying to produce distinct structures. The current code is a
 		// small refactoring away to produce all equal structures! We
 		// added a WARNING in the TestKeys doc to defend against such a
-		// dangerous refactoring, while waiting to make core more robust.
+		// dangerous refactoring, while waiting to make code more robust.
 		current.Elapsed = result.elapsed
 		current.Received = result.received
 		current.RequestTicks = result.requestTicks

--- a/internal/experiment/dash/runner.go
+++ b/internal/experiment/dash/runner.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/tracex"
 )
 
-// runner runs the experiment.
+// runner contains settings for running the dash experiment.
 type runner struct {
 	// callbacks contains the callbacks for emitting progress.
 	callbacks model.ExperimentCallbacks
@@ -37,32 +37,31 @@ type runner struct {
 	tk *TestKeys
 }
 
-var _ dependencies = runner{}
+var _ dependencies = &runner{}
 
 // HTTPClient returns the configured HTTP client.
-func (r runner) HTTPClient() model.HTTPClient {
+func (r *runner) HTTPClient() model.HTTPClient {
 	return r.httpClient
 }
 
 // Logger returns the logger to use.
-func (r runner) Logger() model.Logger {
+func (r *runner) Logger() model.Logger {
 	return r.sess.Logger()
 }
 
 // NewHTTPRequestWithContext allows mocking the [http.NewRequestWithContext] function.
-func (r runner) NewHTTPRequestWithContext(
+func (r *runner) NewHTTPRequestWithContext(
 	ctx context.Context, method, url string, body io.Reader) (*http.Request, error) {
 	return http.NewRequestWithContext(ctx, method, url, body)
 }
 
 // UserAgent returns the user-agent to use.
-func (r runner) UserAgent() string {
+func (r *runner) UserAgent() string {
 	return r.sess.UserAgent()
 }
 
-// loop (probably a misnomer) is the main function of the experiment, where
-// we perform in sequence all the dash experiment's phases.
-func (r runner) loop(ctx context.Context, numIterations int64) error {
+// runnerRunAllPhases runs all the experiment phases.
+func runnerRunAllPhases(ctx context.Context, r *runner, numIterations int64) error {
 	// 1. locate the server with which to perform the measurement
 	locateResult, err := locate(ctx, r)
 	if err != nil {
@@ -87,7 +86,7 @@ func (r runner) loop(ctx context.Context, numIterations int64) error {
 	}
 
 	// 3. perform the measurement loop running for numIterations iterations.
-	if err := r.measure(ctx, fqdn, negotiateResp, numIterations); err != nil {
+	if err := runnerMeasure(ctx, r, fqdn, negotiateResp, numIterations); err != nil {
 		return err
 	}
 
@@ -106,11 +105,15 @@ func (r runner) loop(ctx context.Context, numIterations int64) error {
 	return r.tk.analyze()
 }
 
-// measure performs DASH measurements with the server. The numIterations
+// runnerMeasure performs DASH measurements with the server. The numIterations
 // parameter controls the total number of iterations we'll make.
-func (r runner) measure(
-	ctx context.Context, fqdn string, negotiateResp negotiateResponse,
-	numIterations int64) error {
+func runnerMeasure(
+	ctx context.Context,
+	r *runner,
+	fqdn string,
+	negotiateResp negotiateResponse,
+	numIterations int64,
+) error {
 
 	// 1. fill the initial client results.
 	//
@@ -161,7 +164,9 @@ func (r runner) measure(
 		// TODO(bassosimone): we should create a new structure in each
 		// loop rather than overwriting the same structure and relying on
 		// copying to produce distinct structures. The current code is a
-		// small refactoring away to produce all equal structures!
+		// small refactoring away to produce all equal structures! We
+		// added a WARNING in the TestKeys doc to defend against such a
+		// dangerous refactoring, while waiting to make core more robust.
 		current.Elapsed = result.elapsed
 		current.Received = result.received
 		current.RequestTicks = result.requestTicks
@@ -233,11 +238,10 @@ func (tk *TestKeys) analyze() error {
 	return err
 }
 
-// do runs the experiment.
-func (r runner) do(ctx context.Context) error {
+// runnerMain is the main function that runs the experiment.
+func runnerMain(ctx context.Context, r *runner) error {
 	defer r.callbacks.OnProgress(1, "streaming: done")
-	const numIterations = totalStep
-	err := r.loop(ctx, numIterations)
+	err := runnerRunAllPhases(ctx, r, totalStep)
 	if err != nil {
 		s := err.Error()
 		r.tk.Failure = &s

--- a/internal/experiment/dash/runner_test.go
+++ b/internal/experiment/dash/runner_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/tracex"
 )
 
-func TestRunnerLoopLocateFailure(t *testing.T) {
+func TestRunnerRunAllPhasesLocateFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 
-	r := runner{
+	r := &runner{
 		callbacks: model.NewPrinterCallbacks(log.Log),
 		httpClient: &mocks.HTTPClient{
 			MockDo: func(req *http.Request) (*http.Response, error) {
@@ -42,16 +42,16 @@ func TestRunnerLoopLocateFailure(t *testing.T) {
 		tk: &TestKeys{},
 	}
 
-	err := r.loop(context.Background(), 1)
+	err := runnerRunAllPhases(context.Background(), r, 1)
 	if !errors.Is(err, expected) {
 		t.Fatal("not the error we expected")
 	}
 }
 
-func TestRunnerLoopNegotiateFailure(t *testing.T) {
+func TestRunnerRunAllPhasesNegotiateFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 
-	r := runner{
+	r := &runner{
 		callbacks: model.NewPrinterCallbacks(log.Log),
 
 		httpClient: &mocks.HTTPClient{
@@ -85,15 +85,15 @@ func TestRunnerLoopNegotiateFailure(t *testing.T) {
 		tk: &TestKeys{},
 	}
 
-	err := r.loop(context.Background(), 1)
+	err := runnerRunAllPhases(context.Background(), r, 1)
 	if !errors.Is(err, expected) {
 		t.Fatal("not the error we expected")
 	}
 }
 
-func TestRunnerLoopMeasureFailure(t *testing.T) {
+func TestRunnerRunAllPhasesMeasureFailure(t *testing.T) {
 	expected := errors.New("mocked error")
-	r := runner{
+	r := &runner{
 		callbacks: model.NewPrinterCallbacks(log.Log),
 
 		httpClient: &mocks.HTTPClient{
@@ -134,17 +134,17 @@ func TestRunnerLoopMeasureFailure(t *testing.T) {
 		},
 		tk: &TestKeys{},
 	}
-	err := r.loop(context.Background(), 1)
+	err := runnerRunAllPhases(context.Background(), r, 1)
 	if !errors.Is(err, expected) {
 		t.Fatal("not the error we expected")
 	}
 }
 
-func TestRunnerLoopCollectFailure(t *testing.T) {
+func TestRunnerRunAllPhasesCollectFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	saver := new(tracex.Saver)
 	saver.Write(&tracex.EventConnectOperation{V: &tracex.EventValue{Duration: 150 * time.Millisecond}})
-	r := runner{
+	r := &runner{
 		callbacks: model.NewPrinterCallbacks(log.Log),
 
 		httpClient: &mocks.HTTPClient{
@@ -193,17 +193,17 @@ func TestRunnerLoopCollectFailure(t *testing.T) {
 		},
 		tk: &TestKeys{},
 	}
-	err := r.loop(context.Background(), 1)
+	err := runnerRunAllPhases(context.Background(), r, 1)
 	if !errors.Is(err, expected) {
 		t.Fatal("not the error we expected")
 	}
 }
 
-func TestRunnerLoopSuccess(t *testing.T) {
+func TestRunnerRunAllPhasesSuccess(t *testing.T) {
 	saver := &tracex.Saver{}
 	saver.Write(&tracex.EventConnectOperation{V: &tracex.EventValue{Duration: 150 * time.Millisecond}})
 
-	r := runner{
+	r := &runner{
 		callbacks: model.NewPrinterCallbacks(log.Log),
 
 		httpClient: &mocks.HTTPClient{
@@ -258,7 +258,7 @@ func TestRunnerLoopSuccess(t *testing.T) {
 		},
 		tk: &TestKeys{},
 	}
-	err := r.loop(context.Background(), 1)
+	err := runnerRunAllPhases(context.Background(), r, 1)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
I don't like having struct method receivers because they may hide the side effects of mutating fields.

Instead, rewrite the code such that we are using pointer receivers or we are not using methods and we're using functions instead.

Final yak shaving for https://github.com/ooni/probe/issues/2398.
