### PR TITLE
refactor(netemx/scenario.go): start using QAEnvOptionNetStack

### DIFF
--- a/internal/experiment/telegram/telegram_test.go
+++ b/internal/experiment/telegram/telegram_test.go
@@ -280,7 +280,7 @@ func configureDNSWithDefaults(config *netem.DNSConfig) {
 func newQAEnvironment(ipaddrs ...string) *netemx.QAEnv {
 	// create a single factory for handling all the requests
 	factory := &netemx.HTTPCleartextServerFactory{
-		Factory: netemx.HTTPHandlerFactoryFunc(func() http.Handler {
+		Factory: netemx.HTTPHandlerFactoryFunc(func(_ *netem.UNetStack) http.Handler {
 			// we create an empty mux, which should cause a 404 for each webpage, which seems what
 			// the servers used by telegram DC do as of 2023-07-11
 			return http.NewServeMux()

--- a/internal/netemx/geoip.go
+++ b/internal/netemx/geoip.go
@@ -12,9 +12,9 @@ type GeoIPHandlerFactoryUbuntu struct {
 	ProbeIP string
 }
 
-var _ QAEnvHTTPHandlerFactory = &GeoIPHandlerFactoryUbuntu{}
+var _ HTTPHandlerFactory = &GeoIPHandlerFactoryUbuntu{}
 
 // NewHandler implements QAEnvHTTPHandlerFactory.
-func (f *GeoIPHandlerFactoryUbuntu) NewHandler(unet netem.UnderlyingNetwork) http.Handler {
+func (f *GeoIPHandlerFactoryUbuntu) NewHandler(_ *netem.UNetStack) http.Handler {
 	return &testingx.GeoIPHandlerUbuntu{ProbeIP: f.ProbeIP}
 }

--- a/internal/netemx/http.go
+++ b/internal/netemx/http.go
@@ -12,17 +12,17 @@ import (
 
 // HTTPHandlerFactory constructs an [http.Handler].
 type HTTPHandlerFactory interface {
-	NewHandler() http.Handler
+	NewHandler(stack *netem.UNetStack) http.Handler
 }
 
 // HTTPHandlerFactoryFunc allows a func to become an [HTTPHandlerFactory].
-type HTTPHandlerFactoryFunc func() http.Handler
+type HTTPHandlerFactoryFunc func(stack *netem.UNetStack) http.Handler
 
 var _ HTTPHandlerFactory = HTTPHandlerFactoryFunc(nil)
 
 // NewHandler implements HTTPHandlerFactory.
-func (fx HTTPHandlerFactoryFunc) NewHandler() http.Handler {
-	return fx()
+func (fx HTTPHandlerFactoryFunc) NewHandler(stack *netem.UNetStack) http.Handler {
+	return fx(stack)
 }
 
 // HTTPCleartextServerFactory implements [NetStackServerFactory] for cleartext HTTP.
@@ -80,7 +80,7 @@ func (srv *httpCleartextServer) MustStart() {
 	srv.mu.Lock()
 
 	// create the handler
-	handler := srv.factory.NewHandler()
+	handler := srv.factory.NewHandler(srv.unet)
 
 	// create the listening address
 	ipAddr := net.ParseIP(srv.unet.IPAddress())

--- a/internal/netemx/http3.go
+++ b/internal/netemx/http3.go
@@ -72,7 +72,7 @@ func (srv *http3Server) MustStart() {
 	srv.mu.Lock()
 
 	// create the handler
-	handler := srv.factory.NewHandler()
+	handler := srv.factory.NewHandler(srv.unet)
 
 	// create the listening address
 	ipAddr := net.ParseIP(srv.unet.IPAddress())

--- a/internal/netemx/http3_test.go
+++ b/internal/netemx/http3_test.go
@@ -34,7 +34,7 @@ func TestHTTP3ServerFactory(t *testing.T) {
 
 		env := MustNewQAEnv(
 			QAEnvOptionNetStack("10.55.56.57", &HTTP3ServerFactory{
-				Factory: HTTPHandlerFactoryFunc(func() http.Handler {
+				Factory: HTTPHandlerFactoryFunc(func(_ *netem.UNetStack) http.Handler {
 					return ExampleWebPageHandler()
 				}),
 				Ports:     []int{443},
@@ -92,7 +92,7 @@ func TestHTTP3ServerFactory(t *testing.T) {
 
 		env := MustNewQAEnv(
 			QAEnvOptionNetStack("10.55.56.100", &HTTP3ServerFactory{
-				Factory: HTTPHandlerFactoryFunc(func() http.Handler {
+				Factory: HTTPHandlerFactoryFunc(func(_ *netem.UNetStack) http.Handler {
 					return ExampleWebPageHandler()
 				}),
 				Ports:     []int{443},

--- a/internal/netemx/http_test.go
+++ b/internal/netemx/http_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/netem"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
@@ -13,7 +14,7 @@ import (
 func TestHTTPCleartextServerFactory(t *testing.T) {
 	env := MustNewQAEnv(
 		QAEnvOptionNetStack(AddressWwwExampleCom, &HTTPCleartextServerFactory{
-			Factory: HTTPHandlerFactoryFunc(func() http.Handler {
+			Factory: HTTPHandlerFactoryFunc(func(_ *netem.UNetStack) http.Handler {
 				return ExampleWebPageHandler()
 			}),
 			Ports: []int{80},

--- a/internal/netemx/https.go
+++ b/internal/netemx/https.go
@@ -71,7 +71,7 @@ func (srv *httpSecureServer) MustStart() {
 	srv.mu.Lock()
 
 	// create the handler
-	handler := srv.factory.NewHandler()
+	handler := srv.factory.NewHandler(srv.unet)
 
 	// create the listening address
 	ipAddr := net.ParseIP(srv.unet.IPAddress())

--- a/internal/netemx/https_test.go
+++ b/internal/netemx/https_test.go
@@ -15,7 +15,7 @@ func TestHTTPSecureServerFactory(t *testing.T) {
 	t.Run("when using the TLSConfig provided by netem", func(t *testing.T) {
 		env := MustNewQAEnv(
 			QAEnvOptionNetStack(AddressWwwExampleCom, &HTTPSecureServerFactory{
-				Factory: HTTPHandlerFactoryFunc(func() http.Handler {
+				Factory: HTTPHandlerFactoryFunc(func(_ *netem.UNetStack) http.Handler {
 					return ExampleWebPageHandler()
 				}),
 				Ports:     []int{443},
@@ -54,7 +54,7 @@ func TestHTTPSecureServerFactory(t *testing.T) {
 
 		env := MustNewQAEnv(
 			QAEnvOptionNetStack(AddressWwwExampleCom, &HTTPSecureServerFactory{
-				Factory: HTTPHandlerFactoryFunc(func() http.Handler {
+				Factory: HTTPHandlerFactoryFunc(func(_ *netem.UNetStack) http.Handler {
 					return ExampleWebPageHandler()
 				}),
 				Ports:     []int{443},

--- a/internal/netemx/ooapi.go
+++ b/internal/netemx/ooapi.go
@@ -12,10 +12,10 @@ import (
 // OOAPIHandlerFactory is a [QAEnvHTTPHandlerFactory] that creates [OOAPIHandler] instances.
 type OOAPIHandlerFactory struct{}
 
-var _ QAEnvHTTPHandlerFactory = &OOAPIHandlerFactory{}
+var _ HTTPHandlerFactory = &OOAPIHandlerFactory{}
 
 // NewHandler implements QAEnvHTTPHandlerFactory.
-func (*OOAPIHandlerFactory) NewHandler(unet netem.UnderlyingNetwork) http.Handler {
+func (*OOAPIHandlerFactory) NewHandler(_ *netem.UNetStack) http.Handler {
 	return &OOAPIHandler{}
 }
 

--- a/internal/netemx/oohelperd.go
+++ b/internal/netemx/oohelperd.go
@@ -17,10 +17,10 @@ import (
 // test helper using a specific [netem.UnderlyingNetwork].
 type OOHelperDFactory struct{}
 
-var _ QAEnvHTTPHandlerFactory = &OOHelperDFactory{}
+var _ HTTPHandlerFactory = &OOHelperDFactory{}
 
 // NewHandler implements QAEnvHTTPHandlerFactory.NewHandler.
-func (f *OOHelperDFactory) NewHandler(unet netem.UnderlyingNetwork) http.Handler {
+func (f *OOHelperDFactory) NewHandler(unet *netem.UNetStack) http.Handler {
 	netx := netxlite.Netx{Underlying: &netxlite.NetemUnderlyingNetworkAdapter{UNet: unet}}
 	handler := oohelperd.NewHandler()
 

--- a/internal/netemx/scenario.go
+++ b/internal/netemx/scenario.go
@@ -143,18 +143,30 @@ func MustNewScenario(config []*ScenarioDomainAddresses) *QAEnv {
 
 		case ScenarioRoleOONIAPI:
 			for _, addr := range sad.Addresses {
-				opts = append(opts, QAEnvOptionHTTPServer(addr, &OOAPIHandlerFactory{}))
+				opts = append(opts, QAEnvOptionNetStack(addr, &HTTPSecureServerFactory{
+					Factory:   &OOAPIHandlerFactory{},
+					Ports:     []int{443},
+					TLSConfig: nil, // use netem's default
+				}))
 			}
 
 		case ScenarioRoleOONITestHelper:
 			for _, addr := range sad.Addresses {
-				opts = append(opts, QAEnvOptionHTTPServer(addr, &OOHelperDFactory{}))
+				opts = append(opts, QAEnvOptionNetStack(addr, &HTTPSecureServerFactory{
+					Factory:   &OOHelperDFactory{},
+					Ports:     []int{443},
+					TLSConfig: nil, // use netem's default
+				}))
 			}
 
 		case ScenarioRoleUbuntuGeoIP:
 			for _, addr := range sad.Addresses {
-				opts = append(opts, QAEnvOptionHTTPServer(addr, &GeoIPHandlerFactoryUbuntu{
-					ProbeIP: DefaultClientAddress,
+				opts = append(opts, QAEnvOptionNetStack(addr, &HTTPSecureServerFactory{
+					Factory: &GeoIPHandlerFactoryUbuntu{
+						ProbeIP: DefaultClientAddress,
+					},
+					Ports:     []int{443},
+					TLSConfig: nil, // use netem's default
 				}))
 			}
 		}


### PR DESCRIPTION
With the changes we implemented so far, we're not able to start migrating part of scenario.go (probably the easiest part) to use QAEnvOptionNetStack for configuring servers.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1803
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [x] if you changed code inside an experiment, make sure you bump its version number: N/A
