### PR TITLE
refactor(netemx): move notable IP addrs in a separate file

### DIFF
--- a/internal/experiment/webconnectivitylte/qa_test.go
+++ b/internal/experiment/webconnectivitylte/qa_test.go
@@ -16,7 +16,7 @@ func TestQA(t *testing.T) {
 			}
 			measurer := NewExperimentMeasurer(&Config{
 				// We override the resolver to use the one we should be using with netem
-				DNSOverUDPResolver: net.JoinHostPort(netemx.QAEnvDefaultUncensoredResolverAddress, "53"),
+				DNSOverUDPResolver: net.JoinHostPort(netemx.DefaultUncensoredResolverAddress, "53"),
 			})
 			if err := webconnectivityqa.RunTestCase(measurer, tc); err != nil {
 				t.Fatal(err)

--- a/internal/experiment/webconnectivityqa/measurement.go
+++ b/internal/experiment/webconnectivityqa/measurement.go
@@ -27,7 +27,7 @@ func newMeasurement(input string, measurer model.ExperimentMeasurer, t0 time.Tim
 		ProbeNetworkName:          "Consortium GARR",
 		ReportID:                  "",
 		ResolverASN:               "AS137",
-		ResolverIP:                netemx.QAEnvDefaultISPResolverAddress,
+		ResolverIP:                netemx.DefaultISPResolverAddress,
 		ResolverNetworkName:       "Consortium GARR",
 		SoftwareName:              "ooniprobe",
 		SoftwareVersion:           version.Version,

--- a/internal/experiment/webconnectivityqa/session.go
+++ b/internal/experiment/webconnectivityqa/session.go
@@ -57,7 +57,7 @@ func newSession(client model.HTTPClient, logger model.Logger) model.ExperimentSe
 		MockProxyURL: nil,
 
 		MockResolverIP: func() string {
-			return netemx.QAEnvDefaultISPResolverAddress
+			return netemx.DefaultISPResolverAddress
 		},
 
 		MockSoftwareName: nil,

--- a/internal/experiment/webconnectivityqa/tcpblocking.go
+++ b/internal/experiment/webconnectivityqa/tcpblocking.go
@@ -17,7 +17,7 @@ func tcpBlockingConnectTimeout() *TestCase {
 		Configure: func(env *netemx.QAEnv) {
 			env.DPIEngine().AddRule(&netem.DPIDropTrafficForServerEndpoint{
 				Logger:          log.Log,
-				ServerIPAddress: netemx.InternetScenarioAddressWwwExampleCom,
+				ServerIPAddress: netemx.AddressWwwExampleCom,
 				ServerPort:      443,
 				ServerProtocol:  layers.IPProtocolTCP,
 			})
@@ -47,7 +47,7 @@ func tcpBlockingConnectionRefusedWithInconsistentDNS() *TestCase {
 			// spoof the DNS response to force using the server serving blockpages
 			env.DPIEngine().AddRule(&netem.DPISpoofDNSResponse{
 				Addresses: []string{
-					netemx.InternetScenarioAddressPublicBlockpage,
+					netemx.AddressPublicBlockpage,
 				},
 				Logger: log.Log,
 				Domain: "www.example.org",
@@ -56,7 +56,7 @@ func tcpBlockingConnectionRefusedWithInconsistentDNS() *TestCase {
 			// make sure we cannot connect to the public blockpage address
 			env.DPIEngine().AddRule(&netem.DPICloseConnectionForServerEndpoint{
 				Logger:          log.Log,
-				ServerIPAddress: netemx.InternetScenarioAddressPublicBlockpage,
+				ServerIPAddress: netemx.AddressPublicBlockpage,
 				ServerPort:      443,
 			})
 

--- a/internal/experiment/webconnectivityqa/tcpblocking_test.go
+++ b/internal/experiment/webconnectivityqa/tcpblocking_test.go
@@ -17,7 +17,7 @@ func TestTCPBlockingConnectTimeout(t *testing.T) {
 
 	env.Do(func() {
 		dialer := netxlite.NewDialerWithoutResolver(log.Log)
-		endpoint := net.JoinHostPort(netemx.InternetScenarioAddressWwwExampleCom, "443")
+		endpoint := net.JoinHostPort(netemx.AddressWwwExampleCom, "443")
 		conn, err := dialer.DialContext(context.Background(), "tcp", endpoint)
 		if err == nil || err.Error() != netxlite.FailureGenericTimeoutError {
 			t.Fatal("unexpected error", err)

--- a/internal/netemx/adapter.go
+++ b/internal/netemx/adapter.go
@@ -1,9 +1,5 @@
 package netemx
 
-//
-// Code to adapt [netem.UnderlyingNetwork] to [model.UnderlyingNetwork].
-//
-
 import (
 	"time"
 

--- a/internal/netemx/address.go
+++ b/internal/netemx/address.go
@@ -1,0 +1,45 @@
+package netemx
+
+// DefaultClientAddress is the default client IP address.
+const DefaultClientAddress = "130.192.91.211"
+
+// DefaultISPResolverAddress is the default IP address of the client ISP resolver.
+const DefaultISPResolverAddress = "130.192.3.21"
+
+// DefaultUncensoredResolverAddress is the default uncensored resolver IP address.
+const DefaultUncensoredResolverAddress = "1.1.1.1"
+
+// AddressApiOONIIo is the IP address for api.ooni.io.
+const AddressApiOONIIo = "162.55.247.208"
+
+// AddressGeoIPUbuntuCom is the IP address for geoip.ubuntu.com.
+const AddressGeoIPUbuntuCom = "185.125.188.132"
+
+// AddressWwwExampleCom is the IP address for www.example.com.
+const AddressWwwExampleCom = "93.184.216.34"
+
+// AddressZeroThOONIOrg is the IP address for 0.th.ooni.org.
+const AddressZeroThOONIOrg = "68.183.70.80"
+
+// AddressOneThOONIOrg is the IP address for 1.th.ooni.org.
+const AddressOneThOONIOrg = "137.184.235.44"
+
+// AddressTwoThOONIOrg is the IP address for 2.th.ooni.org.
+const AddressTwoThOONIOrg = "178.62.195.24"
+
+// AddressThreeThOONIOrg is the IP address for 3.th.ooni.org.
+const AddressThreeThOONIOrg = "209.97.183.73"
+
+// AddressDNSQuad9Net is the IP address for dns.quad9.net.
+const AddressDNSQuad9Net = "9.9.9.9"
+
+// AddressMozillaCloudflareDNSCom is the IP address for mozilla.cloudflare-dns.com.
+const AddressMozillaCloudflareDNSCom = "172.64.41.4"
+
+// AddressDNSGoogle is the IP address for dns.google.
+const AddressDNSGoogle = "8.8.4.4"
+
+// AddressPublicBlockpage is the IP address we use for modeling a public IP address that is serving
+// blockpages to its users. As of 2023-09-04, this is the IP address resolving for thepiratebay.com when
+// you're attempting to access this website from Italy.
+const AddressPublicBlockpage = "83.224.65.41"

--- a/internal/netemx/doc.go
+++ b/internal/netemx/doc.go
@@ -1,2 +1,2 @@
-// Package netemx contains code to run integration tests using netem.
+// Package netemx contains code to run integration tests using [github.com/ooni/netem].
 package netemx

--- a/internal/netemx/example_test.go
+++ b/internal/netemx/example_test.go
@@ -20,10 +20,10 @@ import (
 func exampleNewEnvironment() *netemx.QAEnv {
 	return netemx.MustNewQAEnv(
 		netemx.QAEnvOptionDNSOverUDPResolvers("8.8.4.4", "9.9.9.9"),
-		netemx.QAEnvOptionClientAddress(netemx.QAEnvDefaultClientAddress),
-		netemx.QAEnvOptionISPResolverAddress(netemx.QAEnvDefaultISPResolverAddress),
+		netemx.QAEnvOptionClientAddress(netemx.DefaultClientAddress),
+		netemx.QAEnvOptionISPResolverAddress(netemx.DefaultISPResolverAddress),
 		netemx.QAEnvOptionHTTPServer(
-			netemx.InternetScenarioAddressWwwExampleCom, netemx.ExampleWebPageHandlerFactory()),
+			netemx.AddressWwwExampleCom, netemx.ExampleWebPageHandlerFactory()),
 		netemx.QAEnvOptionLogger(log.Log),
 	)
 }
@@ -34,7 +34,7 @@ func exampleAddRecordToAllResolvers(env *netemx.QAEnv) {
 	env.AddRecordToAllResolvers(
 		"example.com",
 		"", // CNAME
-		netemx.InternetScenarioAddressWwwExampleCom,
+		netemx.AddressWwwExampleCom,
 	)
 }
 
@@ -93,7 +93,7 @@ func Example_resolverConfig() {
 	env.OtherResolversConfig().AddRecord(
 		"example.com",
 		"", // CNAME
-		netemx.InternetScenarioAddressWwwExampleCom,
+		netemx.AddressWwwExampleCom,
 	)
 
 	// create a censored configuration for getaddrinfo
@@ -226,8 +226,8 @@ func Example_dnsOverUDPWithInternetScenario() {
 
 	env.Do(func() {
 		resolvers := []string{
-			net.JoinHostPort(netemx.QAEnvDefaultISPResolverAddress, "53"),
-			net.JoinHostPort(netemx.QAEnvDefaultUncensoredResolverAddress, "53"),
+			net.JoinHostPort(netemx.DefaultISPResolverAddress, "53"),
+			net.JoinHostPort(netemx.DefaultUncensoredResolverAddress, "53"),
 		}
 
 		for _, endpoint := range resolvers {

--- a/internal/netemx/oohelperd_test.go
+++ b/internal/netemx/oohelperd_test.go
@@ -26,7 +26,7 @@ func TestOOHelperDHandler(t *testing.T) {
 				"accept-language": {model.HTTPHeaderAcceptLanguage},
 				"user-agent":      {model.HTTPHeaderUserAgent},
 			},
-			TCPConnect:   []string{InternetScenarioAddressWwwExampleCom},
+			TCPConnect:   []string{AddressWwwExampleCom},
 			XQUICEnabled: true,
 		}
 		thReqRaw := runtimex.Try1(json.Marshal(thReq))

--- a/internal/netemx/qaenv.go
+++ b/internal/netemx/qaenv.go
@@ -20,15 +20,6 @@ import (
 	"github.com/quic-go/quic-go/http3"
 )
 
-// QAEnvDefaultClientAddress is the default client IP address.
-const QAEnvDefaultClientAddress = "130.192.91.211"
-
-// QAEnvDefaultISPResolverAddress is the default IP address of the client ISP resolver.
-const QAEnvDefaultISPResolverAddress = "130.192.3.21"
-
-// QAEnvDefaultUncensoredResolverAddress is the default uncensored resolver IP address.
-const QAEnvDefaultUncensoredResolverAddress = "1.1.1.1"
-
 type qaEnvConfig struct {
 	// clientAddress is the client IP address to use.
 	clientAddress string
@@ -56,7 +47,7 @@ type qaEnvConfig struct {
 type QAEnvOption func(config *qaEnvConfig)
 
 // QAEnvOptionClientAddress sets the client IP address. If you do not set this option
-// we will use [QAEnvDefaultClientAddress].
+// we will use [DefaultClientAddress].
 func QAEnvOptionClientAddress(ipAddr string) QAEnvOption {
 	runtimex.Assert(net.ParseIP(ipAddr) != nil, "not an IP addr")
 	return func(config *qaEnvConfig) {
@@ -73,7 +64,7 @@ func QAEnvOptionClientNICWrapper(wrapper netem.LinkNICWrapper) QAEnvOption {
 }
 
 // QAEnvOptionDNSOverUDPResolvers adds the given DNS-over-UDP resolvers. If you do not set this option
-// we will create a single resolver using [QAEnvDefaultUncensoredResolverAddress].
+// we will create a single resolver using [DefaultUncensoredResolverAddress].
 func QAEnvOptionDNSOverUDPResolvers(ipAddrs ...string) QAEnvOption {
 	for _, a := range ipAddrs {
 		runtimex.Assert(net.ParseIP(a) != nil, "not an IP addr")
@@ -99,7 +90,7 @@ func QAEnvOptionHTTPServer(ipAddr string, factory QAEnvHTTPHandlerFactory) QAEnv
 }
 
 // QAEnvOptionISPResolverAddress sets the ISP's resolver IP address. If you do not set this option
-// we will use [QAEnvDefaultISPResolverAddress] as the address.
+// we will use [DefaultISPResolverAddress] as the address.
 func QAEnvOptionISPResolverAddress(ipAddr string) QAEnvOption {
 	runtimex.Assert(net.ParseIP(ipAddr) != nil, "not an IP addr")
 	return func(config *qaEnvConfig) {
@@ -177,11 +168,11 @@ type QAEnv struct {
 func MustNewQAEnv(options ...QAEnvOption) *QAEnv {
 	// initialize the configuration
 	config := &qaEnvConfig{
-		clientAddress:       QAEnvDefaultClientAddress,
+		clientAddress:       DefaultClientAddress,
 		clientNICWrapper:    nil,
 		dnsOverUDPResolvers: []string{},
 		httpServers:         map[string]QAEnvHTTPHandlerFactory{},
-		ispResolver:         QAEnvDefaultISPResolverAddress,
+		ispResolver:         DefaultISPResolverAddress,
 		logger:              model.DiscardLogger,
 		netStacks:           map[string]QAEnvNetStackHandler{},
 	}
@@ -189,7 +180,7 @@ func MustNewQAEnv(options ...QAEnvOption) *QAEnv {
 		option(config)
 	}
 	if len(config.dnsOverUDPResolvers) < 1 {
-		config.dnsOverUDPResolvers = append(config.dnsOverUDPResolvers, QAEnvDefaultUncensoredResolverAddress)
+		config.dnsOverUDPResolvers = append(config.dnsOverUDPResolvers, DefaultUncensoredResolverAddress)
 	}
 
 	// use a prefix logger for the QA env
@@ -261,7 +252,7 @@ func (env *QAEnv) mustNewClientStack(config *qaEnvConfig) *netem.UNetStack {
 	// TODO(bassosimone,kelmenhorst): consider allowing to configure the
 	// delays and losses should the need for this arise in the future.
 	return runtimex.Try1(env.topology.AddHost(
-		QAEnvDefaultClientAddress,
+		DefaultClientAddress,
 		config.ispResolver,
 		&netem.LinkConfig{
 			DPIEngine:        env.dpi,

--- a/internal/netemx/qaenv_test.go
+++ b/internal/netemx/qaenv_test.go
@@ -76,7 +76,7 @@ func TestQAEnv(t *testing.T) {
 		// create QA env
 		env := netemx.MustNewQAEnv(
 			netemx.QAEnvOptionHTTPServer(
-				netemx.InternetScenarioAddressWwwExampleCom,
+				netemx.AddressWwwExampleCom,
 				netemx.ExampleWebPageHandlerFactory(),
 			),
 		)
@@ -86,7 +86,7 @@ func TestQAEnv(t *testing.T) {
 		env.AddRecordToAllResolvers(
 			"www.example.com",
 			"", // CNAME
-			netemx.InternetScenarioAddressWwwExampleCom,
+			netemx.AddressWwwExampleCom,
 		)
 
 		env.Do(func() {
@@ -139,7 +139,7 @@ func TestQAEnv(t *testing.T) {
 		// create QA env
 		env := netemx.MustNewQAEnv(
 			netemx.QAEnvOptionHTTPServer(
-				netemx.InternetScenarioAddressWwwExampleCom,
+				netemx.AddressWwwExampleCom,
 				netemx.ExampleWebPageHandlerFactory(),
 			),
 		)
@@ -149,7 +149,7 @@ func TestQAEnv(t *testing.T) {
 		env.AddRecordToAllResolvers(
 			"www.example.com",
 			"", // CNAME
-			netemx.InternetScenarioAddressWwwExampleCom,
+			netemx.AddressWwwExampleCom,
 		)
 
 		env.Do(func() {

--- a/internal/netemx/scenario.go
+++ b/internal/netemx/scenario.go
@@ -34,110 +34,72 @@ type ScenarioDomainAddresses struct {
 	WebServerFactory QAEnvHTTPHandlerFactory
 }
 
-const (
-	// InternetScenarioAddressApiOONIIo is the IP address we use for api.ooni.io in the [InternetScenario].
-	InternetScenarioAddressApiOONIIo = "162.55.247.208"
-
-	// InternetScenarioAddressGeoIPUbuntuCom is the IP address we use for geoip.ubuntu.com in the [InternetScenario].
-	InternetScenarioAddressGeoIPUbuntuCom = "185.125.188.132"
-
-	// InternetScenarioAddressWwwExampleCom is the IP address we use for www.example.com in the [InternetScenario].
-	InternetScenarioAddressWwwExampleCom = "93.184.216.34"
-
-	// InternetScenarioAddressZeroThOONIOrg is the IP address we use for 0.th.ooni.org in the [InternetScenario].
-	InternetScenarioAddressZeroThOONIOrg = "68.183.70.80"
-
-	// InternetScenarioAddressOneThOONIOrg is the IP address we use for 1.th.ooni.org in the [InternetScenario].
-	InternetScenarioAddressOneThOONIOrg = "137.184.235.44"
-
-	// InternetScenarioAddressTwoThOONIOrg is the IP address we use for 2.th.ooni.org in the [InternetScenario].
-	InternetScenarioAddressTwoThOONIOrg = "178.62.195.24"
-
-	// InternetScenarioAddressThreeThOONIOrg is the IP address we use for 3.th.ooni.org in the [InternetScenario].
-	InternetScenarioAddressThreeThOONIOrg = "209.97.183.73"
-
-	// InternetScenarioAddressDNSQuad9Net is the IP address we use for dns.quad9.net in the [InternetScenario].
-	InternetScenarioAddressDNSQuad9Net = "9.9.9.9"
-
-	// InternetScenarioAddressMozillaCloudflareDNSCom is the IP address we use for mozilla.cloudflare-dns.com
-	// in the [InternetScenario].
-	InternetScenarioAddressMozillaCloudflareDNSCom = "172.64.41.4"
-
-	// InternetScenarioAddressDNSGoogle is the IP address we use for dns.google in the [InternetScenario].
-	InternetScenarioAddressDNSGoogle = "8.8.4.4"
-
-	// InternetScenarioAddressPublicBlockpage is the IP address we use for modeling a public IP address
-	// that is serving blockpages to its users. As of 2023-09-04, this is the IP address resolving for
-	// thepiratebay.com when you're attempting to access this website from Italy.
-	InternetScenarioAddressPublicBlockpage = "83.224.65.41"
-)
-
 // InternetScenario contains the domains and addresses used by [NewInternetScenario].
 var InternetScenario = []*ScenarioDomainAddresses{{
 	Domains: []string{"api.ooni.io"},
 	Addresses: []string{
-		InternetScenarioAddressApiOONIIo,
+		AddressApiOONIIo,
 	},
 	Role: ScenarioRoleOONIAPI,
 }, {
 	Domains: []string{"geoip.ubuntu.com"},
 	Addresses: []string{
-		InternetScenarioAddressGeoIPUbuntuCom,
+		AddressGeoIPUbuntuCom,
 	},
 	Role: ScenarioRoleUbuntuGeoIP,
 }, {
 	Domains: []string{"www.example.com", "example.com", "www.example.org", "example.org"},
 	Addresses: []string{
-		InternetScenarioAddressWwwExampleCom,
+		AddressWwwExampleCom,
 	},
 	Role:             ScenarioRoleWebServer,
 	WebServerFactory: ExampleWebPageHandlerFactory(),
 }, {
 	Domains: []string{"0.th.ooni.org"},
 	Addresses: []string{
-		InternetScenarioAddressZeroThOONIOrg,
+		AddressZeroThOONIOrg,
 	},
 	Role: ScenarioRoleOONITestHelper,
 }, {
 	Domains: []string{"1.th.ooni.org"},
 	Addresses: []string{
-		InternetScenarioAddressOneThOONIOrg,
+		AddressOneThOONIOrg,
 	},
 	Role: ScenarioRoleOONITestHelper,
 }, {
 	Domains: []string{"2.th.ooni.org"},
 	Addresses: []string{
-		InternetScenarioAddressTwoThOONIOrg,
+		AddressTwoThOONIOrg,
 	},
 	Role: ScenarioRoleOONITestHelper,
 }, {
 	Domains: []string{"3.th.ooni.org"},
 	Addresses: []string{
-		InternetScenarioAddressThreeThOONIOrg,
+		AddressThreeThOONIOrg,
 	},
 	Role: ScenarioRoleOONITestHelper,
 }, {
 	Domains: []string{"dns.quad9.net"},
 	Addresses: []string{
-		InternetScenarioAddressDNSQuad9Net,
+		AddressDNSQuad9Net,
 	},
 	Role: ScenarioRoleDNSOverHTTPS,
 }, {
 	Domains: []string{"mozilla.cloudflare-dns.com"},
 	Addresses: []string{
-		InternetScenarioAddressMozillaCloudflareDNSCom,
+		AddressMozillaCloudflareDNSCom,
 	},
 	Role: ScenarioRoleDNSOverHTTPS,
 }, {
 	Domains: []string{"dns.google"},
 	Addresses: []string{
-		InternetScenarioAddressDNSGoogle,
+		AddressDNSGoogle,
 	},
 	Role: ScenarioRoleDNSOverHTTPS,
 }, {
 	Domains: []string{},
 	Addresses: []string{
-		InternetScenarioAddressPublicBlockpage,
+		AddressPublicBlockpage,
 	},
 	Role:             ScenarioRoleWebServer,
 	WebServerFactory: BlockpageHandlerFactory(),
@@ -162,7 +124,7 @@ func MustNewScenario(config []*ScenarioDomainAddresses) *QAEnv {
 	}
 
 	// explicitly create the uncensored resolver
-	opts = append(opts, QAEnvOptionDNSOverUDPResolvers(QAEnvDefaultUncensoredResolverAddress))
+	opts = append(opts, QAEnvOptionDNSOverUDPResolvers(DefaultUncensoredResolverAddress))
 
 	// fill options based on the scenario config
 	for _, sad := range config {
@@ -192,7 +154,7 @@ func MustNewScenario(config []*ScenarioDomainAddresses) *QAEnv {
 		case ScenarioRoleUbuntuGeoIP:
 			for _, addr := range sad.Addresses {
 				opts = append(opts, QAEnvOptionHTTPServer(addr, &GeoIPHandlerFactoryUbuntu{
-					ProbeIP: QAEnvDefaultClientAddress,
+					ProbeIP: DefaultClientAddress,
 				}))
 			}
 		}


### PR DESCRIPTION
I am trying to lift some netemx restrictions that make certain Web Connectivity integration tests a bit unrealistic. To progress towards this goal, I have determined that I need to (1) improve the construction for the  QAEnv and (2) make the scenario constructor a function that initialized a given QAEnv rather than rolling additional abstraction on top of it.

The current diff moves IP addresses around to create space for myself to attempt to implement the above changes.

The reference issue is https://github.com/ooni/probe/issues/1803.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: see above
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [x] if you changed code inside an experiment, make sure you bump its version number: N/A
