### PR TITLE
chore(webconnectivityqa): import webconnectivity_nonexistent_domain

### DIFF
--- a/QA/webconnectivity.py
+++ b/QA/webconnectivity.py
@@ -193,48 +193,6 @@ def webconnectivity_dns_hijacking(ooni_exe, outfile):
     assert_status_flags_are(ooni_exe, tk, 1)
 
 
-def webconnectivity_nonexistent_domain(ooni_exe, outfile):
-    """Test case where the domain does not exist"""
-    args = []
-    tk = execute_jafar_and_return_validated_test_keys(
-        ooni_exe,
-        outfile,
-        "-i http://www.ooni.nonexistent web_connectivity",
-        "webconnectivity_nonexistent_domain",
-        args,
-    )
-    # TODO(bassosimone): Debateable result. We need to do better here.
-    # See <https://github.com/ooni/probe-engine/issues/579>.
-    #
-    # Note that MK is not doing it right here because it's suppressing the
-    # dns_nxdomain_error that instead is very informative. Yet, it is reporting
-    # a failure in HTTP, which miniooni does not because it does not make
-    # sense to perform HTTP when there are no IP addresses.
-    #
-    # The following seems indeed a bug in MK where we don't properly record the
-    # actual error that occurred when performing the DNS experiment.
-    #
-    # See <https://github.com/measurement-kit/measurement-kit/issues/1931>.
-    if "miniooni" in ooni_exe:
-        assert tk["dns_experiment_failure"] == "dns_nxdomain_error"
-    else:
-        assert tk["dns_experiment_failure"] == None
-    assert tk["dns_consistency"] == "consistent"
-    assert tk["control_failure"] == None
-    if "miniooni" in ooni_exe:
-        assert tk["http_experiment_failure"] == None
-    else:
-        assert tk["http_experiment_failure"] == "dns_lookup_error"
-    assert tk["body_length_match"] == None
-    assert tk["body_proportion"] == 0
-    assert tk["status_code_match"] == None
-    assert tk["headers_match"] == None
-    assert tk["title_match"] == None
-    assert tk["blocking"] == False
-    assert tk["accessible"] == True
-    assert_status_flags_are(ooni_exe, tk, 2052)
-
-
 def webconnectivity_tcpip_blocking_with_consistent_dns(ooni_exe, outfile):
     """Test case where there's TCP/IP blocking w/ consistent DNS"""
     ip = socket.gethostbyname("nexa.polito.it")
@@ -839,7 +797,6 @@ def main():
         webconnectivity_transparent_http_proxy,
         webconnectivity_transparent_https_proxy,
         webconnectivity_dns_hijacking,
-        webconnectivity_nonexistent_domain,
         webconnectivity_tcpip_blocking_with_consistent_dns,
         webconnectivity_tcpip_blocking_with_inconsistent_dns,
         webconnectivity_http_connection_refused_with_consistent_dns,

--- a/QA/webconnectivity.py
+++ b/QA/webconnectivity.py
@@ -454,54 +454,6 @@ def webconnectivity_http_connection_reset_with_inconsistent_dns(ooni_exe, outfil
     assert_status_flags_are(ooni_exe, tk, 8480)
 
 
-def webconnectivity_http_successful_website(ooni_exe, outfile):
-    """Test case where we succeed with an HTTP only webpage"""
-    args = []
-    tk = execute_jafar_and_return_validated_test_keys(
-        ooni_exe,
-        outfile,
-        "-i http://example.org/ web_connectivity",
-        "webconnectivity_http_successful_website",
-        args,
-    )
-    assert tk["dns_experiment_failure"] == None
-    assert tk["dns_consistency"] == "consistent"
-    assert tk["control_failure"] == None
-    assert tk["http_experiment_failure"] == None
-    assert tk["body_length_match"] == True
-    assert tk["body_proportion"] == 1
-    assert tk["status_code_match"] == True
-    assert tk["headers_match"] == True
-    assert tk["title_match"] == True
-    assert tk["blocking"] == False
-    assert tk["accessible"] == True
-    assert_status_flags_are(ooni_exe, tk, 2)
-
-
-def webconnectivity_https_successful_website(ooni_exe, outfile):
-    """Test case where we succeed with an HTTPS only webpage"""
-    args = []
-    tk = execute_jafar_and_return_validated_test_keys(
-        ooni_exe,
-        outfile,
-        "-i https://example.com/ web_connectivity",
-        "webconnectivity_https_successful_website",
-        args,
-    )
-    assert tk["dns_experiment_failure"] == None
-    assert tk["dns_consistency"] == "consistent"
-    assert tk["control_failure"] == None
-    assert tk["http_experiment_failure"] == None
-    assert tk["body_length_match"] == True
-    assert tk["body_proportion"] == 1
-    assert tk["status_code_match"] == True
-    assert tk["headers_match"] == True
-    assert tk["title_match"] == True
-    assert tk["blocking"] == False
-    assert tk["accessible"] == True
-    assert_status_flags_are(ooni_exe, tk, 1)
-
-
 def webconnectivity_http_diff_with_inconsistent_dns(ooni_exe, outfile):
     """Test case where we get an http-diff and the DNS is inconsistent"""
     args = [
@@ -805,8 +757,6 @@ def main():
         webconnectivity_http_eof_error_with_consistent_dns,
         webconnectivity_http_generic_timeout_error_with_consistent_dns,
         webconnectivity_http_connection_reset_with_inconsistent_dns,
-        webconnectivity_http_successful_website,
-        webconnectivity_https_successful_website,
         webconnectivity_http_diff_with_inconsistent_dns,
         webconnectivity_http_diff_with_consistent_dns,
         webconnectivity_https_expired_certificate,

--- a/internal/experiment/webconnectivityqa/testcase.go
+++ b/internal/experiment/webconnectivityqa/testcase.go
@@ -40,5 +40,7 @@ func AllTestCases() []*TestCase {
 
 		sucessWithHTTP(),
 		sucessWithHTTPS(),
+
+		websiteDownNXDOMAIN(),
 	}
 }

--- a/internal/experiment/webconnectivityqa/websitedown.go
+++ b/internal/experiment/webconnectivityqa/websitedown.go
@@ -1,0 +1,38 @@
+package webconnectivityqa
+
+// websiteDownNXDOMAIN describes the test case where the website domain
+// is NXDOMAIN according to the TH and the probe.
+func websiteDownNXDOMAIN() *TestCase {
+	/*
+	   TODO(bassosimone): Debateable result for v0.4, while v0.5 behaves in the
+	   correct way. See <https://github.com/ooni/probe-engine/issues/579>.
+
+	   Some historical context follows:
+
+	   Note that MK is not doing it right here because it's suppressing the
+	   dns_nxdomain_error that instead is very informative. Yet, it is reporting
+	   a failure in HTTP, which miniooni does not because it does not make
+	   sense to perform HTTP when there are no IP addresses.
+
+	   The following seems indeed a bug in MK where we don't properly record the
+	   actual error that occurred when performing the DNS experiment.
+
+	   See <https://github.com/measurement-kit/measurement-kit/issues/1931>.
+	*/
+	return &TestCase{
+		Name:      "websiteDownNXDOMAIN",
+		Flags:     TestCaseFlagNoV04,         // see above
+		Input:     "http://www.example.xyz/", // domain not defined in the simulation
+		Configure: nil,
+		ExpectErr: false,
+		ExpectTestKeys: &testKeys{
+			DNSExperimentFailure: "dns_nxdomain_error",
+			DNSConsistency:       "consistent",
+			XStatus:              2052,
+			XBlockingFlags:       0,
+			XNullNullFlags:       1,
+			Accessible:           false,
+			Blocking:             false,
+		},
+	}
+}


### PR DESCRIPTION
This diff imports the QA/webconnectivity.py integration test into the webconnectivityqa framework and removes it from Python. While there, remove other QA/webconnectivity.py tests that I have already converted.

Part of https://github.com/ooni/probe/issues/1803.

See also https://github.com/ooni/probe/issues/1536.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: see above
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [x] if you changed code inside an experiment, make sure you bump its version number: N/A

