### PR TITLE
feat(netxlite): use *Netx for creating DoH resolvers

### DIFF
--- a/internal/netxlite/resolvercore.go
+++ b/internal/netxlite/resolvercore.go
@@ -39,10 +39,17 @@ func NewStdlibResolver(logger model.DebugLogger) model.Resolver {
 // NewParallelDNSOverHTTPSResolver creates a new DNS over HTTPS resolver
 // that uses the standard library for all operations. This function constructs
 // all the building blocks and calls WrapResolver on the returned resolver.
-func NewParallelDNSOverHTTPSResolver(logger model.DebugLogger, URL string) model.Resolver {
-	client := &http.Client{Transport: NewHTTPTransportStdlib(logger)}
+func (netx *Netx) NewParallelDNSOverHTTPSResolver(logger model.DebugLogger, URL string) model.Resolver {
+	client := &http.Client{Transport: netx.NewHTTPTransportStdlib(logger)}
 	txp := wrapDNSTransport(NewUnwrappedDNSOverHTTPSTransport(client, URL))
 	return WrapResolver(logger, NewUnwrappedParallelResolver(txp))
+}
+
+// NewParallelDNSOverHTTPSResolver is equivalent to creating an empty [*Netx]
+// and calling its NewParallelDNSOverHTTPSResolver method.
+func NewParallelDNSOverHTTPSResolver(logger model.DebugLogger, URL string) model.Resolver {
+	netx := &Netx{Underlying: nil}
+	return netx.NewParallelDNSOverHTTPSResolver(logger, URL)
 }
 
 func (netx *Netx) newUnwrappedStdlibResolver() model.Resolver {


### PR DESCRIPTION
While working on removing technical debt, as part of https://github.com/ooni/probe/issues/2531, it makes sense ensuring that there is a single way of constructing netxlite types by always using an instance of *Netx. This job is relatively easy because we are a couple of patches away from achieving this goal and, by doing this, we would avoid creating future technical debt. So, I am going to ahead and implement this.

Also, apparently, the oohelperd uses this functionality and somehow we missed
doing this when converting it to using netemx. We should fix this soon. (This issue
immediately validates what I was saying above about techdebt 😅)