### PR TITLE
fix(oohelperd): use cached cert pool for quic and tls

### DIFF
--- a/internal/cmd/oohelperd/main.go
+++ b/internal/cmd/oohelperd/main.go
@@ -23,6 +23,13 @@ import (
 
 const maxAcceptableBody = 1 << 24
 
+// certpool caches the default X509 certificate pool used by this program. Profiling
+// shows that, without caching, this program spends a significant amount of time
+// building and garbage collecting the certificate pool.
+//
+// See https://github.com/ooni/probe/issues/2413 for context.
+var certpool = netxlite.NewDefaultCertPool()
+
 var (
 	endpoint  = flag.String("endpoint", "127.0.0.1:8080", "API endpoint")
 	srvAddr   = make(chan string, 1) // with buffer

--- a/internal/cmd/oohelperd/quic.go
+++ b/internal/cmd/oohelperd/quic.go
@@ -13,7 +13,6 @@ import (
 	"github.com/lucas-clemente/quic-go"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
-	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
 // ctrlQUICResult is the result of the QUIC check performed by the test helper.
@@ -78,9 +77,11 @@ func quicDo(ctx context.Context, config *quicConfig) {
 	dialer := config.NewQUICDialer(config.Logger)
 	defer dialer.CloseIdleConnections()
 
+	// See https://github.com/ooni/probe/issues/2413 to understand
+	// why we're using a cached cert pool.
 	tlsConfig := &tls.Config{
 		NextProtos: []string{"h3"},
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    certpool,
 		ServerName: config.URLHostname,
 	}
 	quicConn, err := dialer.DialContext(ctx, config.Endpoint, tlsConfig, &quic.Config{})

--- a/internal/cmd/oohelperd/tcptls.go
+++ b/internal/cmd/oohelperd/tcptls.go
@@ -98,9 +98,11 @@ func tcpTLSDo(ctx context.Context, config *tcpTLSConfig) {
 		ol.Stop(err)
 		return
 	}
+	// See https://github.com/ooni/probe/issues/2413 to understand
+	// why we're using a cached cert pool.
 	tlsConfig := &tls.Config{
 		NextProtos: []string{"h2", "http/1.1"},
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    certpool,
 		ServerName: config.URLHostname,
 	}
 	thx := config.NewTSLHandshaker(config.Logger)


### PR DESCRIPTION
This commit creates a private static cert pool to use in the oohelperd when issuing QUIC and TLS connections.

See https://github.com/ooni/probe/issues/2413 for context.
