### PR TITLE
chore(webconnectivityqa): import webconnectivity_dns_blocking_nxdomain

### DIFF
--- a/.github/workflows/libtorlinux.yml
+++ b/.github/workflows/libtorlinux.yml
@@ -1,7 +1,6 @@
 # Runs tests for internal/libtor with -tags=ooni_libtor
 name: libtorlinux
 on:
-  pull_request:
   push:
     branches:
       - "master"

--- a/QA/webconnectivity.py
+++ b/QA/webconnectivity.py
@@ -662,45 +662,6 @@ def webconnectivity_https_untrusted_root(ooni_exe, outfile):
     assert_status_flags_are(ooni_exe, tk, 16)
 
 
-def webconnectivity_dns_blocking_nxdomain(ooni_exe, outfile):
-    """Test case where there is blocking using NXDOMAIN"""
-    args = [
-        "-iptables-hijack-dns-to",
-        "127.0.0.1:53",
-        "-dns-proxy-block",
-        "example.com",
-    ]
-    tk = execute_jafar_and_return_validated_test_keys(
-        ooni_exe,
-        outfile,
-        "-i https://example.com/ web_connectivity",
-        "webconnectivity_dns_blocking_nxdomain",
-        args,
-    )
-    # The following seems a bug in MK where we don't properly record the
-    # actual error that occurred when performing the DNS experiment.
-    #
-    # See <https://github.com/measurement-kit/measurement-kit/issues/1931>.
-    if "miniooni" in ooni_exe:
-        assert tk["dns_experiment_failure"] == "dns_nxdomain_error"
-    else:
-        assert tk["dns_experiment_failure"] == None
-    assert tk["dns_consistency"] == "inconsistent"
-    assert tk["control_failure"] == None
-    if "miniooni" in ooni_exe:
-        assert tk["http_experiment_failure"] == None
-    else:
-        assert tk["http_experiment_failure"] == "dns_lookup_error"
-    assert tk["body_length_match"] == None
-    assert tk["body_proportion"] == 0
-    assert tk["status_code_match"] == None
-    assert tk["headers_match"] == None
-    assert tk["title_match"] == None
-    assert tk["blocking"] == "dns"
-    assert tk["accessible"] == False
-    assert_status_flags_are(ooni_exe, tk, 2080)
-
-
 def webconnectivity_https_unknown_authority_with_inconsistent_dns(ooni_exe, outfile):
     """Test case where the DNS is sending us towards a website where
     we're served an invalid certificate"""
@@ -763,7 +724,6 @@ def main():
         webconnectivity_https_wrong_host,
         webconnectivity_https_self_signed,
         webconnectivity_https_untrusted_root,
-        webconnectivity_dns_blocking_nxdomain,
         webconnectivity_https_unknown_authority_with_inconsistent_dns,
     ]
     for test in tests:

--- a/internal/experiment/webconnectivityqa/dnsblocking.go
+++ b/internal/experiment/webconnectivityqa/dnsblocking.go
@@ -30,3 +30,34 @@ func dnsBlockingAndroidDNSCacheNoData() *TestCase {
 		},
 	}
 }
+
+// dnsBlockingNXDOMAIN is the case where there's DNS blocking using NXDOMAIN.
+func dnsBlockingNXDOMAIN() *TestCase {
+	/*
+		Historical note:
+
+		With this test case there was an MK bug where we didn't properly record the
+		actual error that occurred when performing the DNS experiment.
+
+		See <https://github.com/measurement-kit/measurement-kit/issues/1931>.
+	*/
+	return &TestCase{
+		Name:  "dnsBlockingNXDOMAIN",
+		Flags: 0,
+		Input: "https://www.example.com/",
+		Configure: func(env *netemx.QAEnv) {
+			// remove the record so that the DNS query returns NXDOMAIN, which is then
+			// converted into android_dns_cache_no_data by the emulation layer
+			env.ISPResolverConfig().RemoveRecord("www.example.com")
+		},
+		ExpectErr: false,
+		ExpectTestKeys: &testKeys{
+			DNSExperimentFailure: "dns_nxdomain_error",
+			DNSConsistency:       "inconsistent",
+			XDNSFlags:            2080,
+			XBlockingFlags:       33,
+			Accessible:           false,
+			Blocking:             "dns",
+		},
+	}
+}

--- a/internal/experiment/webconnectivityqa/dnsblocking.go
+++ b/internal/experiment/webconnectivityqa/dnsblocking.go
@@ -54,7 +54,8 @@ func dnsBlockingNXDOMAIN() *TestCase {
 		ExpectTestKeys: &testKeys{
 			DNSExperimentFailure: "dns_nxdomain_error",
 			DNSConsistency:       "inconsistent",
-			XDNSFlags:            2080,
+			XStatus:              2080,
+			XDNSFlags:            2,
 			XBlockingFlags:       33,
 			Accessible:           false,
 			Blocking:             "dns",

--- a/internal/experiment/webconnectivityqa/dnsblocking_test.go
+++ b/internal/experiment/webconnectivityqa/dnsblocking_test.go
@@ -26,3 +26,20 @@ func TestDNSBlockingAndroidDNSCacheNoData(t *testing.T) {
 		}
 	})
 }
+
+func TestDNSBlockingNXDOMAIN(t *testing.T) {
+	env := netemx.MustNewScenario(netemx.InternetScenario)
+	tc := dnsBlockingNXDOMAIN()
+	tc.Configure(env)
+
+	env.Do(func() {
+		reso := netxlite.NewStdlibResolver(log.Log)
+		addrs, err := reso.LookupHost(context.Background(), "www.example.com")
+		if err == nil || err.Error() != netxlite.FailureDNSNXDOMAINError {
+			t.Fatal("unexpected error", err)
+		}
+		if len(addrs) != 0 {
+			t.Fatal("expected to see no addresses")
+		}
+	})
+}

--- a/internal/experiment/webconnectivityqa/testcase.go
+++ b/internal/experiment/webconnectivityqa/testcase.go
@@ -35,6 +35,7 @@ type TestCase struct {
 func AllTestCases() []*TestCase {
 	return []*TestCase{
 		dnsBlockingAndroidDNSCacheNoData(),
+		dnsBlockingNXDOMAIN(),
 
 		tlsBlockingConnectionReset(),
 


### PR DESCRIPTION
This diff imports the given QA/webconnectivity.py integration test into the webconnectivityqa framework and removes it from Python. While there, stop building libtorlinux.yml on pull requests, since currently there's no need.

Part of https://github.com/ooni/probe/issues/1803.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: see above
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [x] if you changed code inside an experiment, make sure you bump its version number: N/A
