### PR TITLE
cleanup(netemx): QAEnvOptionHTTPServer is now syntactic sugar

### DIFF
--- a/internal/experiment/webconnectivity/qa_test.go
+++ b/internal/experiment/webconnectivity/qa_test.go
@@ -10,7 +10,7 @@ func TestQA(t *testing.T) {
 	for _, tc := range webconnectivityqa.AllTestCases() {
 		t.Run(tc.Name, func(t *testing.T) {
 			if (tc.Flags & webconnectivityqa.TestCaseFlagNoV04) != 0 {
-				t.Skip("this nettest cannot run on Web Connectivity v0.4")
+				t.Skip("this test case cannot run on Web Connectivity v0.4")
 			}
 			measurer := NewExperimentMeasurer(Config{})
 			if err := webconnectivityqa.RunTestCase(measurer, tc); err != nil {

--- a/internal/experiment/webconnectivitylte/qa_test.go
+++ b/internal/experiment/webconnectivitylte/qa_test.go
@@ -10,7 +10,7 @@ func TestQA(t *testing.T) {
 	for _, tc := range webconnectivityqa.AllTestCases() {
 		t.Run(tc.Name, func(t *testing.T) {
 			if (tc.Flags & webconnectivityqa.TestCaseFlagNoLTE) != 0 {
-				t.Skip("this nettest cannot run on Web Connectivity LTE")
+				t.Skip("this test case cannot run on Web Connectivity LTE")
 			}
 			measurer := NewExperimentMeasurer(&Config{})
 			if err := webconnectivityqa.RunTestCase(measurer, tc); err != nil {

--- a/internal/experiment/webconnectivityqa/tcpblocking.go
+++ b/internal/experiment/webconnectivityqa/tcpblocking.go
@@ -40,8 +40,8 @@ func tcpBlockingConnectTimeout() *TestCase {
 func tcpBlockingConnectionRefusedWithInconsistentDNS() *TestCase {
 	return &TestCase{
 		Name:  "tcpBlockingConnectionRefusedWithInconsistentDNS",
-		Flags: 0,
-		Input: "https://www.example.org/",
+		Flags: TestCaseFlagNoLTE, // with LTE we can bypass the blocking
+		Input: "http://www.example.org/",
 		Configure: func(env *netemx.QAEnv) {
 
 			// spoof the DNS response to force using the server serving blockpages
@@ -57,7 +57,7 @@ func tcpBlockingConnectionRefusedWithInconsistentDNS() *TestCase {
 			env.DPIEngine().AddRule(&netem.DPICloseConnectionForServerEndpoint{
 				Logger:          log.Log,
 				ServerIPAddress: netemx.AddressPublicBlockpage,
-				ServerPort:      443,
+				ServerPort:      80,
 			})
 
 		},

--- a/internal/netemx/example_test.go
+++ b/internal/netemx/example_test.go
@@ -446,7 +446,7 @@ func Example_examplePublicBlockpage() {
 	env.Do(func() {
 		client := netxlite.NewHTTPClientStdlib(log.Log)
 
-		req, err := http.NewRequest("GET", "https://"+netemx.AddressPublicBlockpage+"/", nil)
+		req, err := http.NewRequest("GET", "http://"+netemx.AddressPublicBlockpage+"/", nil)
 		if err != nil {
 			log.Fatalf("http.NewRequest failed: %s", err.Error())
 		}

--- a/internal/netemx/scenario.go
+++ b/internal/netemx/scenario.go
@@ -15,6 +15,9 @@ const (
 
 	// ScenarioRoleOONITestHelper means we should instantiate the oohelperd.
 	ScenarioRoleOONITestHelper
+
+	// ScenarioRoleBlockpageServer means we should serve a blockpage using HTTP.
+	ScenarioRoleBlockpageServer
 )
 
 // ScenarioDomainAddresses describes a domain and address used in a scenario.
@@ -100,7 +103,7 @@ var InternetScenario = []*ScenarioDomainAddresses{{
 	Addresses: []string{
 		AddressPublicBlockpage,
 	},
-	Role:             ScenarioRoleWebServer,
+	Role:             ScenarioRoleBlockpageServer,
 	WebServerFactory: BlockpageHandlerFactory(),
 }}
 
@@ -127,18 +130,7 @@ func MustNewScenario(config []*ScenarioDomainAddresses) *QAEnv {
 
 		case ScenarioRoleWebServer:
 			for _, addr := range sad.Addresses {
-				opts = append(opts, QAEnvOptionNetStack(addr, &HTTPCleartextServerFactory{
-					Factory: sad.WebServerFactory,
-					Ports:   []int{80},
-				}, &HTTPSecureServerFactory{
-					Factory:   sad.WebServerFactory,
-					Ports:     []int{443},
-					TLSConfig: nil, // use netem's default
-				}, &HTTP3ServerFactory{
-					Factory:   sad.WebServerFactory,
-					Ports:     []int{443},
-					TLSConfig: nil, // use netem's default
-				}))
+				opts = append(opts, QAEnvOptionHTTPServer(addr, sad.WebServerFactory))
 			}
 
 		case ScenarioRoleOONIAPI:
@@ -167,6 +159,14 @@ func MustNewScenario(config []*ScenarioDomainAddresses) *QAEnv {
 					},
 					Ports:     []int{443},
 					TLSConfig: nil, // use netem's default
+				}))
+			}
+
+		case ScenarioRoleBlockpageServer:
+			for _, addr := range sad.Addresses {
+				opts = append(opts, QAEnvOptionNetStack(addr, &HTTPCleartextServerFactory{
+					Factory: BlockpageHandlerFactory(),
+					Ports:   []int{80},
 				}))
 			}
 		}

--- a/internal/netemx/web.go
+++ b/internal/netemx/web.go
@@ -80,14 +80,10 @@ const Blockpage = `<!doctype html>
 </html>
 `
 
-// TODO(bassosimone): it is not realistic that this webserver is able to serve valid
-// blockpages over TLS but unfortunately this is currently a netem limitation.
-
 // BlockpageHandlerFactory returns a blockpage regardless of the incoming domain.
 func BlockpageHandlerFactory() HTTPHandlerFactory {
 	return HTTPHandlerFactoryFunc(func(env NetStackServerFactoryEnv, stack *netem.UNetStack) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Add("Alt-Svc", `h3=":443"`)
 			w.Header().Add("Date", "Thu, 24 Aug 2023 14:35:29 GMT")
 			w.Write([]byte(Blockpage))
 		})


### PR DESCRIPTION
With all the changes implemented so far, we're now well positioned to futher cleanup netemx by implementing QAEnvOptionHTTPServer as just syntactic sugar for QAEnvOptionNetStack.

This change allows us to delete more code that is duplicating existing functionality and is not otherwise useful.

While there, introduce a role for a blockpage server and make sure that such a server only listens for HTTP, thus fixing a case in which the behavior of netemx was not consistent with the reality. After this change, we need to skip a QA test for LTE, because LTE is actually able to bypass the block and thus produces accurate webpage content.

Part of https://github.com/ooni/probe/issues/1803.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1803
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [x] if you changed code inside an experiment, make sure you bump its version number: N/A
