### PR TITLE
fix(netemx): avoid suggesting more than one role is possible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/montanaflynn/stats v0.7.1
 	github.com/ooni/go-libtor v1.1.8
-	github.com/ooni/netem v0.0.0-20230824091252-b50edc007f81
+	github.com/ooni/netem v0.0.0-20230824170255-db1220e00a4b
 	github.com/ooni/oocrypto v0.5.3
 	github.com/ooni/oohttp v0.6.3
 	github.com/ooni/probe-assets v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -483,8 +483,8 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.27.7 h1:fVih9JD6ogIiHUN6ePK7HJidyEDpWGVB5mzM7cWNXoU=
 github.com/ooni/go-libtor v1.1.8 h1:Wo3V3DVTxl5vZdxtQakqYP+DAHx7pPtAFSl1bnAa08w=
 github.com/ooni/go-libtor v1.1.8/go.mod h1:q1YyLwRD9GeMyeerVvwc0vJ2YgwDLTp2bdVcrh/JXyI=
-github.com/ooni/netem v0.0.0-20230824091252-b50edc007f81 h1:tkDAxLyszxPct9r94Wqr/gnYs7rfm34ynx4xxaVEVuc=
-github.com/ooni/netem v0.0.0-20230824091252-b50edc007f81/go.mod h1:3LJOzTIu2O4ADDJN2ILG4ViJOqyH/u9fKY8QT2Rma8Y=
+github.com/ooni/netem v0.0.0-20230824170255-db1220e00a4b h1:bO3uWwIFe1ViVGQG5tIPfI6uVWNQozN0lxzS+VyG9F4=
+github.com/ooni/netem v0.0.0-20230824170255-db1220e00a4b/go.mod h1:3LJOzTIu2O4ADDJN2ILG4ViJOqyH/u9fKY8QT2Rma8Y=
 github.com/ooni/oocrypto v0.5.3 h1:CAb0Ze6q/EWD1PRGl9KqpzMfkut4O3XMaiKYsyxrWOs=
 github.com/ooni/oocrypto v0.5.3/go.mod h1:HjEQ5pQBl6btcWgAsKKq1tFo8CfBrZu63C/vPAUGIDk=
 github.com/ooni/oohttp v0.6.3 h1:MHydpeAPU/LSDSI/hIFJwZm4afBhd2Yo+rNxxFdeMCY=

--- a/internal/netemx/scenario.go
+++ b/internal/netemx/scenario.go
@@ -3,27 +3,27 @@ package netemx
 import "github.com/ooni/netem"
 
 const (
-	// ScenarioFlagDNSOverHTTPS means we should create a DNS-over-HTTPS server.
-	ScenarioFlagDNSOverHTTPS = 1 << iota
+	// ScenarioRoleDNSOverHTTPS means we should create a DNS-over-HTTPS server.
+	ScenarioRoleDNSOverHTTPS = iota
 
-	// ScenarioFlagExampleLikeWebServer means we should instantiate a www.example.com-like web server.
-	ScenarioFlagExampleLikeWebServer
+	// ScenarioRoleExampleLikeWebServer means we should instantiate a www.example.com-like web server.
+	ScenarioRoleExampleLikeWebServer
 
-	// ScenarioFlagOONIAPI means we should instantiate the OONI API.
-	ScenarioFlagOONIAPI
+	// ScenarioRoleOONIAPI means we should instantiate the OONI API.
+	ScenarioRoleOONIAPI
 
-	// ScenarioFlagUbuntuGeoIP means we should instantiate the Ubuntu geoip service.
-	ScenarioFlagUbuntuGeoIP
+	// ScenarioRoleUbuntuGeoIP means we should instantiate the Ubuntu geoip service.
+	ScenarioRoleUbuntuGeoIP
 
-	// ScenarioFlagOONITestHelper means we should instantiate the oohelperd.
-	ScenarioFlagOONITestHelper
+	// ScenarioRoleOONITestHelper means we should instantiate the oohelperd.
+	ScenarioRoleOONITestHelper
 )
 
 // ScenarioDomainAddresses describes a domain and address used in a scenario.
 type ScenarioDomainAddresses struct {
 	Domain    string
 	Addresses []string
-	Flags     uint64
+	Role      uint64
 }
 
 // InternetScenario contains the domains and addresses used by [NewInternetScenario].
@@ -35,43 +35,43 @@ type ScenarioDomainAddresses struct {
 var InternetScenario = []*ScenarioDomainAddresses{{
 	Domain:    "api.ooni.io",
 	Addresses: []string{"130.192.91.5"},
-	Flags:     ScenarioFlagOONIAPI,
+	Role:      ScenarioRoleOONIAPI,
 }, {
 	Domain:    "geoip.ubuntu.com",
 	Addresses: []string{"130.192.91.6"},
-	Flags:     ScenarioFlagUbuntuGeoIP,
+	Role:      ScenarioRoleUbuntuGeoIP,
 }, {
 	Domain:    "www.example.com",
 	Addresses: []string{"130.192.91.7"},
-	Flags:     ScenarioFlagExampleLikeWebServer,
+	Role:      ScenarioRoleExampleLikeWebServer,
 }, {
 	Domain:    "0.th.ooni.org",
 	Addresses: []string{"130.192.91.8"},
-	Flags:     ScenarioFlagOONITestHelper,
+	Role:      ScenarioRoleOONITestHelper,
 }, {
 	Domain:    "1.th.ooni.org",
 	Addresses: []string{"130.192.91.9"},
-	Flags:     ScenarioFlagOONITestHelper,
+	Role:      ScenarioRoleOONITestHelper,
 }, {
 	Domain:    "2.th.ooni.org",
 	Addresses: []string{"130.192.91.10"},
-	Flags:     ScenarioFlagOONITestHelper,
+	Role:      ScenarioRoleOONITestHelper,
 }, {
 	Domain:    "3.th.ooni.org",
 	Addresses: []string{"130.192.91.11"},
-	Flags:     ScenarioFlagOONITestHelper,
+	Role:      ScenarioRoleOONITestHelper,
 }, {
 	Domain:    "dns.quad9.net",
 	Addresses: []string{"130.192.91.12"},
-	Flags:     ScenarioFlagDNSOverHTTPS,
+	Role:      ScenarioRoleDNSOverHTTPS,
 }, {
 	Domain:    "mozilla.cloudflare-dns.com",
 	Addresses: []string{"130.192.91.13"},
-	Flags:     ScenarioFlagDNSOverHTTPS,
+	Role:      ScenarioRoleDNSOverHTTPS,
 }, {
 	Domain:    "dns.google",
 	Addresses: []string{"130.192.91.14"},
-	Flags:     ScenarioFlagDNSOverHTTPS,
+	Role:      ScenarioRoleDNSOverHTTPS,
 }}
 
 // NewScenario constructs a complete testing scenario using the domains and IP
@@ -90,33 +90,30 @@ func NewScenario(cfg []*ScenarioDomainAddresses) *QAEnv {
 
 	// fill options based on the scenario config
 	for _, sad := range cfg {
-		if (sad.Flags & ScenarioFlagDNSOverHTTPS) != 0 {
+		switch sad.Role {
+		case ScenarioRoleDNSOverHTTPS:
 			for _, addr := range sad.Addresses {
 				opts = append(opts, QAEnvOptionHTTPServer(addr, &DNSOverHTTPSHandlerFactory{
 					Config: dohConfig,
 				}))
 			}
-		}
 
-		if (sad.Flags & ScenarioFlagExampleLikeWebServer) != 0 {
+		case ScenarioRoleExampleLikeWebServer:
 			for _, addr := range sad.Addresses {
 				opts = append(opts, QAEnvOptionHTTPServer(addr, ExampleWebPageHandlerFactory()))
 			}
-		}
 
-		if (sad.Flags & ScenarioFlagOONIAPI) != 0 {
+		case ScenarioRoleOONIAPI:
 			for _, addr := range sad.Addresses {
 				opts = append(opts, QAEnvOptionHTTPServer(addr, &OOAPIHandlerFactory{}))
 			}
-		}
 
-		if (sad.Flags & ScenarioFlagOONITestHelper) != 0 {
+		case ScenarioRoleOONITestHelper:
 			for _, addr := range sad.Addresses {
 				opts = append(opts, QAEnvOptionHTTPServer(addr, &OOHelperDFactory{}))
 			}
-		}
 
-		if (sad.Flags & ScenarioFlagUbuntuGeoIP) != 0 {
+		case ScenarioRoleUbuntuGeoIP:
 			for _, addr := range sad.Addresses {
 				opts = append(opts, QAEnvOptionHTTPServer(addr, &GeoIPHandlerFactoryUbuntu{
 					ProbeIP: QAEnvDefaultClientAddress,


### PR DESCRIPTION
This diff modifies the netemx scenario to avoid using a bit mask since it's not possible for a host to have multiple roles.

While there, upgrade github.com/ooni/netem to pull a fix that causes the start topology to return an error if you attempt to add the same host's IP address multiple times.

Part of https://github.com/ooni/probe/issues/2461
