### PR TITLE
chore(cdeps): upgrade to OpenSSL 3.1.2

### DIFF
--- a/CDEPS/openssl/001.patch
+++ b/CDEPS/openssl/001.patch
@@ -1,14 +1,15 @@
-diff --git a/include/openssl/opensslv.h b/include/openssl/opensslv.h
-index fd9400a..0d2c9dc 100644
---- a/include/openssl/opensslv.h
-+++ b/include/openssl/opensslv.h
-@@ -94,6 +94,9 @@ extern "C" {
- # define SHLIB_VERSION_HISTORY ""
- # define SHLIB_VERSION_NUMBER "1.1"
-
+diff --git a/include/openssl/opensslv.h.in b/include/openssl/opensslv.h.in
+index 3f47a2a..af1db51 100644
+--- a/include/openssl/opensslv.h.in
++++ b/include/openssl/opensslv.h.in
+@@ -101,6 +101,10 @@ extern "C" {
+       |(OPENSSL_VERSION_PATCH<<4)        \
+       |_OPENSSL_VERSION_PRE_RELEASE )
+ 
 +/* OPENSSL_OONI is used by dependencies to ensure they are using the
 +   correct OpenSSL headers and not some other headers. */
 +#define OPENSSL_OONI 1
-
- #ifdef  __cplusplus
++
+ # ifdef  __cplusplus
  }
+ # endif

--- a/internal/cmd/buildtool/android_test.go
+++ b/internal/cmd/buildtool/android_test.go
@@ -702,12 +702,12 @@ func TestAndroidBuildCdepsOpenSSL(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-1.1.1u.tar.gz",
+				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-3.1.2.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "openssl-1.1.1u.tar.gz",
+				"tar", "-xf", "openssl-3.1.2.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -730,10 +730,10 @@ func TestAndroidBuildCdepsOpenSSL(t *testing.T) {
 			},
 			Argv: []string{
 				"./Configure", "no-comp", "no-dtls", "no-ec2m", "no-psk", "no-srp",
-				"no-ssl2", "no-ssl3", "no-camellia", "no-idea", "no-md2", "no-md4",
-				"no-mdc2", "no-rc2", "no-rc4", "no-rc5", "no-rmd160", "no-whirlpool",
-				"no-dso", "no-hw", "no-ui-console", "no-shared", "no-unit-test",
-				"android-arm", "-D__ANDROID_API__=21", "--libdir=lib", "--prefix=/", "--openssldir=/",
+				"no-ssl3", "no-camellia", "no-idea", "no-md2", "no-md4", "no-mdc2",
+				"no-rc2", "no-rc4", "no-rc5", "no-rmd160", "no-whirlpool", "no-dso",
+				"no-ui-console", "no-shared", "no-unit-test", "android-arm",
+				"-D__ANDROID_API__=21", "--libdir=lib", "--prefix=/", "--openssldir=/",
 			},
 		}, {
 			Env: []string{
@@ -763,12 +763,12 @@ func TestAndroidBuildCdepsOpenSSL(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-1.1.1u.tar.gz",
+				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-3.1.2.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "openssl-1.1.1u.tar.gz",
+				"tar", "-xf", "openssl-3.1.2.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -791,10 +791,10 @@ func TestAndroidBuildCdepsOpenSSL(t *testing.T) {
 			},
 			Argv: []string{
 				"./Configure", "no-comp", "no-dtls", "no-ec2m", "no-psk", "no-srp",
-				"no-ssl2", "no-ssl3", "no-camellia", "no-idea", "no-md2", "no-md4",
-				"no-mdc2", "no-rc2", "no-rc4", "no-rc5", "no-rmd160", "no-whirlpool",
-				"no-dso", "no-hw", "no-ui-console", "no-shared", "no-unit-test",
-				"android-arm64", "-D__ANDROID_API__=21", "--libdir=lib", "--prefix=/", "--openssldir=/",
+				"no-ssl3", "no-camellia", "no-idea", "no-md2", "no-md4", "no-mdc2",
+				"no-rc2", "no-rc4", "no-rc5", "no-rmd160", "no-whirlpool", "no-dso",
+				"no-ui-console", "no-shared", "no-unit-test", "android-arm64",
+				"-D__ANDROID_API__=21", "--libdir=lib", "--prefix=/", "--openssldir=/",
 			},
 		}, {
 			Env: []string{
@@ -824,12 +824,12 @@ func TestAndroidBuildCdepsOpenSSL(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-1.1.1u.tar.gz",
+				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-3.1.2.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "openssl-1.1.1u.tar.gz",
+				"tar", "-xf", "openssl-3.1.2.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -852,10 +852,10 @@ func TestAndroidBuildCdepsOpenSSL(t *testing.T) {
 			},
 			Argv: []string{
 				"./Configure", "no-comp", "no-dtls", "no-ec2m", "no-psk", "no-srp",
-				"no-ssl2", "no-ssl3", "no-camellia", "no-idea", "no-md2", "no-md4",
-				"no-mdc2", "no-rc2", "no-rc4", "no-rc5", "no-rmd160", "no-whirlpool",
-				"no-dso", "no-hw", "no-ui-console", "no-shared", "no-unit-test",
-				"android-x86", "-D__ANDROID_API__=21", "--libdir=lib", "--prefix=/", "--openssldir=/",
+				"no-ssl3", "no-camellia", "no-idea", "no-md2", "no-md4", "no-mdc2",
+				"no-rc2", "no-rc4", "no-rc5", "no-rmd160", "no-whirlpool", "no-dso",
+				"no-ui-console", "no-shared", "no-unit-test", "android-x86",
+				"-D__ANDROID_API__=21", "--libdir=lib", "--prefix=/", "--openssldir=/",
 			},
 		}, {
 			Env: []string{
@@ -885,12 +885,12 @@ func TestAndroidBuildCdepsOpenSSL(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-1.1.1u.tar.gz",
+				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-3.1.2.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "openssl-1.1.1u.tar.gz",
+				"tar", "-xf", "openssl-3.1.2.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -913,10 +913,10 @@ func TestAndroidBuildCdepsOpenSSL(t *testing.T) {
 			},
 			Argv: []string{
 				"./Configure", "no-comp", "no-dtls", "no-ec2m", "no-psk", "no-srp",
-				"no-ssl2", "no-ssl3", "no-camellia", "no-idea", "no-md2", "no-md4",
-				"no-mdc2", "no-rc2", "no-rc4", "no-rc5", "no-rmd160", "no-whirlpool",
-				"no-dso", "no-hw", "no-ui-console", "no-shared", "no-unit-test",
-				"android-x86_64", "-D__ANDROID_API__=21", "--libdir=lib", "--prefix=/", "--openssldir=/",
+				"no-ssl3", "no-camellia", "no-idea", "no-md2", "no-md4", "no-mdc2",
+				"no-rc2", "no-rc4", "no-rc5", "no-rmd160", "no-whirlpool", "no-dso",
+				"no-ui-console", "no-shared", "no-unit-test", "android-x86_64",
+				"-D__ANDROID_API__=21", "--libdir=lib", "--prefix=/", "--openssldir=/",
 			},
 		}, {
 			Env: []string{

--- a/internal/cmd/buildtool/cdepsopenssl.go
+++ b/internal/cmd/buildtool/cdepsopenssl.go
@@ -56,8 +56,7 @@ func cdepsOpenSSLBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependencie
 
 	// QUIRK: OpenSSL-1.1.1v wanted the PATH to contain the
 	// directory where the Android compiler lives.
-	// TODO(bassosimone): do we still need this? It seems to work without,
-	// but I can't find reliable information on this.
+	// TODO(bassosimone): do we still need this?
 	if mergedEnv.BINPATH != "" {
 		envp.Append("PATH", cdepsPrependToPath(mergedEnv.BINPATH))
 	}

--- a/internal/cmd/buildtool/cdepsopenssl.go
+++ b/internal/cmd/buildtool/cdepsopenssl.go
@@ -26,14 +26,14 @@ func cdepsOpenSSLBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependencie
 	restore := cdepsMustChdir(work)
 	defer restore()
 
-	// See https://github.com/Homebrew/homebrew-core/blob/master/Formula/openssl@1.1.rb
-	cdepsMustFetch("https://www.openssl.org/source/openssl-1.1.1u.tar.gz")
+	// See https://github.com/Homebrew/homebrew-core/blob/master/Formula/openssl@3.rb
+	cdepsMustFetch("https://www.openssl.org/source/openssl-3.1.2.tar.gz")
 	deps.VerifySHA256( // must be mockable
-		"e2f8d84b523eecd06c7be7626830370300fbcc15386bf5142d72758f6963ebc6",
-		"openssl-1.1.1u.tar.gz",
+		"a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539",
+		"openssl-3.1.2.tar.gz",
 	)
-	must.Run(log.Log, "tar", "-xf", "openssl-1.1.1u.tar.gz")
-	_ = deps.MustChdir("openssl-1.1.1u") // must be mockable
+	must.Run(log.Log, "tar", "-xf", "openssl-3.1.2.tar.gz")
+	_ = deps.MustChdir("openssl-3.1.2") // must be mockable
 
 	mydir := filepath.Join(topdir, "CDEPS", "openssl")
 	for _, patch := range cdepsMustListPatches(mydir) {
@@ -47,12 +47,14 @@ func cdepsOpenSSLBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependencie
 	mergedEnv := cBuildMerge(globalEnv, localEnv)
 	envp := cBuildExportOpenSSL(mergedEnv)
 
-	// QUIRK: OpenSSL-1.1.1u wants ANDROID_NDK_HOME
+	// QUIRK: OpenSSL-3.1.2 wants ANDROID_NDK_HOME
+	// TODO(bassosimone): 	Do we still need this? It seems to work without,
+	//						but I can't find reliable information on this.
 	if mergedEnv.ANDROID_NDK_ROOT != "" {
 		envp.Append("ANDROID_NDK_HOME", mergedEnv.ANDROID_NDK_ROOT)
 	}
 
-	// QUIRK: OpenSSL-1.1.1u wants the PATH to contain the
+	// QUIRK: OpenSSL-3.1.2 wants the PATH to contain the
 	// directory where the Android compiler lives.
 	if mergedEnv.BINPATH != "" {
 		envp.Append("PATH", cdepsPrependToPath(mergedEnv.BINPATH))
@@ -60,10 +62,9 @@ func cdepsOpenSSLBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependencie
 
 	argv := runtimex.Try1(shellx.NewArgv(
 		"./Configure", "no-comp", "no-dtls", "no-ec2m", "no-psk", "no-srp",
-		"no-ssl2", "no-ssl3", "no-camellia", "no-idea", "no-md2", "no-md4",
-		"no-mdc2", "no-rc2", "no-rc4", "no-rc5", "no-rmd160", "no-whirlpool",
-		"no-dso", "no-hw", "no-ui-console", "no-shared", "no-unit-test",
-		globalEnv.OPENSSL_COMPILER,
+		"no-ssl3", "no-camellia", "no-idea", "no-md2", "no-md4", "no-mdc2",
+		"no-rc2", "no-rc4", "no-rc5", "no-rmd160", "no-whirlpool", "no-dso",
+		"no-ui-console", "no-shared", "no-unit-test", globalEnv.OPENSSL_COMPILER,
 	))
 	if globalEnv.OPENSSL_API_DEFINE != "" {
 		argv.Append(globalEnv.OPENSSL_API_DEFINE)

--- a/internal/cmd/buildtool/linuxcdeps_test.go
+++ b/internal/cmd/buildtool/linuxcdeps_test.go
@@ -92,12 +92,12 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-1.1.1u.tar.gz",
+				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-3.1.2.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "openssl-1.1.1u.tar.gz",
+				"tar", "-xf", "openssl-3.1.2.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -116,10 +116,10 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 			},
 			Argv: []string{
 				"./Configure", "no-comp", "no-dtls", "no-ec2m", "no-psk", "no-srp",
-				"no-ssl2", "no-ssl3", "no-camellia", "no-idea", "no-md2", "no-md4",
-				"no-mdc2", "no-rc2", "no-rc4", "no-rc5", "no-rmd160", "no-whirlpool",
-				"no-dso", "no-hw", "no-ui-console", "no-shared", "no-unit-test",
-				"linux-x86_64", "--libdir=lib", "--prefix=/", "--openssldir=/",
+				"no-ssl3", "no-camellia", "no-idea", "no-md2", "no-md4", "no-mdc2",
+				"no-rc2", "no-rc4", "no-rc5", "no-rmd160", "no-whirlpool", "no-dso",
+				"no-ui-console", "no-shared", "no-unit-test", "linux-x86_64",
+				"--libdir=lib", "--prefix=/", "--openssldir=/",
 			},
 		}, {
 			Env: []string{


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2498

## Description
This diff modifies the build process such that we use OpenSSL 3.1.2 for the Android build which is the same OpenSSL version as used by [homebrew-core](https://github.com/Homebrew/homebrew-core/blob/master/Formula/openssl@3.rb). 