### PR TITLE
refactor(oohelperd): improve handler tests

### DIFF
--- a/internal/cmd/oohelperd/handler.go
+++ b/internal/cmd/oohelperd/handler.go
@@ -5,6 +5,7 @@ package main
 //
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -18,7 +19,8 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/version"
 )
 
-// handler implements the Web Connectivity test helper HTTP API.
+// handler is an [http.Handler] implementing the Web
+// Connectivity test helper HTTP API.
 type handler struct {
 	// BaseLogger is the MANDATORY logger to use.
 	BaseLogger model.Logger
@@ -28,6 +30,10 @@ type handler struct {
 
 	// MaxAcceptableBody is the MANDATORY maximum acceptable response body.
 	MaxAcceptableBody int64
+
+	// Measure is the MANDATORY function that the handler should call
+	// for producing a response for a valid incoming request.
+	Measure func(ctx context.Context, config *handler, creq *model.THRequest) (*model.THResponse, error)
 
 	// NewDialer is the MANDATORY factory to create a new Dialer.
 	NewDialer func(model.Logger) model.Dialer
@@ -50,19 +56,28 @@ type handler struct {
 
 var _ http.Handler = &handler{}
 
-// ServeHTTP implements http.Handler.ServeHTTP.
+// ServeHTTP implements http.Handler.
 func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	// track the number of in-flight requests
 	metricRequestsInflight.Inc()
 	defer metricRequestsInflight.Dec()
+
+	// create and add the Server header
 	w.Header().Add("Server", fmt.Sprintf(
-		"oohelperd/%s ooniprobe-engine/%s", version.Version, version.Version,
+		"oohelperd/%s ooniprobe-engine/%s",
+		version.Version,
+		version.Version,
 	))
+
+	// we only handle the POST method
 	if req.Method != "POST" {
 		metricRequestsCount.WithLabelValues("400", "bad_request_method").Inc()
 		w.WriteHeader(400)
 		return
 	}
-	reader := &io.LimitedReader{R: req.Body, N: h.MaxAcceptableBody}
+
+	// read and parse request body
+	reader := io.LimitReader(req.Body, h.MaxAcceptableBody)
 	data, err := netxlite.ReadAllContext(req.Context(), reader)
 	if err != nil {
 		metricRequestsCount.WithLabelValues("400", "request_body_too_large").Inc()
@@ -75,18 +90,27 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(400)
 		return
 	}
+
+	// measure the given input
 	started := time.Now()
-	cresp, err := measure(req.Context(), h, &creq)
+	cresp, err := h.Measure(req.Context(), h, &creq)
 	elapsed := time.Since(started)
+
+	// track the time required to produce a response
 	metricWCTaskDurationSeconds.Observe(float64(elapsed.Seconds()))
+
+	// handle the case of fundamental failure
 	if err != nil {
 		metricRequestsCount.WithLabelValues("400", "wctask_failed").Inc()
 		w.WriteHeader(400)
 		return
 	}
-	metricRequestsCount.WithLabelValues("200", "ok").Inc()
-	// We assume that the following call cannot fail because it's a
+
+	// produce successful response.
+	//
+	// Note: we assume that json.Marshal cannot fail because it's a
 	// clearly-serializable data structure.
+	metricRequestsCount.WithLabelValues("200", "ok").Inc()
 	data, err = json.Marshal(cresp)
 	runtimex.PanicOnError(err, "json.Marshal failed")
 	w.Header().Add("Content-Type", "application/json")

--- a/internal/cmd/oohelperd/logging.go
+++ b/internal/cmd/oohelperd/logging.go
@@ -1,41 +1,45 @@
 package main
 
+//
+// Logging code
+//
+
 import "github.com/ooni/probe-cli/v3/internal/model"
 
-// indexLogger is a logger with an index.
-type indexLogger struct {
+// prefixLogger is a logger with a prefix.
+type prefixLogger struct {
 	indexstr string
 	logger   model.Logger
 }
 
-var _ model.Logger = &indexLogger{}
+var _ model.Logger = &prefixLogger{}
 
 // Debug implements DebugLogger.Debug
-func (p *indexLogger) Debug(msg string) {
+func (p *prefixLogger) Debug(msg string) {
 	p.logger.Debug(p.indexstr + msg)
 }
 
 // Debugf implements DebugLogger.Debugf
-func (p *indexLogger) Debugf(format string, v ...interface{}) {
+func (p *prefixLogger) Debugf(format string, v ...interface{}) {
 	p.logger.Debugf(p.indexstr+format, v...)
 }
 
 // Info implements InfoLogger.Info
-func (p *indexLogger) Info(msg string) {
+func (p *prefixLogger) Info(msg string) {
 	p.logger.Info(p.indexstr + msg)
 }
 
 // Infov implements InfoLogger.Infov
-func (p *indexLogger) Infof(format string, v ...interface{}) {
+func (p *prefixLogger) Infof(format string, v ...interface{}) {
 	p.logger.Infof(p.indexstr+format, v...)
 }
 
 // Warn implements Logger.Warn
-func (p *indexLogger) Warn(msg string) {
+func (p *prefixLogger) Warn(msg string) {
 	p.logger.Warn(p.indexstr + msg)
 }
 
 // Warnf implements Logger.Warnf
-func (p *indexLogger) Warnf(format string, v ...interface{}) {
+func (p *prefixLogger) Warnf(format string, v ...interface{}) {
 	p.logger.Warnf(p.indexstr+format, v...)
 }

--- a/internal/cmd/oohelperd/logging_test.go
+++ b/internal/cmd/oohelperd/logging_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/model/mocks"
 )
 
-func TestIndexLogger(t *testing.T) {
+func TestPrefixLogger(t *testing.T) {
 	t.Run("Debug", func(t *testing.T) {
 		expected := "<0>antani"
 		base := &mocks.Logger{
@@ -16,7 +16,7 @@ func TestIndexLogger(t *testing.T) {
 				}
 			},
 		}
-		logger := &indexLogger{
+		logger := &prefixLogger{
 			indexstr: "<0>",
 			logger:   base,
 		}
@@ -32,7 +32,7 @@ func TestIndexLogger(t *testing.T) {
 				}
 			},
 		}
-		logger := &indexLogger{
+		logger := &prefixLogger{
 			indexstr: "<0>",
 			logger:   base,
 		}
@@ -48,7 +48,7 @@ func TestIndexLogger(t *testing.T) {
 				}
 			},
 		}
-		logger := &indexLogger{
+		logger := &prefixLogger{
 			indexstr: "<0>",
 			logger:   base,
 		}
@@ -64,7 +64,7 @@ func TestIndexLogger(t *testing.T) {
 				}
 			},
 		}
-		logger := &indexLogger{
+		logger := &prefixLogger{
 			indexstr: "<0>",
 			logger:   base,
 		}
@@ -80,7 +80,7 @@ func TestIndexLogger(t *testing.T) {
 				}
 			},
 		}
-		logger := &indexLogger{
+		logger := &prefixLogger{
 			indexstr: "<0>",
 			logger:   base,
 		}
@@ -96,7 +96,7 @@ func TestIndexLogger(t *testing.T) {
 				}
 			},
 		}
-		logger := &indexLogger{
+		logger := &prefixLogger{
 			indexstr: "<0>",
 			logger:   base,
 		}

--- a/internal/cmd/oohelperd/measure.go
+++ b/internal/cmd/oohelperd/measure.go
@@ -26,7 +26,7 @@ type (
 // returns the corresponding response or an error.
 func measure(ctx context.Context, config *handler, creq *ctrlRequest) (*ctrlResponse, error) {
 	// create indexed logger
-	logger := &indexLogger{
+	logger := &prefixLogger{
 		indexstr: fmt.Sprintf("<#%d> ", config.Indexer.Add(1)),
 		logger:   config.BaseLogger,
 	}


### PR DESCRIPTION
This diff attempts to rewrite and steer handler_test.go such that it mostly contains unit tests. As part of this work, we create a single factory function for constructing the handler. While there, we also rename the indexLogger to prefixLogger (a more accurate name) and we deploy more comments and whitespaces.

Part of https://github.com/ooni/probe/issues/2413
