### PR TITLE
fix(oohelperd): disable QUIC by default

### DIFF
--- a/internal/cmd/oohelperd/handler_test.go
+++ b/internal/cmd/oohelperd/handler_test.go
@@ -48,7 +48,8 @@ const requestWithoutDomainName = `{
 	},
 	"tcp_connect": [
 		"8.8.8.8:443"
-	]
+	],
+	"x_quic_enabled": true
 }`
 
 // TestHandlerWorkingAsIntended is an unit test exercising

--- a/internal/cmd/oohelperd/measure.go
+++ b/internal/cmd/oohelperd/measure.go
@@ -121,7 +121,10 @@ func measure(ctx context.Context, config *handler, creq *ctrlRequest) (*ctrlResp
 	// HTTP/3
 	quicconnch := make(chan *quicResult, len(endpoints))
 
-	if cresp.HTTPRequest.DiscoveredH3Endpoint != "" {
+	// In the v3.17.x and possibly v3.18.x release cycles, QUIC is disabled by
+	// default but clients that know QUIC can enable it. We will eventually remove
+	// this flag and enable QUIC measurements for all clients.
+	if creq.XQUICEnabled && cresp.HTTPRequest.DiscoveredH3Endpoint != "" {
 		// quicconnect: start over all the endpoints
 		for _, endpoint := range endpoints {
 			wg.Add(1)
@@ -155,6 +158,7 @@ func measure(ctx context.Context, config *handler, creq *ctrlRequest) (*ctrlResp
 		http3Request := <-http3ch
 		cresp.HTTP3Request = &http3Request
 	}
+
 Loop:
 	for {
 		select {

--- a/internal/model/th.go
+++ b/internal/model/th.go
@@ -3,11 +3,20 @@ package model
 // THDNSNameError is the error returned by the control on NXDOMAIN
 const THDNSNameError = "dns_name_error"
 
-// THRequest is the request that we send to the control
+// THRequest is the request that we send to the control.
+//
+// See https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md
 type THRequest struct {
 	HTTPRequest        string              `json:"http_request"`
 	HTTPRequestHeaders map[string][]string `json:"http_request_headers"`
 	TCPConnect         []string            `json:"tcp_connect"`
+
+	// XQUICEnabled is a feature flag that tells the oohelperd to
+	// conditionally enable QUIC measurements, which are otherwise
+	// disabled by default. We will honour this flag during the
+	// v3.17.x release cycle and possibly also for v3.18.x but we
+	// will eventually enable QUIC for all clients.
+	XQUICEnabled bool `json:"x_quic_enabled"`
 }
 
 // THTCPConnectResult is the result of the TCP connect


### PR DESCRIPTION
I have been eyeballing the performance charts for a few days and it seems that enabling QUIC makes measurements slower.

The TH requires more time to complete. So, the probe can measure less target URLs per run, given finite runtime constraints.

Measuring QUIC in the TH when the probe also measures QUIC is fine because we obtain higher quality measurements.

However, now that most probes do not know about QUIC, it makes sense to avoid measuring QUIC for them, so they continue to measure the same number of URLs as before.

This diff belongs to the not-ever-small set of diffs authored when doing pre-release QA. See https://github.com/ooni/probe/issues/2273.
