### PR TITLE
refactor(netemx): move towards unified factory/server

### DIFF
--- a/internal/experiment/whatsapp/whatsapp_test.go
+++ b/internal/experiment/whatsapp/whatsapp_test.go
@@ -64,7 +64,7 @@ func configureDNSWithDefaults(config *netem.DNSConfig) {
 
 // newQAEnvironment creates a [*netemx.QAEnv] using the default configuration
 func newQAEnvironment() *netemx.QAEnv {
-	endpointsNetStack := netemx.TCPEchoNetStack(log.Log, 443, 5222)
+	endpointsNetStack := netemx.NewTCPEchoServerFactory(log.Log, 443, 5222)
 
 	// We need:
 	//

--- a/internal/netemx/example_test.go
+++ b/internal/netemx/example_test.go
@@ -147,7 +147,7 @@ func Example_customNetStackHandler() {
 
 	// create the QA environment
 	env := netemx.MustNewQAEnv(
-		netemx.QAEnvOptionNetStack(e1WhatsappNet, netemx.TCPEchoNetStack(log.Log, 5222)),
+		netemx.QAEnvOptionNetStack(e1WhatsappNet, netemx.NewTCPEchoServerFactory(log.Log, 5222)),
 		netemx.QAEnvOptionLogger(log.Log),
 	)
 

--- a/internal/netemx/netstack.go
+++ b/internal/netemx/netstack.go
@@ -1,0 +1,26 @@
+package netemx
+
+import "github.com/ooni/netem"
+
+// NetStackServerFactory constructs a new [NetStackServer].
+type NetStackServerFactory interface {
+	// MustNewServer constructs a [NetStackServer] BORROWING a reference to an
+	// underlying network attached to an userspace TCP/IP stack. This method MAY
+	// call PANIC in case of failure.
+	MustNewServer(stack *netem.UNetStack) NetStackServer
+}
+
+// NetStackServer handles the lifecycle of a server using a TCP/IP stack in userspace.
+type NetStackServer interface {
+	// MustStart uses the underlying stack to create all the listening TCP and UDP sockets
+	// required by the specific test case, as well as to start the required background
+	// goroutines servicing incoming requests for the created listeners. This method
+	// MUST BE CONCURRENCY SAFE and it MUST NOT arrange for the Close method to close
+	// the stack because it is managed by the [QAEnv]. This method MUST call PANIC
+	// in case there is any error in listening or starting the required servers.
+	MustStart()
+
+	// Close should close the listening TCP and UDP sockets and the background
+	// goroutines created by Listen. This method MUST BE CONCURRENCY SAFE and IDEMPOTENT.
+	Close() error
+}

--- a/internal/netemx/tcpecho.go
+++ b/internal/netemx/tcpecho.go
@@ -10,80 +10,94 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
-// TCPEchoNetStack is a [QAEnvNetStackHandler] implementing a TCP echo service.
-func TCPEchoNetStack(logger model.Logger, ports ...uint16) QAEnvNetStackHandler {
-	return &tcpEchoNetStack{
-		closers: []io.Closer{},
-		logger:  logger,
-		mu:      sync.Mutex{},
-		ports:   ports,
+// NewTCPEchoServerFactory is a [QAEnvNetStackHandler] implementing a TCP echo service.
+func NewTCPEchoServerFactory(logger model.Logger, ports ...uint16) NetStackServerFactory {
+	return &tcpEchoServerFactory{
+		logger: logger,
+		ports:  ports,
 	}
 }
 
-type tcpEchoNetStack struct {
+type tcpEchoServerFactory struct {
+	logger model.Logger
+	ports  []uint16
+}
+
+// MustNewServer implements NetStackServerFactory.
+func (f *tcpEchoServerFactory) MustNewServer(stack *netem.UNetStack) NetStackServer {
+	return &tcpEchoServer{
+		closers: []io.Closer{},
+		logger:  f.logger,
+		mu:      sync.Mutex{},
+		ports:   f.ports,
+		unet:    stack,
+	}
+}
+
+type tcpEchoServer struct {
 	closers []io.Closer
 	logger  model.Logger
 	mu      sync.Mutex
 	ports   []uint16
+	unet    *netem.UNetStack
 }
 
-// Close implements QAEnvNetStackHandler.
-func (echo *tcpEchoNetStack) Close() error {
+// Close implements NetStackServer.
+func (srv *tcpEchoServer) Close() error {
 	// "this method MUST be CONCURRENCY SAFE"
-	defer echo.mu.Unlock()
-	echo.mu.Lock()
+	defer srv.mu.Unlock()
+	srv.mu.Lock()
 
 	// make sure we close all the child listeners
-	for _, closer := range echo.closers {
+	for _, closer := range srv.closers {
 		_ = closer.Close()
 	}
 
 	// "this method MUST be IDEMPOTENT"
-	echo.closers = []io.Closer{}
+	srv.closers = []io.Closer{}
 
 	return nil
 }
 
-// Listen implements QAEnvNetStackHandler.
-func (echo *tcpEchoNetStack) Listen(stack *netem.UNetStack) error {
+// MustStart implements NetStackServer.
+func (srv *tcpEchoServer) MustStart() {
 	// "this method MUST be CONCURRENCY SAFE"
-	defer echo.mu.Unlock()
-	echo.mu.Lock()
+	defer srv.mu.Unlock()
+	srv.mu.Lock()
 
 	// for each port of interest - note that here we panic liberally because we are
 	// allowed to do so by the [QAEnvNetStackHandler] documentation.
-	for _, port := range echo.ports {
+	for _, port := range srv.ports {
 		// create the endpoint address
-		ipAddr := net.ParseIP(stack.IPAddress())
+		ipAddr := net.ParseIP(srv.unet.IPAddress())
 		runtimex.Assert(ipAddr != nil, "invalid IP address")
 		epnt := &net.TCPAddr{IP: ipAddr, Port: int(port)}
 
 		// attempt to listen
-		listener := runtimex.Try1(stack.ListenTCP("tcp", epnt))
+		listener := runtimex.Try1(srv.unet.ListenTCP("tcp", epnt))
 
 		// spawn goroutine for accepting
-		go echo.acceptLoop(listener)
+		go srv.acceptLoop(listener)
 
 		// track this listener as something to close later
-		echo.closers = append(echo.closers, listener)
+		srv.closers = append(srv.closers, listener)
 	}
-	return nil
 }
 
-func (echo *tcpEchoNetStack) acceptLoop(listener net.Listener) {
+func (srv *tcpEchoServer) acceptLoop(listener net.Listener) {
 	// Implementation note: because this function is only used for writing QA tests, it is
 	// fine that we are using runtimex.Try1 and ignoring any panic.
-	defer runtimex.CatchLogAndIgnorePanic(echo.logger, "qaEnvNetStackTCPEcho.acceptLoop")
+	defer runtimex.CatchLogAndIgnorePanic(srv.logger, "qaEnvNetStackTCPEcho.acceptLoop")
 	for {
 		conn := runtimex.Try1(listener.Accept())
-		go echo.serve(conn)
+		go srv.serve(conn)
 	}
 }
 
-func (echo *tcpEchoNetStack) serve(conn net.Conn) {
+func (srv *tcpEchoServer) serve(conn net.Conn) {
 	// Implementation note: because this function is only used for writing QA tests, it is
 	// fine that we are using runtimex.Try1 and ignoring any panic.
-	defer runtimex.CatchLogAndIgnorePanic(echo.logger, "qaEnvTCPListenerEcho.serve")
+	defer runtimex.CatchLogAndIgnorePanic(srv.logger, "qaEnvTCPListenerEcho.serve")
 
 	// make sure we close the conn
 	defer conn.Close()

--- a/internal/netemx/tcpecho.go
+++ b/internal/netemx/tcpecho.go
@@ -66,7 +66,7 @@ func (srv *tcpEchoServer) MustStart() {
 	srv.mu.Lock()
 
 	// for each port of interest - note that here we panic liberally because we are
-	// allowed to do so by the [QAEnvNetStackHandler] documentation.
+	// allowed to do so by the [NetStackServer] documentation.
 	for _, port := range srv.ports {
 		// create the endpoint address
 		ipAddr := net.ParseIP(srv.unet.IPAddress())
@@ -87,7 +87,7 @@ func (srv *tcpEchoServer) MustStart() {
 func (srv *tcpEchoServer) acceptLoop(listener net.Listener) {
 	// Implementation note: because this function is only used for writing QA tests, it is
 	// fine that we are using runtimex.Try1 and ignoring any panic.
-	defer runtimex.CatchLogAndIgnorePanic(srv.logger, "qaEnvNetStackTCPEcho.acceptLoop")
+	defer runtimex.CatchLogAndIgnorePanic(srv.logger, "tcpEchoServer.acceptLoop")
 	for {
 		conn := runtimex.Try1(listener.Accept())
 		go srv.serve(conn)
@@ -97,7 +97,7 @@ func (srv *tcpEchoServer) acceptLoop(listener net.Listener) {
 func (srv *tcpEchoServer) serve(conn net.Conn) {
 	// Implementation note: because this function is only used for writing QA tests, it is
 	// fine that we are using runtimex.Try1 and ignoring any panic.
-	defer runtimex.CatchLogAndIgnorePanic(srv.logger, "qaEnvTCPListenerEcho.serve")
+	defer runtimex.CatchLogAndIgnorePanic(srv.logger, "tcpEchoServer.serve")
 
 	// make sure we close the conn
 	defer conn.Close()

--- a/internal/netemx/tcpecho.go
+++ b/internal/netemx/tcpecho.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
-// NewTCPEchoServerFactory is a [QAEnvNetStackHandler] implementing a TCP echo service.
+// NewTCPEchoServerFactory is a [NetStackServerFactory] for the TCP echo service.
 func NewTCPEchoServerFactory(logger model.Logger, ports ...uint16) NetStackServerFactory {
 	return &tcpEchoServerFactory{
 		logger: logger,


### PR DESCRIPTION
This diff starts refactoring netemx such that any kind of service we want to create for a given IP address uses the same interface, which is a generic factory to create a generic server working depending on a netstack.

The overall objective here is to enable the same IP address to serve DNS, HTTP/HTTPS/HTTP3, and possibly arbitrary other services. Currently, we can only choose one of these services per IP address. This limitation, for example, makes it impossible to have 8.8.8.8 handle both Do53 and DoH.

I will move towards this objective incrementally. This diff just refactors the way in which we manage the echo server to follow a model where there is a factory for creating a server, which is what HTTP code is using.

Once this diff lands, I will refactor HTTP and DNS to follow this model. And, after that, I will try to allow multiple factories for each IP addr.

Reference issue: https://github.com/ooni/probe/issues/1803

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: see above
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [x] if you changed code inside an experiment, make sure you bump its version number: N/A
