### PR TITLE
refactor: adapt to netem pinning certificates to hosts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/montanaflynn/stats v0.7.1
 	github.com/ooni/go-libtor v1.1.8
-	github.com/ooni/netem v0.0.0-20230915101649-ab0dc13be014
+	github.com/ooni/netem v0.0.0-20230920215742-15f3ffec0107
 	github.com/ooni/oocrypto v0.5.3
 	github.com/ooni/oohttp v0.6.3
 	github.com/ooni/probe-assets v0.18.0
@@ -60,7 +60,6 @@ require (
 	github.com/go-redis/redis/v8 v8.11.5 // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/google/btree v1.1.2 // indirect
-	github.com/google/martian/v3 v3.3.2 // indirect
 	github.com/google/pprof v0.0.0-20230602150820-91b7bce49751 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.16.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,7 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
+github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/alecthomas/kingpin/v2 v2.3.2 h1:H0aULhgmSzN8xQ3nX1uxtdlTHYoPLu5AhHxWrKI6ocU=
 github.com/alecthomas/kingpin/v2 v2.3.2/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -94,7 +95,6 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
@@ -150,7 +150,6 @@ github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4s
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
-github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
@@ -173,6 +172,7 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
 github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
@@ -211,7 +211,6 @@ github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:x
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
-github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
@@ -219,7 +218,6 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -229,7 +227,6 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
@@ -238,8 +235,6 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
 github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
 github.com/google/gxui v0.0.0-20151028112939-f85e0a97b3a4 h1:OL2d27ueTKnlQJoqLW2fc9pWYulFnJYLWzomGV7HqZo=
-github.com/google/martian/v3 v3.3.2 h1:IqNFLAmvJOgVlpdEBiQbDc2EwKW77amAycfTuWKdfvw=
-github.com/google/martian/v3 v3.3.2/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/pprof v0.0.0-20230602150820-91b7bce49751 h1:hR7/MlvK23p6+lIw9SN1TigNLn9ZnF3W4SYRKq2gAHs=
 github.com/google/pprof v0.0.0-20230602150820-91b7bce49751/go.mod h1:Jh3hGz2jkYak8qXPD19ryItVnUgpgeqzdkY/D0EaeuA=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
@@ -247,7 +242,6 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaU
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
@@ -338,6 +332,7 @@ github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.2.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jinzhu/copier v0.3.5/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/josharian/native v1.0.0 h1:Ts/E8zCSEsG17dUqv7joXJFybuMLjQfWE04tsBODTxk=
@@ -347,6 +342,7 @@ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCV
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/juju/ratelimit v1.0.2 h1:sRxmtRiajbvrcLQT7S+JbqU0ntsb9W2yhSdNN8tWfaI=
@@ -357,6 +353,8 @@ github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1
 github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
+github.com/keltia/proxy v0.9.3/go.mod h1:fLU4DmBPG0oh0md9fWggE2oG2m7Lchv3eim+GiO3pZY=
+github.com/keltia/ripe-atlas v0.0.0-20211221125000-f6eb808d5dc6/go.mod h1:zYa+dM8811qRhclezc/AKX9imyQwPjjSk2cH0xTgTag=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
@@ -448,6 +446,7 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/mroth/weightedrand v1.0.0 h1:V8JeHChvl2MP1sAoXq4brElOcza+jxLkRuwvtQu8L3E=
@@ -483,8 +482,10 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.27.7 h1:fVih9JD6ogIiHUN6ePK7HJidyEDpWGVB5mzM7cWNXoU=
 github.com/ooni/go-libtor v1.1.8 h1:Wo3V3DVTxl5vZdxtQakqYP+DAHx7pPtAFSl1bnAa08w=
 github.com/ooni/go-libtor v1.1.8/go.mod h1:q1YyLwRD9GeMyeerVvwc0vJ2YgwDLTp2bdVcrh/JXyI=
-github.com/ooni/netem v0.0.0-20230915101649-ab0dc13be014 h1:4kOSV4D6mwrdoNUkAbGz1XoFUPcjsuNlLhZMc2CoHGg=
-github.com/ooni/netem v0.0.0-20230915101649-ab0dc13be014/go.mod h1:3LJOzTIu2O4ADDJN2ILG4ViJOqyH/u9fKY8QT2Rma8Y=
+github.com/ooni/netem v0.0.0-20230920203521-c1d8ba36e4aa h1:zaEmTqmzYyXdKOTWtyLLBSniDbMkOblaTzeUcheOA+8=
+github.com/ooni/netem v0.0.0-20230920203521-c1d8ba36e4aa/go.mod h1:5X3Lk4+cnrwrQiYgRlCWXgV33IMDgLaO5s1x0DD/fO0=
+github.com/ooni/netem v0.0.0-20230920215742-15f3ffec0107 h1:PktaCPQ1NYZOaK+J8pQGYiPCYFkGR5H3ZURg9zPkQsI=
+github.com/ooni/netem v0.0.0-20230920215742-15f3ffec0107/go.mod h1:5X3Lk4+cnrwrQiYgRlCWXgV33IMDgLaO5s1x0DD/fO0=
 github.com/ooni/oocrypto v0.5.3 h1:CAb0Ze6q/EWD1PRGl9KqpzMfkut4O3XMaiKYsyxrWOs=
 github.com/ooni/oocrypto v0.5.3/go.mod h1:HjEQ5pQBl6btcWgAsKKq1tFo8CfBrZu63C/vPAUGIDk=
 github.com/ooni/oohttp v0.6.3 h1:MHydpeAPU/LSDSI/hIFJwZm4afBhd2Yo+rNxxFdeMCY=
@@ -857,7 +858,6 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
@@ -1029,8 +1029,6 @@ google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190530194941-fb225487d101/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
-google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f h1:BWUVssLB0HVOSY78gIdvk1dTVYtT1y8SBWtPYuTJ/6w=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.0/go.mod h1:chYK+tFQF0nDUGJgXMSgLCQk3phJEuONr2DCgLDdAQM=
@@ -1041,20 +1039,14 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
-google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
-google.golang.org/grpc v1.37.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.53.0-dev.0.20230123225046-4075ef07c5d5 h1:qq9WB3Dez2tMAKtZTVtZsZSmTkDgPeXx+FRPt5kLEkM=
-google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
-google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=

--- a/internal/enginenetx/http_test.go
+++ b/internal/enginenetx/http_test.go
@@ -194,6 +194,7 @@ func TestHTTPTransportWAI(t *testing.T) {
 			testingx.NewHTTPProxyHandler(log.Log, &netxlite.Netx{
 				Underlying: &netxlite.NetemUnderlyingNetworkAdapter{UNet: env.ClientStack}}),
 			env.ClientStack,
+			"proxy.local",
 		)
 		defer proxy.Close()
 

--- a/internal/enginenetx/httpsdialer_test.go
+++ b/internal/enginenetx/httpsdialer_test.go
@@ -149,6 +149,7 @@ func TestHTTPSDialerWAI(t *testing.T) {
 					"93.184.216.37",
 				},
 				Role:             netemx.ScenarioRoleWebServer,
+				ServerNameMain:   "www.example.com",
 				WebServerFactory: netemx.ExampleWebPageHandlerFactory(),
 			}},
 			configureDPI: func(dpi *netem.DPIEngine) {
@@ -172,6 +173,7 @@ func TestHTTPSDialerWAI(t *testing.T) {
 					"93.184.216.35",
 				},
 				Role:             netemx.ScenarioRoleWebServer,
+				ServerNameMain:   "www.example.com",
 				WebServerFactory: netemx.ExampleWebPageHandlerFactory(),
 			}},
 			configureDPI: func(dpi *netem.DPIEngine) {
@@ -205,6 +207,7 @@ func TestHTTPSDialerWAI(t *testing.T) {
 					"93.184.216.35",
 				},
 				Role:             netemx.ScenarioRoleWebServer,
+				ServerNameMain:   "www.example.com",
 				WebServerFactory: netemx.ExampleWebPageHandlerFactory(),
 			}},
 			configureDPI: func(dpi *netem.DPIEngine) {
@@ -313,6 +316,7 @@ func TestHTTPSDialerWAI(t *testing.T) {
 					"93.184.216.35",
 				},
 				Role:             netemx.ScenarioRoleWebServer,
+				ServerNameMain:   "www.example.com",
 				WebServerFactory: netemx.ExampleWebPageHandlerFactory(),
 			}},
 			configureDPI: func(dpi *netem.DPIEngine) {
@@ -341,6 +345,7 @@ func TestHTTPSDialerWAI(t *testing.T) {
 					"93.184.216.35",
 				},
 				Role:             netemx.ScenarioRoleWebServer,
+				ServerNameMain:   "www.example.com",
 				WebServerFactory: netemx.ExampleWebPageHandlerFactory(),
 			}},
 			configureDPI: func(dpi *netem.DPIEngine) {

--- a/internal/experiment/fbmessenger/fbmessenger_test.go
+++ b/internal/experiment/fbmessenger/fbmessenger_test.go
@@ -74,7 +74,21 @@ func TestMeasurerRun(t *testing.T) {
 		}
 
 		// create a new test environment
-		env := netemx.MustNewQAEnv(netemx.QAEnvOptionHTTPServer(servicesAddr, netemx.ExampleWebPageHandlerFactory()))
+		env := netemx.MustNewQAEnv(netemx.QAEnvOptionNetStack(
+			servicesAddr,
+			&netemx.HTTPSecureServerFactory{
+				Factory:        netemx.ExampleWebPageHandlerFactory(),
+				Ports:          []int{443},
+				ServerNameMain: "b-api.facebook.com",
+				ServerNameExtras: []string{
+					"b-graph.facebook.com",
+					"edge-mqtt.facebook.com",
+					"external.xx.fbcdn.net",
+					"scontent.xx.fbcdn.net",
+					"star.c10r.facebook.com",
+				},
+			},
+		))
 		defer env.Close()
 
 		// configure the DNS for all resolvers
@@ -125,7 +139,21 @@ func TestMeasurerRun(t *testing.T) {
 		}
 
 		// create a new test environment
-		env := netemx.MustNewQAEnv(netemx.QAEnvOptionHTTPServer(servicesAddr, netemx.ExampleWebPageHandlerFactory()))
+		env := netemx.MustNewQAEnv(netemx.QAEnvOptionNetStack(
+			servicesAddr,
+			&netemx.HTTPSecureServerFactory{
+				Factory:        netemx.ExampleWebPageHandlerFactory(),
+				Ports:          []int{443},
+				ServerNameMain: "b-api.facebook.com",
+				ServerNameExtras: []string{
+					"b-graph.facebook.com",
+					"edge-mqtt.facebook.com",
+					"external.xx.fbcdn.net",
+					"scontent.xx.fbcdn.net",
+					"star.c10r.facebook.com",
+				},
+			},
+		))
 		defer env.Close()
 
 		// configure the DNS for all resolvers
@@ -185,7 +213,21 @@ func TestMeasurerRun(t *testing.T) {
 		}()
 
 		// create a new test environment
-		env := netemx.MustNewQAEnv(netemx.QAEnvOptionHTTPServer(servicesAddr, netemx.ExampleWebPageHandlerFactory()))
+		env := netemx.MustNewQAEnv(netemx.QAEnvOptionNetStack(
+			servicesAddr,
+			&netemx.HTTPSecureServerFactory{
+				Factory:        netemx.ExampleWebPageHandlerFactory(),
+				Ports:          []int{443},
+				ServerNameMain: "b-api.facebook.com",
+				ServerNameExtras: []string{
+					"b-graph.facebook.com",
+					"edge-mqtt.facebook.com",
+					"external.xx.fbcdn.net",
+					"scontent.xx.fbcdn.net",
+					"star.c10r.facebook.com",
+				},
+			},
+		))
 		defer env.Close()
 
 		// configure the DNS for all resolvers
@@ -245,7 +287,21 @@ func TestMeasurerRun(t *testing.T) {
 		}
 
 		// create a new test environment
-		env := netemx.MustNewQAEnv(netemx.QAEnvOptionHTTPServer(servicesAddr, netemx.ExampleWebPageHandlerFactory()))
+		env := netemx.MustNewQAEnv(netemx.QAEnvOptionNetStack(
+			servicesAddr,
+			&netemx.HTTPSecureServerFactory{
+				Factory:        netemx.ExampleWebPageHandlerFactory(),
+				Ports:          []int{443},
+				ServerNameMain: "b-api.facebook.com",
+				ServerNameExtras: []string{
+					"b-graph.facebook.com",
+					"edge-mqtt.facebook.com",
+					"external.xx.fbcdn.net",
+					"scontent.xx.fbcdn.net",
+					"star.c10r.facebook.com",
+				},
+			},
+		))
 		defer env.Close()
 
 		// configure all DNS servers but the ISP's one

--- a/internal/experiment/simplequicping/simplequicping_test.go
+++ b/internal/experiment/simplequicping/simplequicping_test.go
@@ -104,7 +104,15 @@ func TestMeasurerRun(t *testing.T) {
 
 	t.Run("with netem: without DPI: expect success", func(t *testing.T) {
 		// create a new test environment
-		env := netemx.MustNewQAEnv(netemx.QAEnvOptionHTTPServer("8.8.8.8", netemx.ExampleWebPageHandlerFactory()))
+		env := netemx.MustNewQAEnv(netemx.QAEnvOptionNetStack(
+			"8.8.8.8",
+			&netemx.HTTP3ServerFactory{
+				Factory:          netemx.ExampleWebPageHandlerFactory(),
+				Ports:            []int{443},
+				ServerNameMain:   SNI,
+				ServerNameExtras: []string{},
+			},
+		))
 		defer env.Close()
 
 		env.Do(func() {
@@ -140,7 +148,15 @@ func TestMeasurerRun(t *testing.T) {
 
 	t.Run("with netem: with DPI that drops UDP datagrams to 8.8.8.8:443: expect failure", func(t *testing.T) {
 		// create a new test environment
-		env := netemx.MustNewQAEnv(netemx.QAEnvOptionHTTPServer("8.8.8.8", netemx.ExampleWebPageHandlerFactory()))
+		env := netemx.MustNewQAEnv(netemx.QAEnvOptionNetStack(
+			"8.8.8.8",
+			&netemx.HTTP3ServerFactory{
+				Factory:          netemx.ExampleWebPageHandlerFactory(),
+				Ports:            []int{443},
+				ServerNameMain:   SNI,
+				ServerNameExtras: []string{},
+			},
+		))
 		defer env.Close()
 
 		// add DPI engine to emulate the censorship condition

--- a/internal/experiment/tcpping/tcpping_test.go
+++ b/internal/experiment/tcpping/tcpping_test.go
@@ -90,7 +90,15 @@ func TestMeasurer_run(t *testing.T) {
 	})
 
 	t.Run("with netem: without DPI: expect success", func(t *testing.T) {
-		env := netemx.MustNewQAEnv(netemx.QAEnvOptionHTTPServer("8.8.8.8", netemx.ExampleWebPageHandlerFactory()))
+		env := netemx.MustNewQAEnv(netemx.QAEnvOptionNetStack(
+			"8.8.8.8",
+			&netemx.HTTPSecureServerFactory{
+				Factory:          netemx.ExampleWebPageHandlerFactory(),
+				Ports:            []int{443},
+				ServerNameMain:   "dns.google",
+				ServerNameExtras: []string{},
+			},
+		))
 		defer env.Close()
 
 		env.Do(func() {
@@ -132,7 +140,15 @@ func TestMeasurer_run(t *testing.T) {
 
 	t.Run("with netem: with DPI that drops TCP segments to 8.8.8.8:443: expect failure", func(t *testing.T) {
 		// create a new test environment
-		env := netemx.MustNewQAEnv(netemx.QAEnvOptionHTTPServer("8.8.8.8", netemx.ExampleWebPageHandlerFactory()))
+		env := netemx.MustNewQAEnv(netemx.QAEnvOptionNetStack(
+			"8.8.8.8",
+			&netemx.HTTPSecureServerFactory{
+				Factory:          netemx.ExampleWebPageHandlerFactory(),
+				Ports:            []int{443},
+				ServerNameMain:   "dns.google",
+				ServerNameExtras: []string{},
+			},
+		))
 		defer env.Close()
 
 		// add DPI engine to emulate the censorship condition

--- a/internal/experiment/telegram/telegram_test.go
+++ b/internal/experiment/telegram/telegram_test.go
@@ -299,7 +299,15 @@ func newQAEnvironment(ipaddrs ...string) *netemx.QAEnv {
 
 	// add handler for telegram web (we're using a different-from-reality HTTP handler
 	// but we're not testing for the returned webpage, so we should be fine)
-	options = append(options, netemx.QAEnvOptionHTTPServer(telegramWebAddr, netemx.ExampleWebPageHandlerFactory()))
+	options = append(options, netemx.QAEnvOptionNetStack(
+		telegramWebAddr,
+		&netemx.HTTPSecureServerFactory{
+			Factory:          netemx.ExampleWebPageHandlerFactory(),
+			Ports:            []int{443},
+			ServerNameMain:   "web.telegram.org",
+			ServerNameExtras: []string{},
+		},
+	))
 
 	// create the environment proper with all the options
 	env := netemx.MustNewQAEnv(options...)

--- a/internal/experiment/tlsping/tlsping_test.go
+++ b/internal/experiment/tlsping/tlsping_test.go
@@ -105,7 +105,15 @@ func TestMeasurerRun(t *testing.T) {
 
 	t.Run("with netem: without DPI: expect success", func(t *testing.T) {
 		// create a new test environment
-		env := netemx.MustNewQAEnv(netemx.QAEnvOptionHTTPServer("8.8.8.8", netemx.ExampleWebPageHandlerFactory()))
+		env := netemx.MustNewQAEnv(netemx.QAEnvOptionNetStack(
+			"8.8.8.8",
+			&netemx.HTTPSecureServerFactory{
+				Factory:          netemx.ExampleWebPageHandlerFactory(),
+				Ports:            []int{443},
+				ServerNameMain:   SNI,
+				ServerNameExtras: []string{},
+			},
+		))
 		defer env.Close()
 
 		env.Do(func() {
@@ -147,7 +155,15 @@ func TestMeasurerRun(t *testing.T) {
 
 	t.Run("with netem: with DPI that drops TCP segments to 8.8.8.8:443: expect failure", func(t *testing.T) {
 		// create a new test environment
-		env := netemx.MustNewQAEnv(netemx.QAEnvOptionHTTPServer("8.8.8.8", netemx.ExampleWebPageHandlerFactory()))
+		env := netemx.MustNewQAEnv(netemx.QAEnvOptionNetStack(
+			"8.8.8.8",
+			&netemx.HTTPSecureServerFactory{
+				Factory:          netemx.ExampleWebPageHandlerFactory(),
+				Ports:            []int{443},
+				ServerNameMain:   SNI,
+				ServerNameExtras: []string{},
+			},
+		))
 		defer env.Close()
 
 		// add DPI engine to emulate the censorship condition
@@ -205,7 +221,15 @@ func TestMeasurerRun(t *testing.T) {
 
 	t.Run("with netem: with DPI that resets TLS to SNI blocked.com: expect failure", func(t *testing.T) {
 		// create a new test environment
-		env := netemx.MustNewQAEnv(netemx.QAEnvOptionHTTPServer("8.8.8.8", netemx.ExampleWebPageHandlerFactory()))
+		env := netemx.MustNewQAEnv(netemx.QAEnvOptionNetStack(
+			"8.8.8.8",
+			&netemx.HTTPSecureServerFactory{
+				Factory:          netemx.ExampleWebPageHandlerFactory(),
+				Ports:            []int{443},
+				ServerNameMain:   SNI,
+				ServerNameExtras: []string{},
+			},
+		))
 		defer env.Close()
 
 		// add DPI engine to emulate the censorship condition

--- a/internal/experiment/whatsapp/whatsapp_test.go
+++ b/internal/experiment/whatsapp/whatsapp_test.go
@@ -73,7 +73,17 @@ func newQAEnvironment() *netemx.QAEnv {
 	// - TCP listeners for endpoints on 443 and 5222
 	env := netemx.MustNewQAEnv(
 		netemx.QAEnvOptionLogger(log.Log),
-		netemx.QAEnvOptionHTTPServer(whatsappWebAddr, netemx.ExampleWebPageHandlerFactory()),
+		netemx.QAEnvOptionNetStack(
+			whatsappWebAddr,
+			&netemx.HTTPSecureServerFactory{
+				Factory:        netemx.ExampleWebPageHandlerFactory(),
+				Ports:          []int{443},
+				ServerNameMain: "web.whatsapp.com",
+				ServerNameExtras: []string{
+					"v.whatsapp.net",
+				},
+			},
+		),
 		netemx.QAEnvOptionNetStack(whatsappEndpointAddr, endpointsNetStack),
 	)
 

--- a/internal/legacy/netx/tls_test.go
+++ b/internal/legacy/netx/tls_test.go
@@ -5,9 +5,9 @@ import (
 	"crypto/tls"
 	"testing"
 
+	"github.com/ooni/netem"
 	"github.com/ooni/probe-cli/v3/internal/legacy/tracex"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
-	"github.com/ooni/probe-cli/v3/internal/runtimex"
 	"github.com/ooni/probe-cli/v3/internal/testingx"
 )
 
@@ -45,8 +45,9 @@ func TestNewTLSDialer(t *testing.T) {
 	})
 
 	t.Run("we can skip TLS verification", func(t *testing.T) {
-		mitm := testingx.MustNewTLSMITMProviderNetem()
-		server := testingx.MustNewTLSServer(testingx.TLSHandlerHandshakeAndWriteText(mitm, testingx.HTTPBlockpage451))
+		ca := netem.MustNewCA()
+		cert := ca.MustNewTLSCertificate("www.example.com")
+		server := testingx.MustNewTLSServer(testingx.TLSHandlerHandshakeAndWriteText(cert, testingx.HTTPBlockpage451))
 		defer server.Close()
 		tdx := NewTLSDialer(Config{TLSConfig: &tls.Config{
 			InsecureSkipVerify: true,
@@ -59,12 +60,13 @@ func TestNewTLSDialer(t *testing.T) {
 	})
 
 	t.Run("we can set the cert pool", func(t *testing.T) {
-		mitm := testingx.MustNewTLSMITMProviderNetem()
-		server := testingx.MustNewTLSServer(testingx.TLSHandlerHandshakeAndWriteText(mitm, testingx.HTTPBlockpage451))
+		ca := netem.MustNewCA()
+		cert := ca.MustNewTLSCertificate("dns.google")
+		server := testingx.MustNewTLSServer(testingx.TLSHandlerHandshakeAndWriteText(cert, testingx.HTTPBlockpage451))
 		defer server.Close()
 		tdx := NewTLSDialer(Config{
 			TLSConfig: &tls.Config{
-				RootCAs:    runtimex.Try1(mitm.DefaultCertPool()),
+				RootCAs:    ca.DefaultCertPool(),
 				ServerName: "dns.google",
 			},
 		})

--- a/internal/netemx/example_test.go
+++ b/internal/netemx/example_test.go
@@ -23,8 +23,25 @@ func exampleNewEnvironment() *netemx.QAEnv {
 		netemx.QAEnvOptionNetStack("8.8.4.4", &netemx.DNSOverUDPServerFactory{}),
 		netemx.QAEnvOptionNetStack("9.9.9.9", &netemx.DNSOverUDPServerFactory{}),
 		netemx.QAEnvOptionClientAddress(netemx.DefaultClientAddress),
-		netemx.QAEnvOptionHTTPServer(
-			netemx.AddressWwwExampleCom, netemx.ExampleWebPageHandlerFactory()),
+		netemx.QAEnvOptionNetStack(
+			netemx.AddressWwwExampleCom,
+			&netemx.HTTPCleartextServerFactory{
+				Factory: netemx.ExampleWebPageHandlerFactory(),
+				Ports:   []int{80},
+			},
+			&netemx.HTTPSecureServerFactory{
+				Factory:          netemx.ExampleWebPageHandlerFactory(),
+				Ports:            []int{443},
+				ServerNameMain:   "www.example.com",
+				ServerNameExtras: []string{},
+			},
+			&netemx.HTTP3ServerFactory{
+				Factory:          netemx.ExampleWebPageHandlerFactory(),
+				Ports:            []int{443},
+				ServerNameMain:   "www.example.com",
+				ServerNameExtras: []string{},
+			},
+		),
 		netemx.QAEnvOptionLogger(log.Log),
 	)
 }

--- a/internal/netemx/https_test.go
+++ b/internal/netemx/https_test.go
@@ -18,8 +18,8 @@ func TestHTTPSecureServerFactory(t *testing.T) {
 				Factory: HTTPHandlerFactoryFunc(func(env NetStackServerFactoryEnv, stack *netem.UNetStack) http.Handler {
 					return ExampleWebPageHandler()
 				}),
-				Ports:     []int{443},
-				TLSConfig: nil, // explicitly nil, let's use netem's config
+				Ports:          []int{443},
+				ServerNameMain: "www.example.com",
 			}),
 		)
 		defer env.Close()
@@ -44,38 +44,6 @@ func TestHTTPSecureServerFactory(t *testing.T) {
 			}
 			if diff := cmp.Diff(ExampleWebPage, string(data)); diff != "" {
 				t.Fatal(diff)
-			}
-		})
-	})
-
-	t.Run("when using an incompatible TLS config", func(t *testing.T) {
-		// we're creating a distinct MITM TLS config and we're using it, so we expect
-		// that we're not able to verify certificates in client code
-		mitmConfig := runtimex.Try1(netem.NewTLSMITMConfig())
-
-		env := MustNewQAEnv(
-			QAEnvOptionNetStack(AddressWwwExampleCom, &HTTPSecureServerFactory{
-				Factory: HTTPHandlerFactoryFunc(func(env NetStackServerFactoryEnv, stack *netem.UNetStack) http.Handler {
-					return ExampleWebPageHandler()
-				}),
-				Ports:     []int{443},
-				TLSConfig: mitmConfig.TLSConfig(), // custom!
-			}),
-		)
-		defer env.Close()
-
-		env.AddRecordToAllResolvers("www.example.com", "", AddressWwwExampleCom)
-
-		env.Do(func() {
-			// TODO(https://github.com/ooni/probe/issues/2534): NewHTTPClientStdlib has QUIRKS but they're not needed here
-			client := netxlite.NewHTTPClientStdlib(log.Log)
-			req := runtimex.Try1(http.NewRequest("GET", "https://www.example.com/", nil))
-			resp, err := client.Do(req)
-			if err == nil || err.Error() != netxlite.FailureSSLUnknownAuthority {
-				t.Fatal("unexpected error", err)
-			}
-			if resp != nil {
-				t.Fatal("expected nil resp")
 			}
 		})
 	})

--- a/internal/netemx/qaenv_test.go
+++ b/internal/netemx/qaenv_test.go
@@ -75,9 +75,14 @@ func TestQAEnv(t *testing.T) {
 	t.Run("we can hijack HTTPS requests", func(t *testing.T) {
 		// create QA env
 		env := netemx.MustNewQAEnv(
-			netemx.QAEnvOptionHTTPServer(
+			netemx.QAEnvOptionNetStack(
 				netemx.AddressWwwExampleCom,
-				netemx.ExampleWebPageHandlerFactory(),
+				&netemx.HTTPSecureServerFactory{
+					Factory:          netemx.ExampleWebPageHandlerFactory(),
+					Ports:            []int{443},
+					ServerNameMain:   "www.example.com",
+					ServerNameExtras: []string{},
+				},
 			),
 		)
 		defer env.Close()
@@ -139,9 +144,14 @@ func TestQAEnv(t *testing.T) {
 	t.Run("we can hijack HTTP3 requests", func(t *testing.T) {
 		// create QA env
 		env := netemx.MustNewQAEnv(
-			netemx.QAEnvOptionHTTPServer(
+			netemx.QAEnvOptionNetStack(
 				netemx.AddressWwwExampleCom,
-				netemx.ExampleWebPageHandlerFactory(),
+				&netemx.HTTP3ServerFactory{
+					Factory:          netemx.ExampleWebPageHandlerFactory(),
+					Ports:            []int{443},
+					ServerNameMain:   "www.example.com",
+					ServerNameExtras: []string{},
+				},
 			),
 		)
 		defer env.Close()
@@ -191,7 +201,15 @@ func TestQAEnv(t *testing.T) {
 	t.Run("we can configure DPI rules", func(t *testing.T) {
 		// create QA env
 		env := netemx.MustNewQAEnv(
-			netemx.QAEnvOptionHTTPServer("8.8.8.8", netemx.ExampleWebPageHandlerFactory()),
+			netemx.QAEnvOptionNetStack(
+				"8.8.8.8",
+				&netemx.HTTPSecureServerFactory{
+					Factory:          netemx.ExampleWebPageHandlerFactory(),
+					Ports:            []int{443},
+					ServerNameMain:   "quad8.com",
+					ServerNameExtras: []string{},
+				},
+			),
 		)
 		defer env.Close()
 
@@ -244,7 +262,15 @@ func TestQAEnv(t *testing.T) {
 
 		// create QA env
 		env := netemx.MustNewQAEnv(
-			netemx.QAEnvOptionHTTPServer("8.8.8.8", netemx.ExampleWebPageHandlerFactory()),
+			netemx.QAEnvOptionNetStack(
+				"8.8.8.8",
+				&netemx.HTTPSecureServerFactory{
+					Factory:          netemx.ExampleWebPageHandlerFactory(),
+					Ports:            []int{443},
+					ServerNameMain:   "quad8.com",
+					ServerNameExtras: []string{},
+				},
+			),
 			netemx.QAEnvOptionClientNICWrapper(dumper),
 		)
 		defer env.Close()

--- a/internal/netemx/scenario.go
+++ b/internal/netemx/scenario.go
@@ -41,14 +41,20 @@ const (
 
 // ScenarioDomainAddresses describes a domain and address used in a scenario.
 type ScenarioDomainAddresses struct {
-	// Domains contains a related set of domains domains (MANDATORY field).
-	Domains []string
-
 	// Addresses contains the MANDATORY list of addresses belonging to the domain.
 	Addresses []string
 
+	// Domains contains a related set of domains domains (MANDATORY field).
+	Domains []string
+
 	// Role is the MANDATORY role of this domain (e.g., ScenarioRoleOONIAPI).
 	Role uint64
+
+	// ServerNameMain is the MANDATORY server name to use as common name for X.509 certs.
+	ServerNameMain string
+
+	// ServerNameExtras contains OPTIONAL extra names to also configure into the cert.
+	ServerNameExtras []string
 
 	// WebServerFactory is the factory to use when Role is ScenarioRoleWebServer.
 	WebServerFactory HTTPHandlerFactory
@@ -60,13 +66,17 @@ var InternetScenario = []*ScenarioDomainAddresses{{
 	Addresses: []string{
 		AddressApiOONIIo,
 	},
-	Role: ScenarioRoleOONIAPI,
+	Role:             ScenarioRoleOONIAPI,
+	ServerNameMain:   "api.ooni.io",
+	ServerNameExtras: []string{},
 }, {
 	Domains: []string{"geoip.ubuntu.com"},
 	Addresses: []string{
 		AddressGeoIPUbuntuCom,
 	},
-	Role: ScenarioRoleUbuntuGeoIP,
+	Role:             ScenarioRoleUbuntuGeoIP,
+	ServerNameMain:   "geoip.ubuntu.com",
+	ServerNameExtras: []string{},
 }, {
 	Domains: []string{"www.example.com", "example.com", "www.example.org", "example.org"},
 	Addresses: []string{
@@ -74,55 +84,73 @@ var InternetScenario = []*ScenarioDomainAddresses{{
 	},
 	Role:             ScenarioRoleWebServer,
 	WebServerFactory: ExampleWebPageHandlerFactory(),
+	ServerNameMain:   "www.example.com",
+	ServerNameExtras: []string{"example.com", "www.example.org", "example.org"},
 }, {
 	Domains: []string{"0.th.ooni.org"},
 	Addresses: []string{
 		AddressZeroThOONIOrg,
 	},
-	Role: ScenarioRoleOONITestHelper,
+	Role:             ScenarioRoleOONITestHelper,
+	ServerNameMain:   "0.th.ooni.org",
+	ServerNameExtras: []string{},
 }, {
 	Domains: []string{"1.th.ooni.org"},
 	Addresses: []string{
 		AddressOneThOONIOrg,
 	},
-	Role: ScenarioRoleOONITestHelper,
+	Role:             ScenarioRoleOONITestHelper,
+	ServerNameMain:   "1.th.ooni.org",
+	ServerNameExtras: []string{},
 }, {
 	Domains: []string{"2.th.ooni.org"},
 	Addresses: []string{
 		AddressTwoThOONIOrg,
 	},
-	Role: ScenarioRoleOONITestHelper,
+	Role:             ScenarioRoleOONITestHelper,
+	ServerNameMain:   "2.th.ooni.org",
+	ServerNameExtras: []string{},
 }, {
 	Domains: []string{"3.th.ooni.org"},
 	Addresses: []string{
 		AddressThreeThOONIOrg,
 	},
-	Role: ScenarioRoleOONITestHelper,
+	Role:             ScenarioRoleOONITestHelper,
+	ServerNameMain:   "3.th.ooni.org",
+	ServerNameExtras: []string{},
 }, {
 	Domains: []string{"d33d1gs9kpq1c5.cloudfront.net"},
 	Addresses: []string{
 		AddressTHCloudfront,
 	},
-	Role: ScenarioRoleOONITestHelper,
+	Role:             ScenarioRoleOONITestHelper,
+	ServerNameMain:   "d33d1gs9kpq1c5.cloudfront.net",
+	ServerNameExtras: []string{},
 }, {
 	Domains: []string{"dns.quad9.net"},
 	Addresses: []string{
 		AddressDNSQuad9Net,
 	},
-	Role: ScenarioRolePublicDNS,
+	Role:             ScenarioRolePublicDNS,
+	ServerNameMain:   "dns.quad9.net",
+	ServerNameExtras: []string{},
 }, {
 	Domains: []string{"mozilla.cloudflare-dns.com"},
 	Addresses: []string{
 		AddressMozillaCloudflareDNSCom,
 	},
-	Role: ScenarioRolePublicDNS,
+	Role:             ScenarioRolePublicDNS,
+	ServerNameMain:   "mozilla.cloudflare-dns.com",
+	ServerNameExtras: []string{},
 }, {
 	Domains: []string{"dns.google", "dns.google.com"},
 	Addresses: []string{
 		AddressDNSGoogle8844,
 		AddressDNSGoogle8888,
 	},
-	Role: ScenarioRolePublicDNS,
+	Role:             ScenarioRolePublicDNS,
+	ServerNameMain:   "dns.google",
+	ServerNameExtras: []string{"dns.google.com"},
 }, {
 	Domains: []string{},
 	Addresses: []string{
@@ -130,19 +158,24 @@ var InternetScenario = []*ScenarioDomainAddresses{{
 	},
 	Role:             ScenarioRoleBlockpageServer,
 	WebServerFactory: BlockpageHandlerFactory(),
+	ServerNameMain:   "blockpage.local",
+	ServerNameExtras: []string{},
 }, {
 	Domains: []string{},
 	Addresses: []string{
 		ISPProxyAddress,
 	},
 	Role:             ScenarioRoleProxy,
-	WebServerFactory: nil,
+	ServerNameMain:   "proxy.local",
+	ServerNameExtras: []string{},
 }, {
 	Domains: []string{"bit.ly", "bitly.com"},
 	Addresses: []string{
 		AddressBitly,
 	},
-	Role: ScenarioRoleURLShortener,
+	Role:             ScenarioRoleURLShortener,
+	ServerNameMain:   "bit.ly",
+	ServerNameExtras: []string{"bitly.com"},
 }, {
 	Domains: []string{
 		"wrong.host.badssl.com",
@@ -152,7 +185,9 @@ var InternetScenario = []*ScenarioDomainAddresses{{
 	Addresses: []string{
 		AddressBadSSLCom,
 	},
-	Role: ScenarioRoleBadSSL,
+	Role:             ScenarioRoleBadSSL,
+	ServerNameMain:   "badssl.com",
+	ServerNameExtras: []string{},
 }}
 
 // MustNewScenario constructs a complete testing scenario using the domains and IP
@@ -169,33 +204,54 @@ func MustNewScenario(config []*ScenarioDomainAddresses) *QAEnv {
 					addr,
 					&DNSOverUDPServerFactory{},
 					&HTTPSecureServerFactory{
-						Factory:   &DNSOverHTTPSHandlerFactory{},
-						Ports:     []int{443},
-						TLSConfig: nil, // use netem's default
+						Factory:          &DNSOverHTTPSHandlerFactory{},
+						Ports:            []int{443},
+						ServerNameMain:   sad.ServerNameMain,
+						ServerNameExtras: sad.ServerNameExtras,
 					},
 				))
 			}
 
 		case ScenarioRoleWebServer:
 			for _, addr := range sad.Addresses {
-				opts = append(opts, QAEnvOptionHTTPServer(addr, sad.WebServerFactory))
+				opts = append(opts, qaEnvOptionNetStack(
+					addr,
+					&HTTPCleartextServerFactory{
+						Factory: sad.WebServerFactory,
+						Ports:   []int{80},
+					},
+					&HTTPSecureServerFactory{
+						Factory:          sad.WebServerFactory,
+						Ports:            []int{443},
+						ServerNameMain:   sad.ServerNameMain,
+						ServerNameExtras: sad.ServerNameExtras,
+					},
+					&HTTP3ServerFactory{
+						Factory:          sad.WebServerFactory,
+						Ports:            []int{443},
+						ServerNameMain:   sad.ServerNameMain,
+						ServerNameExtras: sad.ServerNameExtras,
+					},
+				))
 			}
 
 		case ScenarioRoleOONIAPI:
 			for _, addr := range sad.Addresses {
 				opts = append(opts, QAEnvOptionNetStack(addr, &HTTPSecureServerFactory{
-					Factory:   &OOAPIHandlerFactory{},
-					Ports:     []int{443},
-					TLSConfig: nil, // use netem's default
+					Factory:          &OOAPIHandlerFactory{},
+					Ports:            []int{443},
+					ServerNameMain:   sad.ServerNameMain,
+					ServerNameExtras: sad.ServerNameExtras,
 				}))
 			}
 
 		case ScenarioRoleOONITestHelper:
 			for _, addr := range sad.Addresses {
 				opts = append(opts, QAEnvOptionNetStack(addr, &HTTPSecureServerFactory{
-					Factory:   &OOHelperDFactory{},
-					Ports:     []int{443},
-					TLSConfig: nil, // use netem's default
+					Factory:          &OOHelperDFactory{},
+					Ports:            []int{443},
+					ServerNameMain:   sad.ServerNameMain,
+					ServerNameExtras: sad.ServerNameExtras,
 				}))
 			}
 
@@ -205,8 +261,9 @@ func MustNewScenario(config []*ScenarioDomainAddresses) *QAEnv {
 					Factory: &GeoIPHandlerFactoryUbuntu{
 						ProbeIP: DefaultClientAddress,
 					},
-					Ports:     []int{443},
-					TLSConfig: nil, // use netem's default
+					Ports:            []int{443},
+					ServerNameMain:   sad.ServerNameMain,
+					ServerNameExtras: sad.ServerNameExtras,
 				}))
 			}
 
@@ -234,7 +291,14 @@ func MustNewScenario(config []*ScenarioDomainAddresses) *QAEnv {
 
 		case ScenarioRoleURLShortener:
 			for _, addr := range sad.Addresses {
-				opts = append(opts, QAEnvOptionHTTPServer(addr, URLShortenerFactory(DefaultURLShortenerMapping)))
+				opts = append(opts, QAEnvOptionNetStack(addr,
+					&HTTPSecureServerFactory{
+						Factory:          URLShortenerFactory(DefaultURLShortenerMapping),
+						Ports:            []int{443},
+						ServerNameMain:   sad.ServerNameMain,
+						ServerNameExtras: sad.ServerNameExtras,
+					},
+				))
 			}
 
 		case ScenarioRoleBadSSL:
@@ -244,7 +308,7 @@ func MustNewScenario(config []*ScenarioDomainAddresses) *QAEnv {
 		}
 	}
 
-	// create the QAEnv
+	// create QAEnv
 	env := MustNewQAEnv(opts...)
 
 	// configure all the domain names

--- a/internal/netxlite/netem.go
+++ b/internal/netxlite/netem.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ooni/netem"
 	"github.com/ooni/probe-cli/v3/internal/model"
-	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
 // NetemUnderlyingNetworkAdapter adapts [netem.UnderlyingNetwork] to [model.UnderlyingNetwork].
@@ -20,7 +19,7 @@ var _ model.UnderlyingNetwork = &NetemUnderlyingNetworkAdapter{}
 
 // DefaultCertPool implements model.UnderlyingNetwork
 func (a *NetemUnderlyingNetworkAdapter) DefaultCertPool() *x509.CertPool {
-	return runtimex.Try1(a.UNet.DefaultCertPool())
+	return a.UNet.DefaultCertPool()
 }
 
 // DialTimeout implements model.UnderlyingNetwork

--- a/internal/netxlite/netem_test.go
+++ b/internal/netxlite/netem_test.go
@@ -16,7 +16,7 @@ func TestNetemUnderlyingNetworkAdapter(t *testing.T) {
 	// This test case explicitly ensures we can use the adapter to listen for TCP
 	t.Run("ListenTCP", func(t *testing.T) {
 		// create a star network topology
-		topology := runtimex.Try1(netem.NewStarTopology(log.Log))
+		topology := netem.MustNewStarTopology(log.Log)
 		defer topology.Close()
 
 		// constants for the IP address we're using

--- a/internal/netxlite/tls_test.go
+++ b/internal/netxlite/tls_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/apex/log"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/ooni/netem"
 	"github.com/ooni/probe-cli/v3/internal/mocks"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/testingx"
@@ -371,8 +372,9 @@ func TestTLSHandshakerConfigurable(t *testing.T) {
 				startCalled                 bool
 				doneCalled                  bool
 			)
-			mitm := testingx.MustNewTLSMITMProviderNetem()
-			server := testingx.MustNewTLSServer(testingx.TLSHandlerHandshakeAndWriteText(mitm, testingx.HTTPBlockpage451))
+			ca := netem.MustNewCA()
+			cert := ca.MustNewTLSCertificate(expectedSNI)
+			server := testingx.MustNewTLSServer(testingx.TLSHandlerHandshakeAndWriteText(cert, testingx.HTTPBlockpage451))
 			defer server.Close()
 			zeroTime := time.Now()
 			deterministicTime := testingx.NewTimeDeterministic(zeroTime)

--- a/internal/testingproxy/hosthttps.go
+++ b/internal/testingproxy/hosthttps.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/apex/log"
+	"github.com/ooni/netem"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 	"github.com/ooni/probe-cli/v3/internal/testingx"
@@ -45,8 +46,15 @@ func (tc *hostNetworkTestCaseWithHTTPWithTLS) Run(t *testing.T) {
 	// which means we're using the host's network
 	netx := &netxlite.Netx{Underlying: nil}
 
+	// create CA
+	proxyCA := netem.MustNewCA()
+
 	// create the proxy server using the host network
-	proxyServer := testingx.MustNewHTTPServerTLS(testingx.NewHTTPProxyHandler(log.Log, netx))
+	proxyServer := testingx.MustNewHTTPServerTLS(
+		testingx.NewHTTPProxyHandler(log.Log, netx),
+		proxyCA,
+		"proxy.local",
+	)
 	defer proxyServer.Close()
 
 	// extend the default cert pool with the proxy's own CA

--- a/internal/testingproxy/netemhttp.go
+++ b/internal/testingproxy/netemhttp.go
@@ -43,7 +43,7 @@ func (tc *netemTestCaseWithHTTP) Name() string {
 
 // Run implements TestCase.
 func (tc *netemTestCaseWithHTTP) Run(t *testing.T) {
-	topology := runtimex.Try1(netem.NewStarTopology(log.Log))
+	topology := netem.MustNewStarTopology(log.Log)
 	defer topology.Close()
 
 	const (
@@ -89,6 +89,7 @@ func (tc *netemTestCaseWithHTTP) Run(t *testing.T) {
 			w.Write([]byte("Bonsoir, Elliot!\r\n"))
 		}),
 		wwwStack,
+		"www.example.com",
 	)
 	defer wwwServer443.Close()
 
@@ -118,7 +119,7 @@ func (tc *netemTestCaseWithHTTP) Run(t *testing.T) {
 
 		// TODO(https://github.com/ooni/probe/issues/2536)
 		netxlite.HTTPTransportOptionTLSClientConfig(&tls.Config{
-			RootCAs: runtimex.Try1(clientStack.DefaultCertPool()),
+			RootCAs: clientStack.DefaultCertPool(),
 		}),
 	)
 	client := &http.Client{Transport: txp}

--- a/internal/testingproxy/netemhttps.go
+++ b/internal/testingproxy/netemhttps.go
@@ -93,9 +93,9 @@ func (tc *netemTestCaseWithHTTPWithTLS) Run(t *testing.T) {
 	)
 	defer wwwServer443.Close()
 
-	// configure the proxyStack to implement the HTTP proxy on port 80443
+	// configure the proxyStack to implement the HTTP proxy on port 4443
 	proxyServer := testingx.MustNewHTTPServerTLSEx(
-		&net.TCPAddr{IP: net.ParseIP(proxyIPAddr), Port: 80443},
+		&net.TCPAddr{IP: net.ParseIP(proxyIPAddr), Port: 4443},
 		proxyStack,
 		testingx.NewHTTPProxyHandler(log.Log, &netxlite.Netx{
 			Underlying: &netxlite.NetemUnderlyingNetworkAdapter{UNet: proxyStack}}),

--- a/internal/testingproxy/socksnetem.go
+++ b/internal/testingproxy/socksnetem.go
@@ -43,7 +43,7 @@ func (tc *netemTestCaseWithSOCKS) Name() string {
 
 // Run implements TestCase.
 func (tc *netemTestCaseWithSOCKS) Run(t *testing.T) {
-	topology := runtimex.Try1(netem.NewStarTopology(log.Log))
+	topology := netem.MustNewStarTopology(log.Log)
 	defer topology.Close()
 
 	const (
@@ -89,6 +89,7 @@ func (tc *netemTestCaseWithSOCKS) Run(t *testing.T) {
 			w.Write([]byte("Bonsoir, Elliot!\r\n"))
 		}),
 		wwwStack,
+		"www.example.com",
 	)
 	defer wwwServer443.Close()
 
@@ -118,7 +119,7 @@ func (tc *netemTestCaseWithSOCKS) Run(t *testing.T) {
 
 		// TODO(https://github.com/ooni/probe/issues/2536)
 		netxlite.HTTPTransportOptionTLSClientConfig(&tls.Config{
-			RootCAs: runtimex.Try1(clientStack.DefaultCertPool()),
+			RootCAs: clientStack.DefaultCertPool(),
 		}),
 	)
 	client := &http.Client{Transport: txp}

--- a/internal/testingsocks5/qa_test.go
+++ b/internal/testingsocks5/qa_test.go
@@ -28,7 +28,7 @@ func TestNetem(t *testing.T) {
 }
 
 func TestNetemDialFailure(t *testing.T) {
-	topology := runtimex.Try1(netem.NewStarTopology(log.Log))
+	topology := netem.MustNewStarTopology(log.Log)
 	defer topology.Close()
 
 	const (
@@ -76,7 +76,7 @@ func TestNetemDialFailure(t *testing.T) {
 
 		// TODO(https://github.com/ooni/probe/issues/2536)
 		netxlite.HTTPTransportOptionTLSClientConfig(&tls.Config{
-			RootCAs: runtimex.Try1(clientStack.DefaultCertPool()),
+			RootCAs: clientStack.DefaultCertPool(),
 		}),
 	)
 	client := &http.Client{Transport: txp}

--- a/internal/testingx/httptestx.go
+++ b/internal/testingx/httptestx.go
@@ -44,7 +44,7 @@ type HTTPServer struct {
 	// This field is an extension that is not present in the httptest package.
 	X509CertPool *x509.CertPool
 
-	// CACert is the CA used by this server.
+	// CACert is the CA used by this server or nil.
 	//
 	// This field is an extension that is not present in the httptest package.
 	CACert *x509.Certificate
@@ -68,9 +68,10 @@ func MustNewHTTPServerEx(addr *net.TCPAddr, httpListener TCPListener, handler ht
 	srv := &HTTPServer{
 		Config:       &http.Server{Handler: handler},
 		Listener:     listener,
-		TLS:          nil, // the default when not using TLS
+		TLS:          nil,
 		URL:          baseURL.String(),
-		X509CertPool: nil, // the default when not using TLS
+		X509CertPool: nil,
+		CACert:       nil,
 	}
 
 	go srv.Config.Serve(listener)

--- a/internal/testingx/httptestx.go
+++ b/internal/testingx/httptestx.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/ooni/probe-cli/v3/internal/optional"
+	"github.com/ooni/netem"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
@@ -56,55 +56,71 @@ func MustNewHTTPServer(handler http.Handler) *HTTPServer {
 	return MustNewHTTPServerEx(addr, &TCPListenerStdlib{}, handler)
 }
 
-// MustNewHTTPServerTLS is morally equivalent to [httptest.NewHTTPServerTLS].
-func MustNewHTTPServerTLS(handler http.Handler) *HTTPServer {
-	addr := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
-	provider := MustNewTLSMITMProviderNetem()
-	return MustNewHTTPServerTLSEx(addr, &TCPListenerStdlib{}, handler, provider)
-}
-
 // MustNewHTTPServerEx creates a new [HTTPServer] using HTTP or PANICS.
-func MustNewHTTPServerEx(addr *net.TCPAddr, listener TCPListener, handler http.Handler) *HTTPServer {
-	return mustNewHTTPServer(addr, listener, handler, optional.None[TLSMITMProvider]())
-}
-
-// MustNewHTTPServerTLSEx creates a new [HTTPServer] using HTTPS or PANICS.
-func MustNewHTTPServerTLSEx(addr *net.TCPAddr, listener TCPListener, handler http.Handler, mitm TLSMITMProvider) *HTTPServer {
-	return mustNewHTTPServer(addr, listener, handler, optional.Some(mitm))
-}
-
-// newHTTPOrHTTPSServer is an internal factory for creating a new instance.
-func mustNewHTTPServer(
-	addr *net.TCPAddr,
-	httpListener TCPListener,
-	handler http.Handler,
-	tlsConfig optional.Value[TLSMITMProvider],
-) *HTTPServer {
+func MustNewHTTPServerEx(addr *net.TCPAddr, httpListener TCPListener, handler http.Handler) *HTTPServer {
 	listener := runtimex.Try1(httpListener.ListenTCP("tcp", addr))
+
+	baseURL := &url.URL{
+		Scheme: "http",
+		Host:   listener.Addr().String(),
+		Path:   "/",
+	}
 	srv := &HTTPServer{
 		Config:       &http.Server{Handler: handler},
 		Listener:     listener,
 		TLS:          nil, // the default when not using TLS
-		URL:          "",  // filled later
+		URL:          baseURL.String(),
 		X509CertPool: nil, // the default when not using TLS
 	}
-	baseURL := &url.URL{Host: listener.Addr().String()}
 
-	switch !tlsConfig.IsNone() {
-	case true:
-		baseURL.Scheme = "https"
-		srv.CACert = tlsConfig.Unwrap().CACert()
-		srv.TLS = tlsConfig.Unwrap().ServerTLSConfig()
-		srv.Config.TLSConfig = srv.TLS
-		srv.X509CertPool = runtimex.Try1(tlsConfig.Unwrap().DefaultCertPool())
-		go srv.Config.ServeTLS(listener, "", "") // using server.TLSConfig
+	go srv.Config.Serve(listener)
 
-	default:
-		baseURL.Scheme = "http"
-		go srv.Config.Serve(listener)
+	return srv
+}
+
+// MustNewHTTPServerTLS is morally equivalent to [httptest.NewHTTPServerTLS].
+func MustNewHTTPServerTLS(
+	handler http.Handler,
+	ca netem.CertificationAuthority,
+	commonName string,
+	extraSNIs ...string,
+) *HTTPServer {
+	addr := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
+	return MustNewHTTPServerTLSEx(addr, &TCPListenerStdlib{}, handler, ca, commonName, extraSNIs...)
+}
+
+// MustNewHTTPServerTLSEx creates a new [HTTPServer] using HTTPS or PANICS.
+func MustNewHTTPServerTLSEx(
+	addr *net.TCPAddr,
+	httpListener TCPListener,
+	handler http.Handler,
+	ca netem.CertificationAuthority,
+	commonName string,
+	extraSNIs ...string,
+) *HTTPServer {
+	listener := runtimex.Try1(httpListener.ListenTCP("tcp", addr))
+
+	baseURL := &url.URL{
+		Scheme: "https",
+		Host:   listener.Addr().String(),
+		Path:   "/",
 	}
 
-	srv.URL = baseURL.String()
+	otherNames := append([]string{}, addr.IP.String())
+	otherNames = append(otherNames, extraSNIs...)
+
+	srv := &HTTPServer{
+		Config:       &http.Server{Handler: handler},
+		Listener:     listener,
+		TLS:          ca.MustNewServerTLSConfig(commonName, otherNames...),
+		URL:          baseURL.String(),
+		X509CertPool: ca.DefaultCertPool(),
+		CACert:       ca.CACert(),
+	}
+
+	srv.Config.TLSConfig = srv.TLS
+	go srv.Config.ServeTLS(listener, "", "") // using server.TLSConfig
+
 	return srv
 }
 

--- a/internal/testingx/httptestx_test.go
+++ b/internal/testingx/httptestx_test.go
@@ -43,7 +43,7 @@ func TestHTTPTestxWithStdlib(t *testing.T) {
 		expectBody []byte
 	}
 
-	// create server's CA and leaf certificate
+	// create server's CA
 	serverCA := netem.MustNewCA()
 
 	testcases := []testcase{

--- a/internal/testingx/httptestx_test.go
+++ b/internal/testingx/httptestx_test.go
@@ -43,6 +43,9 @@ func TestHTTPTestxWithStdlib(t *testing.T) {
 		expectBody []byte
 	}
 
+	// create server's CA and leaf certificate
+	serverCA := netem.MustNewCA()
+
 	testcases := []testcase{
 		/*
 		 * HTTP
@@ -91,7 +94,11 @@ func TestHTTPTestxWithStdlib(t *testing.T) {
 		{
 			name: "with HTTPS and the HTTPHandlerBlockpage451 handler",
 			constructor: func() *testingx.HTTPServer {
-				return testingx.MustNewHTTPServerTLS(testingx.HTTPHandlerBlockpage451())
+				return testingx.MustNewHTTPServerTLS(
+					testingx.HTTPHandlerBlockpage451(),
+					serverCA,
+					"webserver.local",
+				)
 			},
 			timeout:    10 * time.Second,
 			expectErr:  nil,
@@ -100,7 +107,11 @@ func TestHTTPTestxWithStdlib(t *testing.T) {
 		}, {
 			name: "with HTTPS and the HTTPHandlerEOF handler",
 			constructor: func() *testingx.HTTPServer {
-				return testingx.MustNewHTTPServerTLS(testingx.HTTPHandlerEOF())
+				return testingx.MustNewHTTPServerTLS(
+					testingx.HTTPHandlerEOF(),
+					serverCA,
+					"webserver.local",
+				)
 			},
 			timeout:    10 * time.Second,
 			expectErr:  io.EOF,
@@ -109,7 +120,11 @@ func TestHTTPTestxWithStdlib(t *testing.T) {
 		}, {
 			name: "with HTTPS and the HTTPHandlerReset handler",
 			constructor: func() *testingx.HTTPServer {
-				return testingx.MustNewHTTPServerTLS(testingx.HTTPHandlerReset())
+				return testingx.MustNewHTTPServerTLS(
+					testingx.HTTPHandlerReset(),
+					serverCA,
+					"webserver.local",
+				)
 			},
 			timeout:    10 * time.Second,
 			expectErr:  netxlite.ECONNRESET,
@@ -118,7 +133,11 @@ func TestHTTPTestxWithStdlib(t *testing.T) {
 		}, {
 			name: "with HTTPS and the HTTPHandlerTimeout handler",
 			constructor: func() *testingx.HTTPServer {
-				return testingx.MustNewHTTPServerTLS(testingx.HTTPHandlerTimeout())
+				return testingx.MustNewHTTPServerTLS(
+					testingx.HTTPHandlerTimeout(),
+					serverCA,
+					"webserver.local",
+				)
 			},
 			timeout:    1 * time.Second,
 			expectErr:  context.DeadlineExceeded,
@@ -309,6 +328,7 @@ func TestHTTPTestxWithNetem(t *testing.T) {
 					unet,
 					testingx.HTTPHandlerBlockpage451(),
 					unet,
+					"webserver.local",
 				)
 			},
 			timeout:    10 * time.Second,
@@ -326,6 +346,7 @@ func TestHTTPTestxWithNetem(t *testing.T) {
 					unet,
 					testingx.HTTPHandlerEOF(),
 					unet,
+					"webserver.local",
 				)
 			},
 			timeout:    10 * time.Second,
@@ -344,6 +365,7 @@ func TestHTTPTestxWithNetem(t *testing.T) {
 					unet,
 					testingx.HTTPHandlerReset(),
 					unet,
+					"webserver.local",
 				)
 			},
 			timeout:    10 * time.Second,
@@ -361,6 +383,7 @@ func TestHTTPTestxWithNetem(t *testing.T) {
 					unet,
 					testingx.HTTPHandlerTimeout(),
 					unet,
+					"webserver.local",
 				)
 			},
 			timeout:    1 * time.Second,
@@ -378,7 +401,7 @@ func TestHTTPTestxWithNetem(t *testing.T) {
 			}
 
 			// create a star topology for hosting the test
-			topology := runtimex.Try1(netem.NewStarTopology(log.Log))
+			topology := netem.MustNewStarTopology(log.Log)
 			defer topology.Close()
 
 			// create a common link config

--- a/internal/testingx/tlssniproxy_test.go
+++ b/internal/testingx/tlssniproxy_test.go
@@ -48,7 +48,7 @@ func TestTLSSNIProxy(t *testing.T) {
 		construct: func() (*testingx.TLSSNIProxy, *netxlite.Netx, []io.Closer) {
 			var closers []io.Closer
 
-			topology := runtimex.Try1(netem.NewStarTopology(log.Log))
+			topology := netem.MustNewStarTopology(log.Log)
 			closers = append(closers, topology)
 
 			wwwStack := runtimex.Try1(topology.AddHost("142.251.209.14", "142.251.209.14", &netem.LinkConfig{}))
@@ -67,6 +67,7 @@ func TestTLSSNIProxy(t *testing.T) {
 					w.Write([]byte("Bonsoir, Elliot!"))
 				}),
 				wwwStack,
+				"www.google.com",
 			)
 			closers = append(closers, wwwServer)
 

--- a/internal/testingx/tlsx.go
+++ b/internal/testingx/tlsx.go
@@ -3,64 +3,14 @@ package testingx
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"net"
 	"sync"
 	"time"
 
 	"github.com/apex/log"
-	"github.com/ooni/netem"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
-
-// TLSMITMProvider provides TLS MITM capabilities. Two structs are known
-// to implement this interface:
-//
-// 1. a [*netem.UNetStack] instance.
-//
-// 2. the one returned by [MustNewTLSMITMProviderNetem].
-//
-// Both use [github.com/google/martian/v3/mitm] under the hood.
-//
-// Use the former when you're using netem; the latter when using the stdlib.
-type TLSMITMProvider interface {
-	// CACert returns the CA certificate used by the server, which
-	// allows you to add to an existing [*x509.CertPool].
-	CACert() *x509.Certificate
-
-	// DefaultCertPool returns the default cert pool to use.
-	DefaultCertPool() (*x509.CertPool, error)
-
-	// ServerTLSConfig returns ready to use server TLS configuration.
-	ServerTLSConfig() *tls.Config
-}
-
-var _ TLSMITMProvider = &netem.UNetStack{}
-
-// MustNewTLSMITMProviderNetem uses [github.com/ooni/netem] to implement [TLSMITMProvider].
-func MustNewTLSMITMProviderNetem() TLSMITMProvider {
-	return &netemTLSMITMProvider{runtimex.Try1(netem.NewTLSMITMConfig())}
-}
-
-type netemTLSMITMProvider struct {
-	cfg *netem.TLSMITMConfig
-}
-
-// CACert implements TLSMITMProvider.
-func (p *netemTLSMITMProvider) CACert() *x509.Certificate {
-	return p.cfg.Cert
-}
-
-// DefaultCertPool implements TLSMITMProvider.
-func (p *netemTLSMITMProvider) DefaultCertPool() (*x509.CertPool, error) {
-	return p.cfg.CertPool()
-}
-
-// ServerTLSConfig implements TLSMITMProvider.
-func (p *netemTLSMITMProvider) ServerTLSConfig() *tls.Config {
-	return p.cfg.TLSConfig()
-}
 
 // TLSHandler handles TLS connections. A handler should first handle the TLS handshake
 // in the GetCertificate method. If GetCertificate did not return an error, and the
@@ -286,24 +236,20 @@ func (*tlsHandlerReset) GetCertificate(ctx context.Context, tcpConn net.Conn, ch
 
 // TLSHandlerHandshakeAndWriteText returns a [TLSHandler] that attempts to
 // complete the handshake and returns the given text to the caller.
-func TLSHandlerHandshakeAndWriteText(mitm TLSMITMProvider, text []byte) TLSHandler {
-	return &tlsHandlerHandshakeAndWriteText{mitm, text}
+func TLSHandlerHandshakeAndWriteText(cert *tls.Certificate, text []byte) TLSHandler {
+	return &tlsHandlerHandshakeAndWriteText{cert, text}
 }
 
 var _ TLSConnHandler = &tlsHandlerHandshakeAndWriteText{}
 
 type tlsHandlerHandshakeAndWriteText struct {
-	mitm TLSMITMProvider
+	cert *tls.Certificate
 	text []byte
 }
 
 // GetCertificate implements TLSHandler.
 func (thx *tlsHandlerHandshakeAndWriteText) GetCertificate(ctx context.Context, tcpConn net.Conn, chi *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	// Implementation note: under the assumption that we're using github.com/ooni/netem in one way or
-	// another here, the ServerTLSConfig method returns a suitable GetCertificate implementation. Since
-	// the primary use case is that of using netem, this code is going to be WAI most of the times.
-	config := thx.mitm.ServerTLSConfig()
-	return config.GetCertificate(chi)
+	return thx.cert, nil
 }
 
 // HandleTLSConn implements TLSHandler.

--- a/internal/testingx/tlsx_test.go
+++ b/internal/testingx/tlsx_test.go
@@ -39,8 +39,9 @@ func TestTLSHandlerWithStdlib(t *testing.T) {
 		expectBody []byte
 	}
 
-	// create MITM config
-	mitm := testingx.MustNewTLSMITMProviderNetem()
+	// create server's CA and leaf certificate
+	serverCA := netem.MustNewCA()
+	serverCert := serverCA.MustNewTLSCertificate("www.example.com")
 
 	testcases := []testcase{{
 		name: "with TLSHandlerTimeout",
@@ -77,7 +78,7 @@ func TestTLSHandlerWithStdlib(t *testing.T) {
 	}, {
 		name: "with TLSHandlerHandshakeAndWriteText",
 		newHandler: func() testingx.TLSHandler {
-			return testingx.TLSHandlerHandshakeAndWriteText(mitm, testingx.HTTPBlockpage451)
+			return testingx.TLSHandlerHandshakeAndWriteText(serverCert, testingx.HTTPBlockpage451)
 		},
 		timeout:    10 * time.Second,
 		expectErr:  nil,
@@ -92,7 +93,7 @@ func TestTLSHandlerWithStdlib(t *testing.T) {
 
 			// create TLS config with a specific SNI
 			tlsConfig := &tls.Config{
-				RootCAs:    runtimex.Try1(mitm.DefaultCertPool()),
+				RootCAs:    serverCA.DefaultCertPool(),
 				ServerName: "www.example.com",
 			}
 
@@ -163,8 +164,9 @@ func TestTLSHandlerWithNetem(t *testing.T) {
 		expectBody []byte
 	}
 
-	// create MITM config
-	mitm := testingx.MustNewTLSMITMProviderNetem()
+	// create server's CA and leaf certificate
+	serverCA := netem.MustNewCA()
+	serverCert := serverCA.MustNewTLSCertificate("www.example.com")
 
 	testcases := []testcase{{
 		name: "with TLSHandlerTimeout",
@@ -202,7 +204,7 @@ func TestTLSHandlerWithNetem(t *testing.T) {
 	}, {
 		name: "with TLSHandlerHandshakeAndWriteText",
 		newHandler: func() testingx.TLSHandler {
-			return testingx.TLSHandlerHandshakeAndWriteText(mitm, testingx.HTTPBlockpage451)
+			return testingx.TLSHandlerHandshakeAndWriteText(serverCert, testingx.HTTPBlockpage451)
 		},
 		timeout:    10 * time.Second,
 		expectErr:  nil,
@@ -216,7 +218,7 @@ func TestTLSHandlerWithNetem(t *testing.T) {
 			}
 
 			// create a star topology for this test case
-			topology := runtimex.Try1(netem.NewStarTopology(log.Log))
+			topology := netem.MustNewStarTopology(log.Log)
 			defer topology.Close()
 
 			// create the server
@@ -235,7 +237,7 @@ func TestTLSHandlerWithNetem(t *testing.T) {
 			netxlite.WithCustomTProxy(&netxlite.NetemUnderlyingNetworkAdapter{UNet: clientStack}, func() {
 				// create TLS config with a specific SNI
 				tlsConfig := &tls.Config{
-					RootCAs:    runtimex.Try1(mitm.DefaultCertPool()),
+					RootCAs:    serverCA.DefaultCertPool(),
 					ServerName: "www.example.com",
 				}
 


### PR DESCRIPTION
As explained in https://github.com/ooni/netem/pull/40, netem used to generate on the fly certificates for any host.

I then discovered that this behavior is not desirable because the internet doesn't work like that. Specifically, TLS dialing to, say, www.example.com with www.google.com as the SNI must return a TLS error (`ssl_invalid_hostname` in OONI).

This wrong behavior of netem has become a bottleneck for writing new tests for the beacons functionality, so it must change.

I have already changed netem and this diff updates the probe-cli tree to use a netem version that behaves more correctly.

While there, I noticed that sniblocking tests were wrong because of the previous netem behavior and asserted that the control should return a nil failure, while it should have been `ssl_invalid_hostname`.

Part of https://github.com/ooni/probe/issues/2531