### PR TITLE
fix(webconnectivitylte): bump to 0.5.24

### DIFF
--- a/internal/experiment/webconnectivitylte/measurer.go
+++ b/internal/experiment/webconnectivitylte/measurer.go
@@ -37,7 +37,7 @@ func (m *Measurer) ExperimentName() string {
 
 // ExperimentVersion implements model.ExperimentMeasurer.
 func (m *Measurer) ExperimentVersion() string {
-	return "0.5.23"
+	return "0.5.24"
 }
 
 // Run implements model.ExperimentMeasurer.


### PR DESCRIPTION
We should have done this in https://github.com/ooni/probe-cli/pull/1166.

We'll account this diff as part of https://github.com/ooni/probe/issues/2493.
