### PR TITLE
refactor(MeasuringNetwork): define dialers without resolver

### DIFF
--- a/internal/mocks/measuringnetwork.go
+++ b/internal/mocks/measuringnetwork.go
@@ -7,13 +7,13 @@ import (
 
 // MeasuringNetwork allows mocking [model.MeasuringNetwork].
 type MeasuringNetwork struct {
-	MockNewDialerWithResolver func(dl model.DebugLogger, r model.Resolver, w ...model.DialerWrapper) model.Dialer
+	MockNewDialerWithoutResolver func(dl model.DebugLogger, w ...model.DialerWrapper) model.Dialer
 
 	MockNewParallelDNSOverHTTPSResolver func(logger model.DebugLogger, URL string) model.Resolver
 
 	MockNewParallelUDPResolver func(logger model.DebugLogger, dialer model.Dialer, address string) model.Resolver
 
-	MockNewQUICDialerWithResolver func(listener model.UDPListener, logger model.DebugLogger, resolver model.Resolver, w ...model.QUICDialerWrapper) model.QUICDialer
+	MockNewQUICDialerWithoutResolver func(listener model.UDPListener, logger model.DebugLogger, w ...model.QUICDialerWrapper) model.QUICDialer
 
 	MockNewStdlibResolver func(logger model.DebugLogger) model.Resolver
 
@@ -26,9 +26,9 @@ type MeasuringNetwork struct {
 
 var _ model.MeasuringNetwork = &MeasuringNetwork{}
 
-// NewDialerWithResolver implements model.MeasuringNetwork.
-func (mn *MeasuringNetwork) NewDialerWithResolver(dl model.DebugLogger, r model.Resolver, w ...model.DialerWrapper) model.Dialer {
-	return mn.MockNewDialerWithResolver(dl, r, w...)
+// NewDialerWithoutResolver implements model.MeasuringNetwork.
+func (mn *MeasuringNetwork) NewDialerWithoutResolver(dl model.DebugLogger, w ...model.DialerWrapper) model.Dialer {
+	return mn.MockNewDialerWithoutResolver(dl, w...)
 }
 
 // NewParallelDNSOverHTTPSResolver implements model.MeasuringNetwork.
@@ -41,9 +41,9 @@ func (mn *MeasuringNetwork) NewParallelUDPResolver(logger model.DebugLogger, dia
 	return mn.MockNewParallelUDPResolver(logger, dialer, address)
 }
 
-// NewQUICDialerWithResolver implements model.MeasuringNetwork.
-func (mn *MeasuringNetwork) NewQUICDialerWithResolver(listener model.UDPListener, logger model.DebugLogger, resolver model.Resolver, w ...model.QUICDialerWrapper) model.QUICDialer {
-	return mn.MockNewQUICDialerWithResolver(listener, logger, resolver, w...)
+// NewQUICDialerWithoutResolver implements model.MeasuringNetwork.
+func (mn *MeasuringNetwork) NewQUICDialerWithoutResolver(listener model.UDPListener, logger model.DebugLogger, w ...model.QUICDialerWrapper) model.QUICDialer {
+	return mn.MockNewQUICDialerWithoutResolver(listener, logger, w...)
 }
 
 // NewStdlibResolver implements model.MeasuringNetwork.

--- a/internal/mocks/measuringnetwork_test.go
+++ b/internal/mocks/measuringnetwork_test.go
@@ -8,14 +8,14 @@ import (
 )
 
 func TestMeasuringN(t *testing.T) {
-	t.Run("MockNewDialerWithResolver", func(t *testing.T) {
+	t.Run("MockNewDialerWithoutResolver", func(t *testing.T) {
 		expected := &Dialer{}
 		mn := &MeasuringNetwork{
-			MockNewDialerWithResolver: func(dl model.DebugLogger, r model.Resolver, w ...model.DialerWrapper) model.Dialer {
+			MockNewDialerWithoutResolver: func(dl model.DebugLogger, w ...model.DialerWrapper) model.Dialer {
 				return expected
 			},
 		}
-		got := mn.NewDialerWithResolver(nil, nil)
+		got := mn.NewDialerWithoutResolver(nil, nil)
 		if expected != got {
 			t.Fatal("unexpected result")
 		}
@@ -47,14 +47,14 @@ func TestMeasuringN(t *testing.T) {
 		}
 	})
 
-	t.Run("MockNewQUICDialerWithResolver", func(t *testing.T) {
+	t.Run("MockNewQUICDialerWithoutResolver", func(t *testing.T) {
 		expected := &QUICDialer{}
 		mn := &MeasuringNetwork{
-			MockNewQUICDialerWithResolver: func(listener model.UDPListener, logger model.DebugLogger, resolver model.Resolver, w ...model.QUICDialerWrapper) model.QUICDialer {
+			MockNewQUICDialerWithoutResolver: func(listener model.UDPListener, logger model.DebugLogger, w ...model.QUICDialerWrapper) model.QUICDialer {
 				return expected
 			},
 		}
-		got := mn.NewQUICDialerWithResolver(nil, nil, nil)
+		got := mn.NewQUICDialerWithoutResolver(nil, nil, nil)
 		if expected != got {
 			t.Fatal("unexpected result")
 		}

--- a/internal/model/netx.go
+++ b/internal/model/netx.go
@@ -183,17 +183,12 @@ type HTTPSSvc struct {
 // implementation of this interface. This interface SHOULD always be implemented in terms of
 // an [UnderlyingNetwork] that allows to switch between the host network and [netemx].
 type MeasuringNetwork interface {
-	// NewDialerWithResolver creates a [Dialer] with error wrapping.
+	// NewDialerWithoutResolver creates a [Dialer] with error wrapping and without an attached
+	// resolver, meaning that you MUST pass TCP or UDP endpoint addresses to this dialer.
 	//
-	// This dialer will try to connect to each of the resolved IP address
-	// sequentially. In case of failure, such a resolver will return the first
-	// error that occurred. This implementation strategy is a QUIRK that is
-	// documented at TODO(https://github.com/ooni/probe/issues/1779).
-	//
-	// The [DialerWrapper] arguments wrap the returned dialer in such a way
-	// that we can implement the legacy [netx] package. New code MUST NOT
-	// use this functionality, which we'd like to remove ASAP.
-	NewDialerWithResolver(dl DebugLogger, r Resolver, w ...DialerWrapper) Dialer
+	// The [DialerWrapper] arguments wrap the returned dialer in such a way that we can implement
+	// the legacy [netx] package. New code MUST NOT use this functionality, which we'd like to remove ASAP.
+	NewDialerWithoutResolver(dl DebugLogger, w ...DialerWrapper) Dialer
 
 	// NewParallelDNSOverHTTPSResolver creates a new DNS-over-HTTPS resolver with error wrapping.
 	NewParallelDNSOverHTTPSResolver(logger DebugLogger, URL string) Resolver
@@ -204,17 +199,14 @@ type MeasuringNetwork interface {
 	// The address argument is the UDP endpoint address (e.g., 1.1.1.1:53, [::1]:53).
 	NewParallelUDPResolver(logger DebugLogger, dialer Dialer, address string) Resolver
 
-	// NewQUICDialerWithResolver creates a QUICDialer with error wrapping.
-	//
-	// Unlike the dialer returned by NewDialerWithResolver, this dialer MAY attempt
-	// happy eyeballs, perform parallel dial attempts, and return an error
-	// that aggregates all the errors that occurred.
+	// NewQUICDialerWithoutResolver creates a [QUICDialer] with error wrapping and without an attached
+	// resolver, meaning that you MUST pass UDP endpoint addresses to this dialer.
 	//
 	// The [QUICDialerWrapper] arguments wrap the returned dialer in such a way
 	// that we can implement the legacy [netx] package. New code MUST NOT
 	// use this functionality, which we'd like to remove ASAP.
-	NewQUICDialerWithResolver(
-		listener UDPListener, logger DebugLogger, resolver Resolver, w ...QUICDialerWrapper) QUICDialer
+	NewQUICDialerWithoutResolver(
+		listener UDPListener, logger DebugLogger, w ...QUICDialerWrapper) QUICDialer
 
 	// NewStdlibResolver creates a new Resolver with error wrapping using
 	// getaddrinfo or &net.Resolver{} depending on `-tags netgo`.


### PR DESCRIPTION
I initially planned on defining only the dialers with resolver and explicitly passing `&NullResolver{}` to them.

But I have just realized that, instead, defining the dialers without resolvers (which is what measurexlite needs anyway) will allow me to rewrite the without-resolver case to be very simple and completely ignore resolvers.

Once I have done this rewrite, we can keep the existing implementation for legacy code, but we can also have:

1. the above-mentioned simple dialing implementation without resolvers that fullfills measurexlite needs;

2. another implementation tailored to the needs of beacons.

So, voila, I think I now have a reasonable way forward to introduce beacons support in netxlite.

Part of https://github.com/ooni/probe/issues/2531

