### PR TITLE
feat(netxlite): use *Netx for creating UTLS handshakers

### DIFF
--- a/internal/netxlite/utls.go
+++ b/internal/netxlite/utls.go
@@ -31,10 +31,18 @@ import (
 // RootCAs field is zero initialized.
 //
 // Passing a nil `id` will make this function panic.
-func NewTLSHandshakerUTLS(logger model.DebugLogger, id *utls.ClientHelloID) model.TLSHandshaker {
+func (netx *Netx) NewTLSHandshakerUTLS(logger model.DebugLogger, id *utls.ClientHelloID) model.TLSHandshaker {
 	return newTLSHandshakerLogger(&tlsHandshakerConfigurable{
-		NewConn: newUTLSConnFactory(id),
+		NewConn:  newUTLSConnFactory(id),
+		provider: netx.maybeCustomUnderlyingNetwork(),
 	}, logger)
+}
+
+// NewTLSHandshakerUTLS is equivalent to creating an empty [*Netx]
+// and calling its NewTLSHandshakerUTLS method.
+func NewTLSHandshakerUTLS(logger model.DebugLogger, id *utls.ClientHelloID) model.TLSHandshaker {
+	netx := &Netx{Underlying: nil}
+	return netx.NewTLSHandshakerUTLS(logger, id)
 }
 
 // UTLSConn implements TLSConn and uses a utls UConn as its underlying connection


### PR DESCRIPTION
While working on removing technical debt, as part of https://github.com/ooni/probe/issues/2531, it makes sense ensuring that there is a single way of constructing netxlite types by always using an instance of *Netx. This job is relatively easy because we are a couple of patches away from achieving this goal and, by doing this, we would avoid creating future technical debt. So, I am going to ahead and implement this.
