### PR TITLE
fix: avoid NewDefaultCertPool when not needed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,12 @@ and `./internal/netxlite.CopyContext` instead of `io.Copy`
 - use `./internal/model.ErrorToStringOrOK` when
 an experiment logs intermediate results
 
+- do not call `netxlite.NewDefaultCertPool` unless you need to
+modify a copy of the default Mozilla CA pool (when using `netxlite`
+as the underlying library--which is the common case--you can just
+leave the `RootCAs` to `nil` in a `tls.Config` and `netxlite`
+will understand you want to use the default pool)
+
 ## Code testing requirements
 
 Make sure all tests pass with `go test -race ./...` run from the

--- a/docs/design/dd-003-step-by-step.md
+++ b/docs/design/dd-003-step-by-step.md
@@ -295,7 +295,7 @@ observations, while reflecting on their pros and cons.
 
 We revisit four distinct tactics:
 
-* [(1) Context-based tracing](#21-context-based-tracing), 
+* [(1) Context-based tracing](#21-context-based-tracing),
 * [(2) Decorator-based tracing](#22-decorator-based-tracing),
 * [(3) Step-by-step measurements](#23-step-by-step-measurements), and
 * [(4) Measurex: splitting DNSLookup and Endpoint Measurements](#24-measurex-splitting-dnslookup-and-endpoint-measurements).
@@ -950,7 +950,7 @@ care about more precisely and with less effort.
 ### 2.3. Step-by-step measurements
 
 We've had many conversations about how to simplify the way we do measurements.
-For instance, [Vinicius](https://github.com/fortuna) at some point advocated 
+For instance, [Vinicius](https://github.com/fortuna) at some point advocated
 for decomposing measurements in simple operations. He rightfully pointed out
 that tracing is excellent for debugging, but it complicates to assign
 meaning to each measurement.
@@ -1050,7 +1050,7 @@ similar to the above code.
 
 #### Issue #1 with step-by-step approach: no persistent connections
 
-Without adding extra complexity, we lose the possibility to use 
+Without adding extra complexity, we lose the possibility to use
 persistent connections. This may not be a huge problem, except for
 redirects. Each redirect will require us to set up a new connection,
 even though an ordinary `http.Transport` would probably have reused an
@@ -1392,7 +1392,7 @@ logger model.Logger, zeroTime time.Time, tk *TestKeys, address string) {
 
 	config := &tls.Config{
 		NextProtos: []string{"h2", "http/1.1"},
-		RootCAs: netxlite.NewDefaultCertPool(),
+		RootCAs: nil, // use the default Mozilla cert pool
 		ServerName: webDomain,
 	}
 	tlsConn, _, err := thx.Handshake(ctx, cw, config)

--- a/internal/cmd/oohelperd/main.go
+++ b/internal/cmd/oohelperd/main.go
@@ -23,13 +23,6 @@ import (
 
 const maxAcceptableBody = 1 << 24
 
-// certpool caches the default X509 certificate pool used by this program. Profiling
-// shows that, without caching, this program spends a significant amount of time
-// building and garbage collecting the certificate pool.
-//
-// See https://github.com/ooni/probe/issues/2413 for context.
-var certpool = netxlite.NewDefaultCertPool()
-
 var (
 	endpoint  = flag.String("endpoint", "127.0.0.1:8080", "API endpoint")
 	srvAddr   = make(chan string, 1) // with buffer

--- a/internal/cmd/oohelperd/quic.go
+++ b/internal/cmd/oohelperd/quic.go
@@ -78,10 +78,11 @@ func quicDo(ctx context.Context, config *quicConfig) {
 	defer dialer.CloseIdleConnections()
 
 	// See https://github.com/ooni/probe/issues/2413 to understand
-	// why we're using a cached cert pool.
+	// why we're using nil to force netxlite to use the cached
+	// default Mozilla cert pool.
 	tlsConfig := &tls.Config{
 		NextProtos: []string{"h3"},
-		RootCAs:    certpool,
+		RootCAs:    nil,
 		ServerName: config.URLHostname,
 	}
 	quicConn, err := dialer.DialContext(ctx, config.Endpoint, tlsConfig, &quic.Config{})

--- a/internal/cmd/oohelperd/tcptls.go
+++ b/internal/cmd/oohelperd/tcptls.go
@@ -99,10 +99,11 @@ func tcpTLSDo(ctx context.Context, config *tcpTLSConfig) {
 		return
 	}
 	// See https://github.com/ooni/probe/issues/2413 to understand
-	// why we're using a cached cert pool.
+	// why we're using nil to force netxlite to use the cached
+	// default Mozilla cert pool.
 	tlsConfig := &tls.Config{
 		NextProtos: []string{"h2", "http/1.1"},
-		RootCAs:    certpool,
+		RootCAs:    nil,
 		ServerName: config.URLHostname,
 	}
 	thx := config.NewTSLHandshaker(config.Logger)

--- a/internal/experiment/echcheck/measure.go
+++ b/internal/experiment/echcheck/measure.go
@@ -3,18 +3,19 @@ package echcheck
 import (
 	"context"
 	"errors"
+	"net"
+	"net/url"
+	"time"
+
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
-	"net"
-	"net/url"
-	"time"
 )
 
 const (
 	testName      = "echcheck"
-	testVersion   = "0.1.0"
+	testVersion   = "0.1.1"
 	defaultDomain = "https://example.org"
 )
 

--- a/internal/experiment/echcheck/measure_test.go
+++ b/internal/experiment/echcheck/measure_test.go
@@ -2,10 +2,11 @@ package echcheck
 
 import (
 	"context"
+	"testing"
+
 	"github.com/apex/log"
 	"github.com/ooni/probe-cli/v3/internal/legacy/mockable"
 	"github.com/ooni/probe-cli/v3/internal/model"
-	"testing"
 )
 
 func TestNewExperimentMeasurer(t *testing.T) {
@@ -13,7 +14,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "echcheck" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.1.0" {
+	if measurer.ExperimentVersion() != "0.1.1" {
 		t.Fatal("unexpected version")
 	}
 }

--- a/internal/experiment/ndt7/dial.go
+++ b/internal/experiment/ndt7/dial.go
@@ -29,6 +29,12 @@ func newDialManager(ndt7URL string, logger model.Logger, userAgent string) dialM
 	}
 }
 
+// We force using our bundled CA pool, which should fix
+// https://github.com/ooni/probe/issues/2031. We are creating
+// the pool just once because there is a performance penalty
+// when creating it every time. See https://github.com/ooni/probe/issues/2413.
+var certpool = netxlite.NewDefaultCertPool()
+
 func (mgr dialManager) dialWithTestName(ctx context.Context, testName string) (*websocket.Conn, error) {
 	reso := netxlite.NewStdlibResolver(mgr.logger)
 	dlr := netxlite.NewDialerWithResolver(mgr.logger, reso)
@@ -36,10 +42,8 @@ func (mgr dialManager) dialWithTestName(ctx context.Context, testName string) (*
 	// Implements shaping if the user builds using `-tags shaping`
 	// See https://github.com/ooni/probe/issues/2112
 	dlr = netxlite.NewMaybeShapingDialer(dlr)
-	// We force using our bundled CA pool, which should fix
-	// https://github.com/ooni/probe/issues/2031
 	tlsConfig := &tls.Config{
-		RootCAs: netxlite.NewDefaultCertPool(),
+		RootCAs: certpool,
 	}
 	dialer := websocket.Dialer{
 		NetDialContext:  dlr.DialContext,

--- a/internal/experiment/ndt7/ndt7.go
+++ b/internal/experiment/ndt7/ndt7.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	testName    = "ndt"
-	testVersion = "0.10.0"
+	testVersion = "0.10.1"
 )
 
 // Config contains the experiment settings

--- a/internal/experiment/ndt7/ndt7_test.go
+++ b/internal/experiment/ndt7/ndt7_test.go
@@ -17,7 +17,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "ndt" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.10.0" {
+	if measurer.ExperimentVersion() != "0.10.1" {
 		t.Fatal("unexpected version")
 	}
 }

--- a/internal/experiment/simplequicping/simplequicping.go
+++ b/internal/experiment/simplequicping/simplequicping.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	testName    = "simplequicping"
-	testVersion = "0.2.0"
+	testVersion = "0.2.1"
 )
 
 // Config contains the experiment configuration.
@@ -173,9 +173,12 @@ func (m *Measurer) quicHandshake(ctx context.Context, index int64,
 	ol := measurexlite.NewOperationLogger(logger, "SimpleQUICPing #%d %s %s %v", index, address, sni, alpn)
 	listener := netxlite.NewQUICListener()
 	dialer := trace.NewQUICDialerWithoutResolver(listener, logger)
+	// See https://github.com/ooni/probe/issues/2413 to understand
+	// why we're using nil to force netxlite to use the cached
+	// default Mozilla cert pool.
 	tlsConfig := &tls.Config{
 		NextProtos: alpn,
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    nil,
 		ServerName: sni,
 	}
 	quicEarlyConn, err := dialer.DialContext(ctx, address, tlsConfig, &quic.Config{})

--- a/internal/experiment/simplequicping/simplequicping_test.go
+++ b/internal/experiment/simplequicping/simplequicping_test.go
@@ -54,7 +54,7 @@ func TestMeasurer_run(t *testing.T) {
 		if m.ExperimentName() != "simplequicping" {
 			t.Fatal("invalid experiment name")
 		}
-		if m.ExperimentVersion() != "0.2.0" {
+		if m.ExperimentVersion() != "0.2.1" {
 			t.Fatal("invalid experiment version")
 		}
 		ctx := context.Background()

--- a/internal/experiment/tlsmiddlebox/measurer.go
+++ b/internal/experiment/tlsmiddlebox/measurer.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	testName    = "tlsmiddlebox"
-	testVersion = "0.1.0"
+	testVersion = "0.1.1"
 )
 
 // Measurer performs the measurement.

--- a/internal/experiment/tlsmiddlebox/measurer_test.go
+++ b/internal/experiment/tlsmiddlebox/measurer_test.go
@@ -18,7 +18,7 @@ func TestMeasurerExperimentNameVersion(t *testing.T) {
 	if measurer.ExperimentName() != "tlsmiddlebox" {
 		t.Fatal("unexpected ExperimentName")
 	}
-	if measurer.ExperimentVersion() != "0.1.0" {
+	if measurer.ExperimentVersion() != "0.1.1" {
 		t.Fatal("unexpected ExperimentVersion")
 	}
 }

--- a/internal/experiment/tlsmiddlebox/tracing.go
+++ b/internal/experiment/tlsmiddlebox/tracing.go
@@ -120,8 +120,11 @@ func extractSoError(conn net.Conn) error {
 
 // genTLSConfig generates tls.Config from a given SNI
 func genTLSConfig(sni string) *tls.Config {
+	// See https://github.com/ooni/probe/issues/2413 to understand
+	// why we're using nil to force netxlite to use the cached
+	// default Mozilla cert pool.
 	return &tls.Config{
-		RootCAs:            netxlite.NewDefaultCertPool(),
+		RootCAs:            nil,
 		ServerName:         sni,
 		NextProtos:         []string{"h2", "http/1.1"},
 		InsecureSkipVerify: true,

--- a/internal/experiment/tlsping/tlsping.go
+++ b/internal/experiment/tlsping/tlsping.go
@@ -15,12 +15,11 @@ import (
 
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
-	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
 const (
 	testName    = "tlsping"
-	testVersion = "0.2.0"
+	testVersion = "0.2.1"
 )
 
 // Config contains the experiment configuration.
@@ -181,9 +180,12 @@ func (m *Measurer) tlsConnectAndHandshake(ctx context.Context, index int64,
 	}
 	defer conn.Close()
 	thx := trace.NewTLSHandshakerStdlib(logger)
+	// See https://github.com/ooni/probe/issues/2413 to understand
+	// why we're using nil to force netxlite to use the cached
+	// default Mozilla cert pool.
 	config := &tls.Config{
 		NextProtos: alpn,
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    nil,
 		ServerName: sni,
 	}
 	_, _, err = thx.Handshake(ctx, conn, config)

--- a/internal/experiment/tlsping/tlsping_test.go
+++ b/internal/experiment/tlsping/tlsping_test.go
@@ -48,7 +48,7 @@ func TestMeasurer_run(t *testing.T) {
 		if m.ExperimentName() != "tlsping" {
 			t.Fatal("invalid experiment name")
 		}
-		if m.ExperimentVersion() != "0.2.0" {
+		if m.ExperimentVersion() != "0.2.1" {
 			t.Fatal("invalid experiment version")
 		}
 		meas := &model.Measurement{

--- a/internal/experiment/webconnectivitylte/measurer.go
+++ b/internal/experiment/webconnectivitylte/measurer.go
@@ -36,7 +36,7 @@ func (m *Measurer) ExperimentName() string {
 
 // ExperimentVersion implements model.ExperimentMeasurer.
 func (m *Measurer) ExperimentVersion() string {
-	return "0.5.20"
+	return "0.5.21"
 }
 
 // Run implements model.ExperimentMeasurer.

--- a/internal/experiment/webconnectivitylte/secureflow.go
+++ b/internal/experiment/webconnectivitylte/secureflow.go
@@ -134,9 +134,12 @@ func (t *SecureFlow) Run(parentCtx context.Context, index int64) error {
 		return err
 	}
 	tlsHandshaker := trace.NewTLSHandshakerStdlib(t.Logger)
+	// See https://github.com/ooni/probe/issues/2413 to understand
+	// why we're using nil to force netxlite to use the cached
+	// default Mozilla cert pool.
 	tlsConfig := &tls.Config{
 		NextProtos: t.alpn(),
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    nil,
 		ServerName: tlsSNI,
 	}
 	const tlsTimeout = 10 * time.Second

--- a/internal/measurex/easy.go
+++ b/internal/measurex/easy.go
@@ -62,7 +62,11 @@ type EasyTLSConfig struct {
 func NewEasyTLSConfig() *EasyTLSConfig {
 	return &EasyTLSConfig{
 		config: &tls.Config{
-			RootCAs: netxlite.NewDefaultCertPool(),
+			// Because here we use nil, this causes netxlite to use
+			// a cached copy of Mozilla's CA pool. We don't create a
+			// new pool every time for performance reasons. See
+			// https://github.com/ooni/probe/issues/2413 for context.
+			RootCAs: nil,
 		},
 	}
 }

--- a/internal/measurex/measurer.go
+++ b/internal/measurex/measurer.go
@@ -299,7 +299,8 @@ func (mx *Measurer) TCPConnectWithDB(ctx context.Context, db WritableDB, address
 // - ServerName to the desired SNI or InsecureSkipVerify to
 // skip the certificate name verification;
 //
-// - RootCAs to nextlite.NewDefaultCertPool() output;
+// - RootCAs to nil to force netxlite to use its cached
+// copy of Mozilla's CA bundle;
 //
 // - NextProtos to the desired ALPN ([]string{"h2", "http/1.1"} for
 // HTTPS and []string{"dot"} for DNS-over-TLS).
@@ -378,7 +379,8 @@ func (mx *Measurer) TLSConnectAndHandshakeWithDB(ctx context.Context,
 // - ServerName to the desired SNI or InsecureSkipVerify to
 // skip the certificate name verification;
 //
-// - RootCAs to nextlite.NewDefaultCertPool() output;
+// - RootCAs to nil to force netxlite to use its cached
+// copy of Mozilla's CA bundle;
 //
 // - NextProtos to the desired ALPN ([]string{"h2", "http/1.1"} for
 // HTTPS and []string{"dot"} for DNS-over-TLS).
@@ -557,10 +559,12 @@ func (mx *Measurer) httpEndpointGetHTTP(ctx context.Context,
 // httpEndpointGetHTTPS specializes httpEndpointGetTCP for HTTPS.
 func (mx *Measurer) httpEndpointGetHTTPS(ctx context.Context,
 	db WritableDB, epnt *HTTPEndpoint, jar http.CookieJar) (*http.Response, error) {
+	// Using a nil cert pool here forces netxlite to use a cached copy of Mozilla's
+	// CA bundle. See https://github.com/ooni/probe/issues/2413 for context.
 	conn, err := mx.TLSConnectAndHandshakeWithDB(ctx, db, epnt.Address, &tls.Config{
 		ServerName: epnt.SNI,
 		NextProtos: epnt.ALPN,
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    nil,
 	})
 	if err != nil {
 		return nil, err
@@ -575,10 +579,12 @@ func (mx *Measurer) httpEndpointGetHTTPS(ctx context.Context,
 // httpEndpointGetQUIC specializes httpEndpointGetTCP for QUIC.
 func (mx *Measurer) httpEndpointGetQUIC(ctx context.Context,
 	db WritableDB, epnt *HTTPEndpoint, jar http.CookieJar) (*http.Response, error) {
+	// Using a nil cert pool here forces netxlite to use a cached copy of Mozilla's
+	// CA bundle. See https://github.com/ooni/probe/issues/2413 for context.
 	qconn, err := mx.QUICHandshakeWithDB(ctx, db, epnt.Address, &tls.Config{
 		ServerName: epnt.SNI,
 		NextProtos: epnt.ALPN,
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    nil,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/model/netx.go
+++ b/internal/model/netx.go
@@ -203,7 +203,7 @@ type QUICDialer interface {
 	//
 	// - set ServerName to be the SNI;
 	//
-	// - set RootCAs to NewDefaultCertPool();
+	// - set RootCAs to nil (which causes us to use the default cert pool);
 	//
 	// - set NextProtos to []string{"h3"}.
 	//
@@ -277,7 +277,7 @@ type TLSHandshaker interface {
 	//
 	// - set ServerName to be the SNI;
 	//
-	// - set RootCAs to NewDefaultCertPool();
+	// - set RootCAs to nil (which causes us to use the default cert pool);
 	//
 	// - set NextProtos to []string{"h2", "http/1.1"} for HTTPS
 	// and []string{"dot"} for DNS-over-TLS.

--- a/internal/netxlite/integration_test.go
+++ b/internal/netxlite/integration_test.go
@@ -289,10 +289,13 @@ func TestMeasureWithTLSHandshaker(t *testing.T) {
 			return fmt.Errorf("dial failed: %w", err)
 		}
 		defer conn.Close()
+		// See https://github.com/ooni/probe/issues/2413 to understand
+		// why we're using nil to force netxlite to use the cached
+		// default Mozilla cert pool.
 		config := &tls.Config{
 			ServerName: "dns.google",
 			NextProtos: []string{"h2", "http/1.1"},
-			RootCAs:    netxlite.NewDefaultCertPool(),
+			RootCAs:    nil,
 		}
 		tconn, _, err := th.Handshake(ctx, conn, config)
 		if err != nil {
@@ -311,10 +314,13 @@ func TestMeasureWithTLSHandshaker(t *testing.T) {
 			return fmt.Errorf("dial failed: %w", err)
 		}
 		defer conn.Close()
+		// See https://github.com/ooni/probe/issues/2413 to understand
+		// why we're using nil to force netxlite to use the cached
+		// default Mozilla cert pool.
 		config := &tls.Config{
 			ServerName: "dns.google",
 			NextProtos: []string{"h2", "http/1.1"},
-			RootCAs:    netxlite.NewDefaultCertPool(),
+			RootCAs:    nil,
 		}
 		tconn, _, err := th.Handshake(ctx, conn, config)
 		if err == nil {
@@ -338,10 +344,13 @@ func TestMeasureWithTLSHandshaker(t *testing.T) {
 			return fmt.Errorf("dial failed: %w", err)
 		}
 		defer conn.Close()
+		// See https://github.com/ooni/probe/issues/2413 to understand
+		// why we're using nil to force netxlite to use the cached
+		// default Mozilla cert pool.
 		config := &tls.Config{
 			ServerName: "dns.google",
 			NextProtos: []string{"h2", "http/1.1"},
-			RootCAs:    netxlite.NewDefaultCertPool(),
+			RootCAs:    nil,
 		}
 		tconn, _, err := th.Handshake(ctx, conn, config)
 		if err == nil {
@@ -430,10 +439,13 @@ func TestMeasureWithQUICDialer(t *testing.T) {
 		d := netxlite.NewQUICDialerWithoutResolver(ql, log.Log)
 		defer d.CloseIdleConnections()
 		ctx := context.Background()
+		// See https://github.com/ooni/probe/issues/2413 to understand
+		// why we're using nil to force netxlite to use the cached
+		// default Mozilla cert pool.
 		config := &tls.Config{
 			ServerName: quictesting.Domain,
 			NextProtos: []string{"h3"},
-			RootCAs:    netxlite.NewDefaultCertPool(),
+			RootCAs:    nil,
 		}
 		sess, err := d.DialContext(ctx, quictesting.Endpoint("443"), config, &quic.Config{})
 		if err != nil {
@@ -450,10 +462,13 @@ func TestMeasureWithQUICDialer(t *testing.T) {
 		d := netxlite.NewQUICDialerWithoutResolver(ql, log.Log)
 		defer d.CloseIdleConnections()
 		ctx := context.Background()
+		// See https://github.com/ooni/probe/issues/2413 to understand
+		// why we're using nil to force netxlite to use the cached
+		// default Mozilla cert pool.
 		config := &tls.Config{
 			ServerName: quictesting.Domain,
 			NextProtos: []string{"h3"},
-			RootCAs:    netxlite.NewDefaultCertPool(),
+			RootCAs:    nil,
 		}
 		// Here we assume <target-address>:1 is filtered
 		sess, err := d.DialContext(ctx, quictesting.Endpoint("1"), config, &quic.Config{})

--- a/internal/netxlite/quic.go
+++ b/internal/netxlite/quic.go
@@ -35,6 +35,15 @@ func (qls *quicListenerStdlib) Listen(addr *net.UDPAddr) (model.UDPLikeConn, err
 // NewQUICDialerWithResolver is the WrapDialer equivalent for QUIC where
 // we return a composed QUICDialer modified by optional wrappers.
 //
+// The returned dialer guarantees:
+//
+// 1. logging;
+//
+// 2. error wrapping;
+//
+// 3. that we are going to use Mozilla CA if the [tls.Config]
+// RootCAs field is zero initialized.
+//
 // Please, note that this fuunction will just ignore any nil wrapper.
 //
 // Unlike the dialer returned by WrapDialer, this dialer MAY attempt

--- a/internal/netxlite/quic_test.go
+++ b/internal/netxlite/quic_test.go
@@ -248,7 +248,7 @@ func TestQUICDialerQUICGo(t *testing.T) {
 			if tlsConfig.RootCAs != nil {
 				t.Fatal("tlsConfig.RootCAs should not have been changed")
 			}
-			if gotTLSConfig.RootCAs == nil {
+			if gotTLSConfig.RootCAs != tproxyDefaultCertPool {
 				t.Fatal("gotTLSConfig.RootCAs should have been set")
 			}
 			if tlsConfig.NextProtos != nil {
@@ -289,7 +289,7 @@ func TestQUICDialerQUICGo(t *testing.T) {
 			if tlsConfig.RootCAs != nil {
 				t.Fatal("tlsConfig.RootCAs should not have been changed")
 			}
-			if gotTLSConfig.RootCAs == nil {
+			if gotTLSConfig.RootCAs != tproxyDefaultCertPool {
 				t.Fatal("gotTLSConfig.RootCAs should have been set")
 			}
 			if tlsConfig.NextProtos != nil {

--- a/internal/netxlite/tls_test.go
+++ b/internal/netxlite/tls_test.go
@@ -269,7 +269,7 @@ func TestTLSHandshakerConfigurable(t *testing.T) {
 			if config.RootCAs != nil {
 				t.Fatal("config.RootCAs should still be nil")
 			}
-			if gotTLSConfig.RootCAs == nil {
+			if gotTLSConfig.RootCAs != tproxyDefaultCertPool {
 				t.Fatal("gotTLSConfig.RootCAs has not been correctly set")
 			}
 		})

--- a/internal/netxlite/utls.go
+++ b/internal/netxlite/utls.go
@@ -23,13 +23,16 @@ import (
 //
 // The handshaker guarantees:
 //
-// 1. logging
+// 1. logging;
 //
-// 2. error wrapping
+// 2. error wrapping;
+//
+// 3. that we are going to use Mozilla CA if the [tls.Config]
+// RootCAs field is zero initialized.
 //
 // Passing a nil `id` will make this function panic.
 func NewTLSHandshakerUTLS(logger model.DebugLogger, id *utls.ClientHelloID) model.TLSHandshaker {
-	return newTLSHandshaker(&tlsHandshakerConfigurable{
+	return newTLSHandshakerLogger(&tlsHandshakerConfigurable{
 		NewConn: newUTLSConnFactory(id),
 	}, logger)
 }

--- a/internal/netxlite/utls_test.go
+++ b/internal/netxlite/utls_test.go
@@ -116,11 +116,14 @@ func Test_newConnUTLSWithHelloID(t *testing.T) {
 		wantErr     error
 	}{{
 		name: "with only supported fields",
+		// See https://github.com/ooni/probe/issues/2413 to understand
+		// why we're using nil to force netxlite to use the cached
+		// default Mozilla cert pool.
 		config: &tls.Config{
 			DynamicRecordSizingDisabled: true,
 			InsecureSkipVerify:          true,
 			NextProtos:                  []string{"h3"},
-			RootCAs:                     NewDefaultCertPool(),
+			RootCAs:                     nil,
 			ServerName:                  "ooni.org",
 		},
 		cid:         &utls.HelloFirefox_55,

--- a/internal/sessionresolver/resolver_test.go
+++ b/internal/sessionresolver/resolver_test.go
@@ -449,7 +449,10 @@ func TestResolverWorkingAsIntendedWithMocks(t *testing.T) {
 		domainToResolve: "example.com",
 		tproxy: &mocks.UnderlyingNetwork{
 			MockDefaultCertPool: func() *x509.CertPool {
-				return netxlite.NewDefaultCertPool()
+				// See https://github.com/ooni/probe/issues/2413 to understand
+				// why we're using the default cert pool used by netxlite
+				// without creating a new one from scratch.
+				return (&netxlite.DefaultTProxy{}).DefaultCertPool()
 			},
 			MockDialContext: func(ctx context.Context, timeout time.Duration, network string, address string) (net.Conn, error) {
 				dialer := &net.Dialer{Timeout: timeout}
@@ -478,7 +481,10 @@ func TestResolverWorkingAsIntendedWithMocks(t *testing.T) {
 		domainToResolve: "example.com",
 		tproxy: &mocks.UnderlyingNetwork{
 			MockDefaultCertPool: func() *x509.CertPool {
-				return netxlite.NewDefaultCertPool()
+				// See https://github.com/ooni/probe/issues/2413 to understand
+				// why we're using the default cert pool used by netxlite
+				// without creating a new one from scratch.
+				return (&netxlite.DefaultTProxy{}).DefaultCertPool()
 			},
 			MockDialContext: func(ctx context.Context, timeout time.Duration, network string, address string) (net.Conn, error) {
 				return nil, syscall.ECONNREFUSED

--- a/internal/tutorial/measurex/chapter04/README.md
+++ b/internal/tutorial/measurex/chapter04/README.md
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/measurex"
-	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
@@ -53,7 +52,7 @@ successful, it will TLS handshake using the given TLS config.
 	m := mx.TLSConnectAndHandshake(ctx, *address, &tls.Config{
 		ServerName: *sni,
 		NextProtos: []string{"h2", "http/1.1"},
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    nil, // use netxlite's default
 	})
 ```
 

--- a/internal/tutorial/measurex/chapter04/main.go
+++ b/internal/tutorial/measurex/chapter04/main.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/measurex"
-	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
@@ -54,7 +53,7 @@ func main() {
 	m := mx.TLSConnectAndHandshake(ctx, *address, &tls.Config{
 		ServerName: *sni,
 		NextProtos: []string{"h2", "http/1.1"},
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    nil, // use netxlite's default
 	})
 	// ```
 	//

--- a/internal/tutorial/measurex/chapter05/README.md
+++ b/internal/tutorial/measurex/chapter05/README.md
@@ -32,7 +32,6 @@ import (
 	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/measurex"
-	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
@@ -55,7 +54,7 @@ except that here we call the `QUICHandshake` function.
 	m := mx.QUICHandshake(ctx, *address, &tls.Config{
 		ServerName: *sni,
 		NextProtos: []string{"h3"},
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    nil, // use netxlite's default
 	})
 ```
 

--- a/internal/tutorial/measurex/chapter05/main.go
+++ b/internal/tutorial/measurex/chapter05/main.go
@@ -33,7 +33,6 @@ import (
 	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/measurex"
-	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
@@ -56,7 +55,7 @@ func main() {
 	m := mx.QUICHandshake(ctx, *address, &tls.Config{
 		ServerName: *sni,
 		NextProtos: []string{"h3"},
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    nil, // use netxlite's default
 	})
 	// ```
 	//

--- a/internal/tutorial/measurex/chapter14/README.md
+++ b/internal/tutorial/measurex/chapter14/README.md
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/measurex"
-	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
@@ -135,7 +134,7 @@ whether the input URL is HTTP or HTTPS.
 			config := &tls.Config{
 				ServerName: parsedURL.Hostname(),
 				NextProtos: []string{"h2", "http/1.1"},
-				RootCAs:    netxlite.NewDefaultCertPool(),
+				RootCAs:    nil, // use netxlite's default
 			}
 			tls := mx.TLSConnectAndHandshake(ctx, epnt.Address, config)
 			m.TCPConnect = append(

--- a/internal/tutorial/measurex/chapter14/main.go
+++ b/internal/tutorial/measurex/chapter14/main.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/measurex"
-	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
@@ -136,7 +135,7 @@ func webConnectivity(ctx context.Context, URL string) (*measurement, error) {
 			config := &tls.Config{
 				ServerName: parsedURL.Hostname(),
 				NextProtos: []string{"h2", "http/1.1"},
-				RootCAs:    netxlite.NewDefaultCertPool(),
+				RootCAs:    nil, // use netxlite's default
 			}
 			tls := mx.TLSConnectAndHandshake(ctx, epnt.Address, config)
 			m.TCPConnect = append(

--- a/internal/tutorial/netxlite/chapter02/README.md
+++ b/internal/tutorial/netxlite/chapter02/README.md
@@ -57,14 +57,14 @@ these three fields when you're performing handshakes:
 - `NextProtos`, which controls the ALPN
 
 - `RootCAs`, which we are forcing here to be the
-CA pool bundled with OONI (so we don't have to trust
-the system-wide certificate store)
+CA pool bundled with OONI by passing nil (so we don't
+have to trust the system-wide certificate store)
 
 ```Go
 	tlsConfig := &tls.Config{
 		ServerName: *sni,
 		NextProtos: []string{"h2", "http/1.1"},
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    nil,
 	}
 ```
 

--- a/internal/tutorial/netxlite/chapter02/main.go
+++ b/internal/tutorial/netxlite/chapter02/main.go
@@ -58,14 +58,14 @@ func main() {
 	// - `NextProtos`, which controls the ALPN
 	//
 	// - `RootCAs`, which we are forcing here to be the
-	// CA pool bundled with OONI (so we don't have to trust
-	// the system-wide certificate store)
+	// CA pool bundled with OONI by passing nil (so we don't
+	// have to trust the system-wide certificate store)
 	//
 	// ```Go
 	tlsConfig := &tls.Config{
 		ServerName: *sni,
 		NextProtos: []string{"h2", "http/1.1"},
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    nil,
 	}
 	// ```
 	//

--- a/internal/tutorial/netxlite/chapter03/README.md
+++ b/internal/tutorial/netxlite/chapter03/README.md
@@ -47,7 +47,7 @@ func main() {
 	tlsConfig := &tls.Config{
 		ServerName: *sni,
 		NextProtos: []string{"h2", "http/1.1"},
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    nil,
 	}
 	conn, state, err := dialTLS(ctx, *address, tlsConfig)
 	if err != nil {

--- a/internal/tutorial/netxlite/chapter03/main.go
+++ b/internal/tutorial/netxlite/chapter03/main.go
@@ -48,7 +48,7 @@ func main() {
 	tlsConfig := &tls.Config{
 		ServerName: *sni,
 		NextProtos: []string{"h2", "http/1.1"},
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    nil,
 	}
 	conn, state, err := dialTLS(ctx, *address, tlsConfig)
 	if err != nil {

--- a/internal/tutorial/netxlite/chapter04/README.md
+++ b/internal/tutorial/netxlite/chapter04/README.md
@@ -50,7 +50,7 @@ QUIC/HTTP3 by using `"h3"` here.
 	config := &tls.Config{
 		ServerName: *sni,
 		NextProtos: []string{"h3"},
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    nil,
 	}
 ```
 

--- a/internal/tutorial/netxlite/chapter04/main.go
+++ b/internal/tutorial/netxlite/chapter04/main.go
@@ -51,7 +51,7 @@ func main() {
 	config := &tls.Config{
 		ServerName: *sni,
 		NextProtos: []string{"h3"},
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    nil,
 	}
 	// ```
 	//

--- a/internal/tutorial/netxlite/chapter07/README.md
+++ b/internal/tutorial/netxlite/chapter07/README.md
@@ -48,7 +48,7 @@ func main() {
 	config := &tls.Config{
 		ServerName: *sni,
 		NextProtos: []string{"h2", "http/1.1"},
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    nil,
 	}
 	conn, _, err := dialTLS(ctx, *address, config)
 	if err != nil {

--- a/internal/tutorial/netxlite/chapter07/main.go
+++ b/internal/tutorial/netxlite/chapter07/main.go
@@ -49,7 +49,7 @@ func main() {
 	config := &tls.Config{
 		ServerName: *sni,
 		NextProtos: []string{"h2", "http/1.1"},
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    nil,
 	}
 	conn, _, err := dialTLS(ctx, *address, config)
 	if err != nil {

--- a/internal/tutorial/netxlite/chapter08/README.md
+++ b/internal/tutorial/netxlite/chapter08/README.md
@@ -47,7 +47,7 @@ func main() {
 	config := &tls.Config{
 		ServerName: *sni,
 		NextProtos: []string{"h3"},
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    nil,
 	}
 	qconn, _, err := dialQUIC(ctx, *address, config)
 	if err != nil {

--- a/internal/tutorial/netxlite/chapter08/main.go
+++ b/internal/tutorial/netxlite/chapter08/main.go
@@ -48,7 +48,7 @@ func main() {
 	config := &tls.Config{
 		ServerName: *sni,
 		NextProtos: []string{"h3"},
-		RootCAs:    netxlite.NewDefaultCertPool(),
+		RootCAs:    nil,
 	}
 	qconn, _, err := dialQUIC(ctx, *address, config)
 	if err != nil {


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2413
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [x] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff modifies the tree to rely on netxlite's property that it will use the Mozilla cert pool when no cert pool has been set.

After this diff has been applied, these are the places where we still call `NewDefaultCertPool`:

```
internal/experiment/echcheck/handshake.go:var certpool = netxlite.NewDefaultCertPool()
internal/experiment/ndt7/dial.go:var certpool = netxlite.NewDefaultCertPool()
internal/experiment/riseupvpn/riseupvpn.go:	certPool := netxlite.NewDefaultCertPool()
internal/experiment/signal/signal.go:	certPool := netxlite.NewDefaultCertPool()
internal/model/netx.go:	// race. Use [netxlite.NewDefaultCertPool] if you wish to get
internal/netxlite/filtering/tls_test.go:				RootCAs:    netxlite.NewDefaultCertPool(),
internal/netxlite/tls.go:// NewDefaultCertPool returns the default x509 certificate pool
internal/netxlite/tls.go:func NewDefaultCertPool() *x509.CertPool {
internal/netxlite/tls_test.go:func TestNewDefaultCertPoolWorks(t *testing.T) {
internal/netxlite/tls_test.go:	pool := NewDefaultCertPool()
internal/netxlite/tproxy.go:var tproxyDefaultCertPool = NewDefaultCertPool()
```

The references in `internal/model` and `internal/netxlite` look good.

In `ndt7` and `echcheck`, we're creating a cached copy, so we're all good.

In `riseupvpn` and `signal`, we need to extend the cert pool, so those are the places where calling `NewDefaultCertPool` makes sense.

These are the places where we modify cert pools:

```
internal/experiment/riseupvpn/riseupvpn.go:		if ok := certPool.AppendCertsFromPEM([]byte(tk.HTTPResponseBody)); !ok {
internal/experiment/signal/signal.go:		if !certPool.AppendCertsFromPEM(caBytes) {
internal/experiment/signal/signal.go:			return errors.New("AppendCertsFromPEM failed")
internal/experiment/signal/signal_test.go:	if err.Error() != "AppendCertsFromPEM failed" {
internal/netxlite/certifi_test.go:		if !pool.AppendCertsFromPEM([]byte(pemcerts)) {
internal/netxlite/internal/gencertifi/main.go:	if !pool.AppendCertsFromPEM(bundle) {
internal/netxlite/tls.go:	// Assumption: AppendCertsFromPEM cannot fail because we
internal/netxlite/tls.go:	ok := pool.AppendCertsFromPEM([]byte(pemcerts))
internal/netxlite/tls.go:	runtimex.Assert(ok, "pool.AppendCertsFromPEM failed")
internal/experiment/urlgetter/multi_test.go:	certpool.AddCert(cert)
internal/netxlite/filtering/http.go:		o.AddCert(p.cert)
internal/netxlite/filtering/tls.go:	o.AddCert(p.cert)
internal/netxlite/tproxy_test.go:				pool.AddCert(srvr.Certificate())
```

Excluding `_test.go` files, this is basically:

* in `riseupvpn` and `signal`, where we need to do that;

* when we generate the bundled certs;

* in `netxlite/tls.go`, where we implement `NewDefaultCertPool`.

Part of https://github.com/ooni/probe/issues/2413.

