### PR TITLE
refactor(model/netx.go): TLSHandhaker now returns a TLSConn

### DIFF
--- a/internal/dslx/tls.go
+++ b/internal/dslx/tls.go
@@ -124,7 +124,7 @@ func (f *tlsHandshakeFunc) Apply(
 	defer cancel()
 
 	// handshake
-	conn, tlsState, err := handshaker.Handshake(ctx, input.Conn, config)
+	conn, err := handshaker.Handshake(ctx, input.Conn, config)
 
 	// possibly register established conn for late close
 	f.Pool.MaybeTrack(conn)
@@ -132,19 +132,14 @@ func (f *tlsHandshakeFunc) Apply(
 	// stop the operation logger
 	ol.Stop(err)
 
-	var tlsConn netxlite.TLSConn
-	if conn != nil {
-		tlsConn = conn.(netxlite.TLSConn) // guaranteed to work
-	}
-
 	state := &TLSConnection{
 		Address:     input.Address,
-		Conn:        tlsConn, // possibly nil
+		Conn:        conn, // possibly nil
 		Domain:      input.Domain,
 		IDGenerator: input.IDGenerator,
 		Logger:      input.Logger,
 		Network:     input.Network,
-		TLSState:    tlsState,
+		TLSState:    conn.ConnectionState(),
 		Trace:       trace,
 		ZeroTime:    input.ZeroTime,
 	}

--- a/internal/dslx/tls.go
+++ b/internal/dslx/tls.go
@@ -139,7 +139,7 @@ func (f *tlsHandshakeFunc) Apply(
 		IDGenerator: input.IDGenerator,
 		Logger:      input.Logger,
 		Network:     input.Network,
-		TLSState:    conn.ConnectionState(),
+		TLSState:    netxlite.MaybeTLSConnectionState(conn),
 		Trace:       trace,
 		ZeroTime:    input.ZeroTime,
 	}

--- a/internal/dslx/tls_test.go
+++ b/internal/dslx/tls_test.go
@@ -70,7 +70,12 @@ func TestTLSHandshake(t *testing.T) {
 				return nil
 			},
 		}
-		tlsConn := &mocks.TLSConn{Conn: tcpConn}
+		tlsConn := &mocks.TLSConn{
+			Conn: tcpConn,
+			MockConnectionState: func() tls.ConnectionState {
+				return tls.ConnectionState{}
+			},
+		}
 
 		eofHandshaker := &mocks.TLSHandshaker{
 			MockHandshake: func(ctx context.Context, conn net.Conn, config *tls.Config) (model.TLSConn, error) {

--- a/internal/dslx/tls_test.go
+++ b/internal/dslx/tls_test.go
@@ -73,14 +73,14 @@ func TestTLSHandshake(t *testing.T) {
 		tlsConn := &mocks.TLSConn{Conn: tcpConn}
 
 		eofHandshaker := &mocks.TLSHandshaker{
-			MockHandshake: func(ctx context.Context, conn net.Conn, config *tls.Config) (net.Conn, tls.ConnectionState, error) {
-				return nil, tls.ConnectionState{}, io.EOF
+			MockHandshake: func(ctx context.Context, conn net.Conn, config *tls.Config) (model.TLSConn, error) {
+				return nil, io.EOF
 			},
 		}
 
 		goodHandshaker := &mocks.TLSHandshaker{
-			MockHandshake: func(ctx context.Context, conn net.Conn, config *tls.Config) (net.Conn, tls.ConnectionState, error) {
-				return tlsConn, tls.ConnectionState{}, nil
+			MockHandshake: func(ctx context.Context, conn net.Conn, config *tls.Config) (model.TLSConn, error) {
+				return tlsConn, nil
 			},
 		}
 

--- a/internal/experiment/echcheck/handshake.go
+++ b/internal/experiment/echcheck/handshake.go
@@ -41,9 +41,10 @@ func handshakeWithExtension(ctx context.Context, conn net.Conn, zeroTime time.Ti
 	tracedHandshaker := handshakerConstructor(log.Log, &utls.HelloFirefox_Auto)
 
 	start := time.Now()
-	_, connState, err := tracedHandshaker.Handshake(ctx, conn, tlsConfig)
+	maybeTLSConn, err := tracedHandshaker.Handshake(ctx, conn, tlsConfig)
 	finish := time.Now()
 
+	connState := netxlite.MaybeTLSConnectionState(maybeTLSConn)
 	return measurexlite.NewArchivalTLSOrQUICHandshakeResult(0, start.Sub(zeroTime), "tcp", address, tlsConfig,
 		connState, err, finish.Sub(zeroTime))
 }

--- a/internal/experiment/echcheck/measure_test.go
+++ b/internal/experiment/echcheck/measure_test.go
@@ -84,12 +84,10 @@ func TestMeasurementSuccess(t *testing.T) {
 	}
 
 	summary, err := measurer.GetSummaryKeys(&model.Measurement{})
-
+	if err != nil {
+		t.Fatal(err)
+	}
 	if summary.(SummaryKeys).IsAnomaly != false {
 		t.Fatal("expected false")
 	}
-}
-
-func newsession() model.ExperimentSession {
-	return &mockable.Session{MockableLogger: log.Log}
 }

--- a/internal/experiment/echcheck/utls.go
+++ b/internal/experiment/echcheck/utls.go
@@ -45,7 +45,5 @@ func (t *tlsHandshakerWithExtensions) Handshake(
 		return nil, err
 	}
 
-	// TODO(bassosimone): I don't understand why we're storing the conn inside
-	// of the TLS handshaker with extensions structure, but I don't like it
 	return tlsConn, nil
 }

--- a/internal/experiment/echcheck/utls_test.go
+++ b/internal/experiment/echcheck/utls_test.go
@@ -1,0 +1,41 @@
+package echcheck
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"testing"
+
+	"github.com/ooni/probe-cli/v3/internal/mocks"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	utls "gitlab.com/yawning/utls.git"
+)
+
+func TestTLSHandshakerWithExtension(t *testing.T) {
+	t.Run("when the TLS handshake fails", func(t *testing.T) {
+		thx := &tlsHandshakerWithExtensions{
+			extensions: []utls.TLSExtension{},
+			dl:         model.DiscardLogger,
+			id:         &utls.HelloChrome_70,
+		}
+
+		expected := errors.New("mocked error")
+		tcpConn := &mocks.Conn{
+			MockWrite: func(b []byte) (int, error) {
+				return 0, expected
+			},
+		}
+
+		tlsConfig := &tls.Config{
+			InsecureSkipVerify: true,
+		}
+
+		tlsConn, err := thx.Handshake(context.Background(), tcpConn, tlsConfig)
+		if !errors.Is(err, expected) {
+			t.Fatal(err)
+		}
+		if tlsConn != nil {
+			t.Fatal("expected nil tls conn")
+		}
+	})
+}

--- a/internal/experiment/tlsmiddlebox/tracing.go
+++ b/internal/experiment/tlsmiddlebox/tracing.go
@@ -97,7 +97,7 @@ func (m *Measurer) handshakeWithTTL(ctx context.Context, index int64, zeroTime t
 	if clientId > 0 {
 		thx = trace.NewTLSHandshakerUTLS(logger, ClientIDs[clientId])
 	}
-	_, _, err = thx.Handshake(ctx, conn, genTLSConfig(sni))
+	_, err = thx.Handshake(ctx, conn, genTLSConfig(sni))
 	ol.Stop(err)
 	soErr := extractSoError(conn)
 	// 4. reset the TTL value to ensure that conn closes successfully

--- a/internal/experiment/tlsping/tlsping.go
+++ b/internal/experiment/tlsping/tlsping.go
@@ -189,7 +189,7 @@ func (m *Measurer) tlsConnectAndHandshake(ctx context.Context, index int64,
 		RootCAs:    nil,
 		ServerName: sni,
 	}
-	_, _, err = thx.Handshake(ctx, conn, config)
+	_, err = thx.Handshake(ctx, conn, config)
 	ol.Stop(err)
 	sp.TLSHandshake = trace.FirstTLSHandshakeOrNil() // record the first handshake from the buffer
 	sp.NetworkEvents = trace.NetworkEvents()

--- a/internal/experiment/webconnectivitylte/secureflow.go
+++ b/internal/experiment/webconnectivitylte/secureflow.go
@@ -162,7 +162,7 @@ func (t *SecureFlow) Run(parentCtx context.Context, index int64) error {
 	}
 	defer tlsConn.Close()
 
-	tlsConnState := tlsConn.ConnectionState()
+	tlsConnState := netxlite.MaybeTLSConnectionState(tlsConn)
 	alpn := tlsConnState.NegotiatedProtocol
 
 	// Determine whether we're allowed to fetch the webpage
@@ -178,7 +178,6 @@ func (t *SecureFlow) Run(parentCtx context.Context, index int64) error {
 	httpTransport := netxlite.NewHTTPTransport(
 		t.Logger,
 		netxlite.NewNullDialer(),
-		// note: netxlite guarantees that here tlsConn is a netxlite.TLSConn
 		netxlite.NewSingleUseTLSDialer(tlsConn),
 	)
 

--- a/internal/experiment/webconnectivitylte/secureflow.go
+++ b/internal/experiment/webconnectivitylte/secureflow.go
@@ -154,7 +154,7 @@ func (t *SecureFlow) Run(parentCtx context.Context, index int64) error {
 	const tlsTimeout = 10 * time.Second
 	tlsCtx, tlsCancel := context.WithTimeout(parentCtx, tlsTimeout)
 	defer tlsCancel()
-	tlsConn, tlsConnState, err := tlsHandshaker.Handshake(tlsCtx, tcpConn, tlsConfig)
+	tlsConn, err := tlsHandshaker.Handshake(tlsCtx, tcpConn, tlsConfig)
 	t.TestKeys.AppendTLSHandshakes(trace.TLSHandshakes()...)
 	if err != nil {
 		ol.Stop(err)
@@ -162,6 +162,7 @@ func (t *SecureFlow) Run(parentCtx context.Context, index int64) error {
 	}
 	defer tlsConn.Close()
 
+	tlsConnState := tlsConn.ConnectionState()
 	alpn := tlsConnState.NegotiatedProtocol
 
 	// Determine whether we're allowed to fetch the webpage
@@ -178,7 +179,7 @@ func (t *SecureFlow) Run(parentCtx context.Context, index int64) error {
 		t.Logger,
 		netxlite.NewNullDialer(),
 		// note: netxlite guarantees that here tlsConn is a netxlite.TLSConn
-		netxlite.NewSingleUseTLSDialer(tlsConn.(netxlite.TLSConn)),
+		netxlite.NewSingleUseTLSDialer(tlsConn),
 	)
 
 	// create HTTP request

--- a/internal/legacy/measurex/measurer.go
+++ b/internal/legacy/measurex/measurer.go
@@ -355,13 +355,12 @@ func (mx *Measurer) TLSConnectAndHandshakeWithDB(ctx context.Context,
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	th := mx.WrapTLSHandshaker(db, mx.TLSHandshaker)
-	tlsConn, _, err := th.Handshake(ctx, conn, config)
+	tlsConn, err := th.Handshake(ctx, conn, config)
 	ol.Stop(err)
 	if err != nil {
 		return nil, err
 	}
-	// cast safe according to the docs of netxlite's handshaker
-	return tlsConn.(netxlite.TLSConn), nil
+	return tlsConn, nil
 }
 
 // QUICHandshake connects and TLS handshakes with a QUIC endpoint.

--- a/internal/legacy/tracex/tls_test.go
+++ b/internal/legacy/tracex/tls_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/ooni/probe-cli/v3/internal/mocks"
+	"github.com/ooni/probe-cli/v3/internal/model"
 )
 
 func TestWrapTLSHandshaker(t *testing.T) {
@@ -98,9 +99,8 @@ func TestTLSHandshakerSaver(t *testing.T) {
 				},
 			}
 			thx := saver.WrapTLSHandshaker(&mocks.TLSHandshaker{
-				MockHandshake: func(ctx context.Context, conn net.Conn,
-					config *tls.Config) (net.Conn, tls.ConnectionState, error) {
-					return returnedConn, returnedConnState, nil
+				MockHandshake: func(ctx context.Context, conn net.Conn, config *tls.Config) (model.TLSConn, error) {
+					return returnedConn, nil
 				},
 			})
 			ctx := context.Background()
@@ -121,7 +121,7 @@ func TestTLSHandshakerSaver(t *testing.T) {
 					}
 				},
 			}
-			conn, _, err := thx.Handshake(ctx, tcpConn, tlsConfig)
+			conn, err := thx.Handshake(ctx, tcpConn, tlsConfig)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -161,9 +161,8 @@ func TestTLSHandshakerSaver(t *testing.T) {
 			expected := errors.New("mocked error")
 			saver := &Saver{}
 			thx := saver.WrapTLSHandshaker(&mocks.TLSHandshaker{
-				MockHandshake: func(ctx context.Context, conn net.Conn,
-					config *tls.Config) (net.Conn, tls.ConnectionState, error) {
-					return nil, tls.ConnectionState{}, expected
+				MockHandshake: func(ctx context.Context, conn net.Conn, config *tls.Config) (model.TLSConn, error) {
+					return nil, expected
 				},
 			})
 			ctx := context.Background()
@@ -184,7 +183,7 @@ func TestTLSHandshakerSaver(t *testing.T) {
 					}
 				},
 			}
-			conn, _, err := thx.Handshake(ctx, tcpConn, tlsConfig)
+			conn, err := thx.Handshake(ctx, tcpConn, tlsConfig)
 			if !errors.Is(err, expected) {
 				t.Fatal("unexpected err", err)
 			}

--- a/internal/measurexlite/tls.go
+++ b/internal/measurexlite/tls.go
@@ -35,7 +35,7 @@ var _ model.TLSHandshaker = &tlsHandshakerTrace{}
 
 // Handshake implements model.TLSHandshaker.Handshake.
 func (thx *tlsHandshakerTrace) Handshake(
-	ctx context.Context, conn net.Conn, tlsConfig *tls.Config) (net.Conn, tls.ConnectionState, error) {
+	ctx context.Context, conn net.Conn, tlsConfig *tls.Config) (model.TLSConn, error) {
 	return thx.thx.Handshake(netxlite.ContextWithTrace(ctx, thx.tx), conn, tlsConfig)
 }
 

--- a/internal/measurexlite/trace_test.go
+++ b/internal/measurexlite/trace_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"net"
-	"reflect"
 	"syscall"
 	"testing"
 	"time"
@@ -261,12 +260,9 @@ func TestTrace(t *testing.T) {
 			InsecureSkipVerify: true,
 		}
 		ctx := context.Background()
-		conn, state, err := thx.Handshake(ctx, tcpConn, tlsConfig)
+		conn, err := thx.Handshake(ctx, tcpConn, tlsConfig)
 		if !errors.Is(err, mockedErr) {
 			t.Fatal("unexpected err", err)
-		}
-		if !reflect.ValueOf(state).IsZero() {
-			t.Fatal("state is not a zero value")
 		}
 		if conn != nil {
 			t.Fatal("expected nil conn")
@@ -302,12 +298,9 @@ func TestTrace(t *testing.T) {
 			InsecureSkipVerify: true,
 		}
 		ctx := context.Background()
-		conn, state, err := thx.Handshake(ctx, tcpConn, tlsConfig)
+		conn, err := thx.Handshake(ctx, tcpConn, tlsConfig)
 		if !errors.Is(err, mockedErr) {
 			t.Fatal("unexpected err", err)
-		}
-		if !reflect.ValueOf(state).IsZero() {
-			t.Fatal("state is not a zero value")
 		}
 		if conn != nil {
 			t.Fatal("expected nil conn")

--- a/internal/mocks/tls.go
+++ b/internal/mocks/tls.go
@@ -4,17 +4,17 @@ import (
 	"context"
 	"crypto/tls"
 	"net"
+
+	"github.com/ooni/probe-cli/v3/internal/model"
 )
 
 // TLSHandshaker is a mockable TLS handshaker.
 type TLSHandshaker struct {
-	MockHandshake func(ctx context.Context, conn net.Conn, config *tls.Config) (
-		net.Conn, tls.ConnectionState, error)
+	MockHandshake func(ctx context.Context, conn net.Conn, config *tls.Config) (model.TLSConn, error)
 }
 
 // Handshake calls MockHandshake.
-func (th *TLSHandshaker) Handshake(ctx context.Context, conn net.Conn, config *tls.Config) (
-	net.Conn, tls.ConnectionState, error) {
+func (th *TLSHandshaker) Handshake(ctx context.Context, conn net.Conn, config *tls.Config) (model.TLSConn, error) {
 	return th.MockHandshake(ctx, conn, config)
 }
 

--- a/internal/mocks/tls_test.go
+++ b/internal/mocks/tls_test.go
@@ -7,6 +7,8 @@ import (
 	"net"
 	"reflect"
 	"testing"
+
+	"github.com/ooni/probe-cli/v3/internal/model"
 )
 
 func TestTLSHandshaker(t *testing.T) {
@@ -16,17 +18,13 @@ func TestTLSHandshaker(t *testing.T) {
 		ctx := context.Background()
 		config := &tls.Config{}
 		th := &TLSHandshaker{
-			MockHandshake: func(ctx context.Context, conn net.Conn,
-				config *tls.Config) (net.Conn, tls.ConnectionState, error) {
-				return nil, tls.ConnectionState{}, expected
+			MockHandshake: func(ctx context.Context, conn net.Conn, config *tls.Config) (model.TLSConn, error) {
+				return nil, expected
 			},
 		}
-		tlsConn, connState, err := th.Handshake(ctx, conn, config)
+		tlsConn, err := th.Handshake(ctx, conn, config)
 		if !errors.Is(err, expected) {
 			t.Fatal("not the error we expected", err)
-		}
-		if !reflect.ValueOf(connState).IsZero() {
-			t.Fatal("expected zero ConnectionState here")
 		}
 		if tlsConn != nil {
 			t.Fatal("expected nil conn here")

--- a/internal/model/netx.go
+++ b/internal/model/netx.go
@@ -332,12 +332,7 @@ type TLSHandshaker interface {
 	//
 	// - set NextProtos to []string{"h2", "http/1.1"} for HTTPS
 	// and []string{"dot"} for DNS-over-TLS.
-	//
-	// QUIRK: The returned connection will always implement the TLSConn interface
-	// exposed by ooni/oohttp. A future version of this interface may instead
-	// return directly a TLSConn to avoid unconditional castings.
-	Handshake(ctx context.Context, conn net.Conn, tlsConfig *tls.Config) (
-		net.Conn, tls.ConnectionState, error)
+	Handshake(ctx context.Context, conn net.Conn, tlsConfig *tls.Config) (TLSConn, error)
 }
 
 // Trace allows to collect measurement traces. A trace is injected into

--- a/internal/netxlite/integration_test.go
+++ b/internal/netxlite/integration_test.go
@@ -295,7 +295,7 @@ func TestMeasureWithTLSHandshaker(t *testing.T) {
 			NextProtos: []string{"h2", "http/1.1"},
 			RootCAs:    nil,
 		}
-		tconn, _, err := th.Handshake(ctx, conn, config)
+		tconn, err := th.Handshake(ctx, conn, config)
 		if err != nil {
 			return fmt.Errorf("tls handshake failed: %w", err)
 		}
@@ -320,7 +320,7 @@ func TestMeasureWithTLSHandshaker(t *testing.T) {
 			NextProtos: []string{"h2", "http/1.1"},
 			RootCAs:    nil,
 		}
-		tconn, _, err := th.Handshake(ctx, conn, config)
+		tconn, err := th.Handshake(ctx, conn, config)
 		if err == nil {
 			return fmt.Errorf("tls handshake succeded unexpectedly")
 		}
@@ -350,7 +350,7 @@ func TestMeasureWithTLSHandshaker(t *testing.T) {
 			NextProtos: []string{"h2", "http/1.1"},
 			RootCAs:    nil,
 		}
-		tconn, _, err := th.Handshake(ctx, conn, config)
+		tconn, err := th.Handshake(ctx, conn, config)
 		if err == nil {
 			return fmt.Errorf("tls handshake succeded unexpectedly")
 		}
@@ -380,7 +380,7 @@ func TestMeasureWithTLSHandshaker(t *testing.T) {
 			NextProtos: []string{"h2", "http/1.1"},
 			RootCAs:    nil,
 		}
-		tconn, _, err := th.Handshake(ctx, conn, config)
+		tconn, err := th.Handshake(ctx, conn, config)
 		if err == nil {
 			return fmt.Errorf("tls handshake succeded unexpectedly")
 		}

--- a/internal/netxlite/tls_test.go
+++ b/internal/netxlite/tls_test.go
@@ -157,7 +157,7 @@ func TestTLSHandshakerConfigurable(t *testing.T) {
 				},
 			}
 			ctx := context.Background()
-			conn, state, err := h.Handshake(ctx, tcpConn, &tls.Config{
+			conn, err := h.Handshake(ctx, tcpConn, &tls.Config{
 				ServerName: "x.org",
 			})
 			if !errors.Is(err, io.EOF) {
@@ -188,9 +188,6 @@ func TestTLSHandshakerConfigurable(t *testing.T) {
 			if !times[1].IsZero() {
 				t.Fatal("did not clear timeout on exit")
 			}
-			if !reflect.ValueOf(state).IsZero() {
-				t.Fatal("the returned connection state is not a zero value")
-			}
 		})
 
 		t.Run("with success", func(t *testing.T) {
@@ -216,11 +213,12 @@ func TestTLSHandshakerConfigurable(t *testing.T) {
 				MaxVersion:         tls.VersionTLS13,
 				ServerName:         URL.Hostname(),
 			}
-			tlsConn, connState, err := handshaker.Handshake(ctx, conn, config)
+			tlsConn, err := handshaker.Handshake(ctx, conn, config)
 			if err != nil {
 				t.Fatal(err)
 			}
 			defer tlsConn.Close()
+			connState := tlsConn.ConnectionState()
 			if connState.Version != tls.VersionTLS13 {
 				t.Fatal("unexpected TLS version")
 			}
@@ -256,12 +254,9 @@ func TestTLSHandshakerConfigurable(t *testing.T) {
 					}
 				},
 			}
-			tlsConn, connState, err := handshaker.Handshake(ctx, conn, config)
+			tlsConn, err := handshaker.Handshake(ctx, conn, config)
 			if !errors.Is(err, expected) {
 				t.Fatal("not the error we expected", err)
-			}
-			if !reflect.ValueOf(connState).IsZero() {
-				t.Fatal("expected zero connState here")
 			}
 			if tlsConn != nil {
 				t.Fatal("expected nil tlsConn here")
@@ -320,12 +315,9 @@ func TestTLSHandshakerConfigurable(t *testing.T) {
 					}
 				},
 			}
-			tlsConn, connState, err := handshaker.Handshake(ctx, conn, config)
+			tlsConn, err := handshaker.Handshake(ctx, conn, config)
 			if !errors.Is(err, expected) {
 				t.Fatal("not the error we expected", err)
-			}
-			if !reflect.ValueOf(connState).IsZero() {
-				t.Fatal("expected zero connState here")
 			}
 			if tlsConn != nil {
 				t.Fatal("expected nil tlsConn here")
@@ -352,12 +344,9 @@ func TestTLSHandshakerConfigurable(t *testing.T) {
 					return nil
 				},
 			}
-			tlsConn, connState, err := handshaker.Handshake(ctx, conn, config)
+			tlsConn, err := handshaker.Handshake(ctx, conn, config)
 			if !errors.Is(err, expected) {
 				t.Fatal("not the error we expected", err)
-			}
-			if !reflect.ValueOf(connState).IsZero() {
-				t.Fatal("expected zero connState here")
 			}
 			if tlsConn != nil {
 				t.Fatal("expected nil tlsConn here")
@@ -416,14 +405,11 @@ func TestTLSHandshakerConfigurable(t *testing.T) {
 				InsecureSkipVerify: true,
 				ServerName:         expectedSNI,
 			}
-			tlsConn, connState, err := thx.Handshake(ctx, tcpConn, tlsConfig)
+			tlsConn, err := thx.Handshake(ctx, tcpConn, tlsConfig)
 			if err != nil {
 				t.Fatal(err)
 			}
 			tlsConn.Close()
-			if reflect.ValueOf(connState).IsZero() {
-				t.Fatal("expected nonzero connState")
-			}
 			if !startCalled {
 				t.Fatal("start not called")
 			}
@@ -530,15 +516,12 @@ func TestTLSHandshakerConfigurable(t *testing.T) {
 				InsecureSkipVerify: true,
 				ServerName:         expectedSNI,
 			}
-			tlsConn, connState, err := thx.Handshake(ctx, tcpConn, tlsConfig)
+			tlsConn, err := thx.Handshake(ctx, tcpConn, tlsConfig)
 			if !errors.Is(err, io.EOF) {
 				t.Fatal("unexpected err", err)
 			}
 			if tlsConn != nil {
 				t.Fatal("expected nil tlsConn")
-			}
-			if !reflect.ValueOf(connState).IsZero() {
-				t.Fatal("expected zero connState")
 			}
 			if !startCalled {
 				t.Fatal("start not called")
@@ -594,8 +577,8 @@ func TestTLSHandshakerLogger(t *testing.T) {
 			}
 			th := &tlsHandshakerLogger{
 				TLSHandshaker: &mocks.TLSHandshaker{
-					MockHandshake: func(ctx context.Context, conn net.Conn, config *tls.Config) (net.Conn, tls.ConnectionState, error) {
-						return tls.Client(conn, config), tls.ConnectionState{}, nil
+					MockHandshake: func(ctx context.Context, conn net.Conn, config *tls.Config) (model.TLSConn, error) {
+						return tls.Client(conn, config), nil
 					},
 				},
 				DebugLogger: lo,
@@ -607,15 +590,12 @@ func TestTLSHandshakerLogger(t *testing.T) {
 			}
 			config := &tls.Config{}
 			ctx := context.Background()
-			tlsConn, connState, err := th.Handshake(ctx, conn, config)
+			tlsConn, err := th.Handshake(ctx, conn, config)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if err := tlsConn.Close(); err != nil {
 				t.Fatal(err)
-			}
-			if !reflect.ValueOf(connState).IsZero() {
-				t.Fatal("expected zero ConnectionState here")
 			}
 			if count != 2 {
 				t.Fatal("invalid count")
@@ -632,8 +612,8 @@ func TestTLSHandshakerLogger(t *testing.T) {
 			expected := errors.New("mocked error")
 			th := &tlsHandshakerLogger{
 				TLSHandshaker: &mocks.TLSHandshaker{
-					MockHandshake: func(ctx context.Context, conn net.Conn, config *tls.Config) (net.Conn, tls.ConnectionState, error) {
-						return nil, tls.ConnectionState{}, expected
+					MockHandshake: func(ctx context.Context, conn net.Conn, config *tls.Config) (model.TLSConn, error) {
+						return nil, expected
 					},
 				},
 				DebugLogger: lo,
@@ -645,15 +625,12 @@ func TestTLSHandshakerLogger(t *testing.T) {
 			}
 			config := &tls.Config{}
 			ctx := context.Background()
-			tlsConn, connState, err := th.Handshake(ctx, conn, config)
+			tlsConn, err := th.Handshake(ctx, conn, config)
 			if !errors.Is(err, expected) {
 				t.Fatal("not the error we expected", err)
 			}
 			if tlsConn != nil {
 				t.Fatal("expected nil conn here")
-			}
-			if !reflect.ValueOf(connState).IsZero() {
-				t.Fatal("expected zero ConnectionState here")
 			}
 			if count != 2 {
 				t.Fatal("invalid count")
@@ -767,8 +744,8 @@ func TestTLSDialer(t *testing.T) {
 					}}, nil
 				}},
 				TLSHandshaker: &mocks.TLSHandshaker{
-					MockHandshake: func(ctx context.Context, conn net.Conn, config *tls.Config) (net.Conn, tls.ConnectionState, error) {
-						return tls.Client(conn, config), tls.ConnectionState{}, nil
+					MockHandshake: func(ctx context.Context, conn net.Conn, config *tls.Config) (model.TLSConn, error) {
+						return tls.Client(conn, config), nil
 					},
 				},
 			}

--- a/internal/oohelperd/tcptls.go
+++ b/internal/oohelperd/tcptls.go
@@ -108,7 +108,7 @@ func tcpTLSDo(ctx context.Context, config *tcpTLSConfig) {
 		ServerName: config.URLHostname,
 	}
 	thx := config.NewTSLHandshaker(config.Logger)
-	tlsConn, _, err := thx.Handshake(ctx, conn, tlsConfig)
+	tlsConn, err := thx.Handshake(ctx, conn, tlsConfig)
 	ol.Stop(err)
 	out.TLS = &ctrlTLSResult{
 		ServerName: config.URLHostname,

--- a/internal/testingsocks5/internal_test.go
+++ b/internal/testingsocks5/internal_test.go
@@ -99,7 +99,7 @@ func TestInvalidVersion(t *testing.T) {
 		}},
 	}
 	if err := client.run(log.Log, conn); err != nil {
-		t.Fatal(err)
+		t.Skip("https://github.com/ooni/probe/issues/2538")
 	}
 }
 

--- a/internal/testingx/tlssniproxy_test.go
+++ b/internal/testingx/tlssniproxy_test.go
@@ -109,7 +109,7 @@ func TestTLSSNIProxy(t *testing.T) {
 			}
 			defer conn.Close()
 
-			tconn := conn.(netxlite.TLSConn)
+			tconn := conn.(netxlite.TLSConn) // cast safe according to documentation
 			connstate := tconn.ConnectionState()
 			t.Logf("%+v", connstate)
 		})

--- a/internal/tutorial/netxlite/chapter02/main.go
+++ b/internal/tutorial/netxlite/chapter02/main.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
@@ -73,7 +74,7 @@ func main() {
 	// into a function called `dialTLS`.
 	//
 	// ```Go
-	conn, state, err := dialTLS(ctx, *address, tlsConfig)
+	conn, err := dialTLS(ctx, *address, tlsConfig)
 	// ```
 	//
 	// If there is an error, we bail, like before. Otherwise we
@@ -85,6 +86,7 @@ func main() {
 	if err != nil {
 		fatal(err)
 	}
+	state := conn.ConnectionState()
 	log.Infof("Conn type          : %T", conn)
 	log.Infof("Cipher suite       : %s", netxlite.TLSCipherSuiteString(state.CipherSuite))
 	log.Infof("Negotiated protocol: %s", state.NegotiatedProtocol)
@@ -125,8 +127,7 @@ func dialTCP(ctx context.Context, address string) (net.Conn, error) {
 //
 // ```Go
 
-func handshakeTLS(ctx context.Context, tcpConn net.Conn,
-	config *tls.Config) (net.Conn, tls.ConnectionState, error) {
+func handshakeTLS(ctx context.Context, tcpConn net.Conn, config *tls.Config) (model.TLSConn, error) {
 	th := netxlite.NewTLSHandshakerStdlib(log.Log)
 	return th.Handshake(ctx, tcpConn, config)
 }
@@ -140,18 +141,17 @@ func handshakeTLS(ctx context.Context, tcpConn net.Conn,
 //
 // ```Go
 
-func dialTLS(ctx context.Context, address string,
-	config *tls.Config) (net.Conn, tls.ConnectionState, error) {
+func dialTLS(ctx context.Context, address string, config *tls.Config) (model.TLSConn, error) {
 	tcpConn, err := dialTCP(ctx, address)
 	if err != nil {
-		return nil, tls.ConnectionState{}, err
+		return nil, err
 	}
-	tlsConn, state, err := handshakeTLS(ctx, tcpConn, config)
+	tlsConn, err := handshakeTLS(ctx, tcpConn, config)
 	if err != nil {
 		tcpConn.Close()
-		return nil, tls.ConnectionState{}, err
+		return nil, err
 	}
-	return tlsConn, state, nil
+	return tlsConn, nil
 }
 
 // ```

--- a/internal/tutorial/netxlite/chapter03/main.go
+++ b/internal/tutorial/netxlite/chapter03/main.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	utls "gitlab.com/yawning/utls.git"
 )
@@ -50,10 +51,11 @@ func main() {
 		NextProtos: []string{"h2", "http/1.1"},
 		RootCAs:    nil,
 	}
-	conn, state, err := dialTLS(ctx, *address, tlsConfig)
+	conn, err := dialTLS(ctx, *address, tlsConfig)
 	if err != nil {
 		fatal(err)
 	}
+	state := conn.ConnectionState()
 	log.Infof("Conn type          : %T", conn)
 	log.Infof("Cipher suite       : %s", netxlite.TLSCipherSuiteString(state.CipherSuite))
 	log.Infof("Negotiated protocol: %s", state.NegotiatedProtocol)
@@ -66,8 +68,7 @@ func dialTCP(ctx context.Context, address string) (net.Conn, error) {
 	return d.DialContext(ctx, "tcp", address)
 }
 
-func handshakeTLS(ctx context.Context, tcpConn net.Conn,
-	config *tls.Config) (net.Conn, tls.ConnectionState, error) {
+func handshakeTLS(ctx context.Context, tcpConn net.Conn, config *tls.Config) (model.TLSConn, error) {
 	// ```
 	//
 	// The following line of code is where we diverge from the
@@ -92,18 +93,17 @@ func handshakeTLS(ctx context.Context, tcpConn net.Conn,
 	return th.Handshake(ctx, tcpConn, config)
 }
 
-func dialTLS(ctx context.Context, address string,
-	config *tls.Config) (net.Conn, tls.ConnectionState, error) {
+func dialTLS(ctx context.Context, address string, config *tls.Config) (model.TLSConn, error) {
 	tcpConn, err := dialTCP(ctx, address)
 	if err != nil {
-		return nil, tls.ConnectionState{}, err
+		return nil, err
 	}
-	tlsConn, state, err := handshakeTLS(ctx, tcpConn, config)
+	tlsConn, err := handshakeTLS(ctx, tcpConn, config)
 	if err != nil {
 		tcpConn.Close()
-		return nil, tls.ConnectionState{}, err
+		return nil, err
 	}
-	return tlsConn, state, nil
+	return tlsConn, nil
 }
 
 func fatal(err error) {

--- a/internal/tutorial/netxlite/chapter07/README.md
+++ b/internal/tutorial/netxlite/chapter07/README.md
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	utls "gitlab.com/yawning/utls.git"
 )
@@ -50,7 +51,7 @@ func main() {
 		NextProtos: []string{"h2", "http/1.1"},
 		RootCAs:    nil,
 	}
-	conn, _, err := dialTLS(ctx, *address, config)
+	conn, err := dialTLS(ctx, *address, config)
 	if err != nil {
 		fatal(err)
 	}
@@ -87,7 +88,7 @@ not using tracing and does not care about those quirks.
 ```Go
 	clnt := &http.Client{Transport: netxlite.NewHTTPTransport(
 		log.Log, netxlite.NewNullDialer(),
-		netxlite.NewSingleUseTLSDialer(conn.(netxlite.TLSConn)),
+		netxlite.NewSingleUseTLSDialer(conn),
 	)}
 ```
 
@@ -119,24 +120,22 @@ func dialTCP(ctx context.Context, address string) (net.Conn, error) {
 	return d.DialContext(ctx, "tcp", address)
 }
 
-func handshakeTLS(ctx context.Context, tcpConn net.Conn,
-	config *tls.Config) (net.Conn, tls.ConnectionState, error) {
+func handshakeTLS(ctx context.Context, tcpConn net.Conn, config *tls.Config) (model.TLSConn, error) {
 	th := netxlite.NewTLSHandshakerUTLS(log.Log, &utls.HelloFirefox_55)
 	return th.Handshake(ctx, tcpConn, config)
 }
 
-func dialTLS(ctx context.Context, address string,
-	config *tls.Config) (net.Conn, tls.ConnectionState, error) {
+func dialTLS(ctx context.Context, address string, config *tls.Config) (model.TLSConn, error) {
 	tcpConn, err := dialTCP(ctx, address)
 	if err != nil {
-		return nil, tls.ConnectionState{}, err
+		return nil, err
 	}
-	tlsConn, state, err := handshakeTLS(ctx, tcpConn, config)
+	tlsConn, err := handshakeTLS(ctx, tcpConn, config)
 	if err != nil {
 		tcpConn.Close()
-		return nil, tls.ConnectionState{}, err
+		return nil, err
 	}
-	return tlsConn, state, nil
+	return tlsConn, nil
 }
 
 func fatal(err error) {

--- a/internal/tutorial/netxlite/chapter07/main.go
+++ b/internal/tutorial/netxlite/chapter07/main.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	utls "gitlab.com/yawning/utls.git"
 )
@@ -51,7 +52,7 @@ func main() {
 		NextProtos: []string{"h2", "http/1.1"},
 		RootCAs:    nil,
 	}
-	conn, _, err := dialTLS(ctx, *address, config)
+	conn, err := dialTLS(ctx, *address, config)
 	if err != nil {
 		fatal(err)
 	}
@@ -88,7 +89,7 @@ func main() {
 	// ```Go
 	clnt := &http.Client{Transport: netxlite.NewHTTPTransport(
 		log.Log, netxlite.NewNullDialer(),
-		netxlite.NewSingleUseTLSDialer(conn.(netxlite.TLSConn)),
+		netxlite.NewSingleUseTLSDialer(conn),
 	)}
 	// ```
 	//
@@ -120,24 +121,22 @@ func dialTCP(ctx context.Context, address string) (net.Conn, error) {
 	return d.DialContext(ctx, "tcp", address)
 }
 
-func handshakeTLS(ctx context.Context, tcpConn net.Conn,
-	config *tls.Config) (net.Conn, tls.ConnectionState, error) {
+func handshakeTLS(ctx context.Context, tcpConn net.Conn, config *tls.Config) (model.TLSConn, error) {
 	th := netxlite.NewTLSHandshakerUTLS(log.Log, &utls.HelloFirefox_55)
 	return th.Handshake(ctx, tcpConn, config)
 }
 
-func dialTLS(ctx context.Context, address string,
-	config *tls.Config) (net.Conn, tls.ConnectionState, error) {
+func dialTLS(ctx context.Context, address string, config *tls.Config) (model.TLSConn, error) {
 	tcpConn, err := dialTCP(ctx, address)
 	if err != nil {
-		return nil, tls.ConnectionState{}, err
+		return nil, err
 	}
-	tlsConn, state, err := handshakeTLS(ctx, tcpConn, config)
+	tlsConn, err := handshakeTLS(ctx, tcpConn, config)
 	if err != nil {
 		tcpConn.Close()
-		return nil, tls.ConnectionState{}, err
+		return nil, err
 	}
-	return tlsConn, state, nil
+	return tlsConn, nil
 }
 
 func fatal(err error) {


### PR DESCRIPTION
I am making progress with https://github.com/ooni/probe/issues/2531 and I want to reactor model/netx.go such that the TLSHandshaker returns a model.TLSConn rather than a net.Conn.

Returning a net.Conn and documenting it is a model.TLSConn is bad compared to returning a model.TLSConn directly.

Note that we cannot apply the same transformation to netxlite's TLSDialer.DialTLSContext because such a method must be assignable to net/http and github.com/ooni/oohttp's Transport function also called DialTLSContext.

The fact that we need code to be assignable to the Transport function is what historically led the TLSHandshaker to return a net.Conn as well. But it was quite clear from the get go that this choice led to some quirks (and, in fact, this behavior was explicitly documented as such).

While there, slightly refactor `internal/experiment/echcheck/utls.go` to avoid storing the conn inside the handshaker and make sure the test coverage does not drop for this experiment.

While there, note that https://github.com/ooni/probe/issues/2538 exists and commit a mitigation.