### PR TITLE
feat(oohelperd): make 0.th.ooni.org deployment easier

### DIFF
--- a/.github/workflows/oohelperd.yml
+++ b/.github/workflows/oohelperd.yml
@@ -28,7 +28,7 @@ jobs:
           cache-key-suffix: "-oohelperd-${{ steps.goversion.outputs.version }}"
 
       - name: build oohelperd binary
-        run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ./CLI/oohelperd-linux-amd64 -v -tags netgo -ldflags="-s -w -extldflags -static" ./internal/cmd/oohelperd
+        run: go run ./internal/cmd/buildtool oohelperd build
 
       - run: ./script/ghpublish.bash ./CLI/oohelperd-linux-amd64
         env:

--- a/CLI/.gitignore
+++ b/CLI/.gitignore
@@ -1,3 +1,4 @@
 /Dockerfile
 /miniooni-*
+/oohelperd-*
 /ooniprobe-*

--- a/internal/cmd/buildtool/main.go
+++ b/internal/cmd/buildtool/main.go
@@ -22,6 +22,7 @@ func main() {
 	root.AddCommand(genericSubcommand())
 	root.AddCommand(iosSubcommand())
 	root.AddCommand(linuxSubcommand())
+	root.AddCommand(oohelperdSubcommand())
 	root.AddCommand(windowsSubcommand())
 
 	logHandler := logx.NewHandlerWithDefaultSettings()

--- a/internal/cmd/buildtool/oohelperd.go
+++ b/internal/cmd/buildtool/oohelperd.go
@@ -1,0 +1,66 @@
+package main
+
+//
+// Builds oohelperd for linux/amd64
+//
+
+import (
+	"path/filepath"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/cmd/buildtool/internal/buildtoolmodel"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
+	"github.com/ooni/probe-cli/v3/internal/shellx"
+	"github.com/spf13/cobra"
+)
+
+// oohelperdSubcommand returns the oohelperd sucommand.
+func oohelperdSubcommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "oohelperd",
+		Short: "Build and deploy oohelperd",
+	}
+	cmd.AddCommand(&cobra.Command{
+		Use:   "build",
+		Short: "Builds oohelperd for linux/amd64",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			oohelperdBuildAndMaybeDeploy(&buildDeps{}, false)
+		},
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:   "deploy",
+		Short: "Builds and deploys oohelperd on 0.th.ooni.org",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			oohelperdBuildAndMaybeDeploy(&buildDeps{}, true)
+		},
+	})
+	return cmd
+}
+
+// oohelperdBuildAndMaybeDeploy builds oohelperd for linux/amd64 and
+// possibly deploys the build to the 0.th.ooni.org server.
+func oohelperdBuildAndMaybeDeploy(deps buildtoolmodel.Dependencies, deploy bool) {
+	deps.GolangCheck()
+
+	log.Info("building oohelperd for linux/amd64")
+	oohelperdBinary := filepath.Join("CLI", "oohelperd-linux-amd64")
+
+	envp := &shellx.Envp{}
+	envp.Append("CGO_ENABLED", "0")
+	envp.Append("GOOS", "linux")
+	envp.Append("GOARCH", "amd64")
+
+	argv := runtimex.Try1(shellx.NewArgv("go", "build"))
+	argv.Append("-o", oohelperdBinary)
+	argv.Append("-tags", "netgo")
+	argv.Append("-ldflags", "-s -w -extldflags -static")
+	argv.Append("./internal/cmd/oohelperd")
+
+	runtimex.Try0(shellx.RunEx(defaultShellxConfig(), argv, envp))
+
+	if deploy {
+		runtimex.Try0(shellx.Run(log.Log, "scp", oohelperdBinary, "0.th.ooni.org:oohelperd"))
+	}
+}

--- a/internal/cmd/buildtool/oohelperd_test.go
+++ b/internal/cmd/buildtool/oohelperd_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/probe-cli/v3/internal/cmd/buildtool/internal/buildtooltest"
+	"github.com/ooni/probe-cli/v3/internal/shellx/shellxtesting"
+)
+
+func TestOohelperdBuildAndMaybeDeploy(t *testing.T) {
+
+	// testspec specifies a test case for this test
+	type testspec struct {
+		// name is the name of the test case
+		name string
+
+		// deploy indicates whether we also want to deploy.
+		deploy bool
+
+		// expectations contains the commands we expect to see
+		expect []buildtooltest.ExecExpectations
+	}
+
+	var testcases = []testspec{{
+		name:   "oohelperd build without automatic deployment",
+		deploy: false,
+		expect: []buildtooltest.ExecExpectations{{
+			Env: []string{
+				"CGO_ENABLED=0",
+				"GOOS=linux",
+				"GOARCH=amd64",
+			},
+			Argv: []string{
+				"go", "build",
+				"-o", filepath.Join("CLI", "oohelperd-linux-amd64"),
+				"-tags", "netgo",
+				"-ldflags", "-s -w -extldflags -static",
+				"./internal/cmd/oohelperd",
+			},
+		}},
+	}, {
+		name:   "oohelperd build with automatic deployment",
+		deploy: true,
+		expect: []buildtooltest.ExecExpectations{{
+			Env: []string{
+				"CGO_ENABLED=0",
+				"GOOS=linux",
+				"GOARCH=amd64",
+			},
+			Argv: []string{
+				"go", "build",
+				"-o", filepath.Join("CLI", "oohelperd-linux-amd64"),
+				"-tags", "netgo",
+				"-ldflags", "-s -w -extldflags -static",
+				"./internal/cmd/oohelperd",
+			},
+		}, {
+			Env: []string{},
+			Argv: []string{
+				"scp", filepath.Join("CLI", "oohelperd-linux-amd64"),
+				"0.th.ooni.org:oohelperd",
+			},
+		}},
+	}}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+
+			cc := &buildtooltest.SimpleCommandCollector{}
+
+			deps := &buildtooltest.DependenciesCallCounter{
+				HasPsiphon: false,
+			}
+
+			shellxtesting.WithCustomLibrary(cc, func() {
+				oohelperdBuildAndMaybeDeploy(deps, testcase.deploy)
+			})
+
+			expectCalls := map[string]int{
+				buildtooltest.TagGolangCheck: 1,
+			}
+
+			if diff := cmp.Diff(expectCalls, deps.Counter); diff != "" {
+				t.Fatal(diff)
+			}
+
+			if err := buildtooltest.CheckManyCommands(cc.Commands, testcase.expect); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/internal/cmd/oohelperd/main_test.go
+++ b/internal/cmd/oohelperd/main_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
-func TestMainWorkingAsIntended(t *testing.T) {
+func TestMainRunServerWorkingAsIntended(t *testing.T) {
 	// let the kernel pick a random free port
 	*apiEndpoint = "127.0.0.1:0"
 
@@ -80,4 +80,18 @@ func TestMainWorkingAsIntended(t *testing.T) {
 
 	// wait for the background goroutine to join
 	srvWg.Wait()
+}
+
+func TestMainReplaceWorkingAsIntended(t *testing.T) {
+	replaceDryRun = true
+	*replace = true
+	main()
+	*replace = false
+	replaceDryRun = false
+}
+
+func TestMainVersionWorkingAsIntended(t *testing.T) {
+	*versionFlag = true
+	main()
+	*versionFlag = false
 }

--- a/internal/cmd/oohelperd/replace.go
+++ b/internal/cmd/oohelperd/replace.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
+	"github.com/ooni/probe-cli/v3/internal/shellx"
+)
+
+// replaceDeps contains dependencies for [replaceRunningInstance].
+type replaceDeps struct {
+	// CopyFile is MANDATORY and MUST behave like [shellx.CopyFile].
+	CopyFile func(source string, dest string, perms fs.FileMode) error
+
+	// Run is MANDATORY and MUST behave like [shellx.Run].
+	Run func(logger model.Logger, command string, args ...string) error
+}
+
+// replaceDryRun is an internal flag used for testing.
+var replaceDryRun bool
+
+// newReplaceDeps creates a fully initialized instance of [replaceDeps].
+func newReplaceDeps() *replaceDeps {
+	deps := &replaceDeps{
+		CopyFile: shellx.CopyFile,
+		Run:      shellx.Run,
+	}
+	if replaceDryRun {
+		deps.CopyFile = func(source, dest string, perms fs.FileMode) error {
+			return nil
+		}
+		deps.Run = func(logger model.Logger, command string, args ...string) error {
+			return nil
+		}
+	}
+	return deps
+}
+
+// replaceRunningInstance executes the command to replace
+// a running instance of oohelperd with this instance.
+func replaceRunningInstance(deps *replaceDeps) {
+	// stop the running instance.
+	runtimex.Try0(deps.Run(log.Log, "systemctl", "stop", "oohelperd.service"))
+
+	// copy oohelperd to the destination path.
+	executable := runtimex.Try1(filepath.Abs(runtimex.Try1(os.Executable())))
+	destpath := string(filepath.Separator) + filepath.Join("usr", "bin", "oohelperd")
+	log.Infof("+ cp %s %s", executable, destpath)
+	runtimex.Try0(deps.CopyFile(executable, destpath, 0755))
+
+	// restart the running instance.
+	runtimex.Try0(deps.Run(log.Log, "systemctl", "start", "oohelperd.service"))
+}

--- a/internal/cmd/oohelperd/replace_test.go
+++ b/internal/cmd/oohelperd/replace_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/probe-cli/v3/internal/model"
+)
+
+func TestReplaceRunningInstance(t *testing.T) {
+	// create the default dependencies
+	deps := newReplaceDeps()
+
+	// override the CopyFile func
+	var (
+		asource string
+		adest   string
+		aperms  fs.FileMode
+	)
+	deps.CopyFile = func(source, dest string, perms fs.FileMode) error {
+		asource = source
+		adest = dest
+		aperms = perms
+		return nil
+	}
+
+	// override the Run func
+	var commands [][]string
+	deps.Run = func(logger model.Logger, command string, args ...string) error {
+		argv := []string{command}
+		argv = append(argv, args...)
+		commands = append(commands, argv)
+		return nil
+	}
+
+	// execute with fake deps
+	replaceRunningInstance(deps)
+
+	// make sure we copied with the correct arguments
+	if asource == "" {
+		t.Fatal("expected to see valid asource")
+	}
+	if adest != string(filepath.Separator)+filepath.Join("usr", "bin", "oohelperd") {
+		t.Fatal("invalid adest", adest)
+	}
+	if aperms != 0755 {
+		t.Fatal("invalid aperms", aperms)
+	}
+
+	// expectCommands contains the expected commands.
+	expectCommands := [][]string{{
+		"systemctl", "stop", "oohelperd.service",
+	}, {
+		"systemctl", "start", "oohelperd.service",
+	}}
+
+	// make sure we've seen the expected commands
+	if diff := cmp.Diff(expectCommands, commands); diff != "" {
+		t.Fatal(diff)
+	}
+}


### PR DESCRIPTION
* buildtool: add rules to build oohelperd

* .github/workflows: use buildtool to build oohelperd

* oohelperd: add `-replace` flag to replace an already running instance of the oohelperd

* oohelperd: add `-version` flag to get version

Part of https://github.com/ooni/probe/issues/2413
