### PR TITLE
refactor(netxlite): use *Netx for creating QUIC dialers

### DIFF
--- a/internal/netxlite/netx.go
+++ b/internal/netxlite/netx.go
@@ -22,17 +22,6 @@ func (netx *Netx) maybeCustomUnderlyingNetwork() *MaybeCustomUnderlyingNetwork {
 	return &MaybeCustomUnderlyingNetwork{netx.Underlying}
 }
 
-// NewQUICDialerWithResolver is like [netxlite.NewQUICDialerWithResolver] but the constructed
-// [model.QUICDialer] uses the [model.UnderlyingNetwork] configured inside the [Netx] structure.
-func (n *Netx) NewQUICDialerWithResolver(listener model.UDPListener, logger model.DebugLogger,
-	resolver model.Resolver, wrappers ...model.QUICDialerWrapper) (outDialer model.QUICDialer) {
-	baseDialer := &quicDialerQUICGo{
-		UDPListener: listener,
-		provider:    n.maybeCustomUnderlyingNetwork(),
-	}
-	return WrapQUICDialer(logger, resolver, baseDialer, wrappers...)
-}
-
 // NewTLSHandshakerStdlib is like [netxlite.NewTLSHandshakerStdlib] but the constructed [model.TLSHandshaker]
 // uses the [model.UnderlyingNetwork] configured inside the [Netx] structure.
 func (n *Netx) NewTLSHandshakerStdlib(logger model.DebugLogger) model.TLSHandshaker {


### PR DESCRIPTION
This diff is like https://github.com/ooni/probe-cli/commit/8a5edc22e3fde71e412715e6f96797376252b0ce but here we use *Netx to create QUIC dialers.

While there, recognize that `WrapQUICDialer` could become a private function.

The general idea of this patchset is to ensure we're not using duplicate code for constructing netxlite types, which is good to do now, because we're about to introduce new netxlite types for the network with which we communicate with the OONI backend.

Reference issue: https://github.com/ooni/probe/issues/2531
