### PR TITLE
feat(netxlite): add (*Netx).ListenTCP

### DIFF
--- a/internal/netemx/tlsproxy.go
+++ b/internal/netemx/tlsproxy.go
@@ -79,7 +79,6 @@ func (srv *tlsProxyServer) MustStart() {
 			srv.logger,
 			&netxlite.Netx{Underlying: &netxlite.NetemUnderlyingNetworkAdapter{UNet: srv.unet}},
 			epnt,
-			srv.unet,
 		)
 
 		// track this server as something to close later

--- a/internal/netxlite/netx.go
+++ b/internal/netxlite/netx.go
@@ -5,7 +5,11 @@ package netxlite
 // network operations using a custom model.UnderlyingNetwork.
 //
 
-import "github.com/ooni/probe-cli/v3/internal/model"
+import (
+	"net"
+
+	"github.com/ooni/probe-cli/v3/internal/model"
+)
 
 // Netx allows constructing netxlite data types using a specific [model.UnderlyingNetwork].
 type Netx struct {
@@ -19,4 +23,9 @@ var _ model.MeasuringNetwork = &Netx{}
 // maybeCustomUnderlyingNetwork wraps the [model.UnderlyingNetwork] using a [*MaybeCustomUnderlyingNetwork].
 func (netx *Netx) maybeCustomUnderlyingNetwork() *MaybeCustomUnderlyingNetwork {
 	return &MaybeCustomUnderlyingNetwork{netx.Underlying}
+}
+
+// ListenTCP creates a new listening TCP socket using the given address.
+func (netx *Netx) ListenTCP(network string, addr *net.TCPAddr) (net.Listener, error) {
+	return netx.maybeCustomUnderlyingNetwork().Get().ListenTCP(network, addr)
 }

--- a/internal/testingx/httptestx.go
+++ b/internal/testingx/httptestx.go
@@ -89,6 +89,7 @@ func mustNewHTTPServer(
 		X509CertPool: nil, // the default when not using TLS
 	}
 	baseURL := &url.URL{Host: listener.Addr().String()}
+
 	switch !tlsConfig.IsNone() {
 	case true:
 		baseURL.Scheme = "https"
@@ -97,10 +98,12 @@ func mustNewHTTPServer(
 		srv.Config.TLSConfig = srv.TLS
 		srv.X509CertPool = runtimex.Try1(tlsConfig.Unwrap().DefaultCertPool())
 		go srv.Config.ServeTLS(listener, "", "") // using server.TLSConfig
+
 	default:
 		baseURL.Scheme = "http"
 		go srv.Config.Serve(listener)
 	}
+
 	srv.URL = baseURL.String()
 	return srv
 }

--- a/internal/testingx/tlssniproxy.go
+++ b/internal/testingx/tlssniproxy.go
@@ -16,6 +16,7 @@ import (
 
 // TLSSNIProxyNetx is how [TLSSNIProxy] views [*netxlite.Netx].
 type TLSSNIProxyNetx interface {
+	ListenTCP(network string, addr *net.TCPAddr) (net.Listener, error)
 	NewDialerWithResolver(dl model.DebugLogger, r model.Resolver, w ...model.DialerWrapper) model.Dialer
 	NewStdlibResolver(logger model.DebugLogger) model.Resolver
 }
@@ -38,13 +39,10 @@ type TLSSNIProxy struct {
 	wg *sync.WaitGroup
 }
 
-// TODO(bassosimone): MustNewTLSSNIProxyEx prototype would be simpler if
-// netxlite.Netx was also able to create listening TCP connections
-
 // MustNewTLSSNIProxyEx creates a new [*TLSSNIProxy].
 func MustNewTLSSNIProxyEx(
-	logger model.Logger, netx TLSSNIProxyNetx, tcpAddr *net.TCPAddr, tcpListener TCPListener) *TLSSNIProxy {
-	listener := runtimex.Try1(tcpListener.ListenTCP("tcp", tcpAddr))
+	logger model.Logger, netx TLSSNIProxyNetx, tcpAddr *net.TCPAddr) *TLSSNIProxy {
+	listener := runtimex.Try1(netx.ListenTCP("tcp", tcpAddr))
 	proxy := &TLSSNIProxy{
 		closeOnce: sync.Once{},
 		listener:  listener,

--- a/internal/testingx/tlssniproxy_test.go
+++ b/internal/testingx/tlssniproxy_test.go
@@ -32,9 +32,8 @@ func TestTLSSNIProxy(t *testing.T) {
 				Underlying: nil, // use the network
 			}
 			tcpAddr := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)}
-			tcpListener := &testingx.TCPListenerStdlib{}
 
-			proxy := testingx.MustNewTLSSNIProxyEx(log.Log, netxProxy, tcpAddr, tcpListener)
+			proxy := testingx.MustNewTLSSNIProxyEx(log.Log, netxProxy, tcpAddr)
 			closers = append(closers, proxy)
 
 			netxClient := &netxlite.Netx{
@@ -75,7 +74,6 @@ func TestTLSSNIProxy(t *testing.T) {
 				log.Log,
 				&netxlite.Netx{Underlying: &netxlite.NetemUnderlyingNetworkAdapter{UNet: proxyStack}},
 				&net.TCPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 443},
-				proxyStack,
 			)
 			closers = append(closers, proxy)
 


### PR DESCRIPTION
This diff adds the ListenTCP function to the *Netx struct.

With this addition, based on https://github.com/ooni/probe-cli/pull/1278, we can remove some techdebt inside the testingx package.

This is yak shaving while trying to add support for testing socks5 in the context of https://github.com/ooni/probe/issues/2531.

