### PR TITLE
chore: minor changes before 3.18.0-alpha

### DIFF
--- a/MOBILE/android/ensure
+++ b/MOBILE/android/ensure
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-__install_extra="build-tools;33.0.1 platforms;android-32"
+__install_extra="build-tools;34.0.0 platforms;android-33"
 
 __ndk_version=$(cat ./NDKVERSION)
 

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/miekg/dns v1.1.54
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/montanaflynn/stats v0.7.1
-	github.com/ooni/go-libtor v1.1.7
+	github.com/ooni/go-libtor v1.1.8
 	github.com/ooni/netem v0.0.0-20230606061801-6bfb478aadf7
 	github.com/ooni/oocrypto v0.5.1
 	github.com/ooni/oohttp v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -636,8 +636,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.27.7 h1:fVih9JD6ogIiHUN6ePK7HJidyEDpWGVB5mzM7cWNXoU=
-github.com/ooni/go-libtor v1.1.7 h1:ooVcdEPBqDox5OfeXAfXIeQFCbqMLJVfIpO+Irr7N9A=
-github.com/ooni/go-libtor v1.1.7/go.mod h1:q1YyLwRD9GeMyeerVvwc0vJ2YgwDLTp2bdVcrh/JXyI=
+github.com/ooni/go-libtor v1.1.8 h1:Wo3V3DVTxl5vZdxtQakqYP+DAHx7pPtAFSl1bnAa08w=
+github.com/ooni/go-libtor v1.1.8/go.mod h1:q1YyLwRD9GeMyeerVvwc0vJ2YgwDLTp2bdVcrh/JXyI=
 github.com/ooni/netem v0.0.0-20230606061801-6bfb478aadf7 h1:YmDaAoEKSSVcoEEpeDeqSzgTHUBvPrnC2VYd77z7buA=
 github.com/ooni/netem v0.0.0-20230606061801-6bfb478aadf7/go.mod h1:3LJOzTIu2O4ADDJN2ILG4ViJOqyH/u9fKY8QT2Rma8Y=
 github.com/ooni/oocrypto v0.5.1 h1:7LD07H2LA7mAQIVhZ1k6eHlRxN7ux/mHhoFdBUgWFSQ=

--- a/internal/model/http.go
+++ b/internal/model/http.go
@@ -13,9 +13,9 @@ const (
 	HTTPHeaderAcceptLanguage = "en-US,en;q=0.9"
 
 	// HTTPHeaderUserAgent is the User-Agent header used for measuring. The current header
-	// is 26.4% of the browser population as of Jan 05, 2023 according to the
+	// is 22.0% of the browser population as of Jun 06, 2023 according to the
 	// https://techblog.willshouse.com/2012/01/03/most-common-user-agents/ webpage.
-	HTTPHeaderUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"
+	HTTPHeaderUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36"
 )
 
 // Additional strings used to report HTTP errors. They're currently only used by


### PR DESCRIPTION
- [x] make sure android dependencies are up-to-date
- [x] update to the latest ooni/go-libtor for iOS
- [x] make sure we're using the most popular user-agent

See https://github.com/ooni/probe/issues/2417

