### PR TITLE
feat(dslx): Add HTTPRequestOverQUIC composition

### DIFF
--- a/internal/dslx/http_test.go
+++ b/internal/dslx/http_test.go
@@ -299,12 +299,20 @@ func TestHTTPTCP(t *testing.T) {
 /*
 Test cases:
 - Get httpTransportQUICFunc
+- Get composed function: QUIC with HTTP
 - Apply httpTransportQUICFunc
 */
 func TestHTTPQUIC(t *testing.T) {
 	t.Run("Get httpTransportQUICFunc", func(t *testing.T) {
 		f := HTTPTransportQUIC()
 		if _, ok := f.(*httpTransportQUICFunc); !ok {
+			t.Fatal("unexpected type")
+		}
+	})
+
+	t.Run("Get composed function: QUIC with HTTP", func(t *testing.T) {
+		f := HTTPRequestOverQUIC()
+		if _, ok := f.(*compose2Func[*QUICConnection, *HTTPTransport, *HTTPResponse]); !ok {
 			t.Fatal("unexpected type")
 		}
 	})

--- a/internal/dslx/httpquic.go
+++ b/internal/dslx/httpquic.go
@@ -10,6 +10,11 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
+// HTTPRequestOverQUIC returns a Func that issues HTTP requests over QUIC.
+func HTTPRequestOverQUIC(options ...HTTPRequestOption) Func[*QUICConnection, *Maybe[*HTTPResponse]] {
+	return Compose2(HTTPTransportQUIC(), HTTPRequest(options...))
+}
+
 // HTTPTransportQUIC converts a QUIC connection into an HTTP transport.
 func HTTPTransportQUIC() Func[*QUICConnection, *Maybe[*HTTPTransport]] {
 	return &httpTransportQUICFunc{}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2402

## Description

This PR adds a utility function to dslx which composes a HTTP-over-QUIC operation by combining `HTTPTransportQUIC()` and `HTTPRequest()`. Similar composition functions exist for HTTP-over-TCP and HTTP-over-TLS and they are useful because in order to do the HTTP "step", we usually need to do both: Create an HTTP Transport and run the HTTP Request.