### PR TITLE
cleanup(monorepo): only clone desktop and android

### DIFF
--- a/MONOREPO/tools/gitconfig.bash
+++ b/MONOREPO/tools/gitconfig.bash
@@ -11,14 +11,8 @@ reporoot=$(dirname $(dirname $(dirname $(realpath $0))))
 #doc: List of repositories to track
 repositories=(
 	. # the dot is git@github.com:ooni/probe-cli and MUST be first
-	git@github.com:ooni/oocrypto
-	git@github.com:ooni/oohttp
 	git@github.com:ooni/probe-android
-	git@github.com:ooni/probe-assets
 	git@github.com:ooni/probe-desktop
-	git@github.com:ooni/probe-ios
-	git@github.com:ooni/probe-releases
-	git@github.com:ooni/spec
 )
 
 #doc:

--- a/MONOREPO/tools/local.example.bash
+++ b/MONOREPO/tools/local.example.bash
@@ -9,6 +9,4 @@ repositories=(
 	. # the dot is git@github.com:ooni/probe-cli and MUST be first
 	git@github.com:ooni/probe-android
 	git@github.com:ooni/probe-desktop
-	git@github.com:ooni/probe-ios
-	git@github.com:ooni/spec
 )


### PR DESCRIPTION
These two repositories are the only ones we can manage through the monorepo scripts for integration testing.

Closes https://github.com/ooni/probe/issues/2432
