### PR TITLE
fix(webconnectivityqa): Close the QAEnv

### DIFF
--- a/internal/experiment/webconnectivityqa/badssl_test.go
+++ b/internal/experiment/webconnectivityqa/badssl_test.go
@@ -33,6 +33,8 @@ func TestBadSSLConditions(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.testCase.Name, func(t *testing.T) {
 			env := netemx.MustNewScenario(netemx.InternetScenario)
+			defer env.Close()
+
 			tc.testCase.Configure(env)
 
 			env.Do(func() {

--- a/internal/experiment/webconnectivityqa/control_test.go
+++ b/internal/experiment/webconnectivityqa/control_test.go
@@ -12,6 +12,8 @@ import (
 
 func TestControlFailureWithSuccessfulHTTPWebsite(t *testing.T) {
 	env := netemx.MustNewScenario(netemx.InternetScenario)
+	defer env.Close()
+
 	tc := controlFailureWithSuccessfulHTTPWebsite()
 	tc.Configure(env)
 
@@ -33,6 +35,8 @@ func TestControlFailureWithSuccessfulHTTPWebsite(t *testing.T) {
 
 func TestControlFailureWithSuccessfulHTTPSWebsite(t *testing.T) {
 	env := netemx.MustNewScenario(netemx.InternetScenario)
+	defer env.Close()
+
 	tc := controlFailureWithSuccessfulHTTPSWebsite()
 	tc.Configure(env)
 

--- a/internal/experiment/webconnectivityqa/dnsblocking_test.go
+++ b/internal/experiment/webconnectivityqa/dnsblocking_test.go
@@ -12,6 +12,8 @@ import (
 
 func TestDNSBlockingAndroidDNSCacheNoData(t *testing.T) {
 	env := netemx.MustNewScenario(netemx.InternetScenario)
+	defer env.Close()
+
 	tc := dnsBlockingAndroidDNSCacheNoData()
 	tc.Configure(env)
 
@@ -29,6 +31,8 @@ func TestDNSBlockingAndroidDNSCacheNoData(t *testing.T) {
 
 func TestDNSBlockingNXDOMAIN(t *testing.T) {
 	env := netemx.MustNewScenario(netemx.InternetScenario)
+	defer env.Close()
+
 	tc := dnsBlockingNXDOMAIN()
 	tc.Configure(env)
 

--- a/internal/experiment/webconnectivityqa/dnshijacking_test.go
+++ b/internal/experiment/webconnectivityqa/dnshijacking_test.go
@@ -19,6 +19,8 @@ func TestDNSHijackingTestCases(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			env := netemx.MustNewScenario(netemx.InternetScenario)
+			defer env.Close()
+
 			tc.Configure(env)
 
 			env.Do(func() {

--- a/internal/experiment/webconnectivityqa/httpdiff_test.go
+++ b/internal/experiment/webconnectivityqa/httpdiff_test.go
@@ -20,6 +20,8 @@ func TestHTTPDiffWithConsistentDNS(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			env := netemx.MustNewScenario(netemx.InternetScenario)
+			defer env.Close()
+
 			tc.Configure(env)
 
 			env.Do(func() {
@@ -50,6 +52,8 @@ func TestHTTPDiffWithInconsistentDNS(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			env := netemx.MustNewScenario(netemx.InternetScenario)
+			defer env.Close()
+
 			tc.Configure(env)
 
 			env.Do(func() {

--- a/internal/experiment/webconnectivityqa/redirect_test.go
+++ b/internal/experiment/webconnectivityqa/redirect_test.go
@@ -23,6 +23,8 @@ func TestRedirectWithConsistentDNSAndThenConnectionRefused(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			env := netemx.MustNewScenario(netemx.InternetScenario)
+			defer env.Close()
+
 			tc.Configure(env)
 
 			env.Do(func() {
@@ -55,6 +57,8 @@ func TestRedirectWithConsistentDNSAndThenConnectionReset(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			env := netemx.MustNewScenario(netemx.InternetScenario)
+			defer env.Close()
+
 			tc.Configure(env)
 
 			env.Do(func() {
@@ -86,6 +90,8 @@ func TestRedirectWithConsistentDNSAndThenNXDOMAIN(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			env := netemx.MustNewScenario(netemx.InternetScenario)
+			defer env.Close()
+
 			tc.Configure(env)
 
 			env.Do(func() {
@@ -125,6 +131,8 @@ func TestRedirectWithConsistentDNSAndThenEOF(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			env := netemx.MustNewScenario(netemx.InternetScenario)
+			defer env.Close()
+
 			tc.Configure(env)
 
 			env.Do(func() {
@@ -157,6 +165,8 @@ func TestRedirectWithConsistentDNSAndThenTimeout(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			env := netemx.MustNewScenario(netemx.InternetScenario)
+			defer env.Close()
+
 			tc.Configure(env)
 
 			env.Do(func() {

--- a/internal/experiment/webconnectivityqa/tcpblocking_test.go
+++ b/internal/experiment/webconnectivityqa/tcpblocking_test.go
@@ -12,6 +12,8 @@ import (
 
 func TestTCPBlockingConnectTimeout(t *testing.T) {
 	env := netemx.MustNewScenario(netemx.InternetScenario)
+	defer env.Close()
+
 	tc := tcpBlockingConnectTimeout()
 	tc.Configure(env)
 
@@ -30,6 +32,8 @@ func TestTCPBlockingConnectTimeout(t *testing.T) {
 
 func TestTCPBlockingConnectionRefusedWithInconsistentDNS(t *testing.T) {
 	env := netemx.MustNewScenario(netemx.InternetScenario)
+	defer env.Close()
+
 	tc := tcpBlockingConnectionRefusedWithInconsistentDNS()
 	tc.Configure(env)
 

--- a/internal/experiment/webconnectivityqa/tlsblocking_test.go
+++ b/internal/experiment/webconnectivityqa/tlsblocking_test.go
@@ -14,6 +14,8 @@ import (
 
 func TestBlockingTLSConnectionResetWithConsistentDNS(t *testing.T) {
 	env := netemx.MustNewScenario(netemx.InternetScenario)
+	defer env.Close()
+
 	tc := tlsBlockingConnectionResetWithConsistentDNS()
 	tc.Configure(env)
 
@@ -40,6 +42,8 @@ func TestBlockingTLSConnectionResetWithConsistentDNS(t *testing.T) {
 
 func TestBlockingTLSConnectionResetWithInconsistentDNS(t *testing.T) {
 	env := netemx.MustNewScenario(netemx.InternetScenario)
+	defer env.Close()
+
 	tc := tlsBlockingConnectionResetWithInconsistentDNS()
 	tc.Configure(env)
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference for this pull request: Error emerged here: https://github.com/ooni/probe-cli/pull/1161

## Description

This diff fixes the panics caused by the new quic-go API. 
We did not close the `QAEnv` in some of our webconnectivityqa tests. Therefore, the QUIC Server would not close the underlying UDP socket (`net.PacketConn`) and the local address of this socket would not be removed from the QUIC multiplexer. 
In the subsequent test case, the new quic-go API (see https://github.com/ooni/probe-cli/pull/1161) would panic because the local address of the server would still be registered in the global QUIC multiplexer.