### PR TITLE
feat(netemx): HTTPS server implementing NetStackServerFactory

### DIFF
--- a/internal/netemx/https.go
+++ b/internal/netemx/https.go
@@ -1,0 +1,106 @@
+package netemx
+
+import (
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+
+	"github.com/ooni/netem"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
+)
+
+// HTTPSecureServerFactory implements [NetStackServerFactory] for HTTP-over-TLS (i.e., HTTPS).
+type HTTPSecureServerFactory struct {
+	// Factory is the MANDATORY factory for creating the [http.Handler].
+	Factory HTTPHandlerFactory
+
+	// Ports is the MANDATORY list of ports where to listen.
+	Ports []int
+
+	// TLSConfig is the OPTIONAL TLS config to use.
+	TLSConfig *tls.Config
+}
+
+var _ NetStackServerFactory = &HTTPSecureServerFactory{}
+
+// MustNewServer implements NetStackServerFactory.
+func (f *HTTPSecureServerFactory) MustNewServer(stack *netem.UNetStack) NetStackServer {
+	return &httpSecureServer{
+		closers:   []io.Closer{},
+		factory:   f.Factory,
+		mu:        sync.Mutex{},
+		ports:     f.Ports,
+		tlsConfig: f.TLSConfig,
+		unet:      stack,
+	}
+}
+
+type httpSecureServer struct {
+	closers   []io.Closer
+	factory   HTTPHandlerFactory
+	mu        sync.Mutex
+	ports     []int
+	tlsConfig *tls.Config
+	unet      *netem.UNetStack
+}
+
+// Close implements NetStackServer.
+func (srv *httpSecureServer) Close() error {
+	// make the method locked as requested by the documentation
+	defer srv.mu.Unlock()
+	srv.mu.Lock()
+
+	// close each of the closers
+	for _, closer := range srv.closers {
+		_ = closer.Close()
+	}
+
+	// be idempotent
+	srv.closers = []io.Closer{}
+	return nil
+}
+
+// MustStart implements NetStackServer.
+func (srv *httpSecureServer) MustStart() {
+	// make the method locked as requested by the documentation
+	defer srv.mu.Unlock()
+	srv.mu.Lock()
+
+	// create the handler
+	handler := srv.factory.NewHandler()
+
+	// create the listening address
+	ipAddr := net.ParseIP(srv.unet.IPAddress())
+	runtimex.Assert(ipAddr != nil, "expected valid IP address")
+
+	for _, port := range srv.ports {
+		srv.mustListenPortLocked(handler, ipAddr, port)
+	}
+}
+
+func (srv *httpSecureServer) mustListenPortLocked(handler http.Handler, ipAddr net.IP, port int) {
+	// create the listening socket
+	addr := &net.TCPAddr{IP: ipAddr, Port: port}
+	listener := runtimex.Try1(srv.unet.ListenTCP("tcp", addr))
+
+	// use the netstack TLS config or the custom one configured by the user
+	tlsConfig := srv.tlsConfig
+	if tlsConfig == nil {
+		tlsConfig = srv.unet.ServerTLSConfig()
+	} else {
+		tlsConfig = tlsConfig.Clone()
+	}
+
+	// serve requests in a background goroutine
+	srvr := &http.Server{
+		Handler:   handler,
+		TLSConfig: tlsConfig,
+	}
+	go srvr.ServeTLS(listener, "", "")
+
+	// make sure we track the server (the .Serve method will close the
+	// listener once we close the server itself)
+	srv.closers = append(srv.closers, srvr)
+}

--- a/internal/netemx/https_test.go
+++ b/internal/netemx/https_test.go
@@ -1,0 +1,80 @@
+package netemx
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/netem"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
+)
+
+func TestHTTPSecureServerFactory(t *testing.T) {
+	t.Run("when using the TLSConfig provided by netem", func(t *testing.T) {
+		env := MustNewQAEnv(
+			QAEnvOptionNetStack(AddressWwwExampleCom, &HTTPSecureServerFactory{
+				Factory: HTTPHandlerFactoryFunc(func() http.Handler {
+					return ExampleWebPageHandler()
+				}),
+				Ports:     []int{443},
+				TLSConfig: nil, // explicitly nil, let's use netem's config
+			}),
+		)
+		defer env.Close()
+
+		env.AddRecordToAllResolvers("www.example.com", "", AddressWwwExampleCom)
+
+		env.Do(func() {
+			client := netxlite.NewHTTPClientStdlib(log.Log)
+			req := runtimex.Try1(http.NewRequest("GET", "https://www.example.com/", nil))
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != 200 {
+				t.Fatal("unexpected StatusCode", resp.StatusCode)
+			}
+			data, err := netxlite.ReadAllContext(req.Context(), resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(ExampleWebPage, string(data)); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	})
+
+	t.Run("when using an incompatible TLS config", func(t *testing.T) {
+		// we're creating a distinct MITM TLS config and we're using it, so we expect
+		// that we're not able to verify certificates in client code
+		mitmConfig := runtimex.Try1(netem.NewTLSMITMConfig())
+
+		env := MustNewQAEnv(
+			QAEnvOptionNetStack(AddressWwwExampleCom, &HTTPSecureServerFactory{
+				Factory: HTTPHandlerFactoryFunc(func() http.Handler {
+					return ExampleWebPageHandler()
+				}),
+				Ports:     []int{443},
+				TLSConfig: mitmConfig.TLSConfig(), // custom!
+			}),
+		)
+		defer env.Close()
+
+		env.AddRecordToAllResolvers("www.example.com", "", AddressWwwExampleCom)
+
+		env.Do(func() {
+			client := netxlite.NewHTTPClientStdlib(log.Log)
+			req := runtimex.Try1(http.NewRequest("GET", "https://www.example.com/", nil))
+			resp, err := client.Do(req)
+			if err == nil || err.Error() != netxlite.FailureSSLUnknownAuthority {
+				t.Fatal("unexpected error", err)
+			}
+			if resp != nil {
+				t.Fatal("expected nil resp")
+			}
+		})
+	})
+}


### PR DESCRIPTION
This diff continues improving and refactoring netemx with the objective of unifying how we create all kind of servers.

Here, specifically, we modify the HTTP server implementing NetStackServerFactory implemented in the previous commit and obtain an HTTPS server honouring NetStackServerFactory.

Crucially, this diff also adds support for overriding the TLS config passed to the server, which enables us to test for expired certificates, self-signed certificates, and so forth.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1803
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [x] if you changed code inside an experiment, make sure you bump its version number: N/A
