### PR TITLE
fix(netxlite): use private static default cert pool

### DIFF
--- a/internal/model/mocks/underlyingnetwork.go
+++ b/internal/model/mocks/underlyingnetwork.go
@@ -11,6 +11,8 @@ import (
 
 // UnderlyingNetwork allows mocking model.UnderlyingNetwork.
 type UnderlyingNetwork struct {
+	MockDefaultCertPool func() *x509.CertPool
+
 	MockDialContext func(ctx context.Context, timeout time.Duration, network, address string) (net.Conn, error)
 
 	MockListenUDP func(network string, addr *net.UDPAddr) (model.UDPLikeConn, error)
@@ -18,11 +20,13 @@ type UnderlyingNetwork struct {
 	MockGetaddrinfoLookupANY func(ctx context.Context, domain string) ([]string, string, error)
 
 	MockGetaddrinfoResolverNetwork func() string
-
-	MockMaybeModifyPool func(pool *x509.CertPool) *x509.CertPool
 }
 
 var _ model.UnderlyingNetwork = &UnderlyingNetwork{}
+
+func (un *UnderlyingNetwork) DefaultCertPool() *x509.CertPool {
+	return un.MockDefaultCertPool()
+}
 
 func (un *UnderlyingNetwork) DialContext(ctx context.Context, timeout time.Duration, network, address string) (net.Conn, error) {
 	return un.MockDialContext(ctx, timeout, network, address)
@@ -38,9 +42,4 @@ func (un *UnderlyingNetwork) GetaddrinfoLookupANY(ctx context.Context, domain st
 
 func (un *UnderlyingNetwork) GetaddrinfoResolverNetwork() string {
 	return un.MockGetaddrinfoResolverNetwork()
-}
-
-// MaybeModifyPool implements model.UnderlyingNetwork
-func (un *UnderlyingNetwork) MaybeModifyPool(pool *x509.CertPool) *x509.CertPool {
-	return un.MockMaybeModifyPool(pool)
 }

--- a/internal/model/mocks/underlyingnetwork_test.go
+++ b/internal/model/mocks/underlyingnetwork_test.go
@@ -12,6 +12,19 @@ import (
 )
 
 func TestUnderlyingNetwork(t *testing.T) {
+	t.Run("DefaultCertPool", func(t *testing.T) {
+		expect := x509.NewCertPool()
+		un := &UnderlyingNetwork{
+			MockDefaultCertPool: func() *x509.CertPool {
+				return expect
+			},
+		}
+		got := un.DefaultCertPool()
+		if got != expect {
+			t.Fatal("unexpected result")
+		}
+	})
+
 	t.Run("DialContext", func(t *testing.T) {
 		expect := errors.New("mocked error")
 		un := &UnderlyingNetwork{
@@ -75,19 +88,6 @@ func TestUnderlyingNetwork(t *testing.T) {
 		got := un.GetaddrinfoResolverNetwork()
 		if got != expect {
 			t.Fatal("unexpected resolver network")
-		}
-	})
-
-	t.Run("MaybeModifyPool", func(t *testing.T) {
-		expect := x509.NewCertPool()
-		un := &UnderlyingNetwork{
-			MockMaybeModifyPool: func(pool *x509.CertPool) *x509.CertPool {
-				return expect
-			},
-		}
-		got := un.MaybeModifyPool(nil)
-		if got != expect {
-			t.Fatal("unexpected result")
 		}
 	})
 }

--- a/internal/model/netx.go
+++ b/internal/model/netx.go
@@ -485,6 +485,13 @@ type UDPLikeConn interface {
 // UnderlyingNetwork implements the underlying network APIs on
 // top of which we implement network extensions.
 type UnderlyingNetwork interface {
+	// DefaultCertPool returns the underlying cert pool used by the
+	// network extensions library. You MUST NOT use this function to
+	// modify the default cert pool since this would lead to a data
+	// race. Use [netxlite.NewDefaultCertPool] if you wish to get
+	// a copy of the default cert pool that you can modify.
+	DefaultCertPool() *x509.CertPool
+
 	// DialContext is equivalent to net.Dialer.DialContext except that
 	// there is also an explicit timeout for dialing.
 	DialContext(ctx context.Context, timeout time.Duration, network, address string) (net.Conn, error)
@@ -498,8 +505,4 @@ type UnderlyingNetwork interface {
 
 	// ListenUDP is equivalent to net.ListenUDP.
 	ListenUDP(network string, addr *net.UDPAddr) (UDPLikeConn, error)
-
-	// MaybeModifyPool typically returns the same pool it is passed
-	// as an argument, but sometimes could modify it for testing.
-	MaybeModifyPool(pool *x509.CertPool) *x509.CertPool
 }

--- a/internal/netxlite/quic.go
+++ b/internal/netxlite/quic.go
@@ -166,7 +166,8 @@ func (d *quicDialerQUICGo) dialEarlyContext(ctx context.Context,
 func (d *quicDialerQUICGo) maybeApplyTLSDefaults(config *tls.Config, port int) *tls.Config {
 	config = config.Clone()
 	if config.RootCAs == nil {
-		config.RootCAs = NewDefaultCertPool()
+		// See https://github.com/ooni/probe/issues/2413 for context
+		config.RootCAs = tproxySingleton().DefaultCertPool()
 	}
 	if len(config.NextProtos) <= 0 {
 		switch port {

--- a/internal/netxlite/tls.go
+++ b/internal/netxlite/tls.go
@@ -105,7 +105,7 @@ func NewDefaultCertPool() *x509.CertPool {
 	// have a test in certify_test.go that guarantees that
 	ok := pool.AppendCertsFromPEM([]byte(pemcerts))
 	runtimex.Assert(ok, "pool.AppendCertsFromPEM failed")
-	return tproxySingleton().MaybeModifyPool(pool)
+	return pool
 }
 
 // ErrInvalidTLSVersion indicates that you passed us a string
@@ -209,7 +209,8 @@ func (h *tlsHandshakerConfigurable) Handshake(
 	conn.SetDeadline(time.Now().Add(timeout))
 	if config.RootCAs == nil {
 		config = config.Clone()
-		config.RootCAs = NewDefaultCertPool()
+		// See https://github.com/ooni/probe/issues/2413 for context
+		config.RootCAs = tproxySingleton().DefaultCertPool()
 	}
 	tlsconn, err := h.newConn(conn, config)
 	if err != nil {

--- a/internal/netxlite/tproxy.go
+++ b/internal/netxlite/tproxy.go
@@ -42,9 +42,19 @@ func tproxySingleton() model.UnderlyingNetwork {
 // DefaultTProxy is the default UnderlyingNetwork implementation.
 type DefaultTProxy struct{}
 
-// MaybeModifyPool implements model.UnderlyingNetwork
-func (tp *DefaultTProxy) MaybeModifyPool(pool *x509.CertPool) *x509.CertPool {
-	return pool
+// tproxyDefaultCertPool is a static copy of the default cert pool. You
+// MUST NOT access this variable directly. You SHOULD use the
+// tproxySingleton().DefaultCertPool() factory instead. By doing
+// that, you would allow integration tests to override the pool
+// we're using. Hence, we can run tests with fake servers.
+//
+// See https://github.com/ooni/probe/issues/2413 to understand why we
+// need a private static default pool.
+var tproxyDefaultCertPool = NewDefaultCertPool()
+
+// DefaultCertPool implements model.UnderlyingNetwork
+func (tp *DefaultTProxy) DefaultCertPool() *x509.CertPool {
+	return tproxyDefaultCertPool
 }
 
 // DialContext implements UnderlyingNetwork.

--- a/internal/netxlite/tproxy_test.go
+++ b/internal/netxlite/tproxy_test.go
@@ -49,6 +49,11 @@ func TestWithCustomTProxy(t *testing.T) {
 		// TODO(bassosimone): we need a more compact and ergonomic
 		// way of overriding the underlying network
 		tproxy := &mocks.UnderlyingNetwork{
+			MockDefaultCertPool: func() *x509.CertPool {
+				pool := x509.NewCertPool()
+				pool.AddCert(srvr.Certificate())
+				return pool
+			},
 			MockDialContext: func(ctx context.Context, timeout time.Duration, network string, address string) (net.Conn, error) {
 				return (&DefaultTProxy{}).DialContext(ctx, timeout, network, address)
 			},
@@ -60,11 +65,6 @@ func TestWithCustomTProxy(t *testing.T) {
 			},
 			MockGetaddrinfoResolverNetwork: func() string {
 				return (&DefaultTProxy{}).GetaddrinfoResolverNetwork()
-			},
-			MockMaybeModifyPool: func(*x509.CertPool) *x509.CertPool {
-				pool := x509.NewCertPool()
-				pool.AddCert(srvr.Certificate())
-				return pool
 			},
 		}
 

--- a/internal/sessionresolver/resolver_test.go
+++ b/internal/sessionresolver/resolver_test.go
@@ -448,6 +448,9 @@ func TestResolverWorkingAsIntendedWithMocks(t *testing.T) {
 		},
 		domainToResolve: "example.com",
 		tproxy: &mocks.UnderlyingNetwork{
+			MockDefaultCertPool: func() *x509.CertPool {
+				return netxlite.NewDefaultCertPool()
+			},
 			MockDialContext: func(ctx context.Context, timeout time.Duration, network string, address string) (net.Conn, error) {
 				dialer := &net.Dialer{Timeout: timeout}
 				return dialer.DialContext(ctx, network, address)
@@ -460,9 +463,6 @@ func TestResolverWorkingAsIntendedWithMocks(t *testing.T) {
 			},
 			MockGetaddrinfoResolverNetwork: func() string {
 				return netxlite.StdlibResolverGetaddrinfo
-			},
-			MockMaybeModifyPool: func(pool *x509.CertPool) *x509.CertPool {
-				return pool
 			},
 		},
 		expectErr:   true,
@@ -477,6 +477,9 @@ func TestResolverWorkingAsIntendedWithMocks(t *testing.T) {
 		},
 		domainToResolve: "example.com",
 		tproxy: &mocks.UnderlyingNetwork{
+			MockDefaultCertPool: func() *x509.CertPool {
+				return netxlite.NewDefaultCertPool()
+			},
 			MockDialContext: func(ctx context.Context, timeout time.Duration, network string, address string) (net.Conn, error) {
 				return nil, syscall.ECONNREFUSED
 			},
@@ -493,9 +496,6 @@ func TestResolverWorkingAsIntendedWithMocks(t *testing.T) {
 			},
 			MockGetaddrinfoResolverNetwork: func() string {
 				return netxlite.StdlibResolverGetaddrinfo
-			},
-			MockMaybeModifyPool: func(pool *x509.CertPool) *x509.CertPool {
-				return pool
 			},
 		},
 		expectErr:   false,


### PR DESCRIPTION
This diff is slightly more complex than the naive diff that creates
a private static pool and uses it for quic and tls. The reason is
that we also need to support a mechanism allowing integration tests
to transparently override the default cert pool.

See https://github.com/ooni/probe/issues/2413 for context.
