### PR TITLE
refactor(measurexlite): move OperationLogger to logx

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/fatih/color v1.15.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/gopacket v1.1.19
-	github.com/google/martian/v3 v3.3.2
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.5.0
@@ -61,6 +60,7 @@ require (
 	github.com/go-redis/redis/v8 v8.11.5 // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/google/btree v1.1.2 // indirect
+	github.com/google/martian/v3 v3.3.2 // indirect
 	github.com/google/pprof v0.0.0-20230602150820-91b7bce49751 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.16.5 // indirect
@@ -73,7 +73,6 @@ require (
 	github.com/pion/transport/v2 v2.2.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.4.0 // indirect
-	github.com/quic-go/qtls-go1-19 v0.3.2 // indirect
 	github.com/quic-go/qtls-go1-20 v0.3.1 // indirect
 	github.com/refraction-networking/conjure v0.4.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,7 +40,6 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
-github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/alecthomas/kingpin/v2 v2.3.2 h1:H0aULhgmSzN8xQ3nX1uxtdlTHYoPLu5AhHxWrKI6ocU=
 github.com/alecthomas/kingpin/v2 v2.3.2/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -174,7 +173,6 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
 github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
@@ -340,7 +338,6 @@ github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.2.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
-github.com/jinzhu/copier v0.3.5/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/josharian/native v1.0.0 h1:Ts/E8zCSEsG17dUqv7joXJFybuMLjQfWE04tsBODTxk=
@@ -360,8 +357,6 @@ github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1
 github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
-github.com/keltia/proxy v0.9.3/go.mod h1:fLU4DmBPG0oh0md9fWggE2oG2m7Lchv3eim+GiO3pZY=
-github.com/keltia/ripe-atlas v0.0.0-20211221125000-f6eb808d5dc6/go.mod h1:zYa+dM8811qRhclezc/AKX9imyQwPjjSk2cH0xTgTag=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
@@ -453,7 +448,6 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/mroth/weightedrand v1.0.0 h1:V8JeHChvl2MP1sAoXq4brElOcza+jxLkRuwvtQu8L3E=
@@ -622,18 +616,8 @@ github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+Pymzi
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/quic-go/qpack v0.4.0 h1:Cr9BXA1sQS2SmDUWjSofMPNKmvF6IiIfDRmgU0w1ZCo=
 github.com/quic-go/qpack v0.4.0/go.mod h1:UZVnYIfi5GRk+zI9UMaCPsmZ2xKJP7XBUvVyT1Knj9A=
-github.com/quic-go/qtls-go1-19 v0.3.2 h1:tFxjCFcTQzK+oMxG6Zcvp4Dq8dx4yD3dDiIiyc86Z5U=
-github.com/quic-go/qtls-go1-19 v0.3.2/go.mod h1:ySOI96ew8lnoKPtSqx2BlI5wCpUVPT05RMAlajtnyOI=
-github.com/quic-go/qtls-go1-20 v0.2.2 h1:WLOPx6OY/hxtTxKV1Zrq20FtXtDEkeY00CGQm8GEa3E=
-github.com/quic-go/qtls-go1-20 v0.2.2/go.mod h1:JKtK6mjbAVcUTN/9jZpvLbGxvdWIKS8uT7EiStoU1SM=
 github.com/quic-go/qtls-go1-20 v0.3.1 h1:O4BLOM3hwfVF3AcktIylQXyl7Yi2iBNVy5QsV+ySxbg=
 github.com/quic-go/qtls-go1-20 v0.3.1/go.mod h1:X9Nh97ZL80Z+bX/gUXMbipO6OxdiDi58b/fMC9mAL+k=
-github.com/quic-go/quic-go v0.33.0 h1:ItNoTDN/Fm/zBlq769lLJc8ECe9gYaW40veHCCco7y0=
-github.com/quic-go/quic-go v0.33.0/go.mod h1:YMuhaAV9/jIu0XclDXwZPAsP/2Kgr5yMYhe9oxhhOFA=
-github.com/quic-go/quic-go v0.35.1 h1:b0kzj6b/cQAf05cT0CkQubHM31wiA+xH3IBkxP62poo=
-github.com/quic-go/quic-go v0.35.1/go.mod h1:+4CVgVppm0FNjpG3UcX8Joi/frKOH7/ciD5yGcwOO1g=
-github.com/quic-go/quic-go v0.36.0 h1:JIrO7p7Ug6hssFcARjWDiqS2RAKJHCiwPxBAA989rbI=
-github.com/quic-go/quic-go v0.36.0/go.mod h1:zPetvwDlILVxt15n3hr3Gf/I3mDf7LpLKPhR4Ez0AZQ=
 github.com/quic-go/quic-go v0.37.3 h1:pkHH3xaMNUNAh6OtgEV/0K6Fz+YIJXhPzgd/ShiRDm4=
 github.com/quic-go/quic-go v0.37.3/go.mod h1:YsbH1r4mSHPJcLF4k4zruUkLBqctEMBDR6VPvcYjIsU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/internal/dslx/dns.go
+++ b/internal/dslx/dns.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
@@ -146,7 +147,7 @@ func (f *dnsLookupGetaddrinfoFunc) Apply(
 	trace := measurexlite.NewTrace(input.IDGenerator.Add(1), input.ZeroTime, input.Tags...)
 
 	// start the operation logger
-	ol := measurexlite.NewOperationLogger(
+	ol := logx.NewOperationLogger(
 		input.Logger,
 		"[#%d] DNSLookup[getaddrinfo] %s",
 		trace.Index,
@@ -209,7 +210,7 @@ func (f *dnsLookupUDPFunc) Apply(
 	trace := measurexlite.NewTrace(input.IDGenerator.Add(1), input.ZeroTime, input.Tags...)
 
 	// start the operation logger
-	ol := measurexlite.NewOperationLogger(
+	ol := logx.NewOperationLogger(
 		input.Logger,
 		"[#%d] DNSLookup[%s/udp] %s",
 		trace.Index,

--- a/internal/dslx/httpcore.go
+++ b/internal/dslx/httpcore.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
@@ -160,7 +161,7 @@ func (f *httpRequestFunc) Apply(
 	if err == nil {
 
 		// start the operation logger
-		ol := measurexlite.NewOperationLogger(
+		ol := logx.NewOperationLogger(
 			input.Logger,
 			"[#%d] HTTPRequest %s with %s/%s host=%s",
 			input.Trace.Index,

--- a/internal/dslx/quic.go
+++ b/internal/dslx/quic.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
@@ -88,7 +89,7 @@ func (f *quicHandshakeFunc) Apply(
 	serverName := f.serverName(input)
 
 	// start the operation logger
-	ol := measurexlite.NewOperationLogger(
+	ol := logx.NewOperationLogger(
 		input.Logger,
 		"[#%d] QUICHandshake with %s SNI=%s",
 		trace.Index,

--- a/internal/dslx/tcp.go
+++ b/internal/dslx/tcp.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
@@ -35,7 +36,7 @@ func (f *tcpConnectFunc) Apply(
 	trace := measurexlite.NewTrace(input.IDGenerator.Add(1), input.ZeroTime, input.Tags...)
 
 	// start the operation logger
-	ol := measurexlite.NewOperationLogger(
+	ol := logx.NewOperationLogger(
 		input.Logger,
 		"[#%d] TCPConnect %s",
 		trace.Index,

--- a/internal/dslx/tls.go
+++ b/internal/dslx/tls.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
@@ -99,7 +100,7 @@ func (f *tlsHandshakeFunc) Apply(
 	nextProto := f.nextProto()
 
 	// start the operation logger
-	ol := measurexlite.NewOperationLogger(
+	ol := logx.NewOperationLogger(
 		input.Logger,
 		"[#%d] TLSHandshake with %s SNI=%s ALPN=%v",
 		trace.Index,

--- a/internal/experiment/dnsping/dnsping.go
+++ b/internal/experiment/dnsping/dnsping.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
@@ -136,7 +137,7 @@ func (m *Measurer) dnsRoundTrip(ctx context.Context, index int64, zeroTime time.
 	defer wg.Done()
 	pings := []*SinglePing{}
 	trace := measurexlite.NewTrace(index, zeroTime)
-	ol := measurexlite.NewOperationLogger(logger, "DNSPing #%d %s %s", index, address, domain)
+	ol := logx.NewOperationLogger(logger, "DNSPing #%d %s %s", index, address, domain)
 	// TODO(bassosimone, DecFox): what should we do if the user passes us a resolver with a
 	// domain name in terms of saving its results? Shall we save also the system resolver's lookups?
 	// Shall we, otherwise, pre-resolve the domain name to IP addresses once and for all? In such

--- a/internal/experiment/portfiltering/tcpconnect.go
+++ b/internal/experiment/portfiltering/tcpconnect.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
@@ -39,7 +40,7 @@ func (m *Measurer) tcpConnectAsync(ctx context.Context, index int64,
 func (m *Measurer) tcpConnect(ctx context.Context, index int64,
 	zeroTime time.Time, logger model.Logger, address string) *model.ArchivalTCPConnectResult {
 	trace := measurexlite.NewTrace(index, zeroTime)
-	ol := measurexlite.NewOperationLogger(logger, "TCPConnect #%d %s", index, address)
+	ol := logx.NewOperationLogger(logger, "TCPConnect #%d %s", index, address)
 	dialer := trace.NewDialerWithoutResolver(logger)
 	conn, err := dialer.DialContext(ctx, "tcp", address)
 	ol.Stop(err)

--- a/internal/experiment/simplequicping/simplequicping.go
+++ b/internal/experiment/simplequicping/simplequicping.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
@@ -170,7 +171,7 @@ func (m *Measurer) quicHandshake(ctx context.Context, index int64,
 	sni := m.config.sni(address)
 	alpn := strings.Split(m.config.alpn(), " ")
 	trace := measurexlite.NewTrace(index, zeroTime)
-	ol := measurexlite.NewOperationLogger(logger, "SimpleQUICPing #%d %s %s %v", index, address, sni, alpn)
+	ol := logx.NewOperationLogger(logger, "SimpleQUICPing #%d %s %s %v", index, address, sni, alpn)
 	listener := netxlite.NewUDPListener()
 	dialer := trace.NewQUICDialerWithoutResolver(listener, logger)
 	// See https://github.com/ooni/probe/issues/2413 to understand

--- a/internal/experiment/tcpping/tcpping.go
+++ b/internal/experiment/tcpping/tcpping.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
@@ -134,7 +135,7 @@ func (m *Measurer) tcpConnect(ctx context.Context, index int64,
 	defer cancel()
 	trace := measurexlite.NewTrace(index, zeroTime)
 	dialer := trace.NewDialerWithoutResolver(logger)
-	ol := measurexlite.NewOperationLogger(logger, "TCPPing #%d %s", index, address)
+	ol := logx.NewOperationLogger(logger, "TCPPing #%d %s", index, address)
 	conn, err := dialer.DialContext(ctx, "tcp", address)
 	ol.Stop(err)
 	measurexlite.MaybeClose(conn)

--- a/internal/experiment/tlsmiddlebox/connect.go
+++ b/internal/experiment/tlsmiddlebox/connect.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
@@ -17,7 +18,7 @@ func (m *Measurer) TCPConnect(ctx context.Context, index int64, zeroTime time.Ti
 	logger model.Logger, address string, tk *TestKeys) error {
 	trace := measurexlite.NewTrace(index, zeroTime)
 	dialer := trace.NewDialerWithoutResolver(logger)
-	ol := measurexlite.NewOperationLogger(logger, "TCPConnect #%d %s", index, address)
+	ol := logx.NewOperationLogger(logger, "TCPConnect #%d %s", index, address)
 	conn, err := dialer.DialContext(ctx, "tcp", address)
 	ol.Stop(err)
 	measurexlite.MaybeClose(conn)

--- a/internal/experiment/tlsmiddlebox/dns.go
+++ b/internal/experiment/tlsmiddlebox/dns.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
@@ -17,7 +18,7 @@ func (m *Measurer) DNSLookup(ctx context.Context, index int64, zeroTime time.Tim
 	logger model.Logger, domain string, tk *TestKeys) ([]string, error) {
 	url := m.config.resolverURL()
 	trace := measurexlite.NewTrace(index, zeroTime)
-	ol := measurexlite.NewOperationLogger(logger, "DNSLookup #%d, %s, %s", index, url, domain)
+	ol := logx.NewOperationLogger(logger, "DNSLookup #%d, %s, %s", index, url, domain)
 	// TODO(DecFox, bassosimone): We are currently using the DoH resolver, we will
 	// switch to the TRR2 resolver once we have it in measurexlite
 	// Issue: https://github.com/ooni/probe/issues/2185

--- a/internal/experiment/tlsmiddlebox/tracing.go
+++ b/internal/experiment/tlsmiddlebox/tracing.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
@@ -72,7 +73,7 @@ func (m *Measurer) handshakeWithTTL(ctx context.Context, index int64, zeroTime t
 	// 1. Connect to the target IP
 	// TODO(DecFox, bassosimone): Do we need a trace for this TCP connect?
 	d := NewDialerTTLWrapper()
-	ol := measurexlite.NewOperationLogger(logger, "Handshake Trace #%d TTL %d %s %s", index, ttl, address, sni)
+	ol := logx.NewOperationLogger(logger, "Handshake Trace #%d TTL %d %s %s", index, ttl, address, sni)
 	conn, err := d.DialContext(ctx, "tcp", address)
 	if err != nil {
 		iteration := newIterationFromHandshake(ttl, err, nil, nil)

--- a/internal/experiment/tlsping/tlsping.go
+++ b/internal/experiment/tlsping/tlsping.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
@@ -171,7 +172,7 @@ func (m *Measurer) tlsConnectAndHandshake(ctx context.Context, index int64,
 	dialer := trace.NewDialerWithoutResolver(logger)
 	alpn := strings.Split(m.config.alpn(), " ")
 	sni := m.config.sni(address)
-	ol := measurexlite.NewOperationLogger(logger, "TLSPing #%d %s %s %v", index, address, sni, alpn)
+	ol := logx.NewOperationLogger(logger, "TLSPing #%d %s %s %v", index, address, sni, alpn)
 	conn, err := dialer.DialContext(ctx, "tcp", address)
 	sp.TCPConnect = trace.FirstTCPConnectOrNil() // record the first connect from the buffer
 	if err != nil {

--- a/internal/experiment/webconnectivitylte/cleartextflow.go
+++ b/internal/experiment/webconnectivitylte/cleartextflow.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
@@ -107,7 +108,7 @@ func (t *CleartextFlow) Run(parentCtx context.Context, index int64) error {
 	}()
 
 	// start the operation logger
-	ol := measurexlite.NewOperationLogger(
+	ol := logx.NewOperationLogger(
 		t.Logger, "[#%d] GET http://%s using %s", index, t.HostHeader, t.Address,
 	)
 

--- a/internal/experiment/webconnectivitylte/control.go
+++ b/internal/experiment/webconnectivitylte/control.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/ooni/probe-cli/v3/internal/experiment/webconnectivity"
 	"github.com/ooni/probe-cli/v3/internal/httpapi"
-	"github.com/ooni/probe-cli/v3/internal/measurexlite"
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/ooapi"
@@ -102,7 +102,7 @@ func (c *Control) Run(parentCtx context.Context) {
 	c.TestKeys.SetControlRequest(creq)
 
 	// create logger for this operation
-	ol := measurexlite.NewOperationLogger(
+	ol := logx.NewOperationLogger(
 		c.Logger,
 		"control for %s using %+v",
 		creq.HTTPRequest,

--- a/internal/experiment/webconnectivitylte/dnsresolvers.go
+++ b/internal/experiment/webconnectivitylte/dnsresolvers.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
@@ -212,7 +213,7 @@ func (t *DNSResolvers) lookupHostSystem(parentCtx context.Context, out chan<- []
 	trace := measurexlite.NewTrace(index, t.ZeroTime)
 
 	// start the operation logger
-	ol := measurexlite.NewOperationLogger(
+	ol := logx.NewOperationLogger(
 		t.Logger, "[#%d] lookup %s using system", index, t.Domain,
 	)
 
@@ -239,7 +240,7 @@ func (t *DNSResolvers) lookupHostUDP(parentCtx context.Context, udpAddress strin
 	trace := measurexlite.NewTrace(index, t.ZeroTime)
 
 	// start the operation logger
-	ol := measurexlite.NewOperationLogger(
+	ol := logx.NewOperationLogger(
 		t.Logger, "[#%d] lookup %s using %s", index, t.Domain, udpAddress,
 	)
 
@@ -377,7 +378,7 @@ func (t *DNSResolvers) lookupHostDNSOverHTTPS(parentCtx context.Context, out cha
 	trace := measurexlite.NewTrace(index, t.ZeroTime)
 
 	// start the operation logger
-	ol := measurexlite.NewOperationLogger(
+	ol := logx.NewOperationLogger(
 		t.Logger, "[#%d] lookup %s using %s", index, t.Domain, URL,
 	)
 

--- a/internal/experiment/webconnectivitylte/secureflow.go
+++ b/internal/experiment/webconnectivitylte/secureflow.go
@@ -17,6 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
@@ -114,7 +115,7 @@ func (t *SecureFlow) Run(parentCtx context.Context, index int64) error {
 	}()
 
 	// start the operation logger
-	ol := measurexlite.NewOperationLogger(
+	ol := logx.NewOperationLogger(
 		t.Logger, "[#%d] GET https://%s using %s", index, t.HostHeader, t.Address,
 	)
 

--- a/internal/logx/operation.go
+++ b/internal/logx/operation.go
@@ -1,8 +1,4 @@
-package measurexlite
-
-//
-// Logging support
-//
+package logx
 
 import (
 	"fmt"
@@ -11,8 +7,6 @@ import (
 
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
-
-// TODO(bassosimone): consider moving inside the logx package?
 
 // NewOperationLogger creates a new logger that logs
 // about an in-progress operation. If it takes too much

--- a/internal/logx/operation_test.go
+++ b/internal/logx/operation_test.go
@@ -1,4 +1,4 @@
-package measurexlite
+package logx
 
 import (
 	"fmt"

--- a/internal/measurex/logger.go
+++ b/internal/measurex/logger.go
@@ -1,6 +1,6 @@
 package measurex
 
-import "github.com/ooni/probe-cli/v3/internal/measurexlite"
+import "github.com/ooni/probe-cli/v3/internal/logx"
 
 //
 // Logger
@@ -9,7 +9,7 @@ import "github.com/ooni/probe-cli/v3/internal/measurexlite"
 //
 
 // NewOperationLogger is an alias for measurex.NewOperationLogger.
-var NewOperationLogger = measurexlite.NewOperationLogger
+var NewOperationLogger = logx.NewOperationLogger
 
 // OperationLogger is an alias for measurex.OperationLogger.
-type OperationLogger = measurexlite.OperationLogger
+type OperationLogger = logx.OperationLogger

--- a/internal/oohelperd/dns.go
+++ b/internal/oohelperd/dns.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ooni/probe-cli/v3/internal/measurexlite"
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/tracex"
@@ -55,7 +55,7 @@ func dnsDo(ctx context.Context, config *dnsConfig) {
 	defer reso.CloseIdleConnections()
 
 	// perform and log the actual DNS lookup
-	ol := measurexlite.NewOperationLogger(config.Logger, "DNSLookup %s", config.Domain)
+	ol := logx.NewOperationLogger(config.Logger, "DNSLookup %s", config.Domain)
 	addrs, err := reso.LookupHost(ctx, config.Domain)
 	ol.Stop(err)
 

--- a/internal/oohelperd/http.go
+++ b/internal/oohelperd/http.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
@@ -56,7 +57,7 @@ type httpConfig struct {
 
 // httpDo performs the HTTP check.
 func httpDo(ctx context.Context, config *httpConfig) {
-	ol := measurexlite.NewOperationLogger(config.Logger, "GET %s", config.URL)
+	ol := logx.NewOperationLogger(config.Logger, "GET %s", config.URL)
 	const timeout = 15 * time.Second
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/oohelperd/quic.go
+++ b/internal/oohelperd/quic.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/quic-go/quic-go"
@@ -68,7 +69,7 @@ func quicDo(ctx context.Context, config *quicConfig) {
 	defer func() {
 		config.Out <- out
 	}()
-	ol := measurexlite.NewOperationLogger(
+	ol := logx.NewOperationLogger(
 		config.Logger,
 		"QUICConnect %s SNI=%s",
 		config.Endpoint,

--- a/internal/oohelperd/tcptls.go
+++ b/internal/oohelperd/tcptls.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
@@ -81,7 +82,7 @@ func tcpTLSDo(ctx context.Context, config *tcpTLSConfig) {
 	defer func() {
 		config.Out <- out
 	}()
-	ol := measurexlite.NewOperationLogger(
+	ol := logx.NewOperationLogger(
 		config.Logger,
 		"TCPConnect %s EnableTLS=%v SNI=%s",
 		config.Endpoint,

--- a/internal/sessionresolver/resolver.go
+++ b/internal/sessionresolver/resolver.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/bytecounter"
-	"github.com/ooni/probe-cli/v3/internal/measurexlite"
+	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/multierror"
 )
@@ -139,7 +139,7 @@ func (r *Resolver) lookupHost(ctx context.Context, ri *resolverinfo, hostname st
 		ri.Score = 0 // this is a hard error
 		return nil, err
 	}
-	op := measurexlite.NewOperationLogger(
+	op := logx.NewOperationLogger(
 		r.logger(), "sessionresolver: lookup %s using %s", hostname, ri.URL)
 	addrs, err := timeLimitedLookup(ctx, re, hostname)
 	op.Stop(err)


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2531
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [x] if you changed code inside an experiment, make sure you bump its version number: N/A

## Description

I am starting to look into how to support beacons into the codebase as explained by https://github.com/ooni/probe/issues/2531.

The first issue that I stumbled upon is that there is excessive coupling between packages at the lower-levels, which we can reduce with easy refactoring, and which would help reasoning on what to do to address the underlying issue.

This diff is the first minor step towards cleaning up the code a bit: we are moving a functionality that pertains to logging from measurexlite to logx (which is where it should be).

While there, I noticed I needed to run `go mod tidy` to update the `go.mod` and `go.sum` files, which were outdated.
