### PR TITLE
fix(dslx): Remove calls to NewDefaultCertPool

### DIFF
--- a/internal/dslx/quic.go
+++ b/internal/dslx/quic.go
@@ -49,7 +49,6 @@ func QUICHandshake(pool *ConnPool, options ...QUICHandshakeOption) Func[
 	f := &quicHandshakeFunc{
 		InsecureSkipVerify: false,
 		Pool:               pool,
-		RootCAs:            netxlite.NewDefaultCertPool(),
 		ServerName:         "",
 	}
 	for _, option := range options {

--- a/internal/dslx/tls.go
+++ b/internal/dslx/tls.go
@@ -55,7 +55,6 @@ func TLSHandshake(pool *ConnPool, options ...TLSHandshakeOption) Func[
 		InsecureSkipVerify: false,
 		NextProto:          []string{},
 		Pool:               pool,
-		RootCAs:            netxlite.NewDefaultCertPool(),
 		ServerName:         "",
 	}
 	for _, option := range options {


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2402 

## Description
We don't want to use `NewDefaultCertPool` anymore outside of netxlite (https://github.com/ooni/probe/issues/2444). 
