### PR TITLE
feat(netxlite): use *Netx for NewParallelUDPResolver

### DIFF
--- a/internal/netxlite/resolvercore.go
+++ b/internal/netxlite/resolvercore.go
@@ -94,10 +94,17 @@ func NewSerialUDPResolver(logger model.DebugLogger, dialer model.Dialer, address
 // - dialer is the dialer to create and connect UDP conns
 //
 // - address is the server address (e.g., 1.1.1.1:53)
-func NewParallelUDPResolver(logger model.DebugLogger, dialer model.Dialer, address string) model.Resolver {
+func (netx *Netx) NewParallelUDPResolver(logger model.DebugLogger, dialer model.Dialer, address string) model.Resolver {
 	return WrapResolver(logger, NewUnwrappedParallelResolver(
 		wrapDNSTransport(NewUnwrappedDNSOverUDPTransport(dialer, address)),
 	))
+}
+
+// NewParallelUDPResolver is equivalent to creating an empty [*Netx]
+// and calling its NewParallelUDPResolver method.
+func NewParallelUDPResolver(logger model.DebugLogger, dialer model.Dialer, address string) model.Resolver {
+	netx := &Netx{Underlying: nil}
+	return netx.NewParallelUDPResolver(logger, dialer, address)
 }
 
 // WrapResolver creates a new resolver that wraps an


### PR DESCRIPTION
The overall idea at this point is that we will have an interface containing the methods we currently have inside *Netx and we will sever the hard dependency between measurexlite and netxlite.

We will probably still need to import some contants from netxlite but, for all effects and purposes, measurexlite would become completely mockable (as it is now) with an explicit dependency on the related behavior.

In turn, this refactoring would clarify which netxlite functionality we use for measuring, which are legacy, and which we use for communicating with the OONI backend. That change would definitely make it obvious to modify netxlite and go in the overall direction defined by https://github.com/ooni/probe/issues/2531.

