### PR TITLE
refactor(netemx): factor function for listening

### DIFF
--- a/internal/netemx/qaenv.go
+++ b/internal/netemx/qaenv.go
@@ -329,8 +329,8 @@ func (env *QAEnv) mustCreateAllHTTPServers(
 		srv := &http3.Server{TLSConfig: stack.ServerTLSConfig(), Handler: handler}
 		closables = append(closables, listener, srv)
 		go srv.Serve(listener)
-
 	}
+
 	return
 }
 

--- a/internal/netemx/qaenv.go
+++ b/internal/netemx/qaenv.go
@@ -296,33 +296,40 @@ func (env *QAEnv) mustNewHTTPServers(config *qaEnvConfig) (closables []io.Closer
 			},
 		))
 
-		ipAddr := net.ParseIP(addr)
-		runtimex.Assert(ipAddr != nil, "invalid IP addr")
+		// create HTTP, HTTPS and HTTP/3 servers for this stack
+		closables = append(closables, env.mustCreateAllHTTPServers(stack, handler, addr)...)
+	}
+	return
+}
 
-		// listen for HTTP
-		{
-			listener := runtimex.Try1(stack.ListenTCP("tcp", &net.TCPAddr{IP: ipAddr, Port: 80}))
-			srv := &http.Server{Handler: handler}
-			closables = append(closables, srv)
-			go srv.Serve(listener)
-		}
+func (env *QAEnv) mustCreateAllHTTPServers(
+	stack *netem.UNetStack, handler http.Handler, addr string) (closables []io.Closer) {
+	ipAddr := net.ParseIP(addr)
+	runtimex.Assert(ipAddr != nil, "invalid IP addr")
 
-		// listen for HTTPS
-		{
-			listener := runtimex.Try1(stack.ListenTCP("tcp", &net.TCPAddr{IP: ipAddr, Port: 443}))
-			srv := &http.Server{TLSConfig: stack.ServerTLSConfig(), Handler: handler}
-			closables = append(closables, srv)
-			go srv.ServeTLS(listener, "", "")
-		}
+	// listen for HTTP
+	{
+		listener := runtimex.Try1(stack.ListenTCP("tcp", &net.TCPAddr{IP: ipAddr, Port: 80}))
+		srv := &http.Server{Handler: handler}
+		closables = append(closables, srv)
+		go srv.Serve(listener)
+	}
 
-		// listen for HTTP3
-		{
-			listener := runtimex.Try1(stack.ListenUDP("udp", &net.UDPAddr{IP: ipAddr, Port: 443}))
-			srv := &http3.Server{TLSConfig: stack.ServerTLSConfig(), Handler: handler}
-			closables = append(closables, listener, srv)
-			go srv.Serve(listener)
+	// listen for HTTPS
+	{
+		listener := runtimex.Try1(stack.ListenTCP("tcp", &net.TCPAddr{IP: ipAddr, Port: 443}))
+		srv := &http.Server{TLSConfig: stack.ServerTLSConfig(), Handler: handler}
+		closables = append(closables, srv)
+		go srv.ServeTLS(listener, "", "")
+	}
 
-		}
+	// listen for HTTP3
+	{
+		listener := runtimex.Try1(stack.ListenUDP("udp", &net.UDPAddr{IP: ipAddr, Port: 443}))
+		srv := &http3.Server{TLSConfig: stack.ServerTLSConfig(), Handler: handler}
+		closables = append(closables, listener, srv)
+		go srv.Serve(listener)
+
 	}
 	return
 }


### PR DESCRIPTION
This diff factors the function used for listening out of the loop where we create all the servers stacks. The same diff is part of the original PR that introduced these changes: https://github.com/ooni/probe-cli/pull/1185.

The intent of pushing this commit is to make sure the diff we're merging next is easier to understand because there's no refactoring noise.

Reference issue: https://github.com/ooni/probe/issues/2461.

---------

Co-authored-by: kelmenhorst <k.elmenhorst@mailbox.org>

