### PR TITLE
chore(webconnectivityqa): port tests where the control fails

### DIFF
--- a/QA/webconnectivity.py
+++ b/QA/webconnectivity.py
@@ -47,72 +47,6 @@ def assert_status_flags_are(ooni_exe, tk, desired):
     assert tk["x_status"] == desired
 
 
-def webconnectivity_https_ok_with_control_failure(ooni_exe, outfile):
-    """Successful HTTPS measurement but control failure."""
-    # Note: this QA check will increasingly become more difficult to implement
-    # as we continue to improve our fallback TH strategies
-    args = [
-        "-iptables-reset-keyword",
-        "th.ooni.org",
-        "-iptables-reset-keyword",
-        "d33d1gs9kpq1c5.cloudfront.net",
-    ]
-    tk = execute_jafar_and_return_validated_test_keys(
-        ooni_exe,
-        outfile,
-        "-i https://example.com/ web_connectivity",
-        "webconnectivity_https_ok_with_control_failure",
-        args,
-    )
-    assert tk["dns_experiment_failure"] == None
-    assert tk["dns_consistency"] == None
-    assert "connection_reset" in tk["control_failure"]
-    assert tk["http_experiment_failure"] == None
-    assert tk["body_length_match"] == None
-    assert tk["body_proportion"] == 0
-    assert tk["status_code_match"] == None
-    assert tk["headers_match"] == None
-    assert tk["title_match"] == None
-    if "miniooni" in ooni_exe:
-        assert tk["blocking"] == False
-        assert tk["accessible"] == True
-    else:
-        assert tk["blocking"] == None
-        assert tk["accessible"] == None
-    assert_status_flags_are(ooni_exe, tk, 1)
-
-
-def webconnectivity_http_ok_with_control_failure(ooni_exe, outfile):
-    """Successful HTTP measurement but control failure."""
-    # Note: this QA check will increasingly become more difficult to implement
-    # as we continue to improve our fallback TH strategies
-    args = [
-        "-iptables-reset-keyword",
-        "th.ooni.org",
-        "-iptables-reset-keyword",
-        "d33d1gs9kpq1c5.cloudfront.net",
-    ]
-    tk = execute_jafar_and_return_validated_test_keys(
-        ooni_exe,
-        outfile,
-        "-i http://example.org/ web_connectivity",
-        "webconnectivity_http_ok_with_control_failure",
-        args,
-    )
-    assert tk["dns_experiment_failure"] == None
-    assert tk["dns_consistency"] == None
-    assert "connection_reset" in tk["control_failure"]
-    assert tk["http_experiment_failure"] == None
-    assert tk["body_length_match"] == None
-    assert tk["body_proportion"] == 0
-    assert tk["status_code_match"] == None
-    assert tk["headers_match"] == None
-    assert tk["title_match"] == None
-    assert tk["blocking"] == None
-    assert tk["accessible"] == None
-    assert_status_flags_are(ooni_exe, tk, 8)
-
-
 def webconnectivity_transparent_http_proxy(ooni_exe, outfile):
     """Test case where we pass through a transparent HTTP proxy"""
     args = []
@@ -642,8 +576,6 @@ def main():
     outfile = "webconnectivity.jsonl"
     ooni_exe = sys.argv[1]
     tests = [
-        webconnectivity_https_ok_with_control_failure,
-        webconnectivity_http_ok_with_control_failure,
         webconnectivity_transparent_http_proxy,
         webconnectivity_transparent_https_proxy,
         webconnectivity_dns_hijacking,

--- a/internal/experiment/webconnectivityqa/control.go
+++ b/internal/experiment/webconnectivityqa/control.go
@@ -1,0 +1,98 @@
+package webconnectivityqa
+
+import (
+	"github.com/apex/log"
+	"github.com/ooni/netem"
+	"github.com/ooni/probe-cli/v3/internal/netemx"
+)
+
+// controlFailureWithSuccessfulHTTPWebsite verifies that we correctly handle the case
+// where we cannot reach the control server but the website measurement is OK.
+func controlFailureWithSuccessfulHTTPWebsite() *TestCase {
+	return &TestCase{
+		Name:  "controlFailureWithSuccessfulHTTPWebsite",
+		Flags: TestCaseFlagNoLTE, // BUG: has "consistent" DNS but still blocking=null and accessible=null
+		Input: "http://www.example.org/",
+		Configure: func(env *netemx.QAEnv) {
+
+			env.DPIEngine().AddRule(&netem.DPIResetTrafficForTLSSNI{
+				Logger: log.Log,
+				SNI:    "0.th.ooni.org",
+			})
+
+			env.DPIEngine().AddRule(&netem.DPIResetTrafficForTLSSNI{
+				Logger: log.Log,
+				SNI:    "1.th.ooni.org",
+			})
+
+			env.DPIEngine().AddRule(&netem.DPIResetTrafficForTLSSNI{
+				Logger: log.Log,
+				SNI:    "2.th.ooni.org",
+			})
+
+			env.DPIEngine().AddRule(&netem.DPIResetTrafficForTLSSNI{
+				Logger: log.Log,
+				SNI:    "3.th.ooni.org",
+			})
+
+			env.DPIEngine().AddRule(&netem.DPIResetTrafficForTLSSNI{
+				Logger: log.Log,
+				SNI:    "d33d1gs9kpq1c5.cloudfront.net",
+			})
+
+		},
+		ExpectErr: false,
+		ExpectTestKeys: &testKeys{
+			ControlFailure: "unknown_failure: httpapi: all endpoints failed: [ connection_reset; connection_reset; connection_reset; connection_reset;]",
+			XStatus:        8, // StatusAnomalyControlUnreachable
+			Accessible:     nil,
+			Blocking:       nil,
+		},
+	}
+}
+
+// controlFailureWithSuccessfulHTTPSWebsite verifies that we correctly handle the case
+// where we cannot reach the control server but the website measurement is OK.
+func controlFailureWithSuccessfulHTTPSWebsite() *TestCase {
+	return &TestCase{
+		Name:  "controlFailureWithSuccessfulHTTPSWebsite",
+		Flags: TestCaseFlagNoLTE, // because it (correctly!) sets the DNS as consistent thanks to TLS
+		Input: "https://www.example.org/",
+		Configure: func(env *netemx.QAEnv) {
+
+			env.DPIEngine().AddRule(&netem.DPIResetTrafficForTLSSNI{
+				Logger: log.Log,
+				SNI:    "0.th.ooni.org",
+			})
+
+			env.DPIEngine().AddRule(&netem.DPIResetTrafficForTLSSNI{
+				Logger: log.Log,
+				SNI:    "1.th.ooni.org",
+			})
+
+			env.DPIEngine().AddRule(&netem.DPIResetTrafficForTLSSNI{
+				Logger: log.Log,
+				SNI:    "2.th.ooni.org",
+			})
+
+			env.DPIEngine().AddRule(&netem.DPIResetTrafficForTLSSNI{
+				Logger: log.Log,
+				SNI:    "3.th.ooni.org",
+			})
+
+			env.DPIEngine().AddRule(&netem.DPIResetTrafficForTLSSNI{
+				Logger: log.Log,
+				SNI:    "d33d1gs9kpq1c5.cloudfront.net",
+			})
+
+		},
+		ExpectErr: false,
+		ExpectTestKeys: &testKeys{
+			ControlFailure: "unknown_failure: httpapi: all endpoints failed: [ connection_reset; connection_reset; connection_reset; connection_reset;]",
+			XStatus:        1, // StatusSuccessSecure
+			XNullNullFlags: 8, // analysisFlagNullNullSuccessfulHTTPS
+			Accessible:     true,
+			Blocking:       false,
+		},
+	}
+}

--- a/internal/experiment/webconnectivityqa/control_test.go
+++ b/internal/experiment/webconnectivityqa/control_test.go
@@ -1,0 +1,53 @@
+package webconnectivityqa
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/netemx"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+)
+
+func TestControlFailureWithSuccessfulHTTPWebsite(t *testing.T) {
+	env := netemx.MustNewScenario(netemx.InternetScenario)
+	tc := controlFailureWithSuccessfulHTTPWebsite()
+	tc.Configure(env)
+
+	env.Do(func() {
+		tcpDialer := netxlite.NewDialerWithStdlibResolver(log.Log)
+		tlsHandshaker := netxlite.NewTLSHandshakerStdlib(log.Log)
+		tlsDialer := netxlite.NewTLSDialer(tcpDialer, tlsHandshaker)
+		for _, sni := range []string{"0.th.ooni.org", "1.th.ooni.org", "2.th.ooni.org", "3.th.ooni.org", "d33d1gs9kpq1c5.cloudfront.net"} {
+			conn, err := tlsDialer.DialTLSContext(context.Background(), "tcp", net.JoinHostPort(sni, "443"))
+			if err == nil || err.Error() != netxlite.FailureConnectionReset {
+				t.Fatal("unexpected error", err)
+			}
+			if conn != nil {
+				t.Fatal("expected nil conn")
+			}
+		}
+	})
+}
+
+func TestControlFailureWithSuccessfulHTTPSWebsite(t *testing.T) {
+	env := netemx.MustNewScenario(netemx.InternetScenario)
+	tc := controlFailureWithSuccessfulHTTPSWebsite()
+	tc.Configure(env)
+
+	env.Do(func() {
+		tcpDialer := netxlite.NewDialerWithStdlibResolver(log.Log)
+		tlsHandshaker := netxlite.NewTLSHandshakerStdlib(log.Log)
+		tlsDialer := netxlite.NewTLSDialer(tcpDialer, tlsHandshaker)
+		for _, sni := range []string{"0.th.ooni.org", "1.th.ooni.org", "2.th.ooni.org", "3.th.ooni.org", "d33d1gs9kpq1c5.cloudfront.net"} {
+			conn, err := tlsDialer.DialTLSContext(context.Background(), "tcp", net.JoinHostPort(sni, "443"))
+			if err == nil || err.Error() != netxlite.FailureConnectionReset {
+				t.Fatal("unexpected error", err)
+			}
+			if conn != nil {
+				t.Fatal("expected nil conn")
+			}
+		}
+	})
+}

--- a/internal/experiment/webconnectivityqa/testcase.go
+++ b/internal/experiment/webconnectivityqa/testcase.go
@@ -34,6 +34,9 @@ type TestCase struct {
 // AllTestCases returns all the defined test cases.
 func AllTestCases() []*TestCase {
 	return []*TestCase{
+		controlFailureWithSuccessfulHTTPWebsite(),
+		controlFailureWithSuccessfulHTTPSWebsite(),
+
 		dnsBlockingAndroidDNSCacheNoData(),
 		dnsBlockingNXDOMAIN(),
 

--- a/internal/netemx/address.go
+++ b/internal/netemx/address.go
@@ -30,6 +30,9 @@ const AddressTwoThOONIOrg = "178.62.195.24"
 // AddressThreeThOONIOrg is the IP address for 3.th.ooni.org.
 const AddressThreeThOONIOrg = "209.97.183.73"
 
+// AddressTHCloudfront is the IP address for d33d1gs9kpq1c5.cloudfront.net.
+const AddressTHCloudfront = "52.85.15.84"
+
 // AddressDNSQuad9Net is the IP address for dns.quad9.net.
 const AddressDNSQuad9Net = "9.9.9.9"
 

--- a/internal/netemx/scenario.go
+++ b/internal/netemx/scenario.go
@@ -80,6 +80,12 @@ var InternetScenario = []*ScenarioDomainAddresses{{
 	},
 	Role: ScenarioRoleOONITestHelper,
 }, {
+	Domains: []string{"d33d1gs9kpq1c5.cloudfront.net"},
+	Addresses: []string{
+		AddressTHCloudfront,
+	},
+	Role: ScenarioRoleOONITestHelper,
+}, {
 	Domains: []string{"dns.quad9.net"},
 	Addresses: []string{
 		AddressDNSQuad9Net,


### PR DESCRIPTION
This diff ports the tests where the control fails from Jafar to the new Web Connectivity QA framework.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1803
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [x] if you changed code inside an experiment, make sure you bump its version number: N/A