### PR TITLE
fix: avoid using 130.192.91.x for most netemx addresses

### DIFF
--- a/internal/experiment/webconnectivitylte/qa_test.go
+++ b/internal/experiment/webconnectivitylte/qa_test.go
@@ -15,9 +15,7 @@ func TestQA(t *testing.T) {
 				t.Skip("this nettest cannot run on Web Connectivity LTE")
 			}
 			measurer := NewExperimentMeasurer(&Config{
-				// We override the resolver used by default because the QA environment uses
-				// only IP addresses in the 130.192.91.x namespace for extra robustness in case
-				// netem is not working as intended and we're using the real network.
+				// We override the resolver to use the one we should be using with netem
 				DNSOverUDPResolver: net.JoinHostPort(netemx.QAEnvDefaultUncensoredResolverAddress, "53"),
 			})
 			if err := webconnectivityqa.RunTestCase(measurer, tc); err != nil {

--- a/internal/experiment/webconnectivityqa/tcpblocking.go
+++ b/internal/experiment/webconnectivityqa/tcpblocking.go
@@ -17,7 +17,7 @@ func tcpBlockingConnectTimeout() *TestCase {
 		Configure: func(env *netemx.QAEnv) {
 			env.DPIEngine().AddRule(&netem.DPIDropTrafficForServerEndpoint{
 				Logger:          log.Log,
-				ServerIPAddress: "130.192.91.7", // www.example.com
+				ServerIPAddress: netemx.InternetScenarioAddressWwwExampleCom,
 				ServerPort:      443,
 				ServerProtocol:  layers.IPProtocolTCP,
 			})

--- a/internal/experiment/webconnectivityqa/tcpblocking_test.go
+++ b/internal/experiment/webconnectivityqa/tcpblocking_test.go
@@ -2,6 +2,7 @@ package webconnectivityqa
 
 import (
 	"context"
+	"net"
 	"testing"
 
 	"github.com/apex/log"
@@ -16,7 +17,8 @@ func TestTCPBlockingConnectTimeout(t *testing.T) {
 
 	env.Do(func() {
 		dialer := netxlite.NewDialerWithoutResolver(log.Log)
-		conn, err := dialer.DialContext(context.Background(), "tcp", "130.192.91.7:443")
+		endpoint := net.JoinHostPort(netemx.InternetScenarioAddressWwwExampleCom, "443")
+		conn, err := dialer.DialContext(context.Background(), "tcp", endpoint)
 		if err == nil || err.Error() != netxlite.FailureGenericTimeoutError {
 			t.Fatal("unexpected error", err)
 		}

--- a/internal/netemx/android_test.go
+++ b/internal/netemx/android_test.go
@@ -1,0 +1,30 @@
+package netemx
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+)
+
+// Make sure we can emulate Android's getaddrinfo behavior.
+func TestEmulateAndroidGetaddrinfo(t *testing.T) {
+	env := MustNewScenario(InternetScenario)
+	defer env.Close()
+
+	env.EmulateAndroidGetaddrinfo(true)
+	defer env.EmulateAndroidGetaddrinfo(false)
+
+	env.Do(func() {
+		reso := netxlite.NewStdlibResolver(log.Log)
+		addrs, err := reso.LookupHost(context.Background(), "www.nonexistent.xyz")
+		if !errors.Is(err, netxlite.ErrAndroidDNSCacheNoData) {
+			t.Fatal("unexpected error")
+		}
+		if len(addrs) != 0 {
+			t.Fatal("expected zero-length addresses")
+		}
+	})
+}

--- a/internal/netemx/oohelperd_test.go
+++ b/internal/netemx/oohelperd_test.go
@@ -15,32 +15,18 @@ import (
 )
 
 func TestOOHelperDHandler(t *testing.T) {
-	// we use completely unrelated IP addresses such that, in the unlikely event in
-	// which we're not using netem, the test is poised to fail.
-	//
-	// (These were two IP addresses assigned to me when I was at polito.it.)
-	const (
-		zeroThOONIOrgAddr = "130.192.91.211"
-		exampleComAddr    = "130.192.91.231"
-	)
-
-	env := MustNewQAEnv(
-		QAEnvOptionHTTPServer(zeroThOONIOrgAddr, &OOHelperDFactory{}),
-		QAEnvOptionHTTPServer(exampleComAddr, ExampleWebPageHandlerFactory()),
-	)
-	env.AddRecordToAllResolvers("example.com", "web01.example.com", exampleComAddr)
-	env.AddRecordToAllResolvers("0.th.ooni.org", "0-th.ooni.org", zeroThOONIOrgAddr)
+	env := MustNewScenario(InternetScenario)
 	defer env.Close()
 
 	env.Do(func() {
 		thReq := &model.THRequest{
-			HTTPRequest: "https://example.com/",
+			HTTPRequest: "https://www.example.com/",
 			HTTPRequestHeaders: map[string][]string{
 				"accept":          {model.HTTPHeaderAccept},
 				"accept-language": {model.HTTPHeaderAcceptLanguage},
 				"user-agent":      {model.HTTPHeaderUserAgent},
 			},
-			TCPConnect:   []string{exampleComAddr},
+			TCPConnect:   []string{InternetScenarioAddressWwwExampleCom},
 			XQUICEnabled: true,
 		}
 		thReqRaw := runtimex.Try1(json.Marshal(thReq))
@@ -76,28 +62,28 @@ func TestOOHelperDHandler(t *testing.T) {
 
 		expectedTHResp := &model.THResponse{
 			TCPConnect: map[string]model.THTCPConnectResult{
-				"130.192.91.231:443": {
+				"93.184.216.34:443": {
 					Status:  true,
 					Failure: nil,
 				},
 			},
 			TLSHandshake: map[string]model.THTLSHandshakeResult{
-				"130.192.91.231:443": {
-					ServerName: "example.com",
+				"93.184.216.34:443": {
+					ServerName: "www.example.com",
 					Status:     true,
 					Failure:    nil,
 				},
 			},
 			QUICHandshake: map[string]model.THTLSHandshakeResult{
-				"130.192.91.231:443": {
-					ServerName: "example.com",
+				"93.184.216.34:443": {
+					ServerName: "www.example.com",
 					Status:     true,
 					Failure:    nil,
 				},
 			},
 			HTTPRequest: model.THHTTPRequestResult{
 				BodyLength:           194,
-				DiscoveredH3Endpoint: "example.com:443",
+				DiscoveredH3Endpoint: "www.example.com:443",
 				Failure:              nil,
 				Title:                "Default Web Page",
 				Headers: map[string]string{
@@ -122,12 +108,12 @@ func TestOOHelperDHandler(t *testing.T) {
 			},
 			DNS: model.THDNSResult{
 				Failure: nil,
-				Addrs:   []string{"130.192.91.231"},
+				Addrs:   []string{"93.184.216.34"},
 				ASNs:    nil,
 			},
 			IPInfo: map[string]*model.THIPInfo{
-				"130.192.91.231": {
-					ASN:   137,
+				"93.184.216.34": {
+					ASN:   15133,
 					Flags: 10,
 				},
 			},

--- a/internal/netemx/qaenv.go
+++ b/internal/netemx/qaenv.go
@@ -21,25 +21,13 @@ import (
 )
 
 // QAEnvDefaultClientAddress is the default client IP address.
-//
-// The 130.192.91.x address space belongs to polito.it and is not used for hosting a DNS server, which
-// gives us additional robustness in case netem is not working as intended. (We have several
-// tests making sure of that, but additional robustness won't hurt.)
-const QAEnvDefaultClientAddress = "130.192.91.2"
+const QAEnvDefaultClientAddress = "130.192.91.211"
 
 // QAEnvDefaultISPResolverAddress is the default IP address of the client ISP resolver.
-//
-// The 130.192.91.x address space belongs to polito.it and is not used for hosting a DNS server, which
-// gives us additional robustness in case netem is not working as intended. (We have several
-// tests making sure of that, but additional robustness won't hurt.)
-const QAEnvDefaultISPResolverAddress = "130.192.91.3"
+const QAEnvDefaultISPResolverAddress = "130.192.3.21"
 
 // QAEnvDefaultUncensoredResolverAddress is the default uncensored resolver IP address.
-//
-// The 130.192.91.x address space belongs to polito.it and is not used for hosting a DNS server, which
-// gives us additional robustness in case netem is not working as intended. (We have several
-// tests making sure of that, but additional robustness won't hurt.)
-const QAEnvDefaultUncensoredResolverAddress = "130.192.91.4"
+const QAEnvDefaultUncensoredResolverAddress = "1.1.1.1"
 
 type qaEnvConfig struct {
 	// clientAddress is the client IP address to use.

--- a/internal/netemx/scenario.go
+++ b/internal/netemx/scenario.go
@@ -21,57 +21,110 @@ const (
 
 // ScenarioDomainAddresses describes a domain and address used in a scenario.
 type ScenarioDomainAddresses struct {
-	Domain    string
+	// Domain is the related domain name (e.g., api.ooni.io).
+	Domain string
+
+	// Addresses contains the related IP addresses.
 	Addresses []string
-	Role      uint64
+
+	// Role is the role for this domain (e.g., ScenarioRoleOONIAPI).
+	Role uint64
 }
 
+const (
+	// InternetScenarioAddressApiOONIIo is the IP address we use for api.ooni.io in the [InternetScenario].
+	InternetScenarioAddressApiOONIIo = "162.55.247.208"
+
+	// InternetScenarioAddressGeoIPUbuntuCom is the IP address we use for geoip.ubuntu.com in the [InternetScenario].
+	InternetScenarioAddressGeoIPUbuntuCom = "185.125.188.132"
+
+	// InternetScenarioAddressWwwExampleCom is the IP address we use for www.example.com in the [InternetScenario].
+	InternetScenarioAddressWwwExampleCom = "93.184.216.34"
+
+	// InternetScenarioAddressZeroThOONIOrg is the IP address we use for 0.th.ooni.org in the [InternetScenario].
+	InternetScenarioAddressZeroThOONIOrg = "68.183.70.80"
+
+	// InternetScenarioAddressOneThOONIOrg is the IP address we use for 1.th.ooni.org in the [InternetScenario].
+	InternetScenarioAddressOneThOONIOrg = "137.184.235.44"
+
+	// InternetScenarioAddressTwoThOONIOrg is the IP address we use for 2.th.ooni.org in the [InternetScenario].
+	InternetScenarioAddressTwoThOONIOrg = "178.62.195.24"
+
+	// InternetScenarioAddressThreeThOONIOrg is the IP address we use for 3.th.ooni.org in the [InternetScenario].
+	InternetScenarioAddressThreeThOONIOrg = "209.97.183.73"
+
+	// InternetScenarioAddressDNSQuad9Net is the IP address we use for dns.quad9.net in the [InternetScenario].
+	InternetScenarioAddressDNSQuad9Net = "9.9.9.9"
+
+	// InternetScenarioAddressMozillaCloudflareDNSCom is the IP address we use for mozilla.cloudflare-dns.com
+	// in the [InternetScenario].
+	InternetScenarioAddressMozillaCloudflareDNSCom = "172.64.41.4"
+
+	// InternetScenarioAddressDNSGoogle is the IP address we use for dns.google in the [InternetScenario].
+	InternetScenarioAddressDNSGoogle = "8.8.4.4"
+)
+
 // InternetScenario contains the domains and addresses used by [NewInternetScenario].
-//
-// Note that the 130.192.91.x address space belongs to polito.it and is not used for hosting
-// servers, therefore we're more confident that tests using this scenario will break in bad
-// way if for some reason netem is not working as intended. (We have several tests making sure
-// of that, but some extra robustness won't hurt.)
 var InternetScenario = []*ScenarioDomainAddresses{{
-	Domain:    "api.ooni.io",
-	Addresses: []string{"130.192.91.5"},
-	Role:      ScenarioRoleOONIAPI,
+	Domain: "api.ooni.io",
+	Addresses: []string{
+		InternetScenarioAddressApiOONIIo,
+	},
+	Role: ScenarioRoleOONIAPI,
 }, {
-	Domain:    "geoip.ubuntu.com",
-	Addresses: []string{"130.192.91.6"},
-	Role:      ScenarioRoleUbuntuGeoIP,
+	Domain: "geoip.ubuntu.com",
+	Addresses: []string{
+		InternetScenarioAddressGeoIPUbuntuCom,
+	},
+	Role: ScenarioRoleUbuntuGeoIP,
 }, {
-	Domain:    "www.example.com",
-	Addresses: []string{"130.192.91.7"},
-	Role:      ScenarioRoleExampleLikeWebServer,
+	Domain: "www.example.com",
+	Addresses: []string{
+		InternetScenarioAddressWwwExampleCom,
+	},
+	Role: ScenarioRoleExampleLikeWebServer,
 }, {
-	Domain:    "0.th.ooni.org",
-	Addresses: []string{"130.192.91.8"},
-	Role:      ScenarioRoleOONITestHelper,
+	Domain: "0.th.ooni.org",
+	Addresses: []string{
+		InternetScenarioAddressZeroThOONIOrg,
+	},
+	Role: ScenarioRoleOONITestHelper,
 }, {
-	Domain:    "1.th.ooni.org",
-	Addresses: []string{"130.192.91.9"},
-	Role:      ScenarioRoleOONITestHelper,
+	Domain: "1.th.ooni.org",
+	Addresses: []string{
+		InternetScenarioAddressOneThOONIOrg,
+	},
+	Role: ScenarioRoleOONITestHelper,
 }, {
-	Domain:    "2.th.ooni.org",
-	Addresses: []string{"130.192.91.10"},
-	Role:      ScenarioRoleOONITestHelper,
+	Domain: "2.th.ooni.org",
+	Addresses: []string{
+		InternetScenarioAddressTwoThOONIOrg,
+	},
+	Role: ScenarioRoleOONITestHelper,
 }, {
-	Domain:    "3.th.ooni.org",
-	Addresses: []string{"130.192.91.11"},
-	Role:      ScenarioRoleOONITestHelper,
+	Domain: "3.th.ooni.org",
+	Addresses: []string{
+		InternetScenarioAddressThreeThOONIOrg,
+	},
+	Role: ScenarioRoleOONITestHelper,
 }, {
-	Domain:    "dns.quad9.net",
-	Addresses: []string{"130.192.91.12"},
-	Role:      ScenarioRoleDNSOverHTTPS,
+	Domain: "dns.quad9.net",
+	Addresses: []string{
+		InternetScenarioAddressDNSQuad9Net,
+	},
+	Role: ScenarioRoleDNSOverHTTPS,
 }, {
-	Domain:    "mozilla.cloudflare-dns.com",
-	Addresses: []string{"130.192.91.13"},
-	Role:      ScenarioRoleDNSOverHTTPS,
+	Domain: "mozilla.cloudflare-dns.com",
+	Addresses: []string{
+		InternetScenarioAddressMozillaCloudflareDNSCom,
+	},
+	Role: ScenarioRoleDNSOverHTTPS,
 }, {
-	Domain:    "dns.google",
-	Addresses: []string{"130.192.91.14"},
-	Role:      ScenarioRoleDNSOverHTTPS,
+	Domain: "dns.google",
+	Addresses: []string{
+		InternetScenarioAddressDNSGoogle,
+	},
+	Role: ScenarioRoleDNSOverHTTPS,
 }}
 
 // MustNewScenario constructs a complete testing scenario using the domains and IP
@@ -86,7 +139,7 @@ func MustNewScenario(cfg []*ScenarioDomainAddresses) *QAEnv {
 	}
 
 	// explicitly create the uncensored resolver
-	opts = append(opts, QAEnvOptionDNSOverUDPResolvers("130.192.91.4"))
+	opts = append(opts, QAEnvOptionDNSOverUDPResolvers(QAEnvDefaultUncensoredResolverAddress))
 
 	// fill options based on the scenario config
 	for _, sad := range cfg {


### PR DESCRIPTION
As we learned in https://github.com/ooni/probe-cli/pull/1216, using the 130.192.91.x namespace for every IP address in netemx breaks mapping domain names to IP addresess in Web Connectivity. No IP address would ever, in fact, be inconsistent, because they all belong to AS137.

Initially, I thought about overriding the code that maps IP addresses to ASNs, to provide a custom implementation. But then I realized it was a more thorough test to use the default implementation (relying on maxminddb files) and using the correct IP addresses in the correct address space.

My original thought for using 130.192.91.x addresses was that they were not the right addresses for the domains we're testing, thus, in the event in which netem was not WAI, all tests would have failed. However, we have many tests checking that netem is WAI already, so probably I was being excessively paranoid.

As a result, this patch modifies the code to use the correct addresses. We're still using some 130.192.91.x addresses where it makes sense to do so (user's IP address and default user's resolver).

Part of https://github.com/ooni/probe/issues/1803.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: see above
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [x] if you changed code inside an experiment, make sure you bump its version number: N/A
