### PR TITLE
show remaining time in CLI as h-m-s instead of seconds #2454

### DIFF
--- a/cmd/ooniprobe/internal/log/handlers/cli/cli.go
+++ b/cmd/ooniprobe/internal/log/handlers/cli/cli.go
@@ -112,7 +112,7 @@ func (h *Handler) TypedLog(t string, e *log.Entry) error {
 		eta := e.Fields.Get("eta").(float64)
 		var etaMessage string
 		if eta >= 0 {
-			etaMessage = fmt.Sprintf("(%ss left)", bold.Sprintf("%.2f", eta))
+			etaMessage = fmt.Sprintf("(%s left)", bold.Sprintf("%s", time.Duration(eta*float64(time.Second)).Round(time.Millisecond)))
 		}
 		s := fmt.Sprintf("   %s %-25s %s",
 			bold.Sprintf("%.2f%%", perc),


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: [ Show remaining time in a human-readable way #2454 ](https://github.com/ooni/probe/issues/2454)
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description
Formatted remaining time in CLI (run websites) as standard time.Duration format, for example shows (1h7m19.018s) left instead of seconds for durations>=60 sec.  Propose rounding to time.Millisecond instead of "%.2f", for cleaner code;  only "time" package used, no extra dependencies.

