### PR TITLE
cleanup(netemx): always init resolvers using QAEnvOptionNetStack

### DIFF
--- a/internal/experiment/dnsping/dnsping_test.go
+++ b/internal/experiment/dnsping/dnsping_test.go
@@ -99,7 +99,7 @@ func TestMeasurer_run(t *testing.T) {
 
 	t.Run("with netem: without DPI: expect success", func(t *testing.T) {
 		// create a new test environment
-		env := netemx.MustNewQAEnv(netemx.QAEnvOptionDNSOverUDPResolvers("8.8.8.8"))
+		env := netemx.MustNewQAEnv(netemx.QAEnvOptionNetStack("8.8.8.8", &netemx.UDPResolverFactory{}))
 		defer env.Close()
 
 		// we use the same configuration for all resolvers
@@ -146,7 +146,7 @@ func TestMeasurer_run(t *testing.T) {
 
 	t.Run("with netem: with DNS spoofing: expect to see delayed responses", func(t *testing.T) {
 		// create a new test environment
-		env := netemx.MustNewQAEnv(netemx.QAEnvOptionDNSOverUDPResolvers("8.8.8.8"))
+		env := netemx.MustNewQAEnv(netemx.QAEnvOptionNetStack("8.8.8.8", &netemx.UDPResolverFactory{}))
 		defer env.Close()
 
 		// we use the same configuration for all resolvers

--- a/internal/experiment/webconnectivitylte/qa_test.go
+++ b/internal/experiment/webconnectivitylte/qa_test.go
@@ -1,11 +1,9 @@
 package webconnectivitylte
 
 import (
-	"net"
 	"testing"
 
 	"github.com/ooni/probe-cli/v3/internal/experiment/webconnectivityqa"
-	"github.com/ooni/probe-cli/v3/internal/netemx"
 )
 
 func TestQA(t *testing.T) {
@@ -14,10 +12,7 @@ func TestQA(t *testing.T) {
 			if (tc.Flags & webconnectivityqa.TestCaseFlagNoLTE) != 0 {
 				t.Skip("this nettest cannot run on Web Connectivity LTE")
 			}
-			measurer := NewExperimentMeasurer(&Config{
-				// We override the resolver to use the one we should be using with netem
-				DNSOverUDPResolver: net.JoinHostPort(netemx.DefaultUncensoredResolverAddress, "53"),
-			})
+			measurer := NewExperimentMeasurer(&Config{})
 			if err := webconnectivityqa.RunTestCase(measurer, tc); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/experiment/webconnectivityqa/measurement.go
+++ b/internal/experiment/webconnectivityqa/measurement.go
@@ -27,7 +27,7 @@ func newMeasurement(input string, measurer model.ExperimentMeasurer, t0 time.Tim
 		ProbeNetworkName:          "Consortium GARR",
 		ReportID:                  "",
 		ResolverASN:               "AS137",
-		ResolverIP:                netemx.DefaultISPResolverAddress,
+		ResolverIP:                netemx.ISPResolverAddress,
 		ResolverNetworkName:       "Consortium GARR",
 		SoftwareName:              "ooniprobe",
 		SoftwareVersion:           version.Version,

--- a/internal/experiment/webconnectivityqa/session.go
+++ b/internal/experiment/webconnectivityqa/session.go
@@ -57,7 +57,7 @@ func newSession(client model.HTTPClient, logger model.Logger) model.ExperimentSe
 		MockProxyURL: nil,
 
 		MockResolverIP: func() string {
-			return netemx.DefaultISPResolverAddress
+			return netemx.ISPResolverAddress
 		},
 
 		MockSoftwareName: nil,

--- a/internal/netemx/address.go
+++ b/internal/netemx/address.go
@@ -3,11 +3,11 @@ package netemx
 // DefaultClientAddress is the default client IP address.
 const DefaultClientAddress = "130.192.91.211"
 
-// DefaultISPResolverAddress is the default IP address of the client ISP resolver.
-const DefaultISPResolverAddress = "130.192.3.21"
+// ISPResolverAddress is the IP address of the client ISP resolver.
+const ISPResolverAddress = "130.192.3.21"
 
-// DefaultUncensoredResolverAddress is the default uncensored resolver IP address.
-const DefaultUncensoredResolverAddress = "1.1.1.1"
+// RootResolverAddress is the root resolver resolver IP address.
+const RootResolverAddress = "193.0.14.129"
 
 // AddressApiOONIIo is the IP address for api.ooni.io.
 const AddressApiOONIIo = "162.55.247.208"
@@ -36,8 +36,11 @@ const AddressDNSQuad9Net = "9.9.9.9"
 // AddressMozillaCloudflareDNSCom is the IP address for mozilla.cloudflare-dns.com.
 const AddressMozillaCloudflareDNSCom = "172.64.41.4"
 
-// AddressDNSGoogle is the IP address for dns.google.
-const AddressDNSGoogle = "8.8.4.4"
+// AddressDNSGoogle8844 is the 8.8.4.4 address for dns.google.
+const AddressDNSGoogle8844 = "8.8.4.4"
+
+// AddressDNSGoogle8888 is the 8.8.8.8 address for dns.google.
+const AddressDNSGoogle8888 = "8.8.8.8"
 
 // AddressPublicBlockpage is the IP address we use for modeling a public IP address that is serving
 // blockpages to its users. As of 2023-09-04, this is the IP address resolving for thepiratebay.com when

--- a/internal/netemx/example_test.go
+++ b/internal/netemx/example_test.go
@@ -20,9 +20,9 @@ import (
 // to use this QA environment in all the examples for this package.
 func exampleNewEnvironment() *netemx.QAEnv {
 	return netemx.MustNewQAEnv(
-		netemx.QAEnvOptionDNSOverUDPResolvers("8.8.4.4", "9.9.9.9"),
+		netemx.QAEnvOptionNetStack("8.8.4.4", &netemx.UDPResolverFactory{}),
+		netemx.QAEnvOptionNetStack("9.9.9.9", &netemx.UDPResolverFactory{}),
 		netemx.QAEnvOptionClientAddress(netemx.DefaultClientAddress),
-		netemx.QAEnvOptionISPResolverAddress(netemx.DefaultISPResolverAddress),
 		netemx.QAEnvOptionHTTPServer(
 			netemx.AddressWwwExampleCom, netemx.ExampleWebPageHandlerFactory()),
 		netemx.QAEnvOptionLogger(log.Log),
@@ -252,9 +252,10 @@ func Example_dnsOverUDPWithInternetScenario() {
 
 	env.Do(func() {
 		resolvers := []string{
-			net.JoinHostPort(netemx.DefaultISPResolverAddress, "53"),
-			net.JoinHostPort(netemx.DefaultUncensoredResolverAddress, "53"),
-			net.JoinHostPort(netemx.AddressDNSGoogle, "53"),
+			net.JoinHostPort(netemx.ISPResolverAddress, "53"),
+			net.JoinHostPort(netemx.RootResolverAddress, "53"),
+			net.JoinHostPort(netemx.AddressDNSGoogle8844, "53"),
+			net.JoinHostPort(netemx.AddressDNSGoogle8888, "53"),
 			net.JoinHostPort(netemx.AddressDNSQuad9Net, "53"),
 			net.JoinHostPort(netemx.AddressMozillaCloudflareDNSCom, "53"),
 		}
@@ -274,6 +275,7 @@ func Example_dnsOverUDPWithInternetScenario() {
 	})
 
 	// Output:
+	// [93.184.216.34]
 	// [93.184.216.34]
 	// [93.184.216.34]
 	// [93.184.216.34]

--- a/internal/netemx/netstack.go
+++ b/internal/netemx/netstack.go
@@ -7,6 +7,9 @@ import (
 
 // NetStackServerFactoryEnv is [NetStackServerFactory] view of [*QAEnv].
 type NetStackServerFactoryEnv interface {
+	// ISPResolverConfig returns the configuration used by the ISP's resolver.
+	ISPResolverConfig() *netem.DNSConfig
+
 	// Logger returns the base logger configured for the [*QAEnv].
 	Logger() model.Logger
 

--- a/internal/netemx/scenario.go
+++ b/internal/netemx/scenario.go
@@ -89,9 +89,10 @@ var InternetScenario = []*ScenarioDomainAddresses{{
 	},
 	Role: ScenarioRolePublicDNS,
 }, {
-	Domains: []string{"dns.google"},
+	Domains: []string{"dns.google", "dns.google.com"},
 	Addresses: []string{
-		AddressDNSGoogle,
+		AddressDNSGoogle8844,
+		AddressDNSGoogle8888,
 	},
 	Role: ScenarioRolePublicDNS,
 }, {
@@ -107,9 +108,6 @@ var InternetScenario = []*ScenarioDomainAddresses{{
 // addresses contained by the given [ScenarioDomainAddresses] array.
 func MustNewScenario(config []*ScenarioDomainAddresses) *QAEnv {
 	var opts []QAEnvOption
-
-	// explicitly create the uncensored resolver
-	opts = append(opts, QAEnvOptionDNSOverUDPResolvers(DefaultUncensoredResolverAddress))
 
 	// fill options based on the scenario config
 	for _, sad := range config {

--- a/internal/netemx/udpresolver.go
+++ b/internal/netemx/udpresolver.go
@@ -29,6 +29,15 @@ func (f *UDPResolverFactory) MustNewServer(env NetStackServerFactoryEnv, stack *
 	return udpResolverMustNewServer(env.OtherResolversConfig(), env.Logger(), stack)
 }
 
+type udpResolverFactoryForGetaddrinfo struct{}
+
+var _ NetStackServerFactory = &udpResolverFactoryForGetaddrinfo{}
+
+// MustNewServer implements NetStackServerFactory.
+func (f *udpResolverFactoryForGetaddrinfo) MustNewServer(env NetStackServerFactoryEnv, stack *netem.UNetStack) NetStackServer {
+	return udpResolverMustNewServer(env.ISPResolverConfig(), env.Logger(), stack)
+}
+
 // udpResolverMustNewServer is an internal factory for creating a [NetStackServer] that
 // runs a DNS-over-UDP server using the configured logger, DNS config, and stack.
 func udpResolverMustNewServer(config *netem.DNSConfig, logger model.Logger, stack *netem.UNetStack) NetStackServer {

--- a/internal/netemx/udpresolver_test.go
+++ b/internal/netemx/udpresolver_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestUDPResolverFactory(t *testing.T) {
 	env := MustNewQAEnv(
-		QAEnvOptionNetStack(AddressDNSGoogle, &UDPResolverFactory{}),
+		QAEnvOptionNetStack(AddressDNSGoogle8844, &UDPResolverFactory{}),
 	)
 	defer env.Close()
 
@@ -21,7 +21,7 @@ func TestUDPResolverFactory(t *testing.T) {
 	env.Do(func() {
 		reso := netxlite.NewParallelUDPResolver(
 			log.Log, netxlite.NewDialerWithoutResolver(log.Log),
-			net.JoinHostPort(AddressDNSGoogle, "53"))
+			net.JoinHostPort(AddressDNSGoogle8844, "53"))
 		addrs, err := reso.LookupHost(context.Background(), "www.example.com")
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1803
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [x] if you changed code inside an experiment, make sure you bump its version number: N/A

## Description

This diff removes code to init resolvers that does not use QAEnvOptionNetStack. This change allows us to drop duplicate code that we don't really need (in fact, removing this functionality does not produce a huge diff).

While there, we introduce more resolvers IP addresses, including 8.8.8.8, so we can simplify webconnectivitylte tests.

While there, rename the uncensored root resolver as the root resolver and use the F root resolver address for it.

While there, stop allowing to change the ISP resolver address or the root resolver address (there's no need).


