### PR TITLE
fix: do not mention NewDefaultCertPool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ and `./internal/netxlite.CopyContext` instead of `io.Copy`
 - use `./internal/model.ErrorToStringOrOK` when
 an experiment logs intermediate results
 
-- do not call `netxlite.NewDefaultCertPool` unless you need to
+- do not call `netxlite.netxlite.NewMozillaCertPool` unless you need to
 modify a copy of the default Mozilla CA pool (when using `netxlite`
 as the underlying library--which is the common case--you can just
 leave the `RootCAs` to `nil` in a `tls.Config` and `netxlite`

--- a/internal/model/netx.go
+++ b/internal/model/netx.go
@@ -488,7 +488,7 @@ type UnderlyingNetwork interface {
 	// DefaultCertPool returns the underlying cert pool used by the
 	// network extensions library. You MUST NOT use this function to
 	// modify the default cert pool since this would lead to a data
-	// race. Use [netxlite.NewDefaultCertPool] if you wish to get
+	// race. Use [netxlite.netxlite.NewMozillaCertPool] if you wish to get
 	// a copy of the default cert pool that you can modify.
 	DefaultCertPool() *x509.CertPool
 


### PR DESCRIPTION
We renamed it to NewMozillaCertPool in #1129.

