### PR TITLE
feat(webconnectivityqa): import misconfigured-TLS test cases

### DIFF
--- a/QA/webconnectivity.py
+++ b/QA/webconnectivity.py
@@ -47,80 +47,6 @@ def assert_status_flags_are(ooni_exe, tk, desired):
     assert tk["x_status"] == desired
 
 
-def webconnectivity_https_expired_certificate(ooni_exe, outfile):
-    """Test case where the domain's certificate is expired"""
-    args = []
-    tk = execute_jafar_and_return_validated_test_keys(
-        ooni_exe,
-        outfile,
-        "-i https://expired.badssl.com/ web_connectivity",
-        "webconnectivity_https_expired_certificate",
-        args,
-    )
-    assert tk["dns_experiment_failure"] == None
-    assert tk["dns_consistency"] == "consistent"
-    assert tk["control_failure"] == None
-    if "miniooni" in ooni_exe:
-        assert tk["http_experiment_failure"] == "ssl_invalid_certificate"
-    else:
-        assert "certificate verify failed" in tk["http_experiment_failure"]
-    assert tk["body_length_match"] == None
-    assert tk["body_proportion"] == 0
-    assert tk["status_code_match"] == None
-    assert tk["headers_match"] == None
-    assert tk["title_match"] == None
-    # The following strikes me as a measurement_kit bug. We are saying
-    # that all is good with a domain where actually we don't know why the
-    # control is failed and that is clearly not accessible according to
-    # our measurement of the domain (certificate expired).
-    #
-    # See <https://github.com/ooni/probe-engine/issues/858>.
-    if "miniooni" in ooni_exe:
-        assert tk["blocking"] == None
-        assert tk["accessible"] == None
-    else:
-        assert tk["blocking"] == False
-        assert tk["accessible"] == True
-    assert_status_flags_are(ooni_exe, tk, 16)
-
-
-def webconnectivity_https_wrong_host(ooni_exe, outfile):
-    """Test case where the hostname is wrong for the certificate"""
-    args = []
-    tk = execute_jafar_and_return_validated_test_keys(
-        ooni_exe,
-        outfile,
-        "-i https://wrong.host.badssl.com/ web_connectivity",
-        "webconnectivity_https_wrong_host",
-        args,
-    )
-    assert tk["dns_experiment_failure"] == None
-    assert tk["dns_consistency"] == "consistent"
-    assert tk["control_failure"] == None
-    if "miniooni" in ooni_exe:
-        assert tk["http_experiment_failure"] == "ssl_invalid_hostname"
-    else:
-        assert "certificate verify failed" in tk["http_experiment_failure"]
-    assert tk["body_length_match"] == None
-    assert tk["body_proportion"] == 0
-    assert tk["status_code_match"] == None
-    assert tk["headers_match"] == None
-    assert tk["title_match"] == None
-    # The following strikes me as a measurement_kit bug. We are saying
-    # that all is good with a domain where actually we don't know why the
-    # control is failed and that is clearly not accessible according to
-    # our measurement of the domain (wrong host for certificate).
-    #
-    # See <https://github.com/ooni/probe-engine/issues/858>.
-    if "miniooni" in ooni_exe:
-        assert tk["blocking"] == None
-        assert tk["accessible"] == None
-    else:
-        assert tk["blocking"] == False
-        assert tk["accessible"] == True
-    assert_status_flags_are(ooni_exe, tk, 16)
-
-
 def webconnectivity_https_self_signed(ooni_exe, outfile):
     """Test case where the certificate is self signed"""
     args = []
@@ -147,43 +73,6 @@ def webconnectivity_https_self_signed(ooni_exe, outfile):
     # that all is good with a domain where actually we don't know why the
     # control is failed and that is clearly not accessible according to
     # our measurement of the domain (self signed certificate).
-    #
-    # See <https://github.com/ooni/probe-engine/issues/858>.
-    if "miniooni" in ooni_exe:
-        assert tk["blocking"] == None
-        assert tk["accessible"] == None
-    else:
-        assert tk["blocking"] == False
-        assert tk["accessible"] == True
-    assert_status_flags_are(ooni_exe, tk, 16)
-
-
-def webconnectivity_https_untrusted_root(ooni_exe, outfile):
-    """Test case where the certificate has an untrusted root"""
-    args = []
-    tk = execute_jafar_and_return_validated_test_keys(
-        ooni_exe,
-        outfile,
-        "-i https://untrusted-root.badssl.com/ web_connectivity",
-        "webconnectivity_https_untrusted_root",
-        args,
-    )
-    assert tk["dns_experiment_failure"] == None
-    assert tk["dns_consistency"] == "consistent"
-    assert tk["control_failure"] == None
-    if "miniooni" in ooni_exe:
-        assert tk["http_experiment_failure"] == "ssl_unknown_authority"
-    else:
-        assert "certificate verify failed" in tk["http_experiment_failure"]
-    assert tk["body_length_match"] == None
-    assert tk["body_proportion"] == 0
-    assert tk["status_code_match"] == None
-    assert tk["headers_match"] == None
-    assert tk["title_match"] == None
-    # The following strikes me as a measurement_kit bug. We are saying
-    # that all is good with a domain where actually we don't know why the
-    # control is failed and that is clearly not accessible according to
-    # our measurement of the domain (untrusted root certificate).
     #
     # See <https://github.com/ooni/probe-engine/issues/858>.
     if "miniooni" in ooni_exe:
@@ -238,10 +127,7 @@ def main():
     outfile = "webconnectivity.jsonl"
     ooni_exe = sys.argv[1]
     tests = [
-        webconnectivity_https_expired_certificate,
-        webconnectivity_https_wrong_host,
         webconnectivity_https_self_signed,
-        webconnectivity_https_untrusted_root,
         webconnectivity_https_unknown_authority_with_inconsistent_dns,
     ]
     for test in tests:

--- a/QA/webconnectivity.py
+++ b/QA/webconnectivity.py
@@ -84,43 +84,6 @@ def webconnectivity_https_self_signed(ooni_exe, outfile):
     assert_status_flags_are(ooni_exe, tk, 16)
 
 
-def webconnectivity_https_unknown_authority_with_inconsistent_dns(ooni_exe, outfile):
-    """Test case where the DNS is sending us towards a website where
-    we're served an invalid certificate"""
-    args = [
-        "-iptables-hijack-dns-to",
-        "127.0.0.1:53",
-        "-dns-proxy-hijack",
-        "example.org",
-        "-bad-proxy-address-tls",
-        "127.0.0.1:443",
-        "-tls-proxy-address",
-        "127.0.0.1:4114",
-    ]
-    tk = execute_jafar_and_return_validated_test_keys(
-        ooni_exe,
-        outfile,
-        "-i https://example.org/ web_connectivity",
-        "webconnectivity_https_unknown_authority_with_inconsistent_dns",
-        args,
-    )
-    assert tk["dns_experiment_failure"] == None
-    assert tk["dns_consistency"] == "inconsistent"
-    assert tk["control_failure"] == None
-    if "miniooni" in ooni_exe:
-        assert tk["http_experiment_failure"] == "ssl_unknown_authority"
-    else:
-        assert "certificate verify failed" in tk["http_experiment_failure"]
-    assert tk["body_length_match"] == None
-    assert tk["body_proportion"] == 0
-    assert tk["status_code_match"] == None
-    assert tk["headers_match"] == None
-    assert tk["title_match"] == None
-    assert tk["blocking"] == "dns"
-    assert tk["accessible"] == False
-    assert_status_flags_are(ooni_exe, tk, 9248)
-
-
 def main():
     if len(sys.argv) != 2:
         sys.exit("usage: %s /path/to/ooniprobelegacy-like/binary" % sys.argv[0])
@@ -128,7 +91,6 @@ def main():
     ooni_exe = sys.argv[1]
     tests = [
         webconnectivity_https_self_signed,
-        webconnectivity_https_unknown_authority_with_inconsistent_dns,
     ]
     for test in tests:
         test(ooni_exe, outfile)

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/montanaflynn/stats v0.7.1
 	github.com/ooni/go-libtor v1.1.8
-	github.com/ooni/netem v0.0.0-20230905233956-4c9ebf9611c6
+	github.com/ooni/netem v0.0.0-20230906091637-85d962536ff3
 	github.com/ooni/oocrypto v0.5.3
 	github.com/ooni/oohttp v0.6.3
 	github.com/ooni/probe-assets v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -483,8 +483,8 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.27.7 h1:fVih9JD6ogIiHUN6ePK7HJidyEDpWGVB5mzM7cWNXoU=
 github.com/ooni/go-libtor v1.1.8 h1:Wo3V3DVTxl5vZdxtQakqYP+DAHx7pPtAFSl1bnAa08w=
 github.com/ooni/go-libtor v1.1.8/go.mod h1:q1YyLwRD9GeMyeerVvwc0vJ2YgwDLTp2bdVcrh/JXyI=
-github.com/ooni/netem v0.0.0-20230905233956-4c9ebf9611c6 h1:0GHOnir3Dy4BIsoYTKPxPa3ixNOBxx1VSWsV9qxCfN8=
-github.com/ooni/netem v0.0.0-20230905233956-4c9ebf9611c6/go.mod h1:3LJOzTIu2O4ADDJN2ILG4ViJOqyH/u9fKY8QT2Rma8Y=
+github.com/ooni/netem v0.0.0-20230906091637-85d962536ff3 h1:zpTbzNzpo00cKbjLLnWMKjZeGLdoNC81vMiBDiur7NU=
+github.com/ooni/netem v0.0.0-20230906091637-85d962536ff3/go.mod h1:3LJOzTIu2O4ADDJN2ILG4ViJOqyH/u9fKY8QT2Rma8Y=
 github.com/ooni/oocrypto v0.5.3 h1:CAb0Ze6q/EWD1PRGl9KqpzMfkut4O3XMaiKYsyxrWOs=
 github.com/ooni/oocrypto v0.5.3/go.mod h1:HjEQ5pQBl6btcWgAsKKq1tFo8CfBrZu63C/vPAUGIDk=
 github.com/ooni/oohttp v0.6.3 h1:MHydpeAPU/LSDSI/hIFJwZm4afBhd2Yo+rNxxFdeMCY=

--- a/internal/experiment/webconnectivityqa/badssl.go
+++ b/internal/experiment/webconnectivityqa/badssl.go
@@ -1,0 +1,68 @@
+package webconnectivityqa
+
+import "github.com/ooni/probe-cli/v3/internal/netemx"
+
+// Sometimes people we measure the websites of let their certificates expire and
+// we want to be confident about correctly measuring this condition
+func badSSLWithExpiredCertificate() *TestCase {
+	return &TestCase{
+		Name:  "badSSLWithExpiredCertificate",
+		Flags: TestCaseFlagNoLTE, // LTE flags it correctly but let's focus on v0.4 for now
+		Input: "https://expired.badssl.com/",
+		Configure: func(env *netemx.QAEnv) {
+			// nothing
+		},
+		ExpectErr: false,
+		ExpectTestKeys: &testKeys{
+			DNSConsistency:        "consistent",
+			HTTPExperimentFailure: "ssl_invalid_certificate",
+			XStatus:               16, // StatusAnomalyControlFailure
+			XNullNullFlags:        4,  // analysisFlagNullNullTLSMisconfigured
+			Accessible:            nil,
+			Blocking:              nil,
+		},
+	}
+}
+
+// Sometimes people we measure the websites of misconfigured the certificate names and
+// we want to be confident about correctly measuring this condition
+func badSSLWithWrongServerName() *TestCase {
+	return &TestCase{
+		Name:  "badSSLWithWrongServerName",
+		Flags: TestCaseFlagNoLTE, // LTE flags it correctly but let's focus on v0.4 for now
+		Input: "https://wrong.host.badssl.com/",
+		Configure: func(env *netemx.QAEnv) {
+			// nothing
+		},
+		ExpectErr: false,
+		ExpectTestKeys: &testKeys{
+			DNSConsistency:        "consistent",
+			HTTPExperimentFailure: "ssl_invalid_hostname",
+			XStatus:               16, // StatusAnomalyControlFailure
+			XNullNullFlags:        4,  // analysisFlagNullNullTLSMisconfigured
+			Accessible:            nil,
+			Blocking:              nil,
+		},
+	}
+}
+
+// Let's be sure we correctly flag a website using an unknown-to-us authority.
+func badSSLWithUnknownAuthority() *TestCase {
+	return &TestCase{
+		Name:  "badSSLWithUnknownAuthority",
+		Flags: TestCaseFlagNoLTE, // LTE flags it correctly but let's focus on v0.4 for now
+		Input: "https://untrusted-root.badssl.com/",
+		Configure: func(env *netemx.QAEnv) {
+			// nothing
+		},
+		ExpectErr: false,
+		ExpectTestKeys: &testKeys{
+			DNSConsistency:        "consistent",
+			HTTPExperimentFailure: "ssl_unknown_authority",
+			XStatus:               16, // StatusAnomalyControlFailure
+			XNullNullFlags:        4,  // analysisFlagNullNullTLSMisconfigured
+			Accessible:            nil,
+			Blocking:              nil,
+		},
+	}
+}

--- a/internal/experiment/webconnectivityqa/badssl.go
+++ b/internal/experiment/webconnectivityqa/badssl.go
@@ -1,6 +1,9 @@
 package webconnectivityqa
 
-import "github.com/ooni/probe-cli/v3/internal/netemx"
+import (
+	"github.com/ooni/netem"
+	"github.com/ooni/probe-cli/v3/internal/netemx"
+)
 
 // Sometimes people we measure the websites of let their certificates expire and
 // we want to be confident about correctly measuring this condition
@@ -47,9 +50,9 @@ func badSSLWithWrongServerName() *TestCase {
 }
 
 // Let's be sure we correctly flag a website using an unknown-to-us authority.
-func badSSLWithUnknownAuthority() *TestCase {
+func badSSLWithUnknownAuthorityWithConsistentDNS() *TestCase {
 	return &TestCase{
-		Name:  "badSSLWithUnknownAuthority",
+		Name:  "badSSLWithUnknownAuthorityWithConsistentDNS",
 		Flags: TestCaseFlagNoLTE, // LTE flags it correctly but let's focus on v0.4 for now
 		Input: "https://untrusted-root.badssl.com/",
 		Configure: func(env *netemx.QAEnv) {
@@ -63,6 +66,36 @@ func badSSLWithUnknownAuthority() *TestCase {
 			XNullNullFlags:        4,  // analysisFlagNullNullTLSMisconfigured
 			Accessible:            nil,
 			Blocking:              nil,
+		},
+	}
+}
+
+// This test case models when we're redirected to a blockpage website using a custom CA.
+func badSSLWithUnknownAuthorityWithInconsistentDNS() *TestCase {
+	return &TestCase{
+		Name:  "badSSLWithUnknownAuthorityWithInconsistentDNS",
+		Flags: 0,
+		Input: "https://www.example.com/",
+		Configure: func(env *netemx.QAEnv) {
+
+			// add DPI rule to force all the cleartext DNS queries to
+			// point the client to used the ISPProxyAddress
+			env.DPIEngine().AddRule(&netem.DPISpoofDNSResponse{
+				Addresses: []string{netemx.AddressBadSSLCom},
+				Logger:    env.Logger(),
+				Domain:    "www.example.com",
+			})
+
+		},
+		ExpectErr: false,
+		ExpectTestKeys: &testKeys{
+			DNSConsistency:        "inconsistent",
+			HTTPExperimentFailure: "ssl_unknown_authority",
+			XStatus:               9248, // StatusExperimentHTTP | StatusAnomalyTLSHandshake | StatusAnomalyDNS
+			XDNSFlags:             4,    // AnalysisDNSUnexpectedAddrs
+			XBlockingFlags:        33,   // analysisFlagSuccess | analysisFlagDNSBlocking
+			Accessible:            false,
+			Blocking:              "dns",
 		},
 	}
 }

--- a/internal/experiment/webconnectivityqa/badssl_test.go
+++ b/internal/experiment/webconnectivityqa/badssl_test.go
@@ -1,0 +1,38 @@
+package webconnectivityqa
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/netemx"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
+)
+
+func TestBadSSLConditions(t *testing.T) {
+	testcases := map[string]*TestCase{
+		"ssl_unknown_authority":   badSSLWithUnknownAuthority(),
+		"ssl_invalid_certificate": badSSLWithExpiredCertificate(),
+		"ssl_invalid_hostname":    badSSLWithWrongServerName(),
+	}
+
+	for expectedErr, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			env := netemx.MustNewScenario(netemx.InternetScenario)
+			tc.Configure(env)
+
+			env.Do(func() {
+				client := netxlite.NewHTTPClientStdlib(log.Log)
+				req := runtimex.Try1(http.NewRequest("GET", tc.Input, nil))
+				resp, err := client.Do(req)
+				if err == nil || err.Error() != expectedErr {
+					t.Fatal("unexpected err", err)
+				}
+				if resp != nil {
+					t.Fatal("expected nil resp")
+				}
+			})
+		})
+	}
+}

--- a/internal/experiment/webconnectivityqa/testcase.go
+++ b/internal/experiment/webconnectivityqa/testcase.go
@@ -37,9 +37,10 @@ type TestCase struct {
 // AllTestCases returns all the defined test cases.
 func AllTestCases() []*TestCase {
 	return []*TestCase{
-		badSSLWithUnknownAuthority(),
+		badSSLWithUnknownAuthorityWithConsistentDNS(),
 		badSSLWithExpiredCertificate(),
 		badSSLWithWrongServerName(),
+		badSSLWithUnknownAuthorityWithInconsistentDNS(),
 
 		controlFailureWithSuccessfulHTTPWebsite(),
 		controlFailureWithSuccessfulHTTPSWebsite(),

--- a/internal/experiment/webconnectivityqa/testcase.go
+++ b/internal/experiment/webconnectivityqa/testcase.go
@@ -37,6 +37,10 @@ type TestCase struct {
 // AllTestCases returns all the defined test cases.
 func AllTestCases() []*TestCase {
 	return []*TestCase{
+		badSSLWithUnknownAuthority(),
+		badSSLWithExpiredCertificate(),
+		badSSLWithWrongServerName(),
+
 		controlFailureWithSuccessfulHTTPWebsite(),
 		controlFailureWithSuccessfulHTTPSWebsite(),
 

--- a/internal/netemx/address.go
+++ b/internal/netemx/address.go
@@ -52,3 +52,9 @@ const AddressPublicBlockpage = "83.224.65.41"
 
 // ISPProxyAddress is the IP address of the ISP's HTTP transparent proxy.
 const ISPProxyAddress = "130.192.182.17"
+
+// AddressBitly is the IP address of bitly.com.
+const AddressBitly = "67.199.248.11"
+
+// AddressBadSSLCom is the IP address of badssl.com.
+const AddressBadSSLCom = "104.154.89.105"

--- a/internal/netemx/badssl.go
+++ b/internal/netemx/badssl.go
@@ -1,0 +1,127 @@
+package netemx
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/ooni/netem"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
+	"github.com/ooni/probe-cli/v3/internal/testingx"
+)
+
+// BadSSLServerFactory is a [NetStackServerFactory] that instantiates
+// a [NetStackServer] used for testing common TLS issues.
+type BadSSLServerFactory struct{}
+
+var _ NetStackServerFactory = &BadSSLServerFactory{}
+
+// MustNewServer implements NetStackServerFactory.
+func (*BadSSLServerFactory) MustNewServer(env NetStackServerFactoryEnv, stack *netem.UNetStack) NetStackServer {
+	return &badSSLServer{
+		closers: []io.Closer{},
+		logger:  env.Logger(),
+		mu:      sync.Mutex{},
+		unet:    stack,
+	}
+}
+
+type badSSLServer struct {
+	closers []io.Closer
+	logger  model.Logger
+	mu      sync.Mutex
+	unet    *netem.UNetStack
+}
+
+// Close implements NetStackServer.
+func (srv *badSSLServer) Close() error {
+	// "this method MUST be CONCURRENCY SAFE"
+	defer srv.mu.Unlock()
+	srv.mu.Lock()
+
+	// make sure we close all the child listeners
+	for _, closer := range srv.closers {
+		_ = closer.Close()
+	}
+
+	// "this method MUST be IDEMPOTENT"
+	srv.closers = []io.Closer{}
+
+	return nil
+}
+
+// MustStart implements NetStackServer.
+func (srv *badSSLServer) MustStart() {
+	// "this method MUST be CONCURRENCY SAFE"
+	defer srv.mu.Unlock()
+	srv.mu.Lock()
+
+	// build the listening endpoint
+	ipAddr := net.ParseIP(srv.unet.IPAddress())
+	runtimex.Assert(ipAddr != nil, "invalid IP address")
+	epnt := &net.TCPAddr{IP: ipAddr, Port: 443}
+
+	// start the server in a background goroutine
+	server := testingx.MustNewTLSServerEx(epnt, srv.unet, &tlsHandlerForBadSSLServer{srv.unet})
+
+	// track this listener as something to close later
+	srv.closers = append(srv.closers, server)
+}
+
+// tlsHandlerForBadSSLServer is a [testingx.TLSHandler] that only cares about the
+// handshake and applies specific wrong configurations during it.
+//
+// Limitation: this handler does not care about what happens after the handshake
+// and just lets the underlying [*testingx.TLSServer] close the TLS conn.
+type tlsHandlerForBadSSLServer struct {
+	unet *netem.UNetStack
+}
+
+// GetCertificate implements testingx.TLSHandler.
+func (thx *tlsHandlerForBadSSLServer) GetCertificate(
+	ctx context.Context, tcpConn net.Conn, chi *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	switch chi.ServerName {
+	case "wrong.host.badssl.com":
+		// Use the correct root CA but return a certificate for a different
+		// host, which should cause the SNI verification to fail.
+		tlsConfig := thx.unet.ServerTLSConfig()
+		return tlsConfig.GetCertificate(&tls.ClientHelloInfo{
+			CipherSuites:      chi.CipherSuites,
+			ServerName:        "wrong-host.badssl.com", // different!
+			SupportedCurves:   chi.SupportedCurves,
+			SupportedPoints:   chi.SupportedPoints,
+			SignatureSchemes:  chi.SignatureSchemes,
+			SupportedProtos:   chi.SupportedProtos,
+			SupportedVersions: chi.SupportedVersions,
+			Conn:              tcpConn,
+		})
+
+	case "untrusted-root.badssl.com":
+		// Create a custom MITM config and use it to negotiate TLS. Because this would be
+		// a different root CA, validating certs will fail the handshake.
+		//
+		// A more advanced version of this handler could choose different behaviors
+		// depending on the SNI provided as part of the *tls.ClientHelloInfo.
+		mitm := testingx.MustNewTLSMITMProviderNetem()
+		tlsConfig := mitm.ServerTLSConfig()
+		return tlsConfig.GetCertificate(chi)
+
+	case "expired.badssl.com":
+		// Create on-the-fly a certificate with the right SNI but that is clearly expired.
+		mitm := thx.unet.TLSMITMConfig()
+		return mitm.Config.NewCertWithoutCacheWithTimeNow(
+			chi.ServerName,
+			func() time.Time {
+				return time.Date(2017, time.July, 17, 0, 0, 0, 0, time.UTC)
+			},
+		)
+
+	default:
+		// The default is to just clone the TCP connection for good
+		return (testingx.TLSHandlerEOF()).GetCertificate(ctx, tcpConn, chi)
+	}
+}

--- a/internal/netemx/badssl.go
+++ b/internal/netemx/badssl.go
@@ -101,6 +101,8 @@ func (thx *tlsHandlerForBadSSLServer) GetCertificate(
 		})
 
 	case "untrusted-root.badssl.com":
+		fallthrough
+	default:
 		// Create a custom MITM config and use it to negotiate TLS. Because this would be
 		// a different root CA, validating certs will fail the handshake.
 		//
@@ -119,9 +121,5 @@ func (thx *tlsHandlerForBadSSLServer) GetCertificate(
 				return time.Date(2017, time.July, 17, 0, 0, 0, 0, time.UTC)
 			},
 		)
-
-	default:
-		// The default is to just clone the TCP connection for good
-		return (testingx.TLSHandlerEOF()).GetCertificate(ctx, tcpConn, chi)
 	}
 }

--- a/internal/netemx/badssl_test.go
+++ b/internal/netemx/badssl_test.go
@@ -33,8 +33,10 @@ func TestBadSSL(t *testing.T) {
 			serverName: "expired.badssl.com",
 			expectErr:  netxlite.FailureSSLInvalidCertificate,
 		}, {
-			serverName: "unsupported.badssl.com",
-			expectErr:  netxlite.FailureEOFError,
+			// Make sure that we can use the badssl server as something we can
+			// force using the DNS to cause a failure
+			serverName: "www.example.com",
+			expectErr:  netxlite.FailureSSLUnknownAuthority,
 		}}
 
 		for _, tc := range testcases {

--- a/internal/netemx/badssl_test.go
+++ b/internal/netemx/badssl_test.go
@@ -32,6 +32,9 @@ func TestBadSSL(t *testing.T) {
 		}, {
 			serverName: "expired.badssl.com",
 			expectErr:  netxlite.FailureSSLInvalidCertificate,
+		}, {
+			serverName: "unsupported.badssl.com",
+			expectErr:  netxlite.FailureEOFError,
 		}}
 
 		for _, tc := range testcases {

--- a/internal/netemx/badssl_test.go
+++ b/internal/netemx/badssl_test.go
@@ -1,0 +1,58 @@
+package netemx
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+)
+
+func TestBadSSL(t *testing.T) {
+	env := MustNewScenario(InternetScenario)
+	defer env.Close()
+
+	env.Do(func() {
+
+		// testcase is a testcase supported by this function
+		type testcase struct {
+			serverName string
+			expectErr  string
+		}
+
+		testcases := []testcase{{
+			serverName: "untrusted-root.badssl.com",
+			expectErr:  netxlite.FailureSSLUnknownAuthority,
+		}, {
+			serverName: "wrong.host.badssl.com",
+			expectErr:  netxlite.FailureSSLInvalidHostname,
+		}, {
+			serverName: "expired.badssl.com",
+			expectErr:  netxlite.FailureSSLInvalidCertificate,
+		}}
+
+		for _, tc := range testcases {
+			t.Run(fmt.Sprintf("for %s expect %s", tc.serverName, tc.expectErr), func(t *testing.T) {
+				tlsConfig := &tls.Config{ServerName: tc.serverName}
+
+				tlsDialer := netxlite.NewTLSDialerWithConfig(
+					netxlite.NewDialerWithoutResolver(log.Log),
+					netxlite.NewTLSHandshakerStdlib(log.Log),
+					tlsConfig,
+				)
+
+				endpoint := net.JoinHostPort(AddressBadSSLCom, "443")
+				conn, err := tlsDialer.DialTLSContext(context.Background(), "tcp", endpoint)
+				if err == nil || err.Error() != tc.expectErr {
+					t.Fatal("unexpected error", err)
+				}
+				if conn != nil {
+					t.Fatal("expected nil conn")
+				}
+			})
+		}
+	})
+}

--- a/internal/netemx/scenario.go
+++ b/internal/netemx/scenario.go
@@ -33,6 +33,10 @@ const (
 
 	// ScenarioRoleURLShortener means that the host is an URL shortener.
 	ScenarioRoleURLShortener
+
+	// ScenarioRoleBadSSL means that the host hosts services to
+	// measure against common TLS issues.
+	ScenarioRoleBadSSL
 )
 
 // ScenarioDomainAddresses describes a domain and address used in a scenario.
@@ -136,10 +140,19 @@ var InternetScenario = []*ScenarioDomainAddresses{{
 }, {
 	Domains: []string{"bit.ly", "bitly.com"},
 	Addresses: []string{
-		"67.199.248.11",
+		AddressBitly,
 	},
-	Role:             ScenarioRoleURLShortener,
-	WebServerFactory: nil,
+	Role: ScenarioRoleURLShortener,
+}, {
+	Domains: []string{
+		"wrong.host.badssl.com",
+		"untrusted-root.badssl.com",
+		"expired.badssl.com",
+	},
+	Addresses: []string{
+		AddressBadSSLCom,
+	},
+	Role: ScenarioRoleBadSSL,
 }}
 
 // MustNewScenario constructs a complete testing scenario using the domains and IP
@@ -222,6 +235,11 @@ func MustNewScenario(config []*ScenarioDomainAddresses) *QAEnv {
 		case ScenarioRoleURLShortener:
 			for _, addr := range sad.Addresses {
 				opts = append(opts, QAEnvOptionHTTPServer(addr, URLShortenerFactory(DefaultURLShortenerMapping)))
+			}
+
+		case ScenarioRoleBadSSL:
+			for _, addr := range sad.Addresses {
+				opts = append(opts, qaEnvOptionNetStack(addr, &BadSSLServerFactory{}))
 			}
 		}
 	}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1803
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [x] if you changed code inside an experiment, make sure you bump its version number: N/A

## Description

This diff imports the misconfigured-TLS test cases of the QA/webconnectivity.py test suite in webconnectivityqa.

The only QA/webconnectivity.py test case we're not merging is the one about self-signed certificate, which are equivalent enough to an unknown root certificate that it seems unimportant to merge them.

In other word, we have basically finished rewriting Jafar. Now it will be time to drop Jafar. 😅 
