### PR TITLE
feat(oohelperd): allow collecting CPU profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /*.deb
 /*.exe
 /*.jsonl
+/*.pprof
 /*.tar.gz
 /*.zip
 /DEBIAN_INSTALLED_PACKAGE.txt


### PR DESCRIPTION
There is a way to collect CPU profiles using HTTP. However, let's start with a simple diff that allows for performing local profiling, which seems to be enough to start understanding what's wrong with oohelperd.

See https://github.com/ooni/probe/issues/2413
