### PR TITLE
signal: remove check for api.directory.signal.org

### DIFF
--- a/internal/experiment/signal/signal.go
+++ b/internal/experiment/signal/signal.go
@@ -176,11 +176,6 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 			FailOnHTTPError: false,
 			CertPool:        certPool,
 		}},
-		{Target: "https://api.directory.signal.org/", Config: urlgetter.Config{
-			Method:          "GET",
-			FailOnHTTPError: false,
-			CertPool:        certPool,
-		}},
 		{Target: "https://cdn.signal.org/", Config: urlgetter.Config{
 			Method:          "GET",
 			FailOnHTTPError: false,


### PR DESCRIPTION
The reference to the `api.directory.signal.org` domain was removed in signalapp/Signal-TLS-Proxy@461d2d1aeec601a4d62100949a227f0cef2f6154, so the check for Signal fails. This commit removes the reference to the domain in OONI Probe as well.