### PR TITLE
refactor(netxlite): use *Netx for creating UDP sockets

### DIFF
--- a/internal/netxlite/netx.go
+++ b/internal/netxlite/netx.go
@@ -22,12 +22,6 @@ func (netx *Netx) maybeCustomUnderlyingNetwork() *MaybeCustomUnderlyingNetwork {
 	return &MaybeCustomUnderlyingNetwork{netx.Underlying}
 }
 
-// NewUDPListener is like [netxlite.NewUDPListener] but the constructed [model.UDPListener]
-// uses the [model.UnderlyingNetwork] configured inside the [Netx] structure.
-func (n *Netx) NewUDPListener() model.UDPListener {
-	return &udpListenerErrWrapper{&udpListenerStdlib{provider: n.maybeCustomUnderlyingNetwork()}}
-}
-
 // NewQUICDialerWithResolver is like [netxlite.NewQUICDialerWithResolver] but the constructed
 // [model.QUICDialer] uses the [model.UnderlyingNetwork] configured inside the [Netx] structure.
 func (n *Netx) NewQUICDialerWithResolver(listener model.UDPListener, logger model.DebugLogger,

--- a/internal/netxlite/quic.go
+++ b/internal/netxlite/quic.go
@@ -16,25 +16,6 @@ import (
 	"github.com/quic-go/quic-go"
 )
 
-// NewUDPListener creates a new UDPListener using the standard
-// library to create listening UDP sockets.
-func NewUDPListener() model.UDPListener {
-	return &udpListenerErrWrapper{&udpListenerStdlib{}}
-}
-
-// udpListenerStdlib is a UDPListener using the standard library.
-type udpListenerStdlib struct {
-	// provider is the OPTIONAL nil-safe [model.UnderlyingNetwork] provider.
-	provider *MaybeCustomUnderlyingNetwork
-}
-
-var _ model.UDPListener = &udpListenerStdlib{}
-
-// Listen implements UDPListener.Listen.
-func (qls *udpListenerStdlib) Listen(addr *net.UDPAddr) (model.UDPLikeConn, error) {
-	return qls.provider.Get().ListenUDP("udp", addr)
-}
-
 // NewQUICDialerWithResolver is the WrapDialer equivalent for QUIC where
 // we return a composed QUICDialer modified by optional wrappers.
 //

--- a/internal/netxlite/quic_test.go
+++ b/internal/netxlite/quic_test.go
@@ -19,12 +19,6 @@ import (
 	"github.com/quic-go/quic-go"
 )
 
-func TestNewUDPListener(t *testing.T) {
-	ql := NewUDPListener()
-	qew := ql.(*udpListenerErrWrapper)
-	_ = qew.UDPListener.(*udpListenerStdlib)
-}
-
 type extensionQUICDialerFirst struct {
 	model.QUICDialer
 }

--- a/internal/netxlite/udp.go
+++ b/internal/netxlite/udp.go
@@ -1,0 +1,33 @@
+package netxlite
+
+import (
+	"net"
+
+	"github.com/ooni/probe-cli/v3/internal/model"
+)
+
+// NewUDPListener creates a new UDPListener using the underlying
+// [*Netx] structure to create listening UDP sockets.
+func (netx *Netx) NewUDPListener() model.UDPListener {
+	return &udpListenerErrWrapper{&udpListenerStdlib{provider: netx.maybeCustomUnderlyingNetwork()}}
+}
+
+// NewUDPListener is equivalent to creating an empty [*Netx]
+// and calling its NewUDPListener method.
+func NewUDPListener() model.UDPListener {
+	netx := &Netx{Underlying: nil}
+	return netx.NewUDPListener()
+}
+
+// udpListenerStdlib is a UDPListener using the standard library.
+type udpListenerStdlib struct {
+	// provider is the OPTIONAL nil-safe [model.UnderlyingNetwork] provider.
+	provider *MaybeCustomUnderlyingNetwork
+}
+
+var _ model.UDPListener = &udpListenerStdlib{}
+
+// Listen implements UDPListener.Listen.
+func (qls *udpListenerStdlib) Listen(addr *net.UDPAddr) (model.UDPLikeConn, error) {
+	return qls.provider.Get().ListenUDP("udp", addr)
+}

--- a/internal/netxlite/udp_test.go
+++ b/internal/netxlite/udp_test.go
@@ -1,0 +1,9 @@
+package netxlite
+
+import "testing"
+
+func TestNewUDPListener(t *testing.T) {
+	ql := NewUDPListener()
+	qew := ql.(*udpListenerErrWrapper)
+	_ = qew.UDPListener.(*udpListenerStdlib)
+}


### PR DESCRIPTION
This diff is similar to https://github.com/ooni/probe-cli/commit/07a048ce8e944ba68b3fd55faf6c1de9a9620485 but here we use *Netx to create UDP sockets.

While there, recognize that UDP code needs its own files and should not live inside quic{,_test}.go.

Part of https://github.com/ooni/probe/issues/2531.
