### PR TITLE
feat(netemx): implement NetStackServerFactory for DNS-over-UDP

### DIFF
--- a/internal/netemx/http.go
+++ b/internal/netemx/http.go
@@ -26,6 +26,8 @@ func (fx HTTPHandlerFactoryFunc) NewHandler() http.Handler {
 }
 
 // HTTPCleartextServerFactory implements [NetStackServerFactory] for cleartext HTTP.
+//
+// Use this factory along with [QAEnvOptionNetStack] to create cleartext HTTP servers.
 type HTTPCleartextServerFactory struct {
 	// Factory is the MANDATORY factory for creating the [http.Handler].
 	Factory HTTPHandlerFactory
@@ -37,7 +39,7 @@ type HTTPCleartextServerFactory struct {
 var _ NetStackServerFactory = &HTTPCleartextServerFactory{}
 
 // MustNewServer implements NetStackServerFactory.
-func (f *HTTPCleartextServerFactory) MustNewServer(stack *netem.UNetStack) NetStackServer {
+func (f *HTTPCleartextServerFactory) MustNewServer(_ NetStackServerFactoryEnv, stack *netem.UNetStack) NetStackServer {
 	return &httpCleartextServer{
 		closers: []io.Closer{},
 		factory: f.Factory,

--- a/internal/netemx/http3.go
+++ b/internal/netemx/http3.go
@@ -13,6 +13,8 @@ import (
 )
 
 // HTTP3ServerFactory implements [NetStackServerFactory] for HTTP-over-TLS (i.e., HTTPS).
+//
+// Use this factory along with [QAEnvOptionNetStack] to create HTTP3 servers.
 type HTTP3ServerFactory struct {
 	// Factory is the MANDATORY factory for creating the [http.Handler].
 	Factory HTTPHandlerFactory
@@ -27,7 +29,7 @@ type HTTP3ServerFactory struct {
 var _ NetStackServerFactory = &HTTP3ServerFactory{}
 
 // MustNewServer implements NetStackServerFactory.
-func (f *HTTP3ServerFactory) MustNewServer(stack *netem.UNetStack) NetStackServer {
+func (f *HTTP3ServerFactory) MustNewServer(_ NetStackServerFactoryEnv, stack *netem.UNetStack) NetStackServer {
 	return &http3Server{
 		closers:   []io.Closer{},
 		factory:   f.Factory,

--- a/internal/netemx/https.go
+++ b/internal/netemx/https.go
@@ -12,6 +12,8 @@ import (
 )
 
 // HTTPSecureServerFactory implements [NetStackServerFactory] for HTTP-over-TLS (i.e., HTTPS).
+//
+// Use this factory along with [QAEnvOptionNetStack] to create HTTPS servers.
 type HTTPSecureServerFactory struct {
 	// Factory is the MANDATORY factory for creating the [http.Handler].
 	Factory HTTPHandlerFactory
@@ -26,7 +28,7 @@ type HTTPSecureServerFactory struct {
 var _ NetStackServerFactory = &HTTPSecureServerFactory{}
 
 // MustNewServer implements NetStackServerFactory.
-func (f *HTTPSecureServerFactory) MustNewServer(stack *netem.UNetStack) NetStackServer {
+func (f *HTTPSecureServerFactory) MustNewServer(_ NetStackServerFactoryEnv, stack *netem.UNetStack) NetStackServer {
 	return &httpSecureServer{
 		closers:   []io.Closer{},
 		factory:   f.Factory,

--- a/internal/netemx/netstack.go
+++ b/internal/netemx/netstack.go
@@ -1,13 +1,26 @@
 package netemx
 
-import "github.com/ooni/netem"
+import (
+	"github.com/ooni/netem"
+	"github.com/ooni/probe-cli/v3/internal/model"
+)
+
+// NetStackServerFactoryEnv is [NetStackServerFactory] view of [*QAEnv].
+type NetStackServerFactoryEnv interface {
+	// Logger returns the base logger configured for the [*QAEnv].
+	Logger() model.Logger
+
+	// OtherResolversConfig returns the configuration used by all the
+	// DNS resolvers except the ISP's DNS resolver.
+	OtherResolversConfig() *netem.DNSConfig
+}
 
 // NetStackServerFactory constructs a new [NetStackServer].
 type NetStackServerFactory interface {
 	// MustNewServer constructs a [NetStackServer] BORROWING a reference to an
 	// underlying network attached to an userspace TCP/IP stack. This method MAY
 	// call PANIC in case of failure.
-	MustNewServer(stack *netem.UNetStack) NetStackServer
+	MustNewServer(env NetStackServerFactoryEnv, stack *netem.UNetStack) NetStackServer
 }
 
 // NetStackServer handles the lifecycle of a server using a TCP/IP stack in userspace.

--- a/internal/netemx/tcpecho.go
+++ b/internal/netemx/tcpecho.go
@@ -24,7 +24,7 @@ type tcpEchoServerFactory struct {
 }
 
 // MustNewServer implements NetStackServerFactory.
-func (f *tcpEchoServerFactory) MustNewServer(stack *netem.UNetStack) NetStackServer {
+func (f *tcpEchoServerFactory) MustNewServer(_ NetStackServerFactoryEnv, stack *netem.UNetStack) NetStackServer {
 	return &tcpEchoServer{
 		closers: []io.Closer{},
 		logger:  f.logger,

--- a/internal/netemx/udpresolver.go
+++ b/internal/netemx/udpresolver.go
@@ -1,0 +1,90 @@
+package netemx
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/ooni/netem"
+	"github.com/ooni/probe-cli/v3/internal/logx"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
+)
+
+// UDPResolverFactory implements [NetStackServerFactory] for DNS-over-UDP servers.
+//
+// When this factory constructs a [NetStackServer], it will use:
+//
+// 1. the [NetStackServerFactoryEnv.OtherResolversConfig] as DNS configuration;
+//
+// 2. the [NetStackServerFactoryEnv.Logger] as the logger.
+//
+// Use this factory along with [QAEnvOptionNetStack] to create DNS-over-UDP servers.
+type UDPResolverFactory struct{}
+
+var _ NetStackServerFactory = &UDPResolverFactory{}
+
+// MustNewServer implements NetStackServerFactory.
+func (f *UDPResolverFactory) MustNewServer(env NetStackServerFactoryEnv, stack *netem.UNetStack) NetStackServer {
+	return udpResolverMustNewServer(env.OtherResolversConfig(), env.Logger(), stack)
+}
+
+// udpResolverMustNewServer is an internal factory for creating a [NetStackServer] that
+// runs a DNS-over-UDP server using the configured logger, DNS config, and stack.
+func udpResolverMustNewServer(config *netem.DNSConfig, logger model.Logger, stack *netem.UNetStack) NetStackServer {
+	return &udpResolver{
+		closers: []io.Closer{},
+		config:  config,
+		logger:  logger,
+		mu:      sync.Mutex{},
+		unet:    stack,
+	}
+}
+
+type udpResolver struct {
+	closers []io.Closer
+	config  *netem.DNSConfig
+	logger  model.Logger
+	mu      sync.Mutex
+	unet    *netem.UNetStack
+}
+
+// Close implements NetStackServer.
+func (srv *udpResolver) Close() error {
+	// make the method locked as requested by the documentation
+	defer srv.mu.Unlock()
+	srv.mu.Lock()
+
+	// close each of the closers
+	for _, closer := range srv.closers {
+		_ = closer.Close()
+	}
+
+	// be idempotent
+	srv.closers = []io.Closer{}
+	return nil
+}
+
+// MustStart implements NetStackServer.
+func (srv *udpResolver) MustStart() {
+	// make the method locked as requested by the documentation
+	defer srv.mu.Unlock()
+	srv.mu.Lock()
+
+	// Use a prefix logger for the DNS server
+	prefixLogger := &logx.PrefixLogger{
+		Prefix: fmt.Sprintf("%-16s", "RESOLVER"),
+		Logger: srv.logger,
+	}
+
+	// create DNS server
+	server := runtimex.Try1(netem.NewDNSServer(
+		prefixLogger,
+		srv.unet,
+		srv.unet.IPAddress(),
+		srv.config,
+	))
+
+	// track this closable
+	srv.closers = append(srv.closers, server)
+}

--- a/internal/netemx/udpresolver_test.go
+++ b/internal/netemx/udpresolver_test.go
@@ -1,0 +1,33 @@
+package netemx
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+)
+
+func TestUDPResolverFactory(t *testing.T) {
+	env := MustNewQAEnv(
+		QAEnvOptionNetStack(AddressDNSGoogle, &UDPResolverFactory{}),
+	)
+	defer env.Close()
+
+	env.AddRecordToAllResolvers("www.example.com", "", AddressWwwExampleCom)
+
+	env.Do(func() {
+		reso := netxlite.NewParallelUDPResolver(
+			log.Log, netxlite.NewDialerWithoutResolver(log.Log),
+			net.JoinHostPort(AddressDNSGoogle, "53"))
+		addrs, err := reso.LookupHost(context.Background(), "www.example.com")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff([]string{AddressWwwExampleCom}, addrs); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+}


### PR DESCRIPTION
This diff moves forward the work we're doing to try to unify the way in which all the possible servers in netemx are constructed.

The general idea is to enable configuring every kind of server using the QAEnvOptionNetStack option.

To this end, we need to implement NetStackServerFactory.

In this diff, in particular, we're implementing a NetStackServerFactory for constructing DNS-over-UDP servers. These servers would use:

1. the OtherResolversConfig for lookups (which makes sense because the [MustNewQAEnv] internally constructs the ISP resolver);

2. the logger configured for the QAEnv.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1803
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [x] if you changed code inside an experiment, make sure you bump its version number: N/A
