### PR TITLE
fix(libtor): avoid data race

### DIFF
--- a/internal/libtor/enabled.go
+++ b/internal/libtor/enabled.go
@@ -57,6 +57,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"runtime"
 	"sync"
 
 	"github.com/cretz/bine/process"

--- a/internal/libtor/enabled.go
+++ b/internal/libtor/enabled.go
@@ -149,6 +149,13 @@ var ErrNonzeroExitCode = errors.New("libtor: command completed with nonzero exit
 // runtor runs tor until completion and ensures that tor exits when
 // the given ctx is cancelled or its deadline expires.
 func (p *torProcess) runtor(ctx context.Context, cc net.Conn, args ...string) {
+	// make sure we lock to an OS thread otherwise the goroutine can get
+	// preempted midway and cause data races
+	//
+	// See https://github.com/ooni/probe/issues/2406#issuecomment-1479138677
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	// wait for Start or context to expire
 	select {
 	case <-p.awaitStart:


### PR DESCRIPTION
There's a data race in the `libtor` package, as documented by https://github.com/ooni/probe/issues/2406#issuecomment-1479138677. This diff applies the commits mentioned by https://github.com/ooni/probe/issues/2406#issuecomment-1479365235.