### PR TITLE
feat(netemx): adapt NetStackServerFactory from telegram

### DIFF
--- a/internal/netemx/http.go
+++ b/internal/netemx/http.go
@@ -1,0 +1,104 @@
+package netemx
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"sync"
+
+	"github.com/ooni/netem"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
+)
+
+// HTTPHandlerFactory constructs an [http.Handler].
+type HTTPHandlerFactory interface {
+	NewHandler() http.Handler
+}
+
+// HTTPHandlerFactoryFunc allows a func to become an [HTTPHandlerFactory].
+type HTTPHandlerFactoryFunc func() http.Handler
+
+var _ HTTPHandlerFactory = HTTPHandlerFactoryFunc(nil)
+
+// NewHandler implements HTTPHandlerFactory.
+func (fx HTTPHandlerFactoryFunc) NewHandler() http.Handler {
+	return fx()
+}
+
+// HTTPCleartextServerFactory implements [NetStackServerFactory] for cleartext HTTP.
+type HTTPCleartextServerFactory struct {
+	// Factory is the MANDATORY factory for creating the [http.Handler].
+	Factory HTTPHandlerFactory
+
+	// Ports is the MANDATORY list of ports where to listen.
+	Ports []int
+}
+
+var _ NetStackServerFactory = &HTTPCleartextServerFactory{}
+
+// MustNewServer implements NetStackServerFactory.
+func (f *HTTPCleartextServerFactory) MustNewServer(stack *netem.UNetStack) NetStackServer {
+	return &httpCleartextServer{
+		closers: []io.Closer{},
+		factory: f.Factory,
+		mu:      sync.Mutex{},
+		ports:   f.Ports,
+		unet:    stack,
+	}
+}
+
+type httpCleartextServer struct {
+	closers []io.Closer
+	factory HTTPHandlerFactory
+	mu      sync.Mutex
+	ports   []int
+	unet    *netem.UNetStack
+}
+
+// Close implements NetStackServer.
+func (srv *httpCleartextServer) Close() error {
+	// make the method locked as requested by the documentation
+	defer srv.mu.Unlock()
+	srv.mu.Lock()
+
+	// close each of the closers
+	for _, closer := range srv.closers {
+		_ = closer.Close()
+	}
+
+	// be idempotent
+	srv.closers = []io.Closer{}
+	return nil
+}
+
+// MustStart implements NetStackServer.
+func (srv *httpCleartextServer) MustStart() {
+	// make the method locked as requested by the documentation
+	defer srv.mu.Unlock()
+	srv.mu.Lock()
+
+	// create the handler
+	handler := srv.factory.NewHandler()
+
+	// create the listening address
+	ipAddr := net.ParseIP(srv.unet.IPAddress())
+	runtimex.Assert(ipAddr != nil, "expected valid IP address")
+
+	for _, port := range srv.ports {
+		srv.mustListenPortLocked(handler, ipAddr, port)
+	}
+}
+
+func (srv *httpCleartextServer) mustListenPortLocked(handler http.Handler, ipAddr net.IP, port int) {
+	// create the listening socket
+	addr := &net.TCPAddr{IP: ipAddr, Port: port}
+	listener := runtimex.Try1(srv.unet.ListenTCP("tcp", addr))
+
+	// serve requests in a background goroutine
+	srvr := &http.Server{Handler: handler}
+	go srvr.Serve(listener)
+
+	// make sure we track the server (the .Serve method will close the
+	// listener once we close the server itself)
+	srv.closers = append(srv.closers, srvr)
+}

--- a/internal/netemx/http_test.go
+++ b/internal/netemx/http_test.go
@@ -1,0 +1,45 @@
+package netemx
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
+)
+
+func TestHTTPCleartextServerFactory(t *testing.T) {
+	env := MustNewQAEnv(
+		QAEnvOptionNetStack(AddressWwwExampleCom, &HTTPCleartextServerFactory{
+			Factory: HTTPHandlerFactoryFunc(func() http.Handler {
+				return ExampleWebPageHandler()
+			}),
+			Ports: []int{80},
+		}),
+	)
+	defer env.Close()
+
+	env.AddRecordToAllResolvers("www.example.com", "", AddressWwwExampleCom)
+
+	env.Do(func() {
+		client := netxlite.NewHTTPClientStdlib(log.Log)
+		req := runtimex.Try1(http.NewRequest("GET", "http://www.example.com/", nil))
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			t.Fatal("unexpected StatusCode", resp.StatusCode)
+		}
+		data, err := netxlite.ReadAllContext(req.Context(), resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(ExampleWebPage, string(data)); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+}


### PR DESCRIPTION
The overall intent of this work is to unify how we manage HTTP, DNS, and ordinary netstacks for netemx, and allow the same IP address to host multiple servers rather than just one, as it's currently the case.

To this end, the current diff adapts code that used to be an integration test for telegram to become the cleartext HTTP NetStackServerFactory.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1803
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [x] if you changed code inside an experiment, make sure you bump its version number: N/A
