### PR TITLE
fix: honor check-in UTC time

### DIFF
--- a/internal/checkintime/checkintime.go
+++ b/internal/checkintime/checkintime.go
@@ -1,0 +1,110 @@
+// Package checkintime tracks the check-in API time. By tracking such
+// a time we can perform the following actions:
+//
+// 1. submit measurements with a reference time based on the check-in API
+// time rather than on the probe clock;
+//
+// 2. warn the user that the probe clock is definitely off.
+//
+// See https://github.com/ooni/probe/issues/1781 for more details.
+package checkintime
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ooni/probe-cli/v3/internal/model"
+)
+
+// state contains the [checkintime] state. The zero value
+// of this structure is ready to use.
+type state struct {
+	// apiTime contains the time according to the check-in API.
+	apiTime time.Time
+
+	// good indicates whether we have good data.
+	good bool
+
+	// monotonicTimeUTC contains the monotonic UTC clock reading when we
+	// saved the apiTime. We need this variable because times unmarshalled
+	// from JSON contain no monotonic clock readings.
+	//
+	// See https://github.com/golang/go/blob/72c58fb/src/time/time.go#L58.
+	monotonicTimeUTC time.Time
+
+	// mu provides mutual exclusion.
+	mu sync.Mutex
+}
+
+// singleton is the [checkintime] singleton.
+var singleton = &state{}
+
+// Save saves the time according to the check-in API.
+func Save(cur time.Time) {
+	singleton.save(cur)
+}
+
+func (s *state) save(cur time.Time) {
+	if cur.IsZero() {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.apiTime = cur
+	s.good = true
+	s.monotonicTimeUTC = time.Now().UTC()
+}
+
+// Now returns the current time using as zero time the time saved by
+// [Save] rather than the system clock.
+func Now() (time.Time, bool) {
+	return singleton.now()
+}
+
+func (s *state) now() (time.Time, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.good {
+		return time.Time{}, false
+	}
+	delta := time.Since(s.monotonicTimeUTC)
+	out := s.apiTime.Add(delta)
+	return out, true
+}
+
+// Offset returns the offset between the probe clock and the check-in API clock
+// provided that [Save] has been called. If [Save] has not been called, this
+// function returns a zero offset and a false value.  When the probe clock works
+// as intended, there will always be a small positive offset between the probe and
+// the API clocks. It's also acceptable to have a small negative offset.
+func Offset() (time.Duration, bool) {
+	return singleton.offset()
+}
+
+func (s *state) offset() (time.Duration, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.good {
+		return 0, false
+	}
+	delta := s.monotonicTimeUTC.Sub(s.apiTime)
+	return delta, true
+}
+
+// MaybeWarnAboutProbeClockBeingOff emits a warning if the probe clock is off
+// compared to the clock used by the check-in API.
+func MaybeWarnAboutProbeClockBeingOff(logger model.Logger) {
+	singleton.maybeWarnAboutProbeClockBeingOff(logger)
+}
+
+func (s *state) maybeWarnAboutProbeClockBeingOff(logger model.Logger) {
+	delta, good := s.offset()
+	if !good {
+		return
+	}
+	const smallOffset = 5 * time.Minute
+	shouldWarn := delta < -smallOffset || delta > smallOffset
+	if shouldWarn {
+		logger.Warnf("checkintime: the probe clock is off by %s", delta)
+	}
+}

--- a/internal/checkintime/checkintime_test.go
+++ b/internal/checkintime/checkintime_test.go
@@ -1,0 +1,203 @@
+package checkintime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ooni/probe-cli/v3/internal/model/mocks"
+)
+
+// Make sure that we can compute times relative to the base time specified
+// by the check-in API as opposed to the system clock. It does not matter
+// which clock is wrong in this test, by the way. In reality, the wrong clock
+// is the probe clock, while in this test the API clock is wrong.
+func TestWorkingAsIntended(t *testing.T) {
+
+	// This test covers the case where we've not initialized the state yet
+	t.Run("when we have not set the apiTime yet", func(t *testing.T) {
+		s := &state{}
+
+		// we expect the current time to be unavailable
+		t.Run("state.now", func(t *testing.T) {
+			out, good := s.now()
+			if good {
+				t.Fatal("expected false here")
+			}
+			if !out.IsZero() {
+				t.Fatal("expected zero value here")
+			}
+		})
+
+		// we expect that the offset is also unavailable
+		t.Run("state.offset", func(t *testing.T) {
+			delta, good := s.offset()
+			if good {
+				t.Fatal("expected false here")
+			}
+			if delta != 0 {
+				t.Fatal("expected zero here")
+			}
+		})
+
+		// we expect no warning here
+		t.Run("state.maybeWarnAboutTheProbeClockBeingOff", func(t *testing.T) {
+			var called bool
+			logger := &mocks.Logger{
+				MockWarnf: func(format string, v ...interface{}) {
+					called = true
+				},
+			}
+			s.maybeWarnAboutProbeClockBeingOff(logger)
+			if called {
+				t.Fatal("expected false here")
+			}
+		})
+	})
+
+	// This test covers the case where the check-in API specific time
+	// field has not been initialized, so we get a zero value
+	t.Run("when the apiTime is zero", func(t *testing.T) {
+		s := &state{}
+		s.save(time.Time{}) // zero
+
+		// we expect the current time to be unavailable
+		t.Run("state.now", func(t *testing.T) {
+			out, good := s.now()
+			if good {
+				t.Fatal("expected false here")
+			}
+			if !out.IsZero() {
+				t.Fatal("expected zero value here")
+			}
+		})
+
+		// we expect that the offset is also unavailable
+		t.Run("state.offset", func(t *testing.T) {
+			delta, good := s.offset()
+			if good {
+				t.Fatal("expected false here")
+			}
+			if delta != 0 {
+				t.Fatal("expected zero here")
+			}
+		})
+
+		// we expect no warning here
+		t.Run("state.maybeWarnAboutProbeClockBeingOff", func(t *testing.T) {
+			var called bool
+			logger := &mocks.Logger{
+				MockWarnf: func(format string, v ...interface{}) {
+					called = true
+				},
+			}
+			s.maybeWarnAboutProbeClockBeingOff(logger)
+			if called {
+				t.Fatal("expected false here")
+			}
+		})
+	})
+
+	// This test covers the case where we've been given a valid value from
+	// the check-in API, so we can compute offsets etc.
+	t.Run("after we have set the apiTime", func(t *testing.T) {
+		// create empty state
+		s := &state{}
+
+		// pretend the API time is my birthday
+		apiTime := time.Date(2022, 12, 23, 6, 36, 0, 0, time.UTC)
+		s.save(apiTime)
+
+		// await a little bit
+		time.Sleep(time.Second)
+
+		// obtain the current time according to [state]
+		t.Run("state.now", func(t *testing.T) {
+			now, good := s.now()
+
+			// the current time must be good
+			if !good {
+				t.Fatal("expected to see true here")
+			}
+
+			// compute delta between now and the apiTime
+			delta := now.Sub(apiTime)
+
+			// make sure the elapsed time is around one second
+			if delta < 700*time.Millisecond || delta > 1300*time.Millisecond {
+				t.Fatal("expected around one second, got", delta.Seconds(), "seconds")
+			}
+		})
+
+		// we expect that the offset is available
+		t.Run("state.offset", func(t *testing.T) {
+			delta, good := s.offset()
+			if !good {
+				t.Fatal("expected true here")
+			}
+			const oneMonth = 30 * 24 * 60 * time.Minute
+			if delta < oneMonth {
+				t.Fatal("expected more than", oneMonth, "got", delta)
+			}
+		})
+
+		// we expect a warning here
+		t.Run("state.maybeWarnAboutProbeClockBeingOff", func(t *testing.T) {
+			var called bool
+			logger := &mocks.Logger{
+				MockWarnf: func(format string, v ...interface{}) {
+					called = true
+				},
+			}
+			s.maybeWarnAboutProbeClockBeingOff(logger)
+			if !called {
+				t.Fatal("expected true here")
+			}
+		})
+	})
+
+	t.Run("additional tests to cover the public API", func(t *testing.T) {
+		// save the current time as the API time
+		apiTime := time.Now()
+		Save(apiTime)
+
+		// await a little bit
+		time.Sleep(time.Second)
+
+		// we expect to be able to get the current time
+		t.Run("Now", func(t *testing.T) {
+			now, good := Now()
+			if !good {
+				t.Fatal("expected to see true here")
+			}
+			delta := now.Sub(apiTime)
+			if delta < 700*time.Millisecond || delta > 1300*time.Millisecond {
+				t.Fatal("expected around one second, got", delta.Seconds(), "seconds")
+			}
+		})
+
+		// we expect the offset to be small
+		t.Run("Offset", func(t *testing.T) {
+			delta, good := Offset()
+			if !good {
+				t.Fatal("expected to see true here")
+			}
+			if delta < -70*time.Millisecond || delta > 70*time.Millisecond {
+				t.Fatal("expected around +-70µs, got", delta.Seconds(), "seconds")
+			}
+		})
+
+		// we should not warn
+		t.Run("MaybeWarnAboutProbeClockBeingOff", func(t *testing.T) {
+			var called bool
+			logger := &mocks.Logger{
+				MockWarnf: func(format string, v ...interface{}) {
+					called = true
+				},
+			}
+			MaybeWarnAboutProbeClockBeingOff(logger)
+			if called {
+				t.Fatal("expected false here")
+			}
+		})
+	})
+}

--- a/internal/engine/experiment.go
+++ b/internal/engine/experiment.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/bytecounter"
+	"github.com/ooni/probe-cli/v3/internal/checkintime"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/probeservices"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
@@ -199,24 +200,28 @@ func (e *experiment) SubmitAndUpdateMeasurementContext(
 // newMeasurement creates a new measurement for this experiment with the given input.
 func (e *experiment) newMeasurement(input string) *model.Measurement {
 	utctimenow := time.Now().UTC()
+	apiadjustedtimenow, _ := checkintime.Now()
+	clockoffset, _ := checkintime.Offset()
 	m := &model.Measurement{
-		DataFormatVersion:         model.OOAPIReportDefaultDataFormatVersion,
-		Input:                     model.MeasurementTarget(input),
-		MeasurementStartTime:      utctimenow.Format(dateFormat),
-		MeasurementStartTimeSaved: utctimenow,
-		ProbeIP:                   model.DefaultProbeIP,
-		ProbeASN:                  e.session.ProbeASNString(),
-		ProbeCC:                   e.session.ProbeCC(),
-		ProbeNetworkName:          e.session.ProbeNetworkName(),
-		ReportID:                  e.ReportID(),
-		ResolverASN:               e.session.ResolverASNString(),
-		ResolverIP:                e.session.ResolverIP(),
-		ResolverNetworkName:       e.session.ResolverNetworkName(),
-		SoftwareName:              e.session.SoftwareName(),
-		SoftwareVersion:           e.session.SoftwareVersion(),
-		TestName:                  e.testName,
-		TestStartTime:             e.testStartTime,
-		TestVersion:               e.testVersion,
+		DataFormatVersion:            model.OOAPIReportDefaultDataFormatVersion,
+		Input:                        model.MeasurementTarget(input),
+		MeasurementStartTime:         utctimenow.Format(dateFormat),
+		MeasurementStartTimeAdjusted: apiadjustedtimenow, // not serialized if zero
+		MeasurementProbeClockOffset:  clockoffset,        // not serialized if zero
+		MeasurementStartTimeSaved:    utctimenow,
+		ProbeIP:                      model.DefaultProbeIP,
+		ProbeASN:                     e.session.ProbeASNString(),
+		ProbeCC:                      e.session.ProbeCC(),
+		ProbeNetworkName:             e.session.ProbeNetworkName(),
+		ReportID:                     e.ReportID(),
+		ResolverASN:                  e.session.ResolverASNString(),
+		ResolverIP:                   e.session.ResolverIP(),
+		ResolverNetworkName:          e.session.ResolverNetworkName(),
+		SoftwareName:                 e.session.SoftwareName(),
+		SoftwareVersion:              e.session.SoftwareVersion(),
+		TestName:                     e.testName,
+		TestStartTime:                e.testStartTime,
+		TestVersion:                  e.testVersion,
 	}
 	m.AddAnnotation("architecture", runtime.GOARCH)
 	m.AddAnnotation("engine_name", "ooniprobe-engine")

--- a/internal/model/measurement.go
+++ b/internal/model/measurement.go
@@ -84,6 +84,14 @@ type Measurement struct {
 	// MeasurementStartTime is the time when the measurement started
 	MeasurementStartTime string `json:"measurement_start_time"`
 
+	// MeasurementStartTimeAdjusted is the OPTIONAL time when the measurement
+	// started using as time reference the check-in API time.
+	MeasurementStartTimeAdjusted time.Time `json:"measurement_start_time_adjusted,omitempty"`
+
+	// MeasurementProbeClockOffset is the OPTIONAL offset between the probe
+	// clock and the check-in API clock.
+	MeasurementProbeClockOffset time.Duration `json:"measurement_probe_clock_offset,omitempty"`
+
 	// MeasurementStartTimeSaved is the moment in time when we
 	// started the measurement. This is not included into the JSON
 	// and is only used within the ./internal pkg as a "zero" time.

--- a/internal/probeservices/checkin.go
+++ b/internal/probeservices/checkin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/ooni/probe-cli/v3/internal/checkincache"
+	"github.com/ooni/probe-cli/v3/internal/checkintime"
 	"github.com/ooni/probe-cli/v3/internal/httpapi"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/ooapi"
@@ -29,5 +30,12 @@ func (c Client) CheckIn(
 
 	// make sure we track selected parts of the response
 	_ = checkincache.Store(c.KVStore, resp)
+
+	// make sure we save the current time according to the check-in API
+	checkintime.Save(resp.UTCTime)
+
+	// emit warning if the probe clock is off
+	checkintime.MaybeWarnAboutProbeClockBeingOff(c.Logger)
+
 	return resp, nil
 }


### PR DESCRIPTION
This diff honors the check-in API time. We create a new package that stores the check-in API time. Because time.Time structs read from JSON do not contain a monotonic clock reading, we store a time.Time containing a monotonic clock reading as well. These two times will always have a bit of offset between them, but such as offset is smaller than the offset between the check-in API time and the probe clock when the probe clock is severely misconfigured.

We keep these times in memory. If a probe has not observed a check-in API response or the check-in API contained an empty time, we do not consider the check-in clock to be valid and so the package is basically disabled.

Otherwise, we have an API based time reference. We use this reference to:

1. include into measurements the check-in-API based clock reading of when we created a measurement, which allows the OONI backend to determine how safe it is to keep or discard the measurement;

2. warn the user if the offset is +- a few minutes.

See https://github.com/ooni/probe/issues/1781

