### PR TITLE
fix(tutorial): avoid broken pipe caused by passing non-JSON to jq

### DIFF
--- a/internal/tutorial/experiment/torsf/chapter01/main.go
+++ b/internal/tutorial/experiment/torsf/chapter01/main.go
@@ -244,7 +244,7 @@ func main() {
 // You can now run this code as follows:
 //
 // ```
-// $ go run ./experiment/torsf/chapter01 | jq
+// $ go run ./experiment/torsf/chapter01 | tail -n 1 | jq
 // [snip]
 // {
 //   "data_format_version": "",

--- a/internal/tutorial/experiment/torsf/chapter03/torsf.go
+++ b/internal/tutorial/experiment/torsf/chapter03/torsf.go
@@ -161,7 +161,7 @@ func (m *Measurer) run(ctx context.Context,
 // It's now time to run the new code we've written:
 //
 // ```
-// $ go run ./experiment/torsf/chapter03 | jq
+// $ go run ./experiment/torsf/chapter03 | tail -n 1 | jq
 // 2021/06/21 21:21:18  info [  0.1%] torsf experiment is running
 // 2021/06/21 21:21:19  info [  0.2%] torsf experiment is running
 // [...]

--- a/internal/tutorial/experiment/torsf/chapter04/torsf.go
+++ b/internal/tutorial/experiment/torsf/chapter04/torsf.go
@@ -228,7 +228,7 @@ func (m *Measurer) run(ctx context.Context,
 // We can now run the code as follows to obtain:
 //
 // ```
-// $ go run ./experiment/torsf/chapter04 | jq
+// $ go run ./experiment/torsf/chapter04 | tail -n 1 | jq
 // [...]
 // Jun 21 23:40:50.000 [notice] Bootstrapped 100% (done): Done
 // 2021/06/21 23:40:50  info [100.0%] torsf experiment is finished


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2523
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

Following the tutorial code results in a broken pipe. This is a simple fixup that adds a call to tail so that jq is only given valid input.
