### PR TITLE
fix(oohelperd): allow pending requests to complete

### DIFF
--- a/internal/cmd/oohelperd/main_test.go
+++ b/internal/cmd/oohelperd/main_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/ooni/probe-cli/v3/internal/model"
@@ -16,7 +17,7 @@ import (
 
 func TestMainWorkingAsIntended(t *testing.T) {
 	// let the kernel pick a random free port
-	*endpoint = "127.0.0.1:0"
+	*apiEndpoint = "127.0.0.1:0"
 
 	// run the main function in a background goroutine
 	go main()
@@ -75,7 +76,7 @@ func TestMainWorkingAsIntended(t *testing.T) {
 	}
 
 	// tear down the TH
-	srvCancel()
+	sigs <- syscall.SIGINT
 
 	// wait for the background goroutine to join
 	srvWg.Wait()


### PR DESCRIPTION
This diff increases the timeout used to await for pending requests and parallelizes the shutdown of servers.

While there, let's move all the flags at toplevel for clarity.

While there, recognize that we can use the channel's signal for shutting down the server in tests.

These changes are preliminary changes before making the oohelperd more capable of serving interesting metrics and debug info.

See https://github.com/ooni/probe/issues/2413
