### PR TITLE
cleanup: inline NewHTTPTransportWithLoggerResolverAndOptionalProxyURL

### DIFF
--- a/internal/enginenetx/http.go
+++ b/internal/enginenetx/http.go
@@ -47,9 +47,11 @@ func NewHTTPTransport(
 	proxyURL *url.URL,
 	resolver model.Resolver,
 ) *HTTPTransport {
-	txp := netxlite.NewHTTPTransportWithLoggerResolverAndOptionalProxyURL(
-		logger, resolver, proxyURL,
-	)
+	dialer := netxlite.NewDialerWithResolver(logger, resolver)
+	dialer = netxlite.MaybeWrapWithProxyDialer(dialer, proxyURL)
+	handshaker := netxlite.NewTLSHandshakerStdlib(logger)
+	tlsDialer := netxlite.NewTLSDialer(dialer, handshaker)
+	txp := netxlite.NewHTTPTransport(logger, dialer, tlsDialer)
 	txp = bytecounter.WrapHTTPTransport(txp, counter)
 	return &HTTPTransport{txp}
 }

--- a/internal/netxlite/http.go
+++ b/internal/netxlite/http.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"net"
 	"net/http"
-	"net/url"
 	"time"
 
 	oohttp "github.com/ooni/oohttp"
@@ -104,25 +103,6 @@ func (txp *httpTransportConnectionsCloser) CloseIdleConnections() {
 	txp.HTTPTransport.CloseIdleConnections()
 	txp.Dialer.CloseIdleConnections()
 	txp.TLSDialer.CloseIdleConnections()
-}
-
-// NewHTTPTransportWithLoggerResolverAndOptionalProxyURL creates an HTTPTransport using
-// the given logger and resolver and an optional proxy URL.
-//
-// Arguments:
-//
-// - logger is the MANDATORY logger;
-//
-// - resolver is the MANDATORY resolver;
-//
-// - purl is the OPTIONAL proxy URL.
-func NewHTTPTransportWithLoggerResolverAndOptionalProxyURL(
-	logger model.DebugLogger, resolver model.Resolver, purl *url.URL) model.HTTPTransport {
-	dialer := NewDialerWithResolver(logger, resolver)
-	dialer = MaybeWrapWithProxyDialer(dialer, purl)
-	handshaker := NewTLSHandshakerStdlib(logger)
-	tlsDialer := NewTLSDialer(dialer, handshaker)
-	return NewHTTPTransport(logger, dialer, tlsDialer)
 }
 
 // NewHTTPTransportWithResolver creates a new HTTP transport using

--- a/internal/netxlite/http_test.go
+++ b/internal/netxlite/http_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -16,48 +15,6 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/mocks"
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
-
-func TestNewHTTPTransportWithLoggerResolverAndOptionalProxyURL(t *testing.T) {
-	t.Run("without proxy URL", func(t *testing.T) {
-		logger := &mocks.Logger{}
-		resolver := &mocks.Resolver{}
-		txp := NewHTTPTransportWithLoggerResolverAndOptionalProxyURL(logger, resolver, nil)
-		txpLogger := txp.(*httpTransportLogger)
-		if txpLogger.Logger != logger {
-			t.Fatal("unexpected logger")
-		}
-		txpErrWrapper := txpLogger.HTTPTransport.(*httpTransportErrWrapper)
-		txpCc := txpErrWrapper.HTTPTransport.(*httpTransportConnectionsCloser)
-		dialer := txpCc.Dialer
-		dialerWithReadTimeout := dialer.(*httpDialerWithReadTimeout)
-		dialerLog := dialerWithReadTimeout.Dialer.(*dialerLogger)
-		dialerReso := dialerLog.Dialer.(*dialerResolverWithTracing)
-		if dialerReso.Resolver != resolver {
-			t.Fatal("invalid resolver")
-		}
-	})
-
-	t.Run("with proxy URL", func(t *testing.T) {
-		URL := &url.URL{}
-		logger := &mocks.Logger{}
-		resolver := &mocks.Resolver{}
-		txp := NewHTTPTransportWithLoggerResolverAndOptionalProxyURL(logger, resolver, URL)
-		txpLogger := txp.(*httpTransportLogger)
-		if txpLogger.Logger != logger {
-			t.Fatal("unexpected logger")
-		}
-		txpErrWrapper := txpLogger.HTTPTransport.(*httpTransportErrWrapper)
-		txpCc := txpErrWrapper.HTTPTransport.(*httpTransportConnectionsCloser)
-		dialer := txpCc.Dialer
-		dialerWithReadTimeout := dialer.(*httpDialerWithReadTimeout)
-		dialerProxy := dialerWithReadTimeout.Dialer.(*proxyDialer)
-		dialerLog := dialerProxy.Dialer.(*dialerLogger)
-		dialerReso := dialerLog.Dialer.(*dialerResolverWithTracing)
-		if dialerReso.Resolver != resolver {
-			t.Fatal("invalid resolver")
-		}
-	})
-}
 
 func TestNewHTTPTransportWithResolver(t *testing.T) {
 	expected := errors.New("mocked error")


### PR DESCRIPTION
This diff inlines the original implementation of the netxlite.NewHTTPTransportWithLoggerResolverAndOptionalProxyURL function inside the enginex package.

With this diff, we continue to partially detach the engine networking from netxlite, to implement the beacons as described by https://github.com/ooni/probe/issues/2531.
