### PR TITLE
refactor(netxlite): use *Netx for creating HTTP transports

### DIFF
--- a/internal/netxlite/dialer_test.go
+++ b/internal/netxlite/dialer_test.go
@@ -104,6 +104,7 @@ func TestDialerSystem(t *testing.T) {
 			defaultTp := &DefaultTProxy{}
 			tp := &mocks.UnderlyingNetwork{
 				MockDialTimeout: func() time.Duration {
+					// Note: this test is notoriously flaky on Windows
 					return time.Nanosecond
 				},
 				MockDialContext: defaultTp.DialContext,

--- a/internal/netxlite/http.go
+++ b/internal/netxlite/http.go
@@ -342,10 +342,17 @@ func (c *httpTLSConnWithReadTimeout) Read(b []byte) (int, error) {
 //
 // This factory and NewHTTPTransport are the recommended
 // ways of creating a new HTTPTransport.
-func NewHTTPTransportStdlib(logger model.DebugLogger) model.HTTPTransport {
-	dialer := NewDialerWithResolver(logger, NewStdlibResolver(logger))
-	tlsDialer := NewTLSDialer(dialer, NewTLSHandshakerStdlib(logger))
+func (netx *Netx) NewHTTPTransportStdlib(logger model.DebugLogger) model.HTTPTransport {
+	dialer := netx.NewDialerWithResolver(logger, netx.NewStdlibResolver(logger))
+	tlsDialer := NewTLSDialer(dialer, netx.NewTLSHandshakerStdlib(logger))
 	return NewHTTPTransport(logger, dialer, tlsDialer)
+}
+
+// NewHTTPTransportStdlib is equivalent to creating an empty [*Netx]
+// and calling its NewHTTPTransportStdlib method.
+func NewHTTPTransportStdlib(logger model.DebugLogger) model.HTTPTransport {
+	netx := &Netx{Underlying: nil}
+	return netx.NewHTTPTransportStdlib(logger)
 }
 
 // NewHTTPClientStdlib creates a new HTTPClient that uses the

--- a/internal/netxlite/netx.go
+++ b/internal/netxlite/netx.go
@@ -22,14 +22,6 @@ func (netx *Netx) maybeCustomUnderlyingNetwork() *MaybeCustomUnderlyingNetwork {
 	return &MaybeCustomUnderlyingNetwork{netx.Underlying}
 }
 
-// NewHTTPTransportStdlib is like [netxlite.NewHTTPTransportStdlib] but the constructed [model.HTTPTransport]
-// uses the [model.UnderlyingNetwork] configured inside the [Netx] structure.
-func (n *Netx) NewHTTPTransportStdlib(logger model.DebugLogger) model.HTTPTransport {
-	dialer := n.NewDialerWithResolver(logger, n.NewStdlibResolver(logger))
-	tlsDialer := NewTLSDialer(dialer, n.NewTLSHandshakerStdlib(logger))
-	return NewHTTPTransport(logger, dialer, tlsDialer)
-}
-
 // NewHTTP3TransportStdlib is like [netxlite.NewHTTP3TransportStdlib] but the constructed [model.HTTPTransport]
 // uses the [model.UnderlyingNetwork] configured inside the [Netx] structure.
 func (n *Netx) NewHTTP3TransportStdlib(logger model.DebugLogger) model.HTTPTransport {


### PR DESCRIPTION
This diff is like https://github.com/ooni/probe-cli/commit/50279a7f659d407c2dab6904227083087ae745e7 but uses *Netx to create HTTP transports.

While there, annotate a test that is notoriously flaky on Windows.

The general idea of this patchset is to ensure we're not using duplicate code for constructing netxlite types, which is good to do now, because we're about to introduce new netxlite types for the network with which we communicate with the OONI backend.

Reference issue: https://github.com/ooni/probe/issues/2531
