### PR TITLE
chore(webconnectivityqa): import ...tcpip_blocking_with_consistent_dns

### DIFF
--- a/QA/webconnectivity.py
+++ b/QA/webconnectivity.py
@@ -193,34 +193,6 @@ def webconnectivity_dns_hijacking(ooni_exe, outfile):
     assert_status_flags_are(ooni_exe, tk, 1)
 
 
-def webconnectivity_tcpip_blocking_with_consistent_dns(ooni_exe, outfile):
-    """Test case where there's TCP/IP blocking w/ consistent DNS"""
-    ip = socket.gethostbyname("nexa.polito.it")
-    args = [
-        "-iptables-drop-ip",
-        ip,
-    ]
-    tk = execute_jafar_and_return_validated_test_keys(
-        ooni_exe,
-        outfile,
-        "-i http://nexa.polito.it web_connectivity",
-        "webconnectivity_tcpip_blocking_with_consistent_dns",
-        args,
-    )
-    assert tk["dns_experiment_failure"] == None
-    assert tk["dns_consistency"] == "consistent"
-    assert tk["control_failure"] == None
-    assert tk["http_experiment_failure"] == "generic_timeout_error"
-    assert tk["body_length_match"] == None
-    assert tk["body_proportion"] == 0
-    assert tk["status_code_match"] == None
-    assert tk["headers_match"] == None
-    assert tk["title_match"] == None
-    assert tk["blocking"] == "tcp_ip"
-    assert tk["accessible"] == False
-    assert_status_flags_are(ooni_exe, tk, 4224)
-
-
 def webconnectivity_tcpip_blocking_with_inconsistent_dns(ooni_exe, outfile):
     """Test case where there's TCP/IP blocking w/ inconsistent DNS"""
 
@@ -710,7 +682,6 @@ def main():
         webconnectivity_transparent_http_proxy,
         webconnectivity_transparent_https_proxy,
         webconnectivity_dns_hijacking,
-        webconnectivity_tcpip_blocking_with_consistent_dns,
         webconnectivity_tcpip_blocking_with_inconsistent_dns,
         webconnectivity_http_connection_refused_with_consistent_dns,
         webconnectivity_http_connection_reset_with_consistent_dns,

--- a/internal/experiment/webconnectivityqa/dnsblocking.go
+++ b/internal/experiment/webconnectivityqa/dnsblocking.go
@@ -23,8 +23,8 @@ func dnsBlockingAndroidDNSCacheNoData() *TestCase {
 		ExpectTestKeys: &testKeys{
 			DNSExperimentFailure: "android_dns_cache_no_data",
 			DNSConsistency:       "inconsistent",
-			XDNSFlags:            2,
-			XBlockingFlags:       33,
+			XDNSFlags:            2,  // AnalysisDNSUnexpectedFailure
+			XBlockingFlags:       33, // analysisFlagDNSBlocking | analysisFlagSuccess
 			Accessible:           false,
 			Blocking:             "dns",
 		},
@@ -54,9 +54,9 @@ func dnsBlockingNXDOMAIN() *TestCase {
 		ExpectTestKeys: &testKeys{
 			DNSExperimentFailure: "dns_nxdomain_error",
 			DNSConsistency:       "inconsistent",
-			XStatus:              2080,
-			XDNSFlags:            2,
-			XBlockingFlags:       33,
+			XStatus:              2080, // StatusExperimentDNS | StatusAnomalyDNS
+			XDNSFlags:            2,    // AnalysisDNSUnexpectedFailure
+			XBlockingFlags:       33,   // analysisFlagDNSBlocking | analysisFlagSuccess
 			Accessible:           false,
 			Blocking:             "dns",
 		},

--- a/internal/experiment/webconnectivityqa/tcpblocking.go
+++ b/internal/experiment/webconnectivityqa/tcpblocking.go
@@ -1,0 +1,36 @@
+package webconnectivityqa
+
+import (
+	"github.com/apex/log"
+	"github.com/google/gopacket/layers"
+	"github.com/ooni/netem"
+	"github.com/ooni/probe-cli/v3/internal/netemx"
+)
+
+// tcpBlockingConnectTimeout verifies that we correctly handle the case
+// where the connection is timed out.
+func tcpBlockingConnectTimeout() *TestCase {
+	return &TestCase{
+		Name:  "tcpBlockingConnectTimeout",
+		Flags: 0,
+		Input: "https://www.example.com/",
+		Configure: func(env *netemx.QAEnv) {
+			env.DPIEngine().AddRule(&netem.DPIDropTrafficForServerEndpoint{
+				Logger:          log.Log,
+				ServerIPAddress: "130.192.91.7", // www.example.com
+				ServerPort:      443,
+				ServerProtocol:  layers.IPProtocolTCP,
+			})
+		},
+		ExpectErr: false,
+		ExpectTestKeys: &testKeys{
+			DNSExperimentFailure:  nil,
+			DNSConsistency:        "consistent",
+			HTTPExperimentFailure: "generic_timeout_error",
+			XStatus:               4224, // StatusAnomalyConnect | StatusExperimentConnect
+			XBlockingFlags:        2,    // analysisFlagTCPIPBlocking
+			Accessible:            false,
+			Blocking:              "tcp_ip",
+		},
+	}
+}

--- a/internal/experiment/webconnectivityqa/tcpblocking_test.go
+++ b/internal/experiment/webconnectivityqa/tcpblocking_test.go
@@ -1,0 +1,27 @@
+package webconnectivityqa
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/netemx"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+)
+
+func TestTCPBlockingConnectTimeout(t *testing.T) {
+	env := netemx.MustNewScenario(netemx.InternetScenario)
+	tc := tcpBlockingConnectTimeout()
+	tc.Configure(env)
+
+	env.Do(func() {
+		dialer := netxlite.NewDialerWithoutResolver(log.Log)
+		conn, err := dialer.DialContext(context.Background(), "tcp", "130.192.91.7:443")
+		if err == nil || err.Error() != netxlite.FailureGenericTimeoutError {
+			t.Fatal("unexpected error", err)
+		}
+		if conn != nil {
+			t.Fatal("expected to see nil conn")
+		}
+	})
+}

--- a/internal/experiment/webconnectivityqa/testcase.go
+++ b/internal/experiment/webconnectivityqa/testcase.go
@@ -37,10 +37,12 @@ func AllTestCases() []*TestCase {
 		dnsBlockingAndroidDNSCacheNoData(),
 		dnsBlockingNXDOMAIN(),
 
-		tlsBlockingConnectionReset(),
-
 		sucessWithHTTP(),
 		sucessWithHTTPS(),
+
+		tcpBlockingConnectTimeout(),
+
+		tlsBlockingConnectionReset(),
 
 		websiteDownNXDOMAIN(),
 	}

--- a/internal/experiment/webconnectivityqa/tlsblocking.go
+++ b/internal/experiment/webconnectivityqa/tlsblocking.go
@@ -21,8 +21,8 @@ func tlsBlockingConnectionReset() *TestCase {
 		ExpectTestKeys: &testKeys{
 			DNSConsistency:        "consistent",
 			HTTPExperimentFailure: "connection_reset",
-			XStatus:               8448,
-			XBlockingFlags:        4,
+			XStatus:               8448, // StatusExperimentHTTP | StatusAnomalyReadWrite
+			XBlockingFlags:        4,    // analysisFlagTLSBlocking
 			Accessible:            false,
 			Blocking:              "http-failure",
 		},

--- a/internal/experiment/webconnectivityqa/websitedown.go
+++ b/internal/experiment/webconnectivityqa/websitedown.go
@@ -28,9 +28,9 @@ func websiteDownNXDOMAIN() *TestCase {
 		ExpectTestKeys: &testKeys{
 			DNSExperimentFailure: "dns_nxdomain_error",
 			DNSConsistency:       "consistent",
-			XStatus:              2052,
+			XStatus:              2052, // StatusExperimentDNS | StatusSuccessNXDOMAIN
 			XBlockingFlags:       0,
-			XNullNullFlags:       1,
+			XNullNullFlags:       1, // analysisFlagNullNullNoAddrs
 			Accessible:           false,
 			Blocking:             false,
 		},

--- a/internal/mocks/underlyingnetwork.go
+++ b/internal/mocks/underlyingnetwork.go
@@ -13,7 +13,7 @@ import (
 type UnderlyingNetwork struct {
 	MockDefaultCertPool func() *x509.CertPool
 
-	MockDefaultDialTimeout func() time.Duration
+	MockDialTimeout func() time.Duration
 
 	MockDialContext func(ctx context.Context, network, address string) (net.Conn, error)
 
@@ -30,8 +30,8 @@ func (un *UnderlyingNetwork) DefaultCertPool() *x509.CertPool {
 	return un.MockDefaultCertPool()
 }
 
-func (un *UnderlyingNetwork) DefaultDialTimeout() time.Duration {
-	return un.MockDefaultDialTimeout()
+func (un *UnderlyingNetwork) DialTimeout() time.Duration {
+	return un.MockDialTimeout()
 }
 
 func (un *UnderlyingNetwork) DialContext(ctx context.Context, network, address string) (net.Conn, error) {

--- a/internal/mocks/underlyingnetwork.go
+++ b/internal/mocks/underlyingnetwork.go
@@ -13,7 +13,9 @@ import (
 type UnderlyingNetwork struct {
 	MockDefaultCertPool func() *x509.CertPool
 
-	MockDialContext func(ctx context.Context, timeout time.Duration, network, address string) (net.Conn, error)
+	MockDefaultDialTimeout func() time.Duration
+
+	MockDialContext func(ctx context.Context, network, address string) (net.Conn, error)
 
 	MockListenUDP func(network string, addr *net.UDPAddr) (model.UDPLikeConn, error)
 
@@ -28,8 +30,12 @@ func (un *UnderlyingNetwork) DefaultCertPool() *x509.CertPool {
 	return un.MockDefaultCertPool()
 }
 
-func (un *UnderlyingNetwork) DialContext(ctx context.Context, timeout time.Duration, network, address string) (net.Conn, error) {
-	return un.MockDialContext(ctx, timeout, network, address)
+func (un *UnderlyingNetwork) DefaultDialTimeout() time.Duration {
+	return un.MockDefaultDialTimeout()
+}
+
+func (un *UnderlyingNetwork) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return un.MockDialContext(ctx, network, address)
 }
 
 func (un *UnderlyingNetwork) ListenUDP(network string, addr *net.UDPAddr) (model.UDPLikeConn, error) {

--- a/internal/mocks/underlyingnetwork_test.go
+++ b/internal/mocks/underlyingnetwork_test.go
@@ -25,15 +25,28 @@ func TestUnderlyingNetwork(t *testing.T) {
 		}
 	})
 
+	t.Run("DefaultDialTimeout", func(t *testing.T) {
+		expect := 22 * time.Second
+		un := &UnderlyingNetwork{
+			MockDefaultDialTimeout: func() time.Duration {
+				return expect
+			},
+		}
+		got := un.DefaultDialTimeout()
+		if got != expect {
+			t.Fatal("unexpected result")
+		}
+	})
+
 	t.Run("DialContext", func(t *testing.T) {
 		expect := errors.New("mocked error")
 		un := &UnderlyingNetwork{
-			MockDialContext: func(ctx context.Context, timeout time.Duration, network, address string) (net.Conn, error) {
+			MockDialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
 				return nil, expect
 			},
 		}
 		ctx := context.Background()
-		conn, err := un.DialContext(ctx, time.Second, "tcp", "1.1.1.1:443")
+		conn, err := un.DialContext(ctx, "tcp", "1.1.1.1:443")
 		if !errors.Is(err, expect) {
 			t.Fatal("unexpected err", err)
 		}

--- a/internal/mocks/underlyingnetwork_test.go
+++ b/internal/mocks/underlyingnetwork_test.go
@@ -25,14 +25,14 @@ func TestUnderlyingNetwork(t *testing.T) {
 		}
 	})
 
-	t.Run("DefaultDialTimeout", func(t *testing.T) {
+	t.Run("DialTimeout", func(t *testing.T) {
 		expect := 22 * time.Second
 		un := &UnderlyingNetwork{
-			MockDefaultDialTimeout: func() time.Duration {
+			MockDialTimeout: func() time.Duration {
 				return expect
 			},
 		}
-		got := un.DefaultDialTimeout()
+		got := un.DialTimeout()
 		if got != expect {
 			t.Fatal("unexpected result")
 		}

--- a/internal/model/netx.go
+++ b/internal/model/netx.go
@@ -492,9 +492,11 @@ type UnderlyingNetwork interface {
 	// a copy of the default cert pool that you can modify.
 	DefaultCertPool() *x509.CertPool
 
-	// DialContext is equivalent to net.Dialer.DialContext except that
-	// there is also an explicit timeout for dialing.
-	DialContext(ctx context.Context, timeout time.Duration, network, address string) (net.Conn, error)
+	// DefaultDialTimeout returns the default timeout to use for dialing.
+	DefaultDialTimeout() time.Duration
+
+	// DialContext is equivalent to net.Dialer.DialContext.
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
 
 	// GetaddrinfoLookupANY is like net.Resolver.LookupHost except that it
 	// also returns to the caller the CNAME when it is available.

--- a/internal/model/netx.go
+++ b/internal/model/netx.go
@@ -492,8 +492,8 @@ type UnderlyingNetwork interface {
 	// a copy of the default cert pool that you can modify.
 	DefaultCertPool() *x509.CertPool
 
-	// DefaultDialTimeout returns the default timeout to use for dialing.
-	DefaultDialTimeout() time.Duration
+	// DialTimeout returns the default timeout to use for dialing.
+	DialTimeout() time.Duration
 
 	// DialContext is equivalent to net.Dialer.DialContext.
 	DialContext(ctx context.Context, network, address string) (net.Conn, error)

--- a/internal/netemx/adapter.go
+++ b/internal/netemx/adapter.go
@@ -5,12 +5,32 @@ package netemx
 //
 
 import (
+	"time"
+
 	"github.com/ooni/netem"
+	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
 // WithCustomTProxy executes the given function using the given [netem.UnderlyingNetwork]
 // as the [model.UnderlyingNetwork] used by the [netxlite] package.
 func WithCustomTProxy(tproxy netem.UnderlyingNetwork, function func()) {
-	netxlite.WithCustomTProxy(&netxlite.NetemUnderlyingNetworkAdapter{UNet: tproxy}, function)
+	// Implementation note: we use an adapter to reduce timeouts to avoid making the CI run too long
+	// which encourages to skip some tests in short mode, which reduces out confidence in the tree
+	netxlite.WithCustomTProxy(
+		&adapterReduceTimeouts{
+			&netxlite.NetemUnderlyingNetworkAdapter{UNet: tproxy},
+		},
+		function,
+	)
+}
+
+// adapterReduceTimeouts is a [model.UnderlyingNetwork] that reduces the timeouts
+type adapterReduceTimeouts struct {
+	model.UnderlyingNetwork
+}
+
+// DefaultDialTimeout implements [model.UnderlyingNetwork].
+func (art *adapterReduceTimeouts) DefaultDialTimeout() time.Duration {
+	return time.Second
 }

--- a/internal/netemx/adapter.go
+++ b/internal/netemx/adapter.go
@@ -30,7 +30,7 @@ type adapterReduceTimeouts struct {
 	model.UnderlyingNetwork
 }
 
-// DefaultDialTimeout implements [model.UnderlyingNetwork].
-func (art *adapterReduceTimeouts) DefaultDialTimeout() time.Duration {
+// DialTimeout implements [model.UnderlyingNetwork].
+func (art *adapterReduceTimeouts) DialTimeout() time.Duration {
 	return time.Second
 }

--- a/internal/netxlite/dialer.go
+++ b/internal/netxlite/dialer.go
@@ -153,9 +153,10 @@ type DialerSystem struct {
 var _ model.Dialer = &DialerSystem{}
 
 func (d *DialerSystem) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	ctx, cancel := context.WithTimeout(ctx, d.provider.Get().DefaultDialTimeout())
+	p := d.provider.Get()
+	ctx, cancel := context.WithTimeout(ctx, p.DialTimeout())
 	defer cancel()
-	return d.provider.Get().DialContext(ctx, network, address)
+	return p.DialContext(ctx, network, address)
 }
 
 func (d *DialerSystem) CloseIdleConnections() {

--- a/internal/netxlite/dialer_test.go
+++ b/internal/netxlite/dialer_test.go
@@ -103,7 +103,7 @@ func TestDialerSystem(t *testing.T) {
 		t.Run("honours the dial timeout configured by the underlying network", func(t *testing.T) {
 			defaultTp := &DefaultTProxy{}
 			tp := &mocks.UnderlyingNetwork{
-				MockDefaultDialTimeout: func() time.Duration {
+				MockDialTimeout: func() time.Duration {
 					return time.Nanosecond
 				},
 				MockDialContext: defaultTp.DialContext,
@@ -127,7 +127,7 @@ func TestDialerSystem(t *testing.T) {
 		t.Run("with custom underlying network", func(t *testing.T) {
 			expected := errors.New("mocked underlying network")
 			proxy := &mocks.UnderlyingNetwork{
-				MockDefaultDialTimeout: func() time.Duration {
+				MockDialTimeout: func() time.Duration {
 					return defaultDialTimeout
 				},
 				MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {

--- a/internal/netxlite/dialer_test.go
+++ b/internal/netxlite/dialer_test.go
@@ -81,23 +81,6 @@ func TestNewDialer(t *testing.T) {
 }
 
 func TestDialerSystem(t *testing.T) {
-	t.Run("has a default timeout", func(t *testing.T) {
-		d := &DialerSystem{}
-		timeout := d.configuredTimeout()
-		if timeout != dialerDefaultTimeout {
-			t.Fatal("unexpected default timeout")
-		}
-	})
-
-	t.Run("we can change the timeout for testing", func(t *testing.T) {
-		const smaller = 1 * time.Second
-		d := &DialerSystem{timeout: smaller}
-		timeout := d.configuredTimeout()
-		if timeout != smaller {
-			t.Fatal("unexpected timeout")
-		}
-	})
-
 	t.Run("CloseIdleConnections", func(t *testing.T) {
 		d := &DialerSystem{}
 		d.CloseIdleConnections() // to avoid missing coverage
@@ -117,9 +100,15 @@ func TestDialerSystem(t *testing.T) {
 			}
 		})
 
-		t.Run("enforces the configured timeout", func(t *testing.T) {
-			const timeout = 1 * time.Nanosecond
-			d := &DialerSystem{timeout: timeout}
+		t.Run("honours the dial timeout configured by the underlying network", func(t *testing.T) {
+			defaultTp := &DefaultTProxy{}
+			tp := &mocks.UnderlyingNetwork{
+				MockDefaultDialTimeout: func() time.Duration {
+					return time.Nanosecond
+				},
+				MockDialContext: defaultTp.DialContext,
+			}
+			d := &DialerSystem{provider: &tproxyNilSafeProvider{tp}}
 			ctx := context.Background()
 			start := time.Now()
 			conn, err := d.DialContext(ctx, "tcp", "dns.google:443")
@@ -138,7 +127,10 @@ func TestDialerSystem(t *testing.T) {
 		t.Run("with custom underlying network", func(t *testing.T) {
 			expected := errors.New("mocked underlying network")
 			proxy := &mocks.UnderlyingNetwork{
-				MockDialContext: func(ctx context.Context, timeout time.Duration, network string, address string) (net.Conn, error) {
+				MockDefaultDialTimeout: func() time.Duration {
+					return defaultDialTimeout
+				},
+				MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 					return nil, expected
 				},
 			}

--- a/internal/netxlite/netem.go
+++ b/internal/netxlite/netem.go
@@ -23,8 +23,8 @@ func (a *NetemUnderlyingNetworkAdapter) DefaultCertPool() *x509.CertPool {
 	return runtimex.Try1(a.UNet.DefaultCertPool())
 }
 
-// DefaultDialTimeout implements model.UnderlyingNetwork
-func (a *NetemUnderlyingNetworkAdapter) DefaultDialTimeout() time.Duration {
+// DialTimeout implements model.UnderlyingNetwork
+func (a *NetemUnderlyingNetworkAdapter) DialTimeout() time.Duration {
 	return defaultDialTimeout
 }
 

--- a/internal/netxlite/netem.go
+++ b/internal/netxlite/netem.go
@@ -23,10 +23,13 @@ func (a *NetemUnderlyingNetworkAdapter) DefaultCertPool() *x509.CertPool {
 	return runtimex.Try1(a.UNet.DefaultCertPool())
 }
 
+// DefaultDialTimeout implements model.UnderlyingNetwork
+func (a *NetemUnderlyingNetworkAdapter) DefaultDialTimeout() time.Duration {
+	return defaultDialTimeout
+}
+
 // DialContext implements model.UnderlyingNetwork
-func (a *NetemUnderlyingNetworkAdapter) DialContext(ctx context.Context, timeout time.Duration, network string, address string) (net.Conn, error) {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
+func (a *NetemUnderlyingNetworkAdapter) DialContext(ctx context.Context, network string, address string) (net.Conn, error) {
 	return a.UNet.DialContext(ctx, network, address)
 }
 

--- a/internal/netxlite/tproxy.go
+++ b/internal/netxlite/tproxy.go
@@ -75,8 +75,8 @@ func (tp *DefaultTProxy) DefaultCertPool() *x509.CertPool {
 
 const defaultDialTimeout = 15 * time.Second
 
-// DefaultDialTimeout implements model.UnderlyingNetwork
-func (tp *DefaultTProxy) DefaultDialTimeout() time.Duration {
+// DialTimeout implements model.UnderlyingNetwork
+func (tp *DefaultTProxy) DialTimeout() time.Duration {
 	return defaultDialTimeout
 }
 

--- a/internal/netxlite/tproxy.go
+++ b/internal/netxlite/tproxy.go
@@ -73,11 +73,16 @@ func (tp *DefaultTProxy) DefaultCertPool() *x509.CertPool {
 	return tproxyDefaultCertPool
 }
 
+const defaultDialTimeout = 15 * time.Second
+
+// DefaultDialTimeout implements model.UnderlyingNetwork
+func (tp *DefaultTProxy) DefaultDialTimeout() time.Duration {
+	return defaultDialTimeout
+}
+
 // DialContext implements UnderlyingNetwork.
-func (tp *DefaultTProxy) DialContext(ctx context.Context, timeout time.Duration, network, address string) (net.Conn, error) {
-	d := &net.Dialer{
-		Timeout: timeout,
-	}
+func (tp *DefaultTProxy) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	d := &net.Dialer{}
 	return d.DialContext(ctx, network, address)
 }
 

--- a/internal/netxlite/tproxy_test.go
+++ b/internal/netxlite/tproxy_test.go
@@ -6,8 +6,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"runtime"
-	"strings"
 	"testing"
 	"time"
 
@@ -51,29 +49,6 @@ func TestTproxyNilSafeProvider(t *testing.T) {
 	})
 }
 
-func TestDefaultTProxy(t *testing.T) {
-	t.Run("DialContext honours the timeout", func(t *testing.T) {
-		if runtime.GOOS == "windows" {
-			// This test is here to give us confidence we're doing the right thing
-			// in terms of the underlying Go API. It's not here to make sure the
-			// github CI behaves exactly equally on Windows, Linux, macOS on edge
-			// cases. So, it seems fine to just skip this test on Windows.
-			//
-			// TODO(https://github.com/ooni/probe/issues/2368).
-			t.Skip("skip test on windows")
-		}
-		tp := &DefaultTProxy{}
-		ctx := context.Background()
-		conn, err := tp.DialContext(ctx, time.Nanosecond, "tcp", "1.1.1.1:443")
-		if err == nil || !strings.HasSuffix(err.Error(), "i/o timeout") {
-			t.Fatal("unexpected err", err)
-		}
-		if conn != nil {
-			t.Fatal("expected nil conn")
-		}
-	})
-}
-
 func TestWithCustomTProxy(t *testing.T) {
 
 	t.Run("we can override the default cert pool", func(t *testing.T) {
@@ -90,8 +65,11 @@ func TestWithCustomTProxy(t *testing.T) {
 				pool.AddCert(srvr.Certificate())
 				return pool
 			},
-			MockDialContext: func(ctx context.Context, timeout time.Duration, network string, address string) (net.Conn, error) {
-				return (&DefaultTProxy{}).DialContext(ctx, timeout, network, address)
+			MockDefaultDialTimeout: func() time.Duration {
+				return defaultDialTimeout
+			},
+			MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
+				return (&DefaultTProxy{}).DialContext(ctx, network, address)
 			},
 			MockListenUDP: func(network string, addr *net.UDPAddr) (model.UDPLikeConn, error) {
 				return (&DefaultTProxy{}).ListenUDP(network, addr)

--- a/internal/netxlite/tproxy_test.go
+++ b/internal/netxlite/tproxy_test.go
@@ -65,7 +65,7 @@ func TestWithCustomTProxy(t *testing.T) {
 				pool.AddCert(srvr.Certificate())
 				return pool
 			},
-			MockDefaultDialTimeout: func() time.Duration {
+			MockDialTimeout: func() time.Duration {
 				return defaultDialTimeout
 			},
 			MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {

--- a/internal/sessionresolver/resolver_test.go
+++ b/internal/sessionresolver/resolver_test.go
@@ -10,7 +10,6 @@ import (
 	"sync/atomic"
 	"syscall"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/ooni/probe-cli/v3/internal/bytecounter"
@@ -454,8 +453,8 @@ func TestResolverWorkingAsIntendedWithMocks(t *testing.T) {
 				// without creating a new one from scratch.
 				return (&netxlite.DefaultTProxy{}).DefaultCertPool()
 			},
-			MockDialContext: func(ctx context.Context, timeout time.Duration, network string, address string) (net.Conn, error) {
-				dialer := &net.Dialer{Timeout: timeout}
+			MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
+				dialer := &net.Dialer{}
 				return dialer.DialContext(ctx, network, address)
 			},
 			MockListenUDP: func(network string, addr *net.UDPAddr) (model.UDPLikeConn, error) {
@@ -486,7 +485,7 @@ func TestResolverWorkingAsIntendedWithMocks(t *testing.T) {
 				// without creating a new one from scratch.
 				return (&netxlite.DefaultTProxy{}).DefaultCertPool()
 			},
-			MockDialContext: func(ctx context.Context, timeout time.Duration, network string, address string) (net.Conn, error) {
+			MockDialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
 				return nil, syscall.ECONNREFUSED
 			},
 			MockListenUDP: func(network string, addr *net.UDPAddr) (model.UDPLikeConn, error) {


### PR DESCRIPTION
This diff imports the given QA/webconnectivity.py integration test into the webconnectivityqa framework and removes it from Python. To this end, we need to modify how we handle timeouts in netxlite such that it is possible to change the default timeout programmatically when using netemx. While there, document the flag magic numbers used in tests, so that each test makes much more sense when reading it.

Part of https://github.com/ooni/probe/issues/1803.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: see above
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [x] if you changed code inside an experiment, make sure you bump its version number: not needed
