### PR TITLE
cleanup: measurexlite should not depend on tracex

### DIFF
--- a/internal/measurexlite/conn.go
+++ b/internal/measurexlite/conn.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
-	"github.com/ooni/probe-cli/v3/internal/tracex"
 )
 
 // MaybeClose is a convenience function for closing a conn only when such a conn isn't nil.
@@ -152,7 +151,7 @@ func NewArchivalNetworkEvent(index int64, started time.Duration, operation strin
 	tags ...string) *model.ArchivalNetworkEvent {
 	return &model.ArchivalNetworkEvent{
 		Address:       address,
-		Failure:       tracex.NewFailure(err),
+		Failure:       NewFailure(err),
 		NumBytes:      int64(count),
 		Operation:     operation,
 		Proto:         network,

--- a/internal/measurexlite/dialer.go
+++ b/internal/measurexlite/dialer.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
-	"github.com/ooni/probe-cli/v3/internal/tracex"
 )
 
 // NewDialerWithoutResolver is equivalent to netxlite.NewDialerWithoutResolver
@@ -100,7 +99,7 @@ func NewArchivalTCPConnectResult(index int64, started time.Duration, address str
 		Port: archivalPortToString(port),
 		Status: model.ArchivalTCPConnectStatus{
 			Blocked: nil,
-			Failure: tracex.NewFailure(err),
+			Failure: NewFailure(err),
 			Success: err == nil,
 		},
 		T0:            started.Seconds(),

--- a/internal/measurexlite/dns.go
+++ b/internal/measurexlite/dns.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/geoipx"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
-	"github.com/ooni/probe-cli/v3/internal/tracex"
 )
 
 // wrapResolver resolver wraps the passed resolver to save data into the trace
@@ -149,7 +148,7 @@ func NewArchivalDNSLookupResultFromRoundTrip(index int64, started time.Duration,
 	return &model.ArchivalDNSLookupResult{
 		Answers:          newArchivalDNSAnswers(addrs, response),
 		Engine:           reso.Network(),
-		Failure:          tracex.NewFailure(err),
+		Failure:          NewFailure(err),
 		GetaddrinfoError: netxlite.ErrorToGetaddrinfoRetvalOrZero(err),
 		Hostname:         query.Domain(),
 		QueryType:        dns.TypeToString[query.Type()],

--- a/internal/measurexlite/http.go
+++ b/internal/measurexlite/http.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/model"
-	"github.com/ooni/probe-cli/v3/internal/tracex"
 )
 
 // NewArchivalHTTPRequestResult creates a new model.ArchivalHTTPRequestResult.
@@ -51,7 +50,7 @@ func NewArchivalHTTPRequestResult(index int64, started time.Duration, network, a
 		Network: network,
 		Address: address,
 		ALPN:    alpn,
-		Failure: tracex.NewFailure(err),
+		Failure: NewFailure(err),
 		Request: model.ArchivalHTTPRequest{
 			Body:            model.ArchivalMaybeBinaryData{},
 			BodyIsTruncated: false,

--- a/internal/measurexlite/tls.go
+++ b/internal/measurexlite/tls.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
-	"github.com/ooni/probe-cli/v3/internal/tracex"
 )
 
 // NewTLSHandshakerStdlib is equivalent to netxlite.NewTLSHandshakerStdlib
@@ -87,7 +86,7 @@ func NewArchivalTLSOrQUICHandshakeResult(
 		Network:            network,
 		Address:            address,
 		CipherSuite:        netxlite.TLSCipherSuiteString(state.CipherSuite),
-		Failure:            tracex.NewFailure(err),
+		Failure:            NewFailure(err),
 		NegotiatedProtocol: state.NegotiatedProtocol,
 		NoTLSVerify:        config.InsecureSkipVerify,
 		PeerCertificates:   TLSPeerCerts(state, err),


### PR DESCRIPTION
I noticed this issue while working on https://github.com/ooni/probe/issues/2493
