### PR TITLE
[forwardport] fix: use correct Xcode and mingw version

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -35,7 +35,7 @@ jobs:
           PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
           PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
 
-      - run: make EXPECTED_XCODE_VERSION=13.2.1 MOBILE/ios
+      - run: make EXPECTED_XCODE_VERSION=14.2 MOBILE/ios
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,7 +38,7 @@ jobs:
           PSIPHON_CONFIG_KEY: ${{ secrets.PSIPHON_CONFIG_KEY }}
           PSIPHON_CONFIG_JSON_AGE_BASE64: ${{ secrets.PSIPHON_CONFIG_JSON_AGE_BASE64 }}
 
-      - run: make EXPECTED_MINGW_W64_VERSION="9.3-win32" CLI/windows
+      - run: make EXPECTED_MINGW_W64_VERSION="10-win32" CLI/windows
 
       - uses: actions/upload-artifact@v3
         with:

--- a/internal/cmd/ghgen/ios.go
+++ b/internal/cmd/ghgen/ios.go
@@ -24,7 +24,7 @@ func buildAndPublishMobileIOS(w io.Writer, job *Job) {
 	newStepCheckout(w)
 	newStepSetupGo(w, "ios")
 	newStepSetupPsiphon(w)
-	newStepMake(w, "EXPECTED_XCODE_VERSION=13.2.1 MOBILE/ios")
+	newStepMake(w, "EXPECTED_XCODE_VERSION=14.2 MOBILE/ios")
 	newStepUploadArtifacts(w, artifacts)
 
 	newJob(w, publishJob, runsOnUbuntu, buildJob, contentsWritePermissions)

--- a/internal/cmd/ghgen/windows.go
+++ b/internal/cmd/ghgen/windows.go
@@ -28,7 +28,7 @@ func buildAndPublishCLIWindows(w io.Writer, job *Job) {
 	newStepSetupGo(w, "windows")
 	newStepInstallMingwW64(w)
 	newStepSetupPsiphon(w)
-	newStepMake(w, "EXPECTED_MINGW_W64_VERSION=\"9.3-win32\" CLI/windows")
+	newStepMake(w, "EXPECTED_MINGW_W64_VERSION=\"10-win32\" CLI/windows")
 
 	newStepUploadArtifacts(w, artifacts)
 


### PR DESCRIPTION
This diff forward ports 8a85b6379ba5ad7c23d494158ea3a5d535b36587 to the master development branch.

We have updated the runners, so the versions have changed as well.

See https://github.com/ooni/probe/issues/2417

