### PR TITLE
fix(oohelperd): use cookiejar for HTTP measurements

### DIFF
--- a/internal/netxlite/http3.go
+++ b/internal/netxlite/http3.go
@@ -73,7 +73,7 @@ func NewHTTP3TransportStdlib(logger model.DebugLogger) model.HTTPTransport {
 
 // NewHTTPTransportWithResolver creates a new HTTPTransport using http3
 // that uses the given logger and the given resolver.
-func NewHTTP3TransportWithResolver(logger model.Logger, reso model.Resolver) model.HTTPTransport {
+func NewHTTP3TransportWithResolver(logger model.DebugLogger, reso model.Resolver) model.HTTPTransport {
 	qd := NewQUICDialerWithResolver(NewQUICListener(), logger, reso)
 	return NewHTTP3Transport(logger, qd, nil)
 }


### PR DESCRIPTION
See https://github.com/ooni/probe/issues/2488.

This patch needs to be backported to the release/3.17 branch.
