### PR TITLE
feat: introduce dslx Observations constructor

### DIFF
--- a/internal/dslx/httpcore.go
+++ b/internal/dslx/httpcore.go
@@ -287,7 +287,9 @@ func (f *httpRequestFunc) do(
 ) (*http.Response, []byte, []*Observations, error) {
 	const maxbody = 1 << 19 // TODO(bassosimone): allow to configure this value?
 	started := input.Trace.TimeSince(input.Trace.ZeroTime)
-	observations := []*Observations{{}} // one entry!
+	observations := []*Observations{
+		NewObservations(),
+	} // one entry
 
 	observations[0].NetworkEvents = append(observations[0].NetworkEvents,
 		measurexlite.NewAnnotationArchivalNetworkEvent(

--- a/internal/dslx/observations.go
+++ b/internal/dslx/observations.go
@@ -31,6 +31,19 @@ type Observations struct {
 	QUICHandshakes []*model.ArchivalTLSOrQUICHandshakeResult `json:"quic_handshakes"`
 }
 
+// NewObservations initializes all measurements to empty arrays and returns the
+// Observations skeleton.
+func NewObservations() *Observations {
+	return &Observations{
+		NetworkEvents:  []*model.ArchivalNetworkEvent{},
+		Queries:        []*model.ArchivalDNSLookupResult{},
+		Requests:       []*model.ArchivalHTTPRequestResult{},
+		TCPConnect:     []*model.ArchivalTCPConnectResult{},
+		TLSHandshakes:  []*model.ArchivalTLSOrQUICHandshakeResult{},
+		QUICHandshakes: []*model.ArchivalTLSOrQUICHandshakeResult{},
+	}
+}
+
 // ExtractObservations extracts observations from a list of [Maybe].
 func ExtractObservations[T any](rs ...*Maybe[T]) (out []*Observations) {
 	for _, r := range rs {


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2482
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff introduces a `dslx.NewObservations` constructor to be used for initializing `Observations` with empty measurements
 