### PR TITLE
feat: lightweight throttling measurements

### DIFF
--- a/internal/experiment/webconnectivitylte/cleartextflow.go
+++ b/internal/experiment/webconnectivitylte/cleartextflow.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
+	"github.com/ooni/probe-cli/v3/internal/throttling"
 )
 
 // Measures HTTP endpoints.
@@ -97,6 +98,13 @@ func (t *CleartextFlow) Run(parentCtx context.Context, index int64) error {
 
 	// create trace
 	trace := measurexlite.NewTrace(index, t.ZeroTime)
+
+	// start measuring throttling
+	sampler := throttling.NewSampler(trace)
+	defer func() {
+		t.TestKeys.AppendNetworkEvents(sampler.ExtractSamples()...)
+		sampler.Close()
+	}()
 
 	// start the operation logger
 	ol := measurexlite.NewOperationLogger(

--- a/internal/experiment/webconnectivitylte/secureflow.go
+++ b/internal/experiment/webconnectivitylte/secureflow.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
+	"github.com/ooni/probe-cli/v3/internal/throttling"
 )
 
 // Measures HTTPS endpoints.
@@ -104,6 +105,13 @@ func (t *SecureFlow) Run(parentCtx context.Context, index int64) error {
 
 	// create trace
 	trace := measurexlite.NewTrace(index, t.ZeroTime)
+
+	// start measuring throttling
+	sampler := throttling.NewSampler(trace)
+	defer func() {
+		t.TestKeys.AppendNetworkEvents(sampler.ExtractSamples()...)
+		sampler.Close()
+	}()
 
 	// start the operation logger
 	ol := measurexlite.NewOperationLogger(

--- a/internal/measurexlite/conn.go
+++ b/internal/measurexlite/conn.go
@@ -54,6 +54,8 @@ func (c *connTrace) Read(b []byte) (int, error) {
 	default: // buffer is full
 	}
 
+	c.tx.BytesReceived.Add(int64(count))
+
 	return count, err
 }
 
@@ -72,6 +74,8 @@ func (c *connTrace) Write(b []byte) (int, error) {
 		err, finished, c.tx.tags...):
 	default: // buffer is full
 	}
+
+	c.tx.BytesSent.Add(int64(count))
 
 	return count, err
 }
@@ -115,6 +119,8 @@ func (c *udpLikeConnTrace) ReadFrom(b []byte) (int, net.Addr, error) {
 	default: // buffer is full
 	}
 
+	c.tx.BytesReceived.Add(int64(count))
+
 	return count, addr, err
 }
 
@@ -132,6 +138,8 @@ func (c *udpLikeConnTrace) WriteTo(b []byte, addr net.Addr) (int, error) {
 		err, finished, c.tx.tags...):
 	default: // buffer is full
 	}
+
+	c.tx.BytesSent.Add(int64(count))
 
 	return count, err
 }

--- a/internal/measurexlite/conn.go
+++ b/internal/measurexlite/conn.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
-// MaybeClose is a convenience function for closing a conn only when such a conn isn't nil.
+// MaybeClose is a convenience function for closing a [net.Conn] when it is not nil.
 func MaybeClose(conn net.Conn) (err error) {
 	if conn != nil {
 		err = conn.Close()
@@ -80,7 +80,7 @@ func (c *connTrace) Write(b []byte) (int, error) {
 	return count, err
 }
 
-// MaybeUDPLikeClose is a convenience function for closing a conn only when such a conn isn't nil.
+// MaybeCloseUDPLikeConn is a convenience function for closing a [model.UDPLikeConn] when it is not nil.
 func MaybeCloseUDPLikeConn(conn model.UDPLikeConn) (err error) {
 	if conn != nil {
 		err = conn.Close()

--- a/internal/measurexlite/conn_test.go
+++ b/internal/measurexlite/conn_test.go
@@ -537,13 +537,13 @@ func TestTrace_updateBytesReceivedMapNetConn(t *testing.T) {
 	})
 }
 
-func TestTrace_updateBytesReceivedMapUDPLikeConn(t *testing.T) {
+func TestTrace_maybeUpdateBytesReceivedMapUDPLikeConn(t *testing.T) {
 	t.Run("we ignore cases where the address is nil", func(t *testing.T) {
 		// create a new trace
 		tx := NewTrace(0, time.Now())
 
 		// insert stats with a nil address
-		tx.updateBytesReceivedMapUDPLikeConn(nil, 128)
+		tx.maybeUpdateBytesReceivedMapUDPLikeConn(nil, 128)
 
 		// inserts stats with a good address
 		goodAddr := &mocks.Addr{
@@ -554,7 +554,7 @@ func TestTrace_updateBytesReceivedMapUDPLikeConn(t *testing.T) {
 				return "udp"
 			},
 		}
-		tx.updateBytesReceivedMapUDPLikeConn(goodAddr, 128)
+		tx.maybeUpdateBytesReceivedMapUDPLikeConn(goodAddr, 128)
 
 		// make sure the result is the expected one
 		expected := map[string]int64{

--- a/internal/measurexlite/conn_test.go
+++ b/internal/measurexlite/conn_test.go
@@ -103,6 +103,16 @@ func TestWrapNetConn(t *testing.T) {
 		if err != nil {
 			t.Fatal("invalid err")
 		}
+
+		t.Run("we update the per-trace I/O counters", func(t *testing.T) {
+			if trace.BytesSent.Load() != 0 {
+				t.Fatal("expected to see some no bytes sent")
+			}
+			if trace.BytesReceived.Load() <= 0 {
+				t.Fatal("expected to see some bytes received")
+			}
+		})
+
 		events := trace.NetworkEvents()
 		if len(events) != 1 {
 			t.Fatal("did not save network events")
@@ -187,6 +197,16 @@ func TestWrapNetConn(t *testing.T) {
 		if err != nil {
 			t.Fatal("invalid err")
 		}
+
+		t.Run("we update the per-trace I/O counters", func(t *testing.T) {
+			if trace.BytesReceived.Load() != 0 {
+				t.Fatal("expected to see no bytes received")
+			}
+			if trace.BytesSent.Load() <= 0 {
+				t.Fatal("expected to see some bytes sent")
+			}
+		})
+
 		events := trace.NetworkEvents()
 		if len(events) != 1 {
 			t.Fatal("did not save network events")
@@ -284,6 +304,16 @@ func TestWrapUDPLikeConn(t *testing.T) {
 		if err != nil {
 			t.Fatal("invalid err")
 		}
+
+		t.Run("we update the per-trace I/O counters", func(t *testing.T) {
+			if trace.BytesReceived.Load() <= 0 {
+				t.Fatal("expected to see some bytes received")
+			}
+			if trace.BytesSent.Load() != 0 {
+				t.Fatal("expected to see no bytes sent")
+			}
+		})
+
 		events := trace.NetworkEvents()
 		if len(events) != 1 {
 			t.Fatal("did not save network events")
@@ -360,6 +390,16 @@ func TestWrapUDPLikeConn(t *testing.T) {
 		if err != nil {
 			t.Fatal("invalid err")
 		}
+
+		t.Run("we update the per-trace I/O counters", func(t *testing.T) {
+			if trace.BytesReceived.Load() != 0 {
+				t.Fatal("expected to see no bytes received")
+			}
+			if trace.BytesSent.Load() <= 0 {
+				t.Fatal("expected to see some bytes sent")
+			}
+		})
+
 		events := trace.NetworkEvents()
 		if len(events) != 1 {
 			t.Fatal("did not save network events")
@@ -379,7 +419,7 @@ func TestWrapUDPLikeConn(t *testing.T) {
 		}
 	})
 
-	t.Run("Write discards the event when the buffer is full", func(t *testing.T) {
+	t.Run("WriteTo discards the event when the buffer is full", func(t *testing.T) {
 		underlying := &mocks.UDPLikeConn{
 			MockWriteTo: func(b []byte, addr net.Addr) (int, error) {
 				return len(b), nil

--- a/internal/measurexlite/conn_test.go
+++ b/internal/measurexlite/conn_test.go
@@ -106,7 +106,7 @@ func TestWrapNetConn(t *testing.T) {
 
 		t.Run("we update the per-trace I/O counters", func(t *testing.T) {
 			if trace.BytesSent.Load() != 0 {
-				t.Fatal("expected to see some no bytes sent")
+				t.Fatal("expected to see no bytes sent")
 			}
 			if trace.BytesReceived.Load() <= 0 {
 				t.Fatal("expected to see some bytes received")

--- a/internal/measurexlite/dialer.go
+++ b/internal/measurexlite/dialer.go
@@ -18,10 +18,6 @@ import (
 
 // NewDialerWithoutResolver is equivalent to netxlite.NewDialerWithoutResolver
 // except that it returns a model.Dialer that uses this trace.
-//
-// Note: unlike code in netx or measurex, this factory DOES NOT return you a
-// dialer that also performs wrapping of a net.Conn in case of success. If you
-// want to wrap the conn, you need to wrap it explicitly using model.Trace.WrapNetConn.
 func (tx *Trace) NewDialerWithoutResolver(dl model.DebugLogger) model.Dialer {
 	return &dialerTrace{
 		d:  tx.newDialerWithoutResolver(dl),

--- a/internal/measurexlite/dns.go
+++ b/internal/measurexlite/dns.go
@@ -267,8 +267,9 @@ func (tx *Trace) FirstDNSLookup() *model.ArchivalDNSLookupResult {
 	return ev[0]
 }
 
-// ErrDelayedDNSResponseBufferFull indicates that the delayedDNSResponse buffer is full.
-var ErrDelayedDNSResponseBufferFull = errors.New("buffer full")
+// ErrDelayedDNSResponseBufferFull indicates that the delayed-DNS-response channel buffer is full.
+var ErrDelayedDNSResponseBufferFull = errors.New(
+	"measurexlite: the delayed-DNS-response channel buffer is full")
 
 // OnDelayedDNSResponse implements model.Trace.OnDelayedDNSResponse
 func (tx *Trace) OnDelayedDNSResponse(started time.Time, txp model.DNSTransport, query model.DNSQuery,

--- a/internal/measurexlite/doc.go
+++ b/internal/measurexlite/doc.go
@@ -1,10 +1,44 @@
-// Package measurexlite contains measurement extensions.
+// Package measurexlite contains measurement extensions. This package is named "measurex lite"
+// because it implements a lightweight approach compared to a previous package named "measurex".
 //
-// See docs/design/dd-003-step-by-step.md in the ooni/probe-cli
-// repository for the design document.
+// [measurexlite] implements the [dd-003-step-by-step.md] design document. The fundamental data type
+// is the [*Trace], which saves events in buffered channels. The [NewTrace] constructor creates
+// channels with sufficient capacity for tracing all the events we expect to see for a single use
+// connection or for a DNS round trip. If you are not draining the channels, the [*Trace] will
+// eventually stop collecting events, though.
 //
-// This implementation features a Trace that saves events in
-// buffered channels as proposed by df-003-step-by-step.md. We
-// have reasonable default buffers for channels. But, if you
-// are not draining them, eventually we stop collecting events.
+// As mentioned above, the expectation is that a [*Trace] will only trace a single use connection or
+// a DNS round trip. Typically, you create a distinct trace for each TCP-TLS-HTTP or TCP-HTTP or
+// QUIC-HTTP or DNS-lookup-with-getaddrinfo or DNS-lookup-with-UDP sequence of operations. There is
+// a "trace ID" for each trace, which you provide to [NewTrace]. This ID is copied into the
+// "transaction_id" field of the archival network events. Therefore, by using distinct trace IDs
+// for distinct operations, you enable [ooni/data] to group related events together.
+//
+// The [*Trace] features methods that mirror existing [netxlite] methods but implement support for
+// collecting network events using the [*Trace]. For example, [*Trace.NewStdlibResolver] is like
+// [netxlite.NewStdlibResolver] but the DNS lookups performed with the resolved returned by
+// [*Trace.NewStdlibResolver] generate events that you can collect using the [*Trace].
+//
+// As mentioned above, internally, the [*Trace] uses buffered channels on which the underlying
+// network objects attempt to write when there is an interesting event. As a user of the
+// [measurexlite] package, you have methods to extract the events from the [*Trace] channels,
+// such as, for example:
+//
+// - [*Trace.DNSLookupsFromRoundTrip]
+//
+// - [*Trace.NetworkEvents]
+//
+// - [*Trace.TCPConnects]
+//
+// - [*Trace.QUICHandshakes]
+//
+// - [*Trace.TLSHandshakes]
+//
+// These methods already return data structures using the archival data format implemented
+// by the [model] package and specified in the [ooni/spec] repository. Hence, these structures
+// are ready to be added to OONI measurements.
+//
+// [dd-003-step-by-step.md]: https://github.com/ooni/probe-cli/blob/master/docs/design/dd-003-step-by-step.md
+// [ooni/data]: https://github.com/ooni/data
+// [ooni/spec]: https://github.com/ooni/spec
 package measurexlite

--- a/internal/measurexlite/quic.go
+++ b/internal/measurexlite/quic.go
@@ -107,8 +107,7 @@ func (tx *Trace) FirstQUICHandshakeOrNil() *model.ArchivalTLSOrQUICHandshakeResu
 	return ev[0]
 }
 
-// MaybeCloseQUICConn is a convenience function for closing a quic.EarlyConnection only when such a conn
-// isn't nil.
+// MaybeCloseQUICConn is a convenience function for closing a [quic.EarlyConnection] when it is not nil.
 func MaybeCloseQUICConn(conn quic.EarlyConnection) (err error) {
 	if conn != nil {
 		err = conn.CloseWithError(0, "")

--- a/internal/measurexlite/trace.go
+++ b/internal/measurexlite/trace.go
@@ -5,6 +5,7 @@ package measurexlite
 //
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/model"
@@ -24,6 +25,12 @@ import (
 // measurements). We have convenience methods for extracting events from the
 // buffered channels.
 type Trace struct {
+	// BytesSent is the atomic counter of bytes sent so far for this trace.
+	BytesSent atomic.Int64
+
+	// BytesReceived is like BytesSent but for the bytes received.
+	BytesReceived atomic.Int64
+
 	// Index is the unique index of this trace within the
 	// current measurement. Note that this field MUST be read-only. Writing it
 	// once you have constructed a trace MAY lead to data races.
@@ -130,7 +137,9 @@ const (
 // to identify that some traces belong to some submeasurements).
 func NewTrace(index int64, zeroTime time.Time, tags ...string) *Trace {
 	return &Trace{
-		Index: index,
+		BytesSent:     atomic.Int64{},
+		BytesReceived: atomic.Int64{},
+		Index:         index,
 		networkEvent: make(
 			chan *model.ArchivalNetworkEvent,
 			NetworkEventBufferSize,

--- a/internal/measurexlite/trace.go
+++ b/internal/measurexlite/trace.go
@@ -26,10 +26,10 @@ import (
 // buffered channels.
 type Trace struct {
 	// BytesSent is the atomic counter of bytes sent so far for this trace.
-	BytesSent atomic.Int64
+	BytesSent *atomic.Int64
 
 	// BytesReceived is like BytesSent but for the bytes received.
-	BytesReceived atomic.Int64
+	BytesReceived *atomic.Int64
 
 	// Index is the unique index of this trace within the
 	// current measurement. Note that this field MUST be read-only. Writing it
@@ -137,8 +137,8 @@ const (
 // to identify that some traces belong to some submeasurements).
 func NewTrace(index int64, zeroTime time.Time, tags ...string) *Trace {
 	return &Trace{
-		BytesSent:     atomic.Int64{},
-		BytesReceived: atomic.Int64{},
+		BytesSent:     &atomic.Int64{},
+		BytesReceived: &atomic.Int64{},
 		Index:         index,
 		networkEvent: make(
 			chan *model.ArchivalNetworkEvent,

--- a/internal/throttling/throttling.go
+++ b/internal/throttling/throttling.go
@@ -18,7 +18,7 @@ type Sampler struct {
 	// cancel tells the background goroutine to stop
 	cancel context.CancelFunc
 
-	// mu provides mutal exclusion
+	// mu provides mutual exclusion
 	mu *sync.Mutex
 
 	// once ensures that close has "once" semantics

--- a/internal/throttling/throttling.go
+++ b/internal/throttling/throttling.go
@@ -1,0 +1,136 @@
+// Package throttling wraps connections to measure throttling.
+package throttling
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/ooni/probe-cli/v3/internal/measurexlite"
+	"github.com/ooni/probe-cli/v3/internal/memoryless"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
+)
+
+// Sampler periodically samples the bytes sent and received by a [*measurexlite.Trace]. The zero
+// value of this structure is invalid; please, construct using [NewSampler].
+type Sampler struct {
+	// cancel tells the background goroutine to stop
+	cancel context.CancelFunc
+
+	// mu provides mutal exclusion
+	mu *sync.Mutex
+
+	// once ensures that close has "once" semantics
+	once *sync.Once
+
+	// q is the queue of events we are collecting
+	q []*model.ArchivalNetworkEvent
+
+	// tx is the trace we are sampling from
+	tx *measurexlite.Trace
+
+	// wg is the waitgroup to wait for the sampler to join
+	wg *sync.WaitGroup
+}
+
+// NewSampler attaches a [*Sampler] to a [*measurexlite.Trace], starts sampling in the
+// background and returns the [*Sampler]. Remember to call [*Sampler.Close] to stop
+// the background goroutine that performs the sampling.
+func NewSampler(tx *measurexlite.Trace) *Sampler {
+	ctx, cancel := context.WithCancel(context.Background())
+	smpl := &Sampler{
+		cancel: cancel,
+		mu:     &sync.Mutex{},
+		once:   &sync.Once{},
+		q:      []*model.ArchivalNetworkEvent{},
+		tx:     tx,
+		wg:     &sync.WaitGroup{},
+	}
+	smpl.wg.Add(1)
+	go smpl.mainLoop(ctx)
+	return smpl
+}
+
+func (smpl *Sampler) mainLoop(ctx context.Context) {
+	// make sure the parent knows when we're done running
+	defer smpl.wg.Done()
+
+	// From the memoryless documentation:
+	//
+	//	The exact mathematical meaning of "too extreme" depends on your situation,
+	//	but a nice rule of thumb is config.Min should be at most 10% of expected and
+	//	config.Max should be at least 250% of expected. These values mean that less
+	//	than 10% of time you will be waiting config.Min and less than 10% of the time
+	//	you will be waiting config.Max.
+	//
+	// So, we are going to use 250 milliseconds of expected, 25 milliseconds for the
+	// minimum value, and 650 milliseconds for the maximum value.
+	config := memoryless.Config{
+		Expected: 250 * time.Millisecond,
+		Min:      25 * time.Millisecond,
+		Max:      650 * time.Millisecond,
+		Once:     false,
+	}
+
+	// create the memoryless ticker
+	ticker := runtimex.Try1(memoryless.NewTicker(ctx, config))
+	defer ticker.Stop()
+
+	// loop until we're asked to stop through the context
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-ticker.C:
+			smpl.collectSnapshot()
+		}
+	}
+}
+
+// BytesReceivedCumulativeOperation is the operation we set for network events.
+const BytesReceivedCumulativeOperation = "bytes_received_cumulative"
+
+func (smpl *Sampler) collectSnapshot() {
+	// fill the event
+	now := smpl.tx.TimeSince(smpl.tx.ZeroTime).Seconds()
+	ev := &model.ArchivalNetworkEvent{
+		Address:       "",
+		Failure:       nil,
+		NumBytes:      smpl.tx.BytesReceived.Load(),
+		Operation:     BytesReceivedCumulativeOperation,
+		Proto:         "",
+		T0:            now,
+		T:             now,
+		TransactionID: smpl.tx.Index,
+		Tags:          smpl.tx.Tags(),
+	}
+
+	// lock and insert
+	smpl.mu.Lock()
+	smpl.q = append(smpl.q, ev)
+	smpl.mu.Unlock()
+}
+
+// Close closes the [*Sampler]. This method is goroutine safe and idempotent.
+func (smpl *Sampler) Close() error {
+	smpl.once.Do(func() {
+		smpl.cancel()
+		smpl.wg.Wait()
+	})
+	return nil
+}
+
+// ExtractSamples extracts the samples from the [*Sampler]
+func (smpl *Sampler) ExtractSamples() []*model.ArchivalNetworkEvent {
+	// collect one last sample -- no need to lock since collectSnapshot locks the mutex
+	smpl.collectSnapshot()
+
+	// lock and extract all samples
+	smpl.mu.Lock()
+	o := smpl.q
+	smpl.q = []*model.ArchivalNetworkEvent{}
+	smpl.mu.Unlock()
+	return o
+}

--- a/internal/throttling/throttling_test.go
+++ b/internal/throttling/throttling_test.go
@@ -70,33 +70,57 @@ func TestSampler(t *testing.T) {
 		t.Fatal("expected", totalBody, "bytes but got", len(body), "bytes")
 	}
 
+	// make sure we have events to process
 	events := sampler.ExtractSamples()
-	var previousCounter int64
-	var previousT float64
+	if len(events) <= 0 {
+		t.Fatal("expected to see at least one event")
+	}
+
+	// make sure each event looks good
+	var (
+		previousCounter int64
+		previousT       float64
+	)
 	for _, ev := range events {
 		t.Log(ev)
 
+		// We do not set any address because we cannot be sure about the address, but the
+		// trace is designed to operate on a single network connection, hence we do not need
+		// to worry about multiple connections being involved. We COULD potentially have
+		// more than a single destination with the [net.PacketConn] we're using for HTTP/3,
+		// because in principle someone could send us lots of spurious packets that are
+		// not meant for the QUIC connection while we're downloading, however this attack
+		// seems quite unlikely in practice, so I think it's reasonable to conclude that
+		// what the trace has seen is what the only conn in the trace has seen.
 		if ev.Address != "" {
 			t.Fatal("invalid address", ev.Address)
 		}
 
+		// There is no failure for this kind of events because we only collect statistics.
 		if ev.Failure != nil {
 			t.Fatal("invalid failure", ev.Failure)
 		}
 
+		// The number of bytes received should increase monotonically
 		if ev.NumBytes < previousCounter {
 			t.Fatal("non-monotonic bytes increase", ev.NumBytes, previousCounter)
 		}
 		previousCounter = ev.NumBytes
 
+		// The operation should always be the expected one
 		if ev.Operation != throttling.BytesReceivedCumulativeOperation {
 			t.Fatal("invalid operation", ev.Operation)
 		}
 
+		// We don't know the protocol. Again, this is not a problem because the trace is
+		// designed to host a single connection and we have the transaction ID, which
+		// mirrors the trace ID and tells us this information.
 		if ev.Proto != "" {
 			t.Fatal("invalid proto", ev.Proto)
 		}
 
+		// The time should also increase monotonically. It may be possible for this test
+		// to sometimes fail in cloud environments, based on other tests we have seen failing.
 		if ev.T != ev.T0 {
 			t.Fatal("T and T0 should be equal", ev.T, ev.T0)
 		}
@@ -105,10 +129,14 @@ func TestSampler(t *testing.T) {
 		}
 		previousT = ev.T
 
+		// This is important: we need to make sure the event's transaction ID mirrors the
+		// trace ID, which is what allows us to attribte the performance events to the
+		// specific connection we have created within the same trace ID.
 		if ev.TransactionID != traceID {
 			t.Fatal("unexpected transaction ID", ev.TransactionID, traceID)
 		}
 
+		// Make sure the tags are the ones we expect to see
 		if diff := cmp.Diff(expectedTags, ev.Tags); diff != "" {
 			t.Fatal(diff)
 		}

--- a/internal/throttling/throttling_test.go
+++ b/internal/throttling/throttling_test.go
@@ -1,0 +1,116 @@
+package throttling_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/probe-cli/v3/internal/measurexlite"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+	"github.com/ooni/probe-cli/v3/internal/randx"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
+	"github.com/ooni/probe-cli/v3/internal/throttling"
+)
+
+func TestSampler(t *testing.T) {
+	const (
+		chunkSize   = 1 << 14
+		repetitions = 10
+		totalBody   = repetitions * chunkSize
+		traceID     = 14
+	)
+
+	// create a testing server that sleeps after each sender for a given number of sends
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		chunk := []byte(randx.Letters(chunkSize))
+		for idx := 0; idx < repetitions; idx++ {
+			w.Write(chunk)
+			time.Sleep(250 * time.Millisecond)
+		}
+	}))
+	defer server.Close()
+
+	// create a trace
+	expectedTags := []string{"antani", "mascetti"}
+	tx := measurexlite.NewTrace(traceID, time.Now(), expectedTags...)
+
+	// create a sampler for the trace
+	sampler := throttling.NewSampler(tx)
+	defer sampler.Close()
+
+	// create a dialer
+	dialer := tx.NewDialerWithoutResolver(model.DiscardLogger)
+
+	// create an HTTP transport
+	txp := netxlite.NewHTTPTransport(model.DiscardLogger, dialer, netxlite.NewNullTLSDialer())
+
+	// create the HTTP request to issue
+	req := runtimex.Try1(http.NewRequest("GET", server.URL, nil))
+
+	// issue the HTTP request and await for response
+	resp, err := txp.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	t.Log("got response", resp)
+
+	// read the response body
+	body, err := netxlite.ReadAllContext(req.Context(), resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// make sure we've read the body
+	if len(body) != totalBody {
+		t.Fatal("expected", totalBody, "bytes but got", len(body), "bytes")
+	}
+
+	events := sampler.ExtractSamples()
+	var previousCounter int64
+	var previousT float64
+	for _, ev := range events {
+		t.Log(ev)
+
+		if ev.Address != "" {
+			t.Fatal("invalid address", ev.Address)
+		}
+
+		if ev.Failure != nil {
+			t.Fatal("invalid failure", ev.Failure)
+		}
+
+		if ev.NumBytes < previousCounter {
+			t.Fatal("non-monotonic bytes increase", ev.NumBytes, previousCounter)
+		}
+		previousCounter = ev.NumBytes
+
+		if ev.Operation != throttling.BytesReceivedCumulativeOperation {
+			t.Fatal("invalid operation", ev.Operation)
+		}
+
+		if ev.Proto != "" {
+			t.Fatal("invalid proto", ev.Proto)
+		}
+
+		if ev.T != ev.T0 {
+			t.Fatal("T and T0 should be equal", ev.T, ev.T0)
+		}
+		if ev.T < previousT {
+			t.Fatal("non-monotonic time increase", ev.T, previousT)
+		}
+		previousT = ev.T
+
+		if ev.TransactionID != traceID {
+			t.Fatal("unexpected transaction ID", ev.TransactionID, traceID)
+		}
+
+		if diff := cmp.Diff(expectedTags, ev.Tags); diff != "" {
+			t.Fatal(diff)
+		}
+	}
+}


### PR DESCRIPTION
This diff implements a lightweight approach to throttling that takes advantage of the step-by-step design and should also be suitable to measure throttling using `dslx` (see https://github.com/ooni/probe/issues/2493).

Before discussing the approach implemented here, it is important to point out that:

1. if we're using step-by-step, we're collecting up to 64 network events for a single network connection;

2. with step-by-step, each trace is bound to a single network connection or DNS round trip;

3. both Web Connectivity v0.5 and dslx use the step-by-step approach;

4. therefore, for extreme throttling of a single connection, 64 I/O events are *a lot of events* to observe throttling;

5. additionally, we're currently limited at downloading `1<<19` bytes of the body, so there is not much room for collecting *lots of data* anyway;

6. additionally, if we were to collect more bytes, the bottleneck would become collecting and uploading the HTTP response body to the OONI backend.

That said, by exploiting the fact that step-by-step means that a trace is bound to a single network connection, we can add passive atomic collection of the bytes received by a trace. Because we're dealing with unconnected UDP sockets, we also need to be careful about accounting the bytes received from the peer that sent the bytes. To this end, we maintain a map from the remote endpoint address and protocol to the number of bytes received. The trace allows one to export the current map. Because data collection is passive, we can start as late as the HTTP download and we would still collect correct cumulative data.

We also introduce a new sampler for measuring throttling. The design of the sampler is similar to the design we're using inside of ndt7. We use a memoryless ticker to avoid sampling periodically but we clamp the distribution such that we will typically receive the expected amount of samplers for each time period.

It is also worth noting that I believe the already collected 64 network events are fine to determine throttling, but we cannot know for sure, hence it makes sense to improve our data collection capabilities.

The related spec PR is https://github.com/ooni/spec/pull/276.

Once this diff is merged, we would still need to do the following:

- [ ] update dslx to use this functionality
- [ ] land Web Connectivity LTE

The latter is fundamental to collect speed samples. We're not doing that with Web Connectivity v0.4.

While there, this diff also improves the measurexlite documentation a bit.