### PR TITLE
chore: upgrade C dependencies

### DIFF
--- a/internal/cmd/buildtool/android_test.go
+++ b/internal/cmd/buildtool/android_test.go
@@ -440,12 +440,12 @@ func TestAndroidBuildCdepsZlib(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://zlib.net/zlib-1.2.13.tar.gz",
+				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "zlib-1.2.13.tar.gz",
+				"tar", "-xf", "zlib-1.3.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -493,12 +493,12 @@ func TestAndroidBuildCdepsZlib(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://zlib.net/zlib-1.2.13.tar.gz",
+				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "zlib-1.2.13.tar.gz",
+				"tar", "-xf", "zlib-1.3.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -546,12 +546,12 @@ func TestAndroidBuildCdepsZlib(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://zlib.net/zlib-1.2.13.tar.gz",
+				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "zlib-1.2.13.tar.gz",
+				"tar", "-xf", "zlib-1.3.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -599,12 +599,12 @@ func TestAndroidBuildCdepsZlib(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://zlib.net/zlib-1.2.13.tar.gz",
+				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "zlib-1.2.13.tar.gz",
+				"tar", "-xf", "zlib-1.3.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -702,12 +702,12 @@ func TestAndroidBuildCdepsOpenSSL(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-1.1.1u.tar.gz",
+				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-1.1.1v.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "openssl-1.1.1u.tar.gz",
+				"tar", "-xf", "openssl-1.1.1v.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -763,12 +763,12 @@ func TestAndroidBuildCdepsOpenSSL(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-1.1.1u.tar.gz",
+				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-1.1.1v.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "openssl-1.1.1u.tar.gz",
+				"tar", "-xf", "openssl-1.1.1v.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -824,12 +824,12 @@ func TestAndroidBuildCdepsOpenSSL(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-1.1.1u.tar.gz",
+				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-1.1.1v.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "openssl-1.1.1u.tar.gz",
+				"tar", "-xf", "openssl-1.1.1v.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -885,12 +885,12 @@ func TestAndroidBuildCdepsOpenSSL(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-1.1.1u.tar.gz",
+				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-1.1.1v.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "openssl-1.1.1u.tar.gz",
+				"tar", "-xf", "openssl-1.1.1v.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -1646,12 +1646,12 @@ func TestAndroidBuildCdepsTor(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.13.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.14.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.7.13.tar.gz",
+				"tar", "-xf", "tor-0.4.7.14.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -1722,12 +1722,12 @@ func TestAndroidBuildCdepsTor(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.13.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.14.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.7.13.tar.gz",
+				"tar", "-xf", "tor-0.4.7.14.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -1798,12 +1798,12 @@ func TestAndroidBuildCdepsTor(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.13.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.14.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.7.13.tar.gz",
+				"tar", "-xf", "tor-0.4.7.14.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -1874,12 +1874,12 @@ func TestAndroidBuildCdepsTor(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.13.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.14.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.7.13.tar.gz",
+				"tar", "-xf", "tor-0.4.7.14.tar.gz",
 			},
 		}, {
 			Env: []string{},

--- a/internal/cmd/buildtool/cdepslibevent.go
+++ b/internal/cmd/buildtool/cdepslibevent.go
@@ -26,7 +26,7 @@ func cdepsLibeventBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependenci
 	restore := cdepsMustChdir(work)
 	defer restore()
 
-	// See https://github.com/Homebrew/homebrew-core/blob/master/Formula/libevent.rb
+	// See https://github.com/Homebrew/homebrew-core/blob/master/Formula/lib/libevent.rb
 	cdepsMustFetch("https://github.com/libevent/libevent/archive/release-2.1.12-stable.tar.gz")
 	deps.VerifySHA256( // must be mockable
 		"7180a979aaa7000e1264da484f712d403fcf7679b1e9212c4e3d09f5c93efc24",

--- a/internal/cmd/buildtool/cdepsopenssl.go
+++ b/internal/cmd/buildtool/cdepsopenssl.go
@@ -26,14 +26,14 @@ func cdepsOpenSSLBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependencie
 	restore := cdepsMustChdir(work)
 	defer restore()
 
-	// See https://github.com/Homebrew/homebrew-core/blob/master/Formula/openssl@1.1.rb
-	cdepsMustFetch("https://www.openssl.org/source/openssl-1.1.1u.tar.gz")
+	// See https://github.com/Homebrew/homebrew-core/blob/master/Formula/o/openssl@1.1.rb
+	cdepsMustFetch("https://www.openssl.org/source/openssl-1.1.1v.tar.gz")
 	deps.VerifySHA256( // must be mockable
-		"e2f8d84b523eecd06c7be7626830370300fbcc15386bf5142d72758f6963ebc6",
-		"openssl-1.1.1u.tar.gz",
+		"d6697e2871e77238460402e9362d47d18382b15ef9f246aba6c7bd780d38a6b0",
+		"openssl-1.1.1v.tar.gz",
 	)
-	must.Run(log.Log, "tar", "-xf", "openssl-1.1.1u.tar.gz")
-	_ = deps.MustChdir("openssl-1.1.1u") // must be mockable
+	must.Run(log.Log, "tar", "-xf", "openssl-1.1.1v.tar.gz")
+	_ = deps.MustChdir("openssl-1.1.1v") // must be mockable
 
 	mydir := filepath.Join(topdir, "CDEPS", "openssl")
 	for _, patch := range cdepsMustListPatches(mydir) {
@@ -47,12 +47,12 @@ func cdepsOpenSSLBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependencie
 	mergedEnv := cBuildMerge(globalEnv, localEnv)
 	envp := cBuildExportOpenSSL(mergedEnv)
 
-	// QUIRK: OpenSSL-1.1.1u wants ANDROID_NDK_HOME
+	// QUIRK: OpenSSL-1.1.1v wants ANDROID_NDK_HOME
 	if mergedEnv.ANDROID_NDK_ROOT != "" {
 		envp.Append("ANDROID_NDK_HOME", mergedEnv.ANDROID_NDK_ROOT)
 	}
 
-	// QUIRK: OpenSSL-1.1.1u wants the PATH to contain the
+	// QUIRK: OpenSSL-1.1.1v wants the PATH to contain the
 	// directory where the Android compiler lives.
 	if mergedEnv.BINPATH != "" {
 		envp.Append("PATH", cdepsPrependToPath(mergedEnv.BINPATH))

--- a/internal/cmd/buildtool/cdepstor.go
+++ b/internal/cmd/buildtool/cdepstor.go
@@ -26,14 +26,14 @@ func cdepsTorBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependencies) {
 	restore := cdepsMustChdir(work)
 	defer restore()
 
-	// See https://github.com/Homebrew/homebrew-core/blob/master/Formula/tor.rb
-	cdepsMustFetch("https://www.torproject.org/dist/tor-0.4.7.13.tar.gz")
+	// See https://github.com/Homebrew/homebrew-core/blob/master/Formula/t/tor.rb
+	cdepsMustFetch("https://www.torproject.org/dist/tor-0.4.7.14.tar.gz")
 	deps.VerifySHA256( // must be mockable
-		"2079172cce034556f110048e26083ce9bea751f3154b0ad2809751815b11ea9d",
-		"tor-0.4.7.13.tar.gz",
+		"a5ac67f6466380fc05e8043d01c581e4e8a2b22fe09430013473e71065e65df8",
+		"tor-0.4.7.14.tar.gz",
 	)
-	must.Run(log.Log, "tar", "-xf", "tor-0.4.7.13.tar.gz")
-	_ = deps.MustChdir("tor-0.4.7.13") // must be mockable
+	must.Run(log.Log, "tar", "-xf", "tor-0.4.7.14.tar.gz")
+	_ = deps.MustChdir("tor-0.4.7.14") // must be mockable
 
 	mydir := filepath.Join(topdir, "CDEPS", "tor")
 	for _, patch := range cdepsMustListPatches(mydir) {

--- a/internal/cmd/buildtool/cdepszlib.go
+++ b/internal/cmd/buildtool/cdepszlib.go
@@ -24,14 +24,14 @@ func cdepsZlibBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependencies) 
 	restore := cdepsMustChdir(work)
 	defer restore()
 
-	// See https://github.com/Homebrew/homebrew-core/blob/master/Formula/zlib.rb
-	cdepsMustFetch("https://zlib.net/zlib-1.2.13.tar.gz")
+	// See https://github.com/Homebrew/homebrew-core/blob/master/Formula/z/zlib.rb
+	cdepsMustFetch("https://zlib.net/zlib-1.3.tar.gz")
 	deps.VerifySHA256( // must be mockable
-		"b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
-		"zlib-1.2.13.tar.gz",
+		"ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e",
+		"zlib-1.3.tar.gz",
 	)
-	must.Run(log.Log, "tar", "-xf", "zlib-1.2.13.tar.gz")
-	_ = deps.MustChdir("zlib-1.2.13") // must be mockable
+	must.Run(log.Log, "tar", "-xf", "zlib-1.3.tar.gz")
+	_ = deps.MustChdir("zlib-1.3") // must be mockable
 
 	mydir := filepath.Join(topdir, "CDEPS", "zlib")
 	for _, patch := range cdepsMustListPatches(mydir) {

--- a/internal/cmd/buildtool/linuxcdeps_test.go
+++ b/internal/cmd/buildtool/linuxcdeps_test.go
@@ -40,12 +40,12 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://zlib.net/zlib-1.2.13.tar.gz",
+				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "zlib-1.2.13.tar.gz",
+				"tar", "-xf", "zlib-1.3.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -92,12 +92,12 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-1.1.1u.tar.gz",
+				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-1.1.1v.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "openssl-1.1.1u.tar.gz",
+				"tar", "-xf", "openssl-1.1.1v.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -299,12 +299,12 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.13.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.7.14.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.7.13.tar.gz",
+				"tar", "-xf", "tor-0.4.7.14.tar.gz",
 			},
 		}, {
 			Env: []string{},

--- a/pkg/oonimkall/xoonirun_test.go
+++ b/pkg/oonimkall/xoonirun_test.go
@@ -27,6 +27,7 @@ func TestOONIRunFetch(t *testing.T) {
 		}
 
 		expect := map[string]any{
+			"archived": false,
 			"descriptor_creation_time": "2023-07-18T15:38:21Z",
 			"descriptor": map[string]any{
 				"author":           "simone@openobservatory.org",
@@ -48,6 +49,7 @@ func TestOONIRunFetch(t *testing.T) {
 				"short_description":      "Integration testing descriptor for ooni/probe-cli/v3/pkg/oonimkall.",
 				"short_description_intl": map[string]any{},
 			},
+			"mine": false,
 			"translation_creation_time": "2023-07-18T15:38:21Z",
 			"v":                         1.0,
 		}


### PR DESCRIPTION
Part of https://github.com/ooni/probe/issues/2524. Prompted by observing a failing Linux build test for zlib.

Upgrading to OpenSSL v3 is tracked by https://github.com/ooni/probe/issues/2498 and implemented by https://github.com/ooni/probe-cli/pull/1191.

While there, fix ./pkg/oonimkall integration tests as well.

