### PR TITLE
refactor: rename sessionresolver engineresolver

### DIFF
--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/bytecounter"
 	"github.com/ooni/probe-cli/v3/internal/checkincache"
 	"github.com/ooni/probe-cli/v3/internal/enginelocate"
+	"github.com/ooni/probe-cli/v3/internal/engineresolver"
 	"github.com/ooni/probe-cli/v3/internal/kvstore"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
@@ -21,7 +22,6 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/probeservices"
 	"github.com/ooni/probe-cli/v3/internal/registry"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
-	"github.com/ooni/probe-cli/v3/internal/sessionresolver"
 	"github.com/ooni/probe-cli/v3/internal/tunnel"
 	"github.com/ooni/probe-cli/v3/internal/version"
 )
@@ -64,7 +64,7 @@ type Session struct {
 	logger                   model.Logger
 	proxyURL                 *url.URL
 	queryProbeServicesCount  *atomic.Int64
-	resolver                 *sessionresolver.Resolver
+	resolver                 *engineresolver.Resolver
 	selectedProbeServiceHook func(*model.OOAPIService)
 	selectedProbeService     *model.OOAPIService
 	softwareName             string
@@ -132,8 +132,8 @@ type sessionProbeServicesClientForCheckIn interface {
 //
 // 5. Create a compound resolver for the session that will attempt
 // to use a bunch of DoT/DoH servers before falling back to the system
-// resolver if nothing else works (see the sessionresolver pkg). This
-// sessionresolver will be using the configured proxy, if any.
+// resolver if nothing else works (see the engineresolver pkg). This
+// engineresolver will be using the configured proxy, if any.
 //
 // 6. Create the default HTTP transport that we should be using when
 // we communicate with the OONI backends. This transport will be
@@ -208,7 +208,7 @@ func NewSession(ctx context.Context, config SessionConfig) (*Session, error) {
 		}
 	}
 	sess.proxyURL = proxyURL
-	sess.resolver = &sessionresolver.Resolver{
+	sess.resolver = &engineresolver.Resolver{
 		ByteCounter: sess.byteCounter,
 		KVStore:     config.KVStore,
 		Logger:      sess.logger,

--- a/internal/engineresolver/doc.go
+++ b/internal/engineresolver/doc.go
@@ -1,4 +1,4 @@
-// Package sessionresolver contains the resolver used by the session. This
+// Package engineresolver contains the resolver used by the OONI engine. This
 // resolver will try to figure out which is the best service for running
 // domain name resolutions and will consistently use it.
 //
@@ -21,4 +21,4 @@
 // We also support a socks5 proxy. When such a proxy is configured,
 // the code WILL skip http3 resolvers AS WELL AS the system
 // resolver, in an attempt to avoid leaking your queries.
-package sessionresolver
+package engineresolver

--- a/internal/engineresolver/errwrapper.go
+++ b/internal/engineresolver/errwrapper.go
@@ -1,4 +1,4 @@
-package sessionresolver
+package engineresolver
 
 //
 // Error wrapping

--- a/internal/engineresolver/errwrapper_test.go
+++ b/internal/engineresolver/errwrapper_test.go
@@ -1,4 +1,4 @@
-package sessionresolver
+package engineresolver
 
 import (
 	"errors"

--- a/internal/engineresolver/factory.go
+++ b/internal/engineresolver/factory.go
@@ -1,4 +1,4 @@
-package sessionresolver
+package engineresolver
 
 import (
 	"errors"

--- a/internal/engineresolver/factory_test.go
+++ b/internal/engineresolver/factory_test.go
@@ -1,4 +1,4 @@
-package sessionresolver
+package engineresolver
 
 import (
 	"context"

--- a/internal/engineresolver/integration_test.go
+++ b/internal/engineresolver/integration_test.go
@@ -1,18 +1,18 @@
-package sessionresolver_test
+package engineresolver_test
 
 import (
 	"context"
 	"testing"
 
+	"github.com/ooni/probe-cli/v3/internal/engineresolver"
 	"github.com/ooni/probe-cli/v3/internal/kvstore"
-	"github.com/ooni/probe-cli/v3/internal/sessionresolver"
 )
 
 func TestSessionResolverGood(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip test in short mode")
 	}
-	reso := &sessionresolver.Resolver{
+	reso := &engineresolver.Resolver{
 		KVStore: &kvstore.Memory{},
 	}
 	defer reso.CloseIdleConnections()

--- a/internal/engineresolver/jsoncodec.go
+++ b/internal/engineresolver/jsoncodec.go
@@ -1,4 +1,4 @@
-package sessionresolver
+package engineresolver
 
 //
 // JSON codec

--- a/internal/engineresolver/jsoncodec_test.go
+++ b/internal/engineresolver/jsoncodec_test.go
@@ -1,4 +1,4 @@
-package sessionresolver
+package engineresolver
 
 import (
 	"testing"

--- a/internal/engineresolver/lookup.go
+++ b/internal/engineresolver/lookup.go
@@ -1,4 +1,4 @@
-package sessionresolver
+package engineresolver
 
 //
 // Actual lookup code

--- a/internal/engineresolver/lookup_test.go
+++ b/internal/engineresolver/lookup_test.go
@@ -1,4 +1,4 @@
-package sessionresolver
+package engineresolver
 
 import (
 	"context"

--- a/internal/engineresolver/resolver.go
+++ b/internal/engineresolver/resolver.go
@@ -1,4 +1,4 @@
-package sessionresolver
+package engineresolver
 
 //
 // Implementation of model.Resolver

--- a/internal/engineresolver/resolver_test.go
+++ b/internal/engineresolver/resolver_test.go
@@ -1,4 +1,4 @@
-package sessionresolver
+package engineresolver
 
 import (
 	"context"

--- a/internal/engineresolver/resolvermaker.go
+++ b/internal/engineresolver/resolvermaker.go
@@ -1,4 +1,4 @@
-package sessionresolver
+package engineresolver
 
 //
 // High-level code for creating a new child resolver

--- a/internal/engineresolver/resolvermaker_test.go
+++ b/internal/engineresolver/resolvermaker_test.go
@@ -1,4 +1,4 @@
-package sessionresolver
+package engineresolver
 
 import (
 	"strings"

--- a/internal/engineresolver/state.go
+++ b/internal/engineresolver/state.go
@@ -1,4 +1,4 @@
-package sessionresolver
+package engineresolver
 
 //
 // Persistent on-disk state
@@ -8,6 +8,9 @@ import (
 	"errors"
 	"sort"
 )
+
+// TODO(bassosimone): we may want to change the key and rename or
+// remove the old file inside the statedir
 
 // storekey is the key used by the key value store to store
 // the state required by this package.

--- a/internal/engineresolver/state_test.go
+++ b/internal/engineresolver/state_test.go
@@ -1,4 +1,4 @@
-package sessionresolver
+package engineresolver
 
 import (
 	"errors"


### PR DESCRIPTION
I am soon going to start addressing the underlying issue described by https://github.com/ooni/probe/issues/2531.

But, before doing that, I have noticed that the packages I need to edit to this end are the following:

```
./internal/engine
./internal/geolocate
./internal/sessionresolver
```

Now, these three packages work in unison to provide an `engine.Session` and they should *sort* together. However, I would like also to avoid nesting because I think each of them serves an ~independent purpose, and geolocate and sessionresolver are possibly building blocks to refactor or reimplement the engine.

For this reason, I have chosen to rename them such that it is clear they are the engine and supporting packages.

This diff addresses the second half of the change by renaming the sessionresolver package.
