### PR TITLE
feat(testingx): adapt jafar HTTP proxy

### DIFF
--- a/internal/model/archival_test.go
+++ b/internal/model/archival_test.go
@@ -1,16 +1,17 @@
-package model
+package model_test
 
 import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/testingx"
 )
 
 func TestArchivalExtSpec(t *testing.T) {
 	t.Run("AddTo", func(t *testing.T) {
-		m := &Measurement{}
-		ArchivalExtDNS.AddTo(m)
+		m := &model.Measurement{}
+		model.ArchivalExtDNS.AddTo(m)
 		expected := map[string]int64{"dnst": 0}
 		if d := cmp.Diff(m.Extensions, expected); d != "" {
 			t.Fatal(d)
@@ -56,7 +57,7 @@ func TestMaybeBinaryValue(t *testing.T) {
 		}}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				hb := ArchivalMaybeBinaryData{
+				hb := model.ArchivalMaybeBinaryData{
 					Value: tt.input,
 				}
 				got, err := hb.MarshalJSON()
@@ -109,7 +110,7 @@ func TestMaybeBinaryValue(t *testing.T) {
 		}}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				hb := &ArchivalMaybeBinaryData{}
+				hb := &model.ArchivalMaybeBinaryData{}
 				if err := hb.UnmarshalJSON(tt.input); (err != nil) != tt.wantErr {
 					t.Fatalf("ArchivalMaybeBinaryData.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
 				}
@@ -124,15 +125,15 @@ func TestMaybeBinaryValue(t *testing.T) {
 func TestHTTPHeader(t *testing.T) {
 	t.Run("MarshalJSON", func(t *testing.T) {
 		tests := []struct {
-			name    string             // test name
-			input   ArchivalHTTPHeader // what to marshal
-			want    []byte             // expected data
-			wantErr bool               // whether we expect an error
+			name    string                   // test name
+			input   model.ArchivalHTTPHeader // what to marshal
+			want    []byte                   // expected data
+			wantErr bool                     // whether we expect an error
 		}{{
 			name: "with string value",
-			input: ArchivalHTTPHeader{
+			input: model.ArchivalHTTPHeader{
 				Key: "Content-Type",
-				Value: ArchivalMaybeBinaryData{
+				Value: model.ArchivalMaybeBinaryData{
 					Value: "text/plain",
 				},
 			},
@@ -140,9 +141,9 @@ func TestHTTPHeader(t *testing.T) {
 			wantErr: false,
 		}, {
 			name: "with binary value",
-			input: ArchivalHTTPHeader{
+			input: model.ArchivalHTTPHeader{
 				Key: "Content-Type",
-				Value: ArchivalMaybeBinaryData{
+				Value: model.ArchivalMaybeBinaryData{
 					Value: string(archivalBinaryInput),
 				},
 			},
@@ -164,40 +165,40 @@ func TestHTTPHeader(t *testing.T) {
 
 	t.Run("UnmarshalJSON", func(t *testing.T) {
 		tests := []struct {
-			name    string             // test name
-			input   []byte             // input for the test
-			want    ArchivalHTTPHeader // expected output
-			wantErr bool               // whether we want an error
+			name    string                   // test name
+			input   []byte                   // input for the test
+			want    model.ArchivalHTTPHeader // expected output
+			wantErr bool                     // whether we want an error
 		}{{
 			name:  "with invalid input",
 			input: []byte(`{}`),
-			want: ArchivalHTTPHeader{
+			want: model.ArchivalHTTPHeader{
 				Key:   "",
-				Value: ArchivalMaybeBinaryData{Value: ""},
+				Value: model.ArchivalMaybeBinaryData{Value: ""},
 			},
 			wantErr: true,
 		}, {
 			name:  "with unexpected number of items",
 			input: []byte(`[]`),
-			want: ArchivalHTTPHeader{
+			want: model.ArchivalHTTPHeader{
 				Key:   "",
-				Value: ArchivalMaybeBinaryData{Value: ""},
+				Value: model.ArchivalMaybeBinaryData{Value: ""},
 			},
 			wantErr: true,
 		}, {
 			name:  "with first item not being a string",
 			input: []byte(`[0,0]`),
-			want: ArchivalHTTPHeader{
+			want: model.ArchivalHTTPHeader{
 				Key:   "",
-				Value: ArchivalMaybeBinaryData{Value: ""},
+				Value: model.ArchivalMaybeBinaryData{Value: ""},
 			},
 			wantErr: true,
 		}, {
 			name:  "with both items being a string",
 			input: []byte(`["x","y"]`),
-			want: ArchivalHTTPHeader{
+			want: model.ArchivalHTTPHeader{
 				Key: "x",
-				Value: ArchivalMaybeBinaryData{
+				Value: model.ArchivalMaybeBinaryData{
 					Value: "y",
 				},
 			},
@@ -205,9 +206,9 @@ func TestHTTPHeader(t *testing.T) {
 		}, {
 			name:  "with second item not being a map[string]interface{}",
 			input: []byte(`["x",[]]`),
-			want: ArchivalHTTPHeader{
+			want: model.ArchivalHTTPHeader{
 				Key: "",
-				Value: ArchivalMaybeBinaryData{
+				Value: model.ArchivalMaybeBinaryData{
 					Value: "",
 				},
 			},
@@ -215,9 +216,9 @@ func TestHTTPHeader(t *testing.T) {
 		}, {
 			name:  "with missing format key in second item",
 			input: []byte(`["x",{}]`),
-			want: ArchivalHTTPHeader{
+			want: model.ArchivalHTTPHeader{
 				Key: "",
-				Value: ArchivalMaybeBinaryData{
+				Value: model.ArchivalMaybeBinaryData{
 					Value: "",
 				},
 			},
@@ -225,9 +226,9 @@ func TestHTTPHeader(t *testing.T) {
 		}, {
 			name:  "with format value not being base64",
 			input: []byte(`["x",{"format":1}]`),
-			want: ArchivalHTTPHeader{
+			want: model.ArchivalHTTPHeader{
 				Key: "",
-				Value: ArchivalMaybeBinaryData{
+				Value: model.ArchivalMaybeBinaryData{
 					Value: "",
 				},
 			},
@@ -235,9 +236,9 @@ func TestHTTPHeader(t *testing.T) {
 		}, {
 			name:  "with missing data field",
 			input: []byte(`["x",{"format":"base64"}]`),
-			want: ArchivalHTTPHeader{
+			want: model.ArchivalHTTPHeader{
 				Key: "",
-				Value: ArchivalMaybeBinaryData{
+				Value: model.ArchivalMaybeBinaryData{
 					Value: "",
 				},
 			},
@@ -245,9 +246,9 @@ func TestHTTPHeader(t *testing.T) {
 		}, {
 			name:  "with data not being a string",
 			input: []byte(`["x",{"format":"base64","data":1}]`),
-			want: ArchivalHTTPHeader{
+			want: model.ArchivalHTTPHeader{
 				Key: "",
-				Value: ArchivalMaybeBinaryData{
+				Value: model.ArchivalMaybeBinaryData{
 					Value: "",
 				},
 			},
@@ -255,9 +256,9 @@ func TestHTTPHeader(t *testing.T) {
 		}, {
 			name:  "with data not being base64",
 			input: []byte(`["x",{"format":"base64","data":"xx"}]`),
-			want: ArchivalHTTPHeader{
+			want: model.ArchivalHTTPHeader{
 				Key: "",
-				Value: ArchivalMaybeBinaryData{
+				Value: model.ArchivalMaybeBinaryData{
 					Value: "",
 				},
 			},
@@ -265,9 +266,9 @@ func TestHTTPHeader(t *testing.T) {
 		}, {
 			name:  "with correctly encoded base64 data",
 			input: []byte(`["x",` + string(archivalEncodedBinaryInput) + `]`),
-			want: ArchivalHTTPHeader{
+			want: model.ArchivalHTTPHeader{
 				Key: "x",
-				Value: ArchivalMaybeBinaryData{
+				Value: model.ArchivalMaybeBinaryData{
 					Value: string(archivalBinaryInput),
 				},
 			},
@@ -275,7 +276,7 @@ func TestHTTPHeader(t *testing.T) {
 		}}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				hh := &ArchivalHTTPHeader{}
+				hh := &model.ArchivalHTTPHeader{}
 				if err := hh.UnmarshalJSON(tt.input); (err != nil) != tt.wantErr {
 					t.Fatalf("ArchivalHTTPHeader.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
 				}
@@ -300,10 +301,10 @@ func TestHTTPBody(t *testing.T) {
 	// However, cmp.Diff also takes into account the data type. Hence, if
 	// we make a mistake and apply the above change (which will in turn
 	// break correct JSON serialization), the this test will fail.
-	var body ArchivalHTTPBody
+	var body model.ArchivalHTTPBody
 	ff := &testingx.FakeFiller{}
 	ff.Fill(&body)
-	data := ArchivalMaybeBinaryData(body)
+	data := model.ArchivalMaybeBinaryData(body)
 	if diff := cmp.Diff(body, data); diff != "" {
 		t.Fatal(diff)
 	}

--- a/internal/testingx/httptestx.go
+++ b/internal/testingx/httptestx.go
@@ -3,10 +3,12 @@ package testingx
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
 
+	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/optional"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
@@ -157,4 +159,71 @@ func httpHandlerHijack(w http.ResponseWriter, r *http.Request, policy string) {
 	case "eof":
 		// nothing
 	}
+}
+
+// TODO(bassosimone): eventually we may want to have a model type
+// that models the equivalent of [netxlite.Netx].
+
+// HTTPHandlerProxyNetx is [netxlite.Netx] as seen by [HTTPHandlerProxy].
+type HTTPHandlerProxyNetx interface {
+	NewHTTPTransportStdlib(logger model.DebugLogger) model.HTTPTransport
+}
+
+// HTTPHandlerProxy is a handler implementing an HTTP proxy using the host header
+// to determine who to connect to. We additionally use the via header to avoid sending
+// requests to ourself. Please, note that we designed this proxy ONLY to be used for
+// testing purposes and that it's rather simplistic.
+func HTTPHandlerProxy(logger model.Logger, netx HTTPHandlerProxyNetx) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// reject requests that already visited the proxy and requests we cannot route
+		if req.Host == "" || req.Header.Get("Via") != "" {
+			rw.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		// be explicit about not supporting request bodies
+		if req.Method != http.MethodGet {
+			rw.WriteHeader(http.StatusNotImplemented)
+			return
+		}
+
+		// clone the request before modifying it
+		req = req.Clone(req.Context())
+
+		// include proxy header to prevent sending requests to ourself
+		req.Header.Add("Via", "testingx/0.1.0")
+
+		// fix: "http: Request.RequestURI can't be set in client requests"
+		req.RequestURI = ""
+
+		// fix: `http: unsupported protocol scheme ""`
+		req.URL.Host = req.Host
+
+		// fix: "http: no Host in request URL"
+		req.URL.Scheme = "http"
+
+		logger.Debugf("PROXY: sending request: %s", req)
+
+		// create HTTP client using netx
+		txp := netx.NewHTTPTransportStdlib(logger)
+
+		// obtain response
+		resp, err := txp.RoundTrip(req)
+		if err != nil {
+			logger.Warnf("PROXY: request failed: %s", err.Error())
+			rw.WriteHeader(http.StatusBadGateway)
+			return
+		}
+
+		// write response
+		rw.WriteHeader(resp.StatusCode)
+		for key, values := range resp.Header {
+			for _, value := range values {
+				rw.Header().Add(key, value)
+			}
+		}
+
+		// write response body
+		_, _ = io.Copy(rw, resp.Body)
+	})
 }

--- a/internal/testingx/httptestx_test.go
+++ b/internal/testingx/httptestx_test.go
@@ -10,12 +10,15 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
 	"github.com/apex/log"
 	"github.com/google/go-cmp/cmp"
 	"github.com/ooni/netem"
+	"github.com/ooni/probe-cli/v3/internal/mocks"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 	"github.com/ooni/probe-cli/v3/internal/testingx"
@@ -466,4 +469,199 @@ func TestHTTPTestxWithNetem(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestHTTPHandlerProxy(t *testing.T) {
+	expectedBody := []byte("Google is built by a large team of engineers, designers, researchers, robots, and others in many different sites across the globe. It is updated continuously, and built with more tools and technologies than we can shake a stick at. If you'd like to help us out, see careers.google.com.\n")
+
+	type testcase struct {
+		name      string
+		construct func() (*netxlite.Netx, string, []io.Closer)
+		short     bool
+	}
+
+	testcases := []testcase{
+		{
+			name: "using the real network",
+			construct: func() (*netxlite.Netx, string, []io.Closer) {
+				var closers []io.Closer
+
+				netx := &netxlite.Netx{
+					Underlying: nil, // so we're using the real network
+				}
+
+				proxyServer := testingx.MustNewHTTPServer(testingx.HTTPHandlerProxy(log.Log, netx))
+				closers = append(closers, proxyServer)
+
+				return netx, proxyServer.URL, closers
+			},
+			short: false,
+		},
+
+		{
+			name: "using netem",
+			construct: func() (*netxlite.Netx, string, []io.Closer) {
+				var closers []io.Closer
+
+				topology := runtimex.Try1(netem.NewStarTopology(log.Log))
+				closers = append(closers, topology)
+
+				wwwStack := runtimex.Try1(topology.AddHost("142.251.209.14", "142.251.209.14", &netem.LinkConfig{}))
+				proxyStack := runtimex.Try1(topology.AddHost("10.0.0.1", "142.251.209.14", &netem.LinkConfig{}))
+				clientStack := runtimex.Try1(topology.AddHost("10.0.0.2", "142.251.209.14", &netem.LinkConfig{}))
+
+				dnsConfig := netem.NewDNSConfig()
+				dnsConfig.AddRecord("www.google.com", "", "142.251.209.14")
+				dnsServer := runtimex.Try1(netem.NewDNSServer(log.Log, wwwStack, "142.251.209.14", dnsConfig))
+				closers = append(closers, dnsServer)
+
+				wwwServer := testingx.MustNewHTTPServerEx(
+					&net.TCPAddr{IP: net.IPv4(142, 251, 209, 14), Port: 80},
+					wwwStack,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.Write(expectedBody)
+					}),
+				)
+				closers = append(closers, wwwServer)
+
+				proxyServer := testingx.MustNewHTTPServerEx(
+					&net.TCPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 80},
+					proxyStack,
+					testingx.HTTPHandlerProxy(log.Log, &netxlite.Netx{
+						Underlying: &netxlite.NetemUnderlyingNetworkAdapter{UNet: proxyStack},
+					}),
+				)
+				closers = append(closers, proxyServer)
+
+				clientNet := &netxlite.Netx{Underlying: &netxlite.NetemUnderlyingNetworkAdapter{UNet: clientStack}}
+				return clientNet, proxyServer.URL, closers
+			},
+			short: true,
+		}}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !tc.short && testing.Short() {
+				t.Skip("skip test in short mode")
+			}
+
+			netx, proxyURL, closers := tc.construct()
+			defer func() {
+				for _, closer := range closers {
+					closer.Close()
+				}
+			}()
+
+			URL := runtimex.Try1(url.Parse(proxyURL))
+			URL.Path = "/humans.txt"
+
+			req := runtimex.Try1(http.NewRequest("GET", URL.String(), nil))
+			req.Host = "www.google.com"
+
+			//log.SetLevel(log.DebugLevel)
+
+			txp := netx.NewHTTPTransportStdlib(log.Log)
+			client := netxlite.NewHTTPClient(txp)
+
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != 200 {
+				t.Fatal("expected to see 200, got", resp.StatusCode)
+			}
+
+			t.Logf("%+v", resp)
+
+			body, err := netxlite.ReadAllContext(req.Context(), resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			t.Logf("%s", string(body))
+
+			if diff := cmp.Diff(expectedBody, body); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+
+	t.Run("rejects requests without a host header", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		netx := &netxlite.Netx{Underlying: &mocks.UnderlyingNetwork{
+			// all nil: panic if we hit the network
+		}}
+		handler := testingx.HTTPHandlerProxy(log.Log, netx)
+		req := &http.Request{
+			Host: "", // explicitly empty
+		}
+		handler.ServeHTTP(rr, req)
+		res := rr.Result()
+		if res.StatusCode != http.StatusBadRequest {
+			t.Fatal("unexpected status code", res.StatusCode)
+		}
+	})
+
+	t.Run("rejects requests with a via header", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		netx := &netxlite.Netx{Underlying: &mocks.UnderlyingNetwork{
+			// all nil: panic if we hit the network
+		}}
+		handler := testingx.HTTPHandlerProxy(log.Log, netx)
+		req := &http.Request{
+			Host: "www.example.com",
+			Header: http.Header{
+				"Via": {"antani/0.1.0"},
+			},
+		}
+		handler.ServeHTTP(rr, req)
+		res := rr.Result()
+		if res.StatusCode != http.StatusBadRequest {
+			t.Fatal("unexpected status code", res.StatusCode)
+		}
+	})
+
+	t.Run("rejects requests with a POST method", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		netx := &netxlite.Netx{Underlying: &mocks.UnderlyingNetwork{
+			// all nil: panic if we hit the network
+		}}
+		handler := testingx.HTTPHandlerProxy(log.Log, netx)
+		req := &http.Request{
+			Host:   "www.example.com",
+			Header: http.Header{},
+			Method: http.MethodPost,
+		}
+		handler.ServeHTTP(rr, req)
+		res := rr.Result()
+		if res.StatusCode != http.StatusNotImplemented {
+			t.Fatal("unexpected status code", res.StatusCode)
+		}
+	})
+
+	t.Run("returns 502 when the round trip fails", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		netx := &netxlite.Netx{Underlying: &mocks.UnderlyingNetwork{
+			MockGetaddrinfoLookupANY: func(ctx context.Context, domain string) ([]string, string, error) {
+				return nil, "", errors.New("mocked error")
+			},
+			MockGetaddrinfoResolverNetwork: func() string {
+				return "antani"
+			},
+		}}
+		handler := testingx.HTTPHandlerProxy(log.Log, netx)
+		req := &http.Request{
+			Host:   "www.example.com",
+			Header: http.Header{},
+			Method: http.MethodGet,
+			URL:    &url.URL{},
+		}
+		handler.ServeHTTP(rr, req)
+		res := rr.Result()
+		if res.StatusCode != http.StatusBadGateway {
+			t.Fatal("unexpected status code", res.StatusCode)
+		}
+	})
 }

--- a/internal/testingx/tlsx_internal_test.go
+++ b/internal/testingx/tlsx_internal_test.go
@@ -1,0 +1,71 @@
+package testingx
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ooni/probe-cli/v3/internal/mocks"
+)
+
+func TestTLSHandlerTimeoutWithShortTimeout(t *testing.T) {
+	thx := &tlsHandlerTimeout{
+		timeout: 250 * time.Microsecond,
+	}
+	conn := &mocks.Conn{
+		MockClose: func() error {
+			return nil
+		},
+	}
+	cert, err := thx.GetCertificate(context.Background(), conn, &tls.ClientHelloInfo{})
+	if err == nil || err.Error() != "internal error" {
+		t.Fatal("unexpected error", err)
+	}
+	if cert != nil {
+		t.Fatal("expected nil cert")
+	}
+}
+
+func TestTLSServerMainLoopTransientError(t *testing.T) {
+	called := &atomic.Bool{}
+	tlx := &TLSServer{
+		cancel: func() {
+			// nothing to do here
+		},
+		closeOnce: sync.Once{},
+		endpoint:  "10.0.0.1:443",
+		handler:   nil, // not used
+		listener: &mocks.Listener{
+			MockAccept: func() (net.Conn, error) {
+				if called.Load() {
+					return nil, net.ErrClosed
+				}
+				called.Store(true)
+				return nil, errors.New("mocked error")
+			},
+			MockClose: func() error {
+				return nil
+			},
+			MockAddr: func() net.Addr {
+				return &mocks.Addr{
+					MockString: func() string {
+						return "10.0.0.1:443"
+					},
+					MockNetwork: func() string {
+						return "tcp"
+					},
+				}
+			},
+		},
+		wg: sync.WaitGroup{},
+	}
+
+	tlx.wg.Add(1)
+	go tlx.mainloop(context.Background())
+	tlx.wg.Wait()
+}

--- a/script/nocopyreadall.bash
+++ b/script/nocopyreadall.bash
@@ -33,6 +33,12 @@ for file in $(find . -type f -name \*.go); do
 		continue
 	fi
 
+	if [ "$file" = "./internal/testingx/httptestx.go" ]; then
+		# We're allowed to use ReadAll and Copy in this file because
+		# it's code that we only use for testing purposes.
+		continue
+	fi
+
 	if [ "$file" = "./internal/testingx/httptestx_test.go" ]; then
 		# We're allowed to use ReadAll and Copy in this file because
 		# it's code that we only use for testing purposes.


### PR DESCRIPTION


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1803
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [x] if you changed code inside an experiment, make sure you bump its version number: N/A

## Description

This diff adapts jafar HTTP proxy to be a testingx proxy.

We need this work to eventually get rid of jafar.

