### PR TITLE
feat(webconnectivityqa): start adapting test cases with redirects

### DIFF
--- a/QA/webconnectivity.py
+++ b/QA/webconnectivity.py
@@ -47,102 +47,6 @@ def assert_status_flags_are(ooni_exe, tk, desired):
     assert tk["x_status"] == desired
 
 
-def webconnectivity_http_connection_refused_with_consistent_dns(ooni_exe, outfile):
-    """Test case where there's TCP/IP blocking w/ consistent DNS that occurs
-    while we're following the chain of redirects."""
-    # We use a bit.ly link redirecting to nexa.polito.it. We block the IP address
-    # used by nexa.polito.it. So the error should happen in the redirect chain.
-    ip = socket.gethostbyname("nexa.polito.it")
-    args = [
-        "-iptables-reset-ip",
-        ip,
-    ]
-    tk = execute_jafar_and_return_validated_test_keys(
-        ooni_exe,
-        outfile,
-        "-i https://bit.ly/3h9EJR3 web_connectivity",
-        "webconnectivity_http_connection_refused_with_consistent_dns",
-        args,
-    )
-    assert tk["dns_experiment_failure"] == None
-    assert tk["dns_consistency"] == "consistent"
-    assert tk["control_failure"] == None
-    assert tk["http_experiment_failure"] == "connection_refused"
-    assert tk["body_length_match"] == None
-    assert tk["body_proportion"] == 0
-    assert tk["status_code_match"] == None
-    assert tk["headers_match"] == None
-    assert tk["title_match"] == None
-    assert tk["blocking"] == "http-failure"
-    assert tk["accessible"] == False
-    assert_status_flags_are(ooni_exe, tk, 8320)
-
-
-def webconnectivity_http_connection_reset_with_consistent_dns(ooni_exe, outfile):
-    """Test case where there's RST-based blocking blocking w/ consistent DNS that
-    occurs while we're following the chain of redirects."""
-    # We use a bit.ly link redirecting to nexa.polito.it. We block the Host header
-    # used for nexa.polito.it. So the error should happen in the redirect chain.
-    args = [
-        "-iptables-reset-keyword",
-        "Host: nexa",
-    ]
-    tk = execute_jafar_and_return_validated_test_keys(
-        ooni_exe,
-        outfile,
-        "-i https://bit.ly/3h9EJR3 web_connectivity",
-        "webconnectivity_http_connection_reset_with_consistent_dns",
-        args,
-    )
-    assert tk["dns_experiment_failure"] == None
-    assert tk["dns_consistency"] == "consistent"
-    assert tk["control_failure"] == None
-    assert tk["http_experiment_failure"] == "connection_reset"
-    assert tk["body_length_match"] == None
-    assert tk["body_proportion"] == 0
-    assert tk["status_code_match"] == None
-    assert tk["headers_match"] == None
-    assert tk["title_match"] == None
-    assert tk["blocking"] == "http-failure"
-    assert tk["accessible"] == False
-    assert_status_flags_are(ooni_exe, tk, 8448)
-
-
-def webconnectivity_http_nxdomain_with_consistent_dns(ooni_exe, outfile):
-    """Test case where there's a redirection and the redirected request cannot
-    continue because a NXDOMAIN error occurs."""
-    # We use a bit.ly link redirecting to nexa.polito.it. We block the DNS request
-    # for nexa.polito.it. So the error should happen in the redirect chain.
-    args = [
-        "-iptables-hijack-dns-to",
-        "127.0.0.1:53",
-        "-dns-proxy-block",
-        "nexa.polito.it",
-    ]
-    tk = execute_jafar_and_return_validated_test_keys(
-        ooni_exe,
-        outfile,
-        "-i https://bit.ly/3h9EJR3 web_connectivity",
-        "webconnectivity_http_nxdomain_with_consistent_dns",
-        args,
-    )
-    assert tk["dns_experiment_failure"] == None
-    assert tk["dns_consistency"] == "consistent"
-    assert tk["control_failure"] == None
-    assert (
-        tk["http_experiment_failure"] == "dns_nxdomain_error"  # miniooni
-        or tk["http_experiment_failure"] == "dns_lookup_error"  # MK
-    )
-    assert tk["body_length_match"] == None
-    assert tk["body_proportion"] == 0
-    assert tk["status_code_match"] == None
-    assert tk["headers_match"] == None
-    assert tk["title_match"] == None
-    assert tk["blocking"] == "dns"
-    assert tk["accessible"] == False
-    assert_status_flags_are(ooni_exe, tk, 8224)
-
-
 def webconnectivity_http_eof_error_with_consistent_dns(ooni_exe, outfile):
     """Test case where there's a redirection and the redirected request cannot
     continue because an eof_error error occurs."""
@@ -496,9 +400,6 @@ def main():
     outfile = "webconnectivity.jsonl"
     ooni_exe = sys.argv[1]
     tests = [
-        webconnectivity_http_connection_refused_with_consistent_dns,
-        webconnectivity_http_connection_reset_with_consistent_dns,
-        webconnectivity_http_nxdomain_with_consistent_dns,
         webconnectivity_http_eof_error_with_consistent_dns,
         webconnectivity_http_generic_timeout_error_with_consistent_dns,
         webconnectivity_http_connection_reset_with_inconsistent_dns,

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/montanaflynn/stats v0.7.1
 	github.com/ooni/go-libtor v1.1.8
-	github.com/ooni/netem v0.0.0-20230825114658-42ca83ac5cbc
+	github.com/ooni/netem v0.0.0-20230905212743-4889f9501fcf
 	github.com/ooni/oocrypto v0.5.3
 	github.com/ooni/oohttp v0.6.3
 	github.com/ooni/probe-assets v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -483,8 +483,8 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.27.7 h1:fVih9JD6ogIiHUN6ePK7HJidyEDpWGVB5mzM7cWNXoU=
 github.com/ooni/go-libtor v1.1.8 h1:Wo3V3DVTxl5vZdxtQakqYP+DAHx7pPtAFSl1bnAa08w=
 github.com/ooni/go-libtor v1.1.8/go.mod h1:q1YyLwRD9GeMyeerVvwc0vJ2YgwDLTp2bdVcrh/JXyI=
-github.com/ooni/netem v0.0.0-20230825114658-42ca83ac5cbc h1:SPkk1q5A/3n0KmVVp1h0BcMZCPYqlgQOANAOnzuNeqI=
-github.com/ooni/netem v0.0.0-20230825114658-42ca83ac5cbc/go.mod h1:3LJOzTIu2O4ADDJN2ILG4ViJOqyH/u9fKY8QT2Rma8Y=
+github.com/ooni/netem v0.0.0-20230905212743-4889f9501fcf h1:dkrCLZASi2HCcAT1TLNFX+EpONGEeYt5VIZKj88aVZU=
+github.com/ooni/netem v0.0.0-20230905212743-4889f9501fcf/go.mod h1:3LJOzTIu2O4ADDJN2ILG4ViJOqyH/u9fKY8QT2Rma8Y=
 github.com/ooni/oocrypto v0.5.3 h1:CAb0Ze6q/EWD1PRGl9KqpzMfkut4O3XMaiKYsyxrWOs=
 github.com/ooni/oocrypto v0.5.3/go.mod h1:HjEQ5pQBl6btcWgAsKKq1tFo8CfBrZu63C/vPAUGIDk=
 github.com/ooni/oohttp v0.6.3 h1:MHydpeAPU/LSDSI/hIFJwZm4afBhd2Yo+rNxxFdeMCY=

--- a/internal/experiment/webconnectivityqa/dnshijacking_test.go
+++ b/internal/experiment/webconnectivityqa/dnshijacking_test.go
@@ -1,0 +1,52 @@
+package webconnectivityqa
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/probe-cli/v3/internal/netemx"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+)
+
+func TestDNSHijackingTestCases(t *testing.T) {
+	testcases := []*TestCase{
+		dnsHijackingToProxyWithHTTPURL(),
+		dnsHijackingToProxyWithHTTPSURL(),
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			env := netemx.MustNewScenario(netemx.InternetScenario)
+			tc.Configure(env)
+
+			env.Do(func() {
+				expect := []string{netemx.ISPProxyAddress}
+
+				t.Run("with stdlib resolver", func(t *testing.T) {
+					reso := netxlite.NewStdlibResolver(log.Log)
+					addrs, err := reso.LookupHost(context.Background(), "www.example.com")
+					if err != nil {
+						t.Fatal(err)
+					}
+					if diff := cmp.Diff(expect, addrs); diff != "" {
+						t.Fatal(diff)
+					}
+				})
+
+				t.Run("with UDP resolver", func(t *testing.T) {
+					d := netxlite.NewDialerWithoutResolver(log.Log)
+					reso := netxlite.NewParallelUDPResolver(log.Log, d, "8.8.8.8:53")
+					addrs, err := reso.LookupHost(context.Background(), "www.example.com")
+					if err != nil {
+						t.Fatal(err)
+					}
+					if diff := cmp.Diff(expect, addrs); diff != "" {
+						t.Fatal(diff)
+					}
+				})
+			})
+		})
+	}
+}

--- a/internal/experiment/webconnectivityqa/redirect.go
+++ b/internal/experiment/webconnectivityqa/redirect.go
@@ -1,0 +1,190 @@
+package webconnectivityqa
+
+import (
+	"github.com/apex/log"
+	"github.com/ooni/netem"
+	"github.com/ooni/probe-cli/v3/internal/netemx"
+)
+
+// redirectWithConsistentDNSAndThenConnectionRefusedForHTTP is a scenario where the redirect
+// works but then there's connection refused for an HTTP URL.
+func redirectWithConsistentDNSAndThenConnectionRefusedForHTTP() *TestCase {
+	return &TestCase{
+		Name:  "redirectWithConsistentDNSAndThenConnectionRefusedForHTTP",
+		Flags: TestCaseFlagNoLTE, // BUG: LTE thinks this website is accessible (WTF?!)
+		Input: "https://bit.ly/32447",
+		Configure: func(env *netemx.QAEnv) {
+
+			// make sure we cannot connect to the example domain on port 80
+			env.DPIEngine().AddRule(&netem.DPICloseConnectionForServerEndpoint{
+				Logger:          log.Log,
+				ServerIPAddress: netemx.AddressWwwExampleCom,
+				ServerPort:      80,
+			})
+
+			// make sure we cannot connect to the example domain on port 443
+			env.DPIEngine().AddRule(&netem.DPICloseConnectionForServerEndpoint{
+				Logger:          log.Log,
+				ServerIPAddress: netemx.AddressWwwExampleCom,
+				ServerPort:      443,
+			})
+
+		},
+		ExpectErr: false,
+		ExpectTestKeys: &testKeys{
+			DNSExperimentFailure:  nil,
+			DNSConsistency:        "consistent",
+			HTTPExperimentFailure: "connection_refused",
+			XStatus:               8320, // StatusExperimentHTTP | StatusAnomalyConnect
+			XDNSFlags:             0,
+			XBlockingFlags:        32, // analysisFlagSuccess
+			Accessible:            false,
+			Blocking:              "http-failure",
+		},
+	}
+}
+
+// redirectWithConsistentDNSAndThenConnectionRefusedForHTTPS is a scenario where the redirect
+// works but then there's connection refused for an HTTPS URL.
+func redirectWithConsistentDNSAndThenConnectionRefusedForHTTPS() *TestCase {
+	return &TestCase{
+		Name:  "redirectWithConsistentDNSAndThenConnectionRefusedForHTTPS",
+		Flags: TestCaseFlagNoLTE, // BUG: LTE thinks this website is accessible (WTF?!)
+		Input: "https://bit.ly/21645",
+		Configure: func(env *netemx.QAEnv) {
+
+			// make sure we cannot connect to the example domain on port 80
+			env.DPIEngine().AddRule(&netem.DPICloseConnectionForServerEndpoint{
+				Logger:          log.Log,
+				ServerIPAddress: netemx.AddressWwwExampleCom,
+				ServerPort:      80,
+			})
+
+			// make sure we cannot connect to the example domain on port 443
+			env.DPIEngine().AddRule(&netem.DPICloseConnectionForServerEndpoint{
+				Logger:          log.Log,
+				ServerIPAddress: netemx.AddressWwwExampleCom,
+				ServerPort:      443,
+			})
+
+		},
+		ExpectErr: false,
+		ExpectTestKeys: &testKeys{
+			DNSExperimentFailure:  nil,
+			DNSConsistency:        "consistent",
+			HTTPExperimentFailure: "connection_refused",
+			XStatus:               8320, // StatusExperimentHTTP | StatusAnomalyConnect
+			XDNSFlags:             0,
+			XBlockingFlags:        32, // analysisFlagSuccess
+			Accessible:            false,
+			Blocking:              "http-failure",
+		},
+	}
+}
+
+// redirectWithConsistentDNSAndThenConnectionResetForHTTP is a scenario where the redirect
+// works but then there's connection refused for an HTTP URL.
+func redirectWithConsistentDNSAndThenConnectionResetForHTTP() *TestCase {
+	return &TestCase{
+		Name:  "redirectWithConsistentDNSAndThenConnectionResetForHTTP",
+		Flags: 0,
+		Input: "https://bit.ly/32447",
+		Configure: func(env *netemx.QAEnv) {
+
+			// make sure we cannot HTTP round trip
+			env.DPIEngine().AddRule(&netem.DPIResetTrafficForString{
+				Logger:          log.Log,
+				ServerIPAddress: netemx.AddressWwwExampleCom,
+				ServerPort:      80,
+				String:          "www.example.com",
+			})
+
+			// make sure we cannot TLS handshake
+			env.DPIEngine().AddRule(&netem.DPIResetTrafficForTLSSNI{
+				Logger: log.Log,
+				SNI:    "www.example.com",
+			})
+
+		},
+		ExpectErr: false,
+		ExpectTestKeys: &testKeys{
+			DNSExperimentFailure:  nil,
+			DNSConsistency:        "consistent",
+			HTTPExperimentFailure: "connection_reset",
+			XStatus:               8448, // StatusExperimentHTTP | StatusAnomalyReadWrite
+			XDNSFlags:             0,
+			XBlockingFlags:        8, // analysisFlagHTTPBlocking
+			Accessible:            false,
+			Blocking:              "http-failure",
+		},
+	}
+}
+
+// redirectWithConsistentDNSAndThenConnectionResetForHTTPS is a scenario where the redirect
+// works but then there's connection refused for an HTTPS URL.
+func redirectWithConsistentDNSAndThenConnectionResetForHTTPS() *TestCase {
+	return &TestCase{
+		Name:  "redirectWithConsistentDNSAndThenConnectionResetForHTTPS",
+		Flags: TestCaseFlagNoLTE, // BUG: LTE thinks this website is accessible (WTF?!)
+		Input: "https://bit.ly/21645",
+		Configure: func(env *netemx.QAEnv) {
+
+			// make sure we cannot HTTP round trip
+			env.DPIEngine().AddRule(&netem.DPIResetTrafficForString{
+				Logger:          log.Log,
+				ServerIPAddress: netemx.AddressWwwExampleCom,
+				ServerPort:      80,
+				String:          "www.example.com",
+			})
+
+			// make sure we cannot TLS handshake
+			env.DPIEngine().AddRule(&netem.DPIResetTrafficForTLSSNI{
+				Logger: log.Log,
+				SNI:    "www.example.com",
+			})
+
+		},
+		ExpectErr: false,
+		ExpectTestKeys: &testKeys{
+			DNSExperimentFailure:  nil,
+			DNSConsistency:        "consistent",
+			HTTPExperimentFailure: "connection_reset",
+			XStatus:               8448, // StatusExperimentHTTP | StatusAnomalyReadWrite
+			XDNSFlags:             0,
+			XBlockingFlags:        8, // analysisFlagHTTPBlocking
+			Accessible:            false,
+			Blocking:              "http-failure",
+		},
+	}
+}
+
+// redirectWithConsistentDNSAndThenNXDOMAIN is a scenario where the redirect
+// works but then there's NXDOMAIN for the URL's domain
+func redirectWithConsistentDNSAndThenNXDOMAIN() *TestCase {
+	return &TestCase{
+		Name:  "redirectWithConsistentDNSAndThenNXDOMAIN",
+		Flags: TestCaseFlagNoLTE, // BUG: LTE thinks this website is accessible (WTF?!)
+		Input: "https://bit.ly/21645",
+		Configure: func(env *netemx.QAEnv) {
+
+			// Empty addresses cause NXDOMAIN
+			env.DPIEngine().AddRule(&netem.DPISpoofDNSResponse{
+				Addresses: []string{},
+				Logger:    env.Logger(),
+				Domain:    "www.example.com",
+			})
+
+		},
+		ExpectErr: false,
+		ExpectTestKeys: &testKeys{
+			DNSExperimentFailure:  nil,
+			DNSConsistency:        "consistent",
+			HTTPExperimentFailure: "dns_nxdomain_error",
+			XStatus:               8224, // StatusExperimentHTTP | StatusAnomalyDNS
+			XDNSFlags:             0,
+			XBlockingFlags:        8, // analysisFlagHTTPBlocking
+			Accessible:            false,
+			Blocking:              "dns",
+		},
+	}
+}

--- a/internal/experiment/webconnectivityqa/redirect_test.go
+++ b/internal/experiment/webconnectivityqa/redirect_test.go
@@ -1,0 +1,116 @@
+package webconnectivityqa
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/netemx"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
+)
+
+func TestRedirectWithConsistentDNSAndThenConnectionRefused(t *testing.T) {
+	testcases := []*TestCase{
+		redirectWithConsistentDNSAndThenConnectionRefusedForHTTP(),
+		redirectWithConsistentDNSAndThenConnectionRefusedForHTTPS(),
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			env := netemx.MustNewScenario(netemx.InternetScenario)
+			tc.Configure(env)
+
+			env.Do(func() {
+				ports := []string{"80", "443"}
+
+				for _, port := range ports {
+					t.Run(fmt.Sprintf("for port %s", port), func(t *testing.T) {
+						dialer := netxlite.NewDialerWithoutResolver(log.Log)
+						endpoint := net.JoinHostPort(netemx.AddressWwwExampleCom, port)
+						conn, err := dialer.DialContext(context.Background(), "tcp", endpoint)
+						if err == nil || err.Error() != netxlite.FailureConnectionRefused {
+							t.Fatal("unexpected err", err)
+						}
+						if conn != nil {
+							t.Fatal("expected nil conn")
+						}
+					})
+				}
+			})
+		})
+	}
+}
+
+func TestRedirectWithConsistentDNSAndThenConnectionReset(t *testing.T) {
+	testcases := []*TestCase{
+		redirectWithConsistentDNSAndThenConnectionResetForHTTP(),
+		redirectWithConsistentDNSAndThenConnectionResetForHTTPS(),
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			env := netemx.MustNewScenario(netemx.InternetScenario)
+			tc.Configure(env)
+
+			env.Do(func() {
+				urls := []string{"http://www.example.com/", "https://www.example.com/"}
+
+				for _, URL := range urls {
+					t.Run(fmt.Sprintf("for URL %s", URL), func(t *testing.T) {
+						client := netxlite.NewHTTPClientStdlib(log.Log)
+						req := runtimex.Try1(http.NewRequest("GET", URL, nil))
+						resp, err := client.Do(req)
+						if err == nil || err.Error() != netxlite.FailureConnectionReset {
+							t.Fatal("unexpected err", err)
+						}
+						if resp != nil {
+							t.Fatal("expected nil resp")
+						}
+					})
+				}
+			})
+		})
+	}
+}
+
+func TestRedirectWithConsistentDNSAndThenNXDOMAIN(t *testing.T) {
+	testcases := []*TestCase{
+		redirectWithConsistentDNSAndThenNXDOMAIN(),
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			env := netemx.MustNewScenario(netemx.InternetScenario)
+			tc.Configure(env)
+
+			env.Do(func() {
+				t.Run("with stdlib resolver", func(t *testing.T) {
+					reso := netxlite.NewStdlibResolver(log.Log)
+					addrs, err := reso.LookupHost(context.Background(), "www.example.com")
+					if err == nil || err.Error() != netxlite.FailureDNSNXDOMAINError {
+						t.Fatal("unexpected error", err)
+					}
+					if len(addrs) != 0 {
+						t.Fatal("expected zero length addrs")
+					}
+				})
+
+				t.Run("with UDP resolver", func(t *testing.T) {
+					d := netxlite.NewDialerWithoutResolver(log.Log)
+					reso := netxlite.NewParallelUDPResolver(log.Log, d, "8.8.8.8:53")
+					addrs, err := reso.LookupHost(context.Background(), "www.example.com")
+					if err == nil || err.Error() != netxlite.FailureDNSNXDOMAINError {
+						t.Fatal("unexpected error", err)
+					}
+					if len(addrs) != 0 {
+						t.Fatal("expected zero length addrs")
+					}
+				})
+			})
+		})
+	}
+}

--- a/internal/experiment/webconnectivityqa/testcase.go
+++ b/internal/experiment/webconnectivityqa/testcase.go
@@ -43,6 +43,12 @@ func AllTestCases() []*TestCase {
 		dnsHijackingToProxyWithHTTPURL(),
 		dnsHijackingToProxyWithHTTPSURL(),
 
+		redirectWithConsistentDNSAndThenConnectionRefusedForHTTP(),
+		redirectWithConsistentDNSAndThenConnectionRefusedForHTTPS(),
+		redirectWithConsistentDNSAndThenConnectionResetForHTTP(),
+		redirectWithConsistentDNSAndThenConnectionResetForHTTPS(),
+		redirectWithConsistentDNSAndThenNXDOMAIN(),
+
 		sucessWithHTTP(),
 		sucessWithHTTPS(),
 

--- a/internal/netemx/example_test.go
+++ b/internal/netemx/example_test.go
@@ -478,3 +478,32 @@ func Example_examplePublicBlockpage() {
 	// </body>
 	// </html>
 }
+
+// This example shows how the [InternetScenario] includes an URL shortener.
+func Example_exampleURLShortener() {
+	env := netemx.MustNewScenario(netemx.InternetScenario)
+	defer env.Close()
+
+	env.Do(func() {
+		client := netxlite.NewHTTPTransportStdlib(log.Log)
+
+		req, err := http.NewRequest("GET", "https://bit.ly/21645", nil)
+		if err != nil {
+			log.Fatalf("http.NewRequest failed: %s", err.Error())
+		}
+
+		resp, err := client.RoundTrip(req)
+		if err != nil {
+			log.Fatalf("client.Do failed: %s", err.Error())
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusPermanentRedirect {
+			log.Fatalf("got unexpected status code: %d", resp.StatusCode)
+		}
+
+		fmt.Printf("%+v\n", resp.Header.Get("Location"))
+	})
+
+	// Output:
+	// https://www.example.com/
+}

--- a/internal/netemx/scenario.go
+++ b/internal/netemx/scenario.go
@@ -30,6 +30,9 @@ const (
 
 	// ScenarioRoleProxy means the host is a transparent proxy.
 	ScenarioRoleProxy
+
+	// ScenarioRoleURLShortener means that the host is an URL shortener.
+	ScenarioRoleURLShortener
 )
 
 // ScenarioDomainAddresses describes a domain and address used in a scenario.
@@ -130,6 +133,13 @@ var InternetScenario = []*ScenarioDomainAddresses{{
 	},
 	Role:             ScenarioRoleProxy,
 	WebServerFactory: nil,
+}, {
+	Domains: []string{"bit.ly", "bitly.com"},
+	Addresses: []string{
+		"67.199.248.11",
+	},
+	Role:             ScenarioRoleURLShortener,
+	WebServerFactory: nil,
 }}
 
 // MustNewScenario constructs a complete testing scenario using the domains and IP
@@ -207,6 +217,11 @@ func MustNewScenario(config []*ScenarioDomainAddresses) *QAEnv {
 					},
 					NewTLSProxyServerFactory(log.Log, 443),
 				))
+			}
+
+		case ScenarioRoleURLShortener:
+			for _, addr := range sad.Addresses {
+				opts = append(opts, QAEnvOptionHTTPServer(addr, URLShortenerFactory(DefaultURLShortenerMapping)))
 			}
 		}
 	}

--- a/internal/netemx/web.go
+++ b/internal/netemx/web.go
@@ -89,3 +89,31 @@ func BlockpageHandlerFactory() HTTPHandlerFactory {
 		})
 	})
 }
+
+// DefaultURLShortenerMapping is the default URL shortener mapping we use.
+var DefaultURLShortenerMapping = map[string]string{
+	"/21645": "https://www.example.com/",
+	"/32447": "http://www.example.com/",
+	"/24561": "https://example.com/",
+	"/21309": "http://example.com/",
+	"/30744": "https://www.example.org/",
+	"/23894": "http://www.example.org/",
+	"/30179": "https://example.org/",
+	"/11372": "http://example.org/",
+}
+
+// URLShortenerFactory returns an [HTTPHandlerFactory] that eventually redirects
+// requests using the map provided as argument or returns 404.
+func URLShortenerFactory(mapping map[string]string) HTTPHandlerFactory {
+	return HTTPHandlerFactoryFunc(func(env NetStackServerFactoryEnv, stack *netem.UNetStack) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			location, found := mapping[r.URL.Path]
+			if !found {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Location", location)
+			w.WriteHeader(http.StatusPermanentRedirect)
+		})
+	})
+}


### PR DESCRIPTION


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1803
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [x] if you changed code inside an experiment, make sure you bump its version number: N/A

## Description

This diff starts adapting from QA/webconnectivity.py some of the test cases involding errors happening during HTTP redirects.

I am pleased to see that we've discovered LTE bugs thanks to these new test cases... well, let's say "pleased".


