### PR TITLE
refactor(netxlite): use *Netx for creating HTTP3 transports

### DIFF
--- a/internal/netxlite/http3.go
+++ b/internal/netxlite/http3.go
@@ -64,11 +64,18 @@ func NewHTTP3Transport(
 
 // NewHTTP3TransportStdlib creates a new HTTPTransport using http3 that
 // uses standard functionality for everything but the logger.
-func NewHTTP3TransportStdlib(logger model.DebugLogger) model.HTTPTransport {
-	ql := NewUDPListener()
-	reso := NewStdlibResolver(logger)
-	qd := NewQUICDialerWithResolver(ql, logger, reso)
+func (netx *Netx) NewHTTP3TransportStdlib(logger model.DebugLogger) model.HTTPTransport {
+	ql := netx.NewUDPListener()
+	reso := netx.NewStdlibResolver(logger)
+	qd := netx.NewQUICDialerWithResolver(ql, logger, reso)
 	return NewHTTP3Transport(logger, qd, nil)
+}
+
+// NewHTTP3TransportStdlib is equivalent to creating an empty [*Netx]
+// and calling its NewHTTP3TransportStdlib method.
+func NewHTTP3TransportStdlib(logger model.DebugLogger) model.HTTPTransport {
+	netx := &Netx{Underlying: nil}
+	return netx.NewHTTP3TransportStdlib(logger)
 }
 
 // NewHTTPTransportWithResolver creates a new HTTPTransport using http3

--- a/internal/netxlite/netx.go
+++ b/internal/netxlite/netx.go
@@ -21,12 +21,3 @@ type Netx struct {
 func (netx *Netx) maybeCustomUnderlyingNetwork() *MaybeCustomUnderlyingNetwork {
 	return &MaybeCustomUnderlyingNetwork{netx.Underlying}
 }
-
-// NewHTTP3TransportStdlib is like [netxlite.NewHTTP3TransportStdlib] but the constructed [model.HTTPTransport]
-// uses the [model.UnderlyingNetwork] configured inside the [Netx] structure.
-func (n *Netx) NewHTTP3TransportStdlib(logger model.DebugLogger) model.HTTPTransport {
-	ql := n.NewUDPListener()
-	reso := n.NewStdlibResolver(logger)
-	qd := n.NewQUICDialerWithResolver(ql, logger, reso)
-	return NewHTTP3Transport(logger, qd, nil)
-}


### PR DESCRIPTION
This diff is like https://github.com/ooni/probe-cli/commit/50279a7f659d407c2dab6904227083087ae745e7 but uses *Netx to create HTTP3 transports.

The general idea of this patchset is to ensure we're not using duplicate code for constructing netxlite types, which is good to do now, because we're about to introduce new netxlite types for the network with which we communicate with the OONI backend.

Reference issue: https://github.com/ooni/probe/issues/2531
