### PR TITLE
refactor(netxlite): use *Netx for creating TLS handshakers

### DIFF
--- a/internal/netxlite/netx.go
+++ b/internal/netxlite/netx.go
@@ -22,12 +22,6 @@ func (netx *Netx) maybeCustomUnderlyingNetwork() *MaybeCustomUnderlyingNetwork {
 	return &MaybeCustomUnderlyingNetwork{netx.Underlying}
 }
 
-// NewTLSHandshakerStdlib is like [netxlite.NewTLSHandshakerStdlib] but the constructed [model.TLSHandshaker]
-// uses the [model.UnderlyingNetwork] configured inside the [Netx] structure.
-func (n *Netx) NewTLSHandshakerStdlib(logger model.DebugLogger) model.TLSHandshaker {
-	return newTLSHandshakerLogger(&tlsHandshakerConfigurable{provider: n.maybeCustomUnderlyingNetwork()}, logger)
-}
-
 // NewHTTPTransportStdlib is like [netxlite.NewHTTPTransportStdlib] but the constructed [model.HTTPTransport]
 // uses the [model.UnderlyingNetwork] configured inside the [Netx] structure.
 func (n *Netx) NewHTTPTransportStdlib(logger model.DebugLogger) model.HTTPTransport {

--- a/internal/netxlite/tls.go
+++ b/internal/netxlite/tls.go
@@ -165,7 +165,9 @@ var _ TLSConn = &tls.Conn{}
 // RootCAs field is zero initialized.
 func (netx *Netx) NewTLSHandshakerStdlib(logger model.DebugLogger) model.TLSHandshaker {
 	return newTLSHandshakerLogger(
-		&tlsHandshakerConfigurable{provider: netx.maybeCustomUnderlyingNetwork()}, logger)
+		&tlsHandshakerConfigurable{provider: netx.maybeCustomUnderlyingNetwork()},
+		logger,
+	)
 }
 
 // NewTLSHandshakerStdlib is equivalent to creating an empty [*Netx]

--- a/internal/netxlite/tls.go
+++ b/internal/netxlite/tls.go
@@ -163,8 +163,16 @@ var _ TLSConn = &tls.Conn{}
 //
 // 3. that we are going to use Mozilla CA if the [tls.Config]
 // RootCAs field is zero initialized.
+func (netx *Netx) NewTLSHandshakerStdlib(logger model.DebugLogger) model.TLSHandshaker {
+	return newTLSHandshakerLogger(
+		&tlsHandshakerConfigurable{provider: netx.maybeCustomUnderlyingNetwork()}, logger)
+}
+
+// NewTLSHandshakerStdlib is equivalent to creating an empty [*Netx]
+// and calling its NewTLSHandshakerStdlib method.
 func NewTLSHandshakerStdlib(logger model.DebugLogger) model.TLSHandshaker {
-	return newTLSHandshakerLogger(&tlsHandshakerConfigurable{}, logger)
+	netx := &Netx{Underlying: nil}
+	return netx.NewTLSHandshakerStdlib(logger)
 }
 
 // newTLSHandshakerLogger creates a new tlsHandshakerLogger instance.


### PR DESCRIPTION
This diff is like https://github.com/ooni/probe-cli/commit/50279a7f659d407c2dab6904227083087ae745e7 but uses *Netx to create TLS handshakers.

The general idea of this patchset is to ensure we're not using duplicate code for constructing netxlite types, which is good to do now, because we're about to introduce new netxlite types for the network with which we communicate with the OONI backend.

Reference issue: https://github.com/ooni/probe/issues/2531
