### PR TITLE
feat(netxlite): expose MaybeCustomUnderlyingNetwork

### DIFF
--- a/internal/netxlite/dialer.go
+++ b/internal/netxlite/dialer.go
@@ -147,7 +147,7 @@ func NewDialerWithoutResolver(dl model.DebugLogger, w ...model.DialerWrapper) mo
 // a fixed timeout for each connect operation equal to 15 seconds.
 type DialerSystem struct {
 	// provider is the OPTIONAL nil-safe [model.UnderlyingNetwork] provider.
-	provider *tproxyNilSafeProvider
+	provider *MaybeCustomUnderlyingNetwork
 }
 
 var _ model.Dialer = &DialerSystem{}

--- a/internal/netxlite/dialer_test.go
+++ b/internal/netxlite/dialer_test.go
@@ -108,7 +108,7 @@ func TestDialerSystem(t *testing.T) {
 				},
 				MockDialContext: defaultTp.DialContext,
 			}
-			d := &DialerSystem{provider: &tproxyNilSafeProvider{tp}}
+			d := &DialerSystem{provider: &MaybeCustomUnderlyingNetwork{tp}}
 			ctx := context.Background()
 			start := time.Now()
 			conn, err := d.DialContext(ctx, "tcp", "dns.google:443")
@@ -134,7 +134,7 @@ func TestDialerSystem(t *testing.T) {
 					return nil, expected
 				},
 			}
-			d := &DialerSystem{provider: &tproxyNilSafeProvider{proxy}}
+			d := &DialerSystem{provider: &MaybeCustomUnderlyingNetwork{proxy}}
 			conn, err := d.DialContext(context.Background(), "tcp", "dns.google:443")
 			if conn != nil {
 				t.Fatal("unexpected conn")

--- a/internal/netxlite/dnsovergetaddrinfo.go
+++ b/internal/netxlite/dnsovergetaddrinfo.go
@@ -24,7 +24,7 @@ type dnsOverGetaddrinfoTransport struct {
 	testableLookupANY func(ctx context.Context, domain string) ([]string, string, error)
 
 	// provider is the OPTIONAL nil-safe [model.UnderlyingNetwork] provider.
-	provider *tproxyNilSafeProvider
+	provider *MaybeCustomUnderlyingNetwork
 }
 
 // NewDNSOverGetaddrinfoTransport creates a new dns-over-getaddrinfo transport.

--- a/internal/netxlite/dnsovergetaddrinfo_test.go
+++ b/internal/netxlite/dnsovergetaddrinfo_test.go
@@ -201,7 +201,7 @@ func TestGetaddrinfoWithCustomUnderlyingNetwork(t *testing.T) {
 		},
 	}
 	txp := &dnsOverGetaddrinfoTransport{
-		provider: &tproxyNilSafeProvider{proxy},
+		provider: &MaybeCustomUnderlyingNetwork{proxy},
 	}
 	encoder := &DNSEncoderMiekg{}
 	query := encoder.Encode("dns.google", dns.TypeANY, false)

--- a/internal/netxlite/netx.go
+++ b/internal/netxlite/netx.go
@@ -18,8 +18,8 @@ type Netx struct {
 }
 
 // tproxyNilSafeProvider wraps the [model.UnderlyingNetwork] using a [tproxyNilSafeProvider].
-func (n *Netx) tproxyNilSafeProvider() *tproxyNilSafeProvider {
-	return &tproxyNilSafeProvider{n.Underlying}
+func (n *Netx) tproxyNilSafeProvider() *MaybeCustomUnderlyingNetwork {
+	return &MaybeCustomUnderlyingNetwork{n.Underlying}
 }
 
 // NewStdlibResolver is like [netxlite.NewStdlibResolver] but the constructed [model.Resolver]

--- a/internal/netxlite/quic.go
+++ b/internal/netxlite/quic.go
@@ -25,7 +25,7 @@ func NewQUICListener() model.QUICListener {
 // quicListenerStdlib is a QUICListener using the standard library.
 type quicListenerStdlib struct {
 	// provider is the OPTIONAL nil-safe [model.UnderlyingNetwork] provider.
-	provider *tproxyNilSafeProvider
+	provider *MaybeCustomUnderlyingNetwork
 }
 
 var _ model.QUICListener = &quicListenerStdlib{}
@@ -106,7 +106,7 @@ type quicDialerQUICGo struct {
 		quicConfig *quic.Config) (quic.EarlyConnection, error)
 
 	// provider is the OPTIONAL nil-safe [model.UnderlyingNetwork] provider.
-	provider *tproxyNilSafeProvider
+	provider *MaybeCustomUnderlyingNetwork
 }
 
 var _ model.QUICDialer = &quicDialerQUICGo{}

--- a/internal/netxlite/quic_test.go
+++ b/internal/netxlite/quic_test.go
@@ -346,7 +346,7 @@ func TestQUICDialerWithCustomUnderlyingNetwork(t *testing.T) {
 			},
 		}
 		systemdialer := &quicDialerQUICGo{
-			QUICListener: &quicListenerStdlib{provider: &tproxyNilSafeProvider{proxy}},
+			QUICListener: &quicListenerStdlib{provider: &MaybeCustomUnderlyingNetwork{proxy}},
 		}
 		qconn, err := systemdialer.DialContext(ctx, "8.8.8.8:443", tlsConf, qConf)
 		if qconn != nil {
@@ -382,7 +382,7 @@ func TestQUICDialerWithCustomUnderlyingNetwork(t *testing.T) {
 				gotTLSConfig = tlsConfig
 				return nil, expected
 			},
-			provider: &tproxyNilSafeProvider{proxy},
+			provider: &MaybeCustomUnderlyingNetwork{proxy},
 		}
 		qconn, err := systemdialer.DialContext(ctx, "8.8.8.8:443", tlsConf, qConf)
 		if qconn != nil {

--- a/internal/netxlite/tls.go
+++ b/internal/netxlite/tls.go
@@ -189,7 +189,7 @@ type tlsHandshakerConfigurable struct {
 	Timeout time.Duration
 
 	// provider is the OPTIONAL nil-safe [model.UnderlyingNetwork] provider.
-	provider *tproxyNilSafeProvider
+	provider *MaybeCustomUnderlyingNetwork
 }
 
 var _ model.TLSHandshaker = &tlsHandshakerConfigurable{}

--- a/internal/netxlite/tls_test.go
+++ b/internal/netxlite/tls_test.go
@@ -302,7 +302,7 @@ func TestTLSHandshakerConfigurable(t *testing.T) {
 						},
 					}, nil
 				},
-				provider: &tproxyNilSafeProvider{proxy},
+				provider: &MaybeCustomUnderlyingNetwork{proxy},
 			}
 			ctx := context.Background()
 			config := &tls.Config{ServerName: "dns.google"}

--- a/internal/netxlite/tproxy.go
+++ b/internal/netxlite/tproxy.go
@@ -10,16 +10,16 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
 
-// tproxyNilSafeProvider is a nil-safe [model.UnderlyingNetwork] provider. When the pointer
-// to the [tproxyNilSafeProvider] is nil or the underlying field is nil, the Get method of the
-// [tproxyNilSafeProvider] falls back to calling [tproxySingleton].
-type tproxyNilSafeProvider struct {
+// MaybeCustomUnderlyingNetwork is a nil-safe [model.UnderlyingNetwork] provider. When the pointer
+// to the [MaybeCustomUnderlyingNetwork] is nil or the underlying field is nil, the Get method of the
+// [MaybeCustomUnderlyingNetwork] falls back to calling [tproxySingleton].
+type MaybeCustomUnderlyingNetwork struct {
 	underlying model.UnderlyingNetwork
 }
 
 // Get returns the [model.UnderlyingNetwork] returned by [tproxySingleton] if p is nil or the
 // underlying field is nil and otherwise returns the value of the underlying field.
-func (p *tproxyNilSafeProvider) Get() model.UnderlyingNetwork {
+func (p *MaybeCustomUnderlyingNetwork) Get() model.UnderlyingNetwork {
 	if p == nil || p.underlying == nil {
 		return tproxySingleton()
 	}

--- a/internal/netxlite/tproxy_test.go
+++ b/internal/netxlite/tproxy_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestTproxyNilSafeProvider(t *testing.T) {
 	type testingstruct struct {
-		provider *tproxyNilSafeProvider
+		provider *MaybeCustomUnderlyingNetwork
 	}
 
 	t.Run("when the pointer is nil", func(t *testing.T) {
@@ -27,7 +27,7 @@ func TestTproxyNilSafeProvider(t *testing.T) {
 
 	t.Run("when underlying is nil", func(t *testing.T) {
 		tsp := &testingstruct{
-			provider: &tproxyNilSafeProvider{
+			provider: &MaybeCustomUnderlyingNetwork{
 				underlying: nil,
 			},
 		}
@@ -39,7 +39,7 @@ func TestTproxyNilSafeProvider(t *testing.T) {
 	t.Run("when underlying is set", func(t *testing.T) {
 		expected := &mocks.UnderlyingNetwork{}
 		tsp := &testingstruct{
-			provider: &tproxyNilSafeProvider{
+			provider: &MaybeCustomUnderlyingNetwork{
 				underlying: expected,
 			},
 		}


### PR DESCRIPTION
If we want to make other OONI components use either the default model.UnderlyingNetwork or a custom one, we need to expose the related routing functionality from netxlite.

Having this functionality handy would be useful, for example, to write a resolver IP lookup package that would work as intended both when using the regular network and when using netem.

In turn, this functionality opens up the possibility of running the whole of ooniprobe inside of netem in an easier way.

Related to https://github.com/ooni/probe/issues/2461.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: see above
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: no need
- [x] if you changed code inside an experiment, make sure you bump its version number: no need
