### PR TITLE
feat(enginenetx): add policy that uses beacons

### DIFF
--- a/internal/enginenetx/circo_qa_test.go
+++ b/internal/enginenetx/circo_qa_test.go
@@ -1,0 +1,184 @@
+package enginenetx_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/netem"
+	"github.com/ooni/probe-cli/v3/internal/enginenetx"
+	"github.com/ooni/probe-cli/v3/internal/netemx"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+	"github.com/ooni/probe-cli/v3/internal/testingx"
+)
+
+func TestCircoQA(t *testing.T) {
+	// testcase is a test case implemented by this function
+	type testcase struct {
+		// name is the name of the test case
+		name string
+
+		// short indicates whether this is a short test
+		short bool
+
+		// policy is the dialer policy
+		policy enginenetx.HTTPSDialerPolicy
+
+		// endpoint is the endpoint to connect to consisting of a domain
+		// name or IP address followed by a TCP port
+		endpoint string
+
+		// scenario is the netemx testing scenario to create
+		scenario []*netemx.ScenarioDomainAddresses
+
+		// configureDPI configures DPI rules (just add an empty
+		// function if you don't need any)
+		configureDPI func(dpi *netem.DPIEngine)
+
+		// expectErr is the error string we expect to see
+		expectErr string
+	}
+
+	allTestCases := []testcase{
+
+		{
+			name:  "successful case",
+			short: true,
+			policy: &enginenetx.CircoPolicy{
+				Config: enginenetx.NewCircoConfig(),
+			},
+			endpoint: "api.ooni.io:443",
+			scenario: netemx.InternetScenario,
+			configureDPI: func(dpi *netem.DPIEngine) {
+				// nothing
+			},
+			expectErr: "",
+		},
+
+		{
+			name:  "with just SNI based blocking",
+			short: true,
+			policy: &enginenetx.CircoPolicy{
+				Config: enginenetx.NewCircoConfig(),
+			},
+			endpoint: "api.ooni.io:443",
+			scenario: netemx.InternetScenario,
+			configureDPI: func(dpi *netem.DPIEngine) {
+				dpi.AddRule(&netem.DPIResetTrafficForTLSSNI{
+					Logger: log.Log,
+					SNI:    "api.ooni.io",
+				})
+			},
+			expectErr: "",
+		},
+
+		{
+			name:  "with DNS injection and SNI based blocking",
+			short: true,
+			policy: &enginenetx.CircoPolicy{
+				Config: enginenetx.NewCircoConfig(),
+			},
+			endpoint: "api.ooni.io:443",
+			scenario: netemx.InternetScenario,
+			configureDPI: func(dpi *netem.DPIEngine) {
+				dpi.AddRule(&netem.DPISpoofDNSResponse{
+					Addresses: []string{
+						netemx.AddressPublicBlockpage,
+					},
+					Logger: log.Log,
+					Domain: "api.ooni.io",
+				})
+				dpi.AddRule(&netem.DPIResetTrafficForTLSSNI{
+					Logger: log.Log,
+					SNI:    "api.ooni.io",
+				})
+			},
+			expectErr: "",
+		}}
+
+	for _, tc := range allTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// make sure we honor `go test -short`
+			if !tc.short && testing.Short() {
+				t.Skip("skip test in short mode")
+			}
+
+			// track all the connections so we can check whether we close them all
+			cv := &testingx.CloseVerify{}
+
+			func() {
+				// create the QA environment
+				env := netemx.MustNewScenario(tc.scenario)
+				defer env.Close()
+
+				// possibly add specific DPI rules
+				tc.configureDPI(env.DPIEngine())
+
+				// create the proper underlying network and wrap it such that
+				// we track whether we close all the connections
+				unet := cv.WrapUnderlyingNetwork(&netxlite.NetemUnderlyingNetworkAdapter{UNet: env.ClientStack})
+
+				// create the network proper
+				netx := &netxlite.Netx{Underlying: unet}
+
+				// create the getaddrinfo resolver
+				resolver := netx.NewStdlibResolver(log.Log)
+
+				// create the TLS dialer
+				dialer := enginenetx.NewHTTPSDialer(
+					log.Log,
+					tc.policy,
+					resolver,
+					unet,
+				)
+				defer dialer.CloseIdleConnections()
+
+				// configure cancellable context--some tests are going to use cancel
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				// Possibly tell the httpsDialerPolicyCancelingContext about the cancel func
+				// depending on which flags have been configured.
+				if p, ok := tc.policy.(*httpsDialerPolicyCancelingContext); ok {
+					p.cancel = cancel
+				}
+
+				// dial the TLS connection
+				tlsConn, err := dialer.DialTLSContext(ctx, "tcp", tc.endpoint)
+
+				t.Logf("%+v %+v", tlsConn, err)
+
+				// make sure the error is the one we expected
+				switch {
+				case err != nil && tc.expectErr == "":
+					t.Fatal("expected", tc.expectErr, "got", err)
+
+				case err == nil && tc.expectErr != "":
+					t.Fatal("expected", tc.expectErr, "got", err)
+
+				case err != nil && tc.expectErr != "":
+					if diff := cmp.Diff(tc.expectErr, err.Error()); diff != "" {
+						t.Fatal(diff)
+					}
+
+				case err == nil && tc.expectErr == "":
+					// all good
+				}
+
+				// make sure we close the conn
+				if tlsConn != nil {
+					defer tlsConn.Close()
+				}
+
+				// wait for background connections to join
+				dialer.WaitGroup().Wait()
+			}()
+
+			// now verify that we have closed all the connections
+			if err := cv.CheckForOpenConns(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/internal/enginenetx/circo_qa_test.go
+++ b/internal/enginenetx/circo_qa_test.go
@@ -134,15 +134,8 @@ func TestCircoQA(t *testing.T) {
 				)
 				defer dialer.CloseIdleConnections()
 
-				// configure cancellable context--some tests are going to use cancel
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-
-				// Possibly tell the httpsDialerPolicyCancelingContext about the cancel func
-				// depending on which flags have been configured.
-				if p, ok := tc.policy.(*httpsDialerPolicyCancelingContext); ok {
-					p.cancel = cancel
-				}
+				// configure context
+				ctx := context.Background()
 
 				// dial the TLS connection
 				tlsConn, err := dialer.DialTLSContext(ctx, "tcp", tc.endpoint)

--- a/internal/enginenetx/circoconfig.go
+++ b/internal/enginenetx/circoconfig.go
@@ -1,0 +1,73 @@
+package enginenetx
+
+// CircoConfig is the root of configuration for circumvention.
+//
+// (If convo is conversation, circo is circumvention.)
+type CircoConfig struct {
+	// Beacons contains configuration for beacons.
+	//
+	// From the point of view of OONI Probe a beacon is a host:
+	//
+	// 1. whose IP address we know in advance or we can dynamically discover using
+	// currently not yet specified discovery mechanisms;
+	//
+	// 2. whose TLS stack is known to continue the handshake even if the incoming
+	// SNI is wrong for the host, thus deferring TLS verification to the client (this
+	// behavior is implicitly RECOMMENDED by RFC 6066 Sect. 3).
+	Beacons map[string]CircoBeaconsDomain
+
+	// Version is the version of the config.
+	Version int
+}
+
+// beaconsIPAddrsForDomain returns either an empty list or a list of valid IP addresses
+// for the given domain that could work as beacons.
+func (c *CircoConfig) beaconsIPAddrsForDomain(domain string) (out []string) {
+	// TODO(bassosimone): lock and unlock the configuration when it becomes dynamic
+	if entry, good := c.Beacons[domain]; good {
+		out = append(out, entry.IPAddrs...)
+	}
+	return
+}
+
+// allServerNamesForDomainIncludingDomain returns a list containing the domain itself as the first
+// entry as well as zero or more additional SNIs for the given domain.
+func (c *CircoConfig) allServerNamesForDomainIncludingDomain(domain string) (out []string) {
+	// TODO(bassosimone): lock and unlock the configuration when it becomes dynamic
+	out = append(out, domain)
+	if entry, good := c.Beacons[domain]; good {
+		out = append(out, entry.SNIs...)
+	}
+	return
+}
+
+// CircoBeaconsDomain contains beacon configuration for a domain.
+type CircoBeaconsDomain struct {
+	// IPAddrs lists the known IP addrs for the beacon.
+	IPAddrs []string
+
+	// SNIs lists possible SNIs for the beacon.
+	SNIs []string
+}
+
+// CircoConfigVersion is the current version of the config used by circumvention.
+const CircoConfigVersion = 0
+
+// NewCircoConfig creates a new [*CircoConfig] using the default settings.
+func NewCircoConfig() *CircoConfig {
+	return &CircoConfig{
+		Beacons: map[string]CircoBeaconsDomain{
+			"api.ooni.io": {
+				IPAddrs: []string{
+					"162.55.247.208",
+				},
+				SNIs: []string{
+					// TODO(bassosimone): we should pick the correct set of SNIs to use here
+					"www.example.com",
+					"www.example.org",
+				},
+			},
+		},
+		Version: CircoConfigVersion,
+	}
+}

--- a/internal/enginenetx/circoconfig_test.go
+++ b/internal/enginenetx/circoconfig_test.go
@@ -24,6 +24,7 @@ func TestCircoConfig(t *testing.T) {
 			},
 			Version: 0,
 		}
+
 		t.Run("for known beacon", func(t *testing.T) {
 			expect := []string{"162.55.247.208"}
 			got := circo.beaconsIPAddrsForDomain("api.ooni.io")
@@ -61,8 +62,8 @@ func TestCircoConfig(t *testing.T) {
 		})
 
 		t.Run("for another host", func(t *testing.T) {
-			expect := []string{"x.org"}
-			got := circo.allServerNamesForDomainIncludingDomain("x.org")
+			expect := []string{"twitter.com"}
+			got := circo.allServerNamesForDomainIncludingDomain("twitter.com")
 			if diff := cmp.Diff(expect, got); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/enginenetx/circoconfig_test.go
+++ b/internal/enginenetx/circoconfig_test.go
@@ -1,0 +1,71 @@
+package enginenetx
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCircoConfig(t *testing.T) {
+	t.Run("NewCircoConfig returns a non-nil pointer", func(t *testing.T) {
+		circo := NewCircoConfig()
+		if circo == nil {
+			t.Fatal("expected non-nil pointer")
+		}
+	})
+
+	t.Run("beaconsIPAddrsForDomain", func(t *testing.T) {
+		circo := &CircoConfig{
+			Beacons: map[string]CircoBeaconsDomain{
+				"api.ooni.io": {
+					IPAddrs: []string{"162.55.247.208"},
+					SNIs:    []string{},
+				},
+			},
+			Version: 0,
+		}
+		t.Run("for known beacon", func(t *testing.T) {
+			expect := []string{"162.55.247.208"}
+			got := circo.beaconsIPAddrsForDomain("api.ooni.io")
+			if diff := cmp.Diff(expect, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+
+		t.Run("for another host", func(t *testing.T) {
+			var expect []string
+			got := circo.beaconsIPAddrsForDomain("www.example.com")
+			if diff := cmp.Diff(expect, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	})
+
+	t.Run("allServerNamesForDomainIncludingDomain", func(t *testing.T) {
+		circo := &CircoConfig{
+			Beacons: map[string]CircoBeaconsDomain{
+				"api.ooni.io": {
+					IPAddrs: []string{},
+					SNIs:    []string{"x.org"},
+				},
+			},
+			Version: 0,
+		}
+
+		t.Run("for known beacon", func(t *testing.T) {
+			expect := []string{"api.ooni.io", "x.org"}
+			got := circo.allServerNamesForDomainIncludingDomain("api.ooni.io")
+			if diff := cmp.Diff(expect, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+
+		t.Run("for another host", func(t *testing.T) {
+			expect := []string{"x.org"}
+			got := circo.allServerNamesForDomainIncludingDomain("x.org")
+			if diff := cmp.Diff(expect, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	})
+}

--- a/internal/enginenetx/circopolicy.go
+++ b/internal/enginenetx/circopolicy.go
@@ -66,6 +66,10 @@ func (p *CircoPolicy) LookupTactics(
 	sniv := p.Config.allServerNamesForDomainIncludingDomain(domain)
 	runtimex.Assert(len(sniv) > 0, "expected at least one SNI in the SNI vector")
 
+	// TODO(bassosimone): I am wondering whether this scheduling where
+	// we always try the default SNI first is good in case there is
+	// residual censorship blocking the endpoints.
+
 	// build the tactics and make sure there is an extra delay for beacons
 	// tactics such that normal tactics are used first
 	//

--- a/internal/enginenetx/circopolicy.go
+++ b/internal/enginenetx/circopolicy.go
@@ -1,0 +1,117 @@
+package enginenetx
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
+)
+
+// CircoPolicy is an [HTTPSDialerPolicy] with circumvention.
+//
+// The zero value is not ready to use; init all the fields marked as MANDATORY.
+type CircoPolicy struct {
+	// Config is the MANDATORY circo root config.
+	Config *CircoConfig
+}
+
+var _ HTTPSDialerPolicy = &CircoPolicy{}
+
+// LookupTactics implements HTTPSDialerPolicy.
+func (p *CircoPolicy) LookupTactics(
+	ctx context.Context, domain string, reso model.Resolver) ([]HTTPSDialerTactic, error) {
+
+	// find addresses using the DNS
+	dnsAddrs, err := reso.LookupHost(ctx, domain)
+
+	// find addresses using beacons config
+	beaconExtraAddrs := p.Config.beaconsIPAddrsForDomain(domain)
+
+	// prepare for unifying IP addrs
+	unifiedAddrsMap := make(map[string]bool)
+	for _, addr := range dnsAddrs {
+		if !netxlite.IsBogon(addr) {
+			unifiedAddrsMap[addr] = true
+		}
+	}
+	for _, addr := range beaconExtraAddrs {
+		if !netxlite.IsBogon(addr) {
+			unifiedAddrsMap[addr] = true
+		}
+	}
+
+	// if we don't have any address, just return the DNS lookup error
+	if len(unifiedAddrsMap) < 1 {
+		if err == nil {
+			err = netxlite.NewErrWrapper(
+				netxlite.ClassifyResolverError,
+				netxlite.TopLevelOperation,
+				netxlite.ErrOODNSNoAnswer,
+			)
+		}
+		return nil, err
+	}
+
+	// sort the unified addresses for predictable testing
+	sortedUnifiedAddrs := []string{}
+	for addr := range unifiedAddrsMap {
+		sortedUnifiedAddrs = append(sortedUnifiedAddrs, addr)
+	}
+	sort.Strings(sortedUnifiedAddrs) // MUTATE
+
+	// get all the SNIs we should use
+	sniv := p.Config.allServerNamesForDomainIncludingDomain(domain)
+	runtimex.Assert(len(sniv) > 0, "expected at least one SNI in the SNI vector")
+
+	// build the tactics and make sure there is an extra delay for beacons
+	// tactics such that normal tactics are used first
+	//
+	// regardless, make sure do do happy eyeballs with the tactics
+	var (
+		out          []HTTPSDialerTactic
+		vanillaIndex time.Duration
+		beaconsIndex time.Duration
+	)
+	const (
+		happyEyeballsDelay = 300 * time.Millisecond
+		beaconsExtraDelay  = 3 * time.Second
+	)
+	for _, ipAddr := range sortedUnifiedAddrs {
+		for _, sni := range sniv {
+			var delay time.Duration
+
+			// Apply happy eyeballs choosing the right offset and index
+			// considering whether the SNI is valid for the domain
+			if sni != domain {
+				delay = beaconsIndex*happyEyeballsDelay + beaconsExtraDelay
+				beaconsIndex++
+			} else {
+				delay = vanillaIndex * happyEyeballsDelay
+				vanillaIndex++
+
+			}
+
+			out = append(out, &circoTactic{
+				Address:            ipAddr,
+				TLSServerName:      sni,
+				X509VerifyHostname: domain,
+				InitialWaitTime:    delay,
+			})
+		}
+	}
+
+	// make sure policies are sorted by increasing wait time
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].InitialDelay() < out[j].InitialDelay()
+	})
+
+	return out, nil
+}
+
+// Parallelism implements HTTPSDialerPolicy.
+func (p *CircoPolicy) Parallelism() int {
+	return 16
+}

--- a/internal/enginenetx/circopolicy_test.go
+++ b/internal/enginenetx/circopolicy_test.go
@@ -1,0 +1,241 @@
+package enginenetx
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/probe-cli/v3/internal/mocks"
+	"github.com/ooni/probe-cli/v3/internal/model"
+)
+
+func TestCircoPolicy(t *testing.T) {
+	// define the config we're using in this test case
+	circo := &CircoConfig{
+		Beacons: map[string]CircoBeaconsDomain{
+			"api.ooni.io": {
+				IPAddrs: []string{
+					"142.250.180.174",
+					"2a00:1450:4002:809::200e",
+				},
+				SNIs: []string{
+					"www.youtube.com",
+				},
+			},
+		},
+		Version: 0,
+	}
+
+	t.Run("Parallelism", func(t *testing.T) {
+		const expected = 16
+		p := &CircoPolicy{circo}
+		if got := p.Parallelism(); got != expected {
+			t.Fatal("wrong parallelism: expected", expected, "got", got)
+		}
+	})
+
+	t.Run("LookupTactics", func(t *testing.T) {
+		// testcase is a testcase for this function
+		type testcase struct {
+			// name is the test case name
+			name string
+
+			// domain is the domain we're looking up tactics for
+			domain string
+
+			// reso is the underlying resolver to use
+			reso model.Resolver
+
+			// expectErr is the error string we expect to see
+			expectErr string
+
+			// tactics contains the returned tactics
+			tactics []HTTPSDialerTactic
+		}
+
+		cases := []testcase{
+
+			// When the DNS fails and there is no beacon, there's nothing to do
+			{
+				name:   "with lookup host failure and non-beacon domain",
+				domain: "www.example.com",
+				reso: &mocks.Resolver{
+					MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
+						return nil, errors.New("dns_nxdomain_error")
+					},
+				},
+				expectErr: "dns_nxdomain_error",
+				tactics:   nil,
+			},
+
+			// When the DNS succeeds with bogons and there is no beacon available
+			{
+				name:   "with lookup host success and non-beacon domain",
+				domain: "www.example.com",
+				reso: &mocks.Resolver{
+					MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
+						addrs := []string{
+							"10.10.34.45",
+						}
+						return addrs, nil
+					},
+				},
+				expectErr: "dns_no_answer",
+				tactics:   nil,
+			},
+
+			// When the DNS succeeds and there is no beacon, we only schedule resolver addrs
+			{
+				name:   "with lookup host success and non-beacon domain",
+				domain: "www.example.com",
+				reso: &mocks.Resolver{
+					MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
+						addrs := []string{
+							"2606:2800:220:1:248:1893:25c8:1946",
+							"93.184.216.34",
+						}
+						return addrs, nil
+					},
+				},
+				expectErr: "",
+				tactics: []HTTPSDialerTactic{
+					&circoTactic{
+						Address:            "2606:2800:220:1:248:1893:25c8:1946",
+						InitialWaitTime:    0,
+						TLSServerName:      "www.example.com",
+						X509VerifyHostname: "www.example.com",
+					},
+					&circoTactic{
+						Address:            "93.184.216.34",
+						InitialWaitTime:    300 * time.Millisecond,
+						TLSServerName:      "www.example.com",
+						X509VerifyHostname: "www.example.com",
+					},
+				},
+			},
+
+			// When the DNS fails and we have beacons, we're going to try using beacons
+			// IP addresses starting from the normal SNI and then trying alternative ones
+			{
+				name:   "with lookup-host failure and beacon domain",
+				domain: "api.ooni.io",
+				reso: &mocks.Resolver{
+					MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
+						return nil, errors.New("dns_nxdomain_error")
+					},
+				},
+				expectErr: "",
+				tactics: []HTTPSDialerTactic{
+					&circoTactic{
+						Address:            "142.250.180.174",
+						InitialWaitTime:    0,
+						TLSServerName:      "api.ooni.io",
+						X509VerifyHostname: "api.ooni.io",
+					},
+					&circoTactic{
+						Address:            "2a00:1450:4002:809::200e",
+						InitialWaitTime:    300 * time.Millisecond,
+						TLSServerName:      "api.ooni.io",
+						X509VerifyHostname: "api.ooni.io",
+					},
+					&circoTactic{
+						Address:            "142.250.180.174",
+						InitialWaitTime:    3 * time.Second,
+						TLSServerName:      "www.youtube.com",
+						X509VerifyHostname: "api.ooni.io",
+					},
+					&circoTactic{
+						Address:            "2a00:1450:4002:809::200e",
+						InitialWaitTime:    3300 * time.Millisecond,
+						TLSServerName:      "www.youtube.com",
+						X509VerifyHostname: "api.ooni.io",
+					},
+				},
+			},
+
+			// When the DNS succeeds and we have beacons, we eventually try using
+			// beacons domains but after a quite large delay
+			{
+				name:   "with lookup host success and beacon domain",
+				domain: "api.ooni.io",
+				reso: &mocks.Resolver{
+					MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
+						addrs := []string{"162.55.247.208"}
+						return addrs, nil
+					},
+				},
+				expectErr: "",
+				tactics: []HTTPSDialerTactic{
+					&circoTactic{
+						Address:            "142.250.180.174",
+						InitialWaitTime:    0,
+						TLSServerName:      "api.ooni.io",
+						X509VerifyHostname: "api.ooni.io",
+					},
+					&circoTactic{
+						Address:            "162.55.247.208",
+						InitialWaitTime:    300 * time.Millisecond,
+						TLSServerName:      "api.ooni.io",
+						X509VerifyHostname: "api.ooni.io",
+					},
+					&circoTactic{
+						Address:            "2a00:1450:4002:809::200e",
+						InitialWaitTime:    600 * time.Millisecond,
+						TLSServerName:      "api.ooni.io",
+						X509VerifyHostname: "api.ooni.io",
+					},
+					&circoTactic{
+						Address:            "142.250.180.174",
+						InitialWaitTime:    3000 * time.Millisecond,
+						TLSServerName:      "www.youtube.com",
+						X509VerifyHostname: "api.ooni.io",
+					},
+					&circoTactic{
+						Address:            "162.55.247.208",
+						InitialWaitTime:    3300 * time.Millisecond,
+						TLSServerName:      "www.youtube.com",
+						X509VerifyHostname: "api.ooni.io",
+					},
+					&circoTactic{
+						Address:            "2a00:1450:4002:809::200e",
+						InitialWaitTime:    3600 * time.Millisecond,
+						TLSServerName:      "www.youtube.com",
+						X509VerifyHostname: "api.ooni.io",
+					},
+				},
+			}}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				p := &CircoPolicy{circo}
+				ctx := context.Background()
+				tactics, err := p.LookupTactics(ctx, tc.domain, tc.reso)
+
+				t.Logf("%s %s", tactics, err)
+
+				// make sure the error is the expected one
+				switch {
+				case err != nil && tc.expectErr == "":
+					t.Fatal("expected", tc.expectErr, "got", err)
+
+				case err == nil && tc.expectErr != "":
+					t.Fatal("expected", tc.expectErr, "got", err)
+
+				case err != nil && tc.expectErr != "":
+					if diff := cmp.Diff(tc.expectErr, err.Error()); diff != "" {
+						t.Fatal(diff)
+					}
+
+				case err == nil && tc.expectErr == "":
+					// all good
+				}
+
+				if diff := cmp.Diff(tc.tactics, tactics); diff != "" {
+					t.Fatal(diff)
+				}
+			})
+		}
+	})
+}

--- a/internal/enginenetx/circotactic.go
+++ b/internal/enginenetx/circotactic.go
@@ -1,0 +1,91 @@
+package enginenetx
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+)
+
+// circoTactic implements [HTTPSDialerTactic] for [CircoPolicy].
+type circoTactic struct {
+	// Address is the IP address to connect to.
+	Address string
+
+	// InitialWaitTime is the time to wait before starting this tactic, or
+	// zero if there's no need to wait.
+	InitialWaitTime time.Duration
+
+	// TLSServerName is the SNI to send as part of the TLS Client Hello.
+	TLSServerName string
+
+	// X509VerifyHostname is the host name to use during certificate verification, which
+	// will be different from the sni field when using the beacons strategy.
+	X509VerifyHostname string
+}
+
+// IPAddr implements HTTPSDialerTactic.
+func (t *circoTactic) IPAddr() string {
+	return t.Address
+}
+
+// NewTLSHandshaker implements HTTPSDialerTactic.
+func (t *circoTactic) NewTLSHandshaker(
+	netx *netxlite.Netx, logger model.Logger) model.TLSHandshaker {
+	return netxlite.NewTLSHandshakerStdlib(logger)
+}
+
+// InitialDelay implements HTTPSDialerTactic.
+func (t *circoTactic) InitialDelay() time.Duration {
+	return t.InitialWaitTime
+}
+
+// OnStarting implements HTTPSDialerTactic.
+func (t *circoTactic) OnStarting() {
+	// TODO(bassosimone): here we should collect metrics used to tweak
+	// how we use beacons depending on the metrics
+}
+
+// OnSuccess implements HTTPSDialerTactic.
+func (t *circoTactic) OnSuccess() {
+	// TODO(bassosimone): here we should collect metrics used to tweak
+	// how we use beacons depending on the metrics
+}
+
+// OnTCPConnectError implements HTTPSDialerTactic.
+func (t *circoTactic) OnTCPConnectError(ctx context.Context, err error) {
+	// TODO(bassosimone): here we should collect metrics used to tweak
+	// how we use beacons depending on the metrics
+}
+
+// OnTLSHandshakeError implements HTTPSDialerTactic.
+func (t *circoTactic) OnTLSHandshakeError(ctx context.Context, err error) {
+	// TODO(bassosimone): here we should collect metrics used to tweak
+	// how we use beacons depending on the metrics
+}
+
+// OnTLSVerifyError implements HTTPSDialerTactic.
+func (*circoTactic) OnTLSVerifyError(ctx context.Context, err error) {
+	// TODO(bassosimone): here we should collect metrics used to tweak
+	// how we use beacons depending on the metrics
+}
+
+// SNI implements HTTPSDialerTactic.
+func (t *circoTactic) SNI() string {
+	return t.TLSServerName
+}
+
+// String implements HTTPSDialerTactic.
+func (t *circoTactic) String() string {
+	return fmt.Sprintf(
+		"circoTactic{ipAddr:\"%s\" sni:\"%s\" verifyHostname:\"%s\" waitTime:%v}",
+		t.Address, t.TLSServerName, t.X509VerifyHostname, t.InitialWaitTime,
+	)
+}
+
+// VerifyHostname implements HTTPSDialerTactic.
+func (t *circoTactic) VerifyHostname() string {
+	return t.X509VerifyHostname
+}


### PR DESCRIPTION
This commit starts introducing support for beacons as a policy of the generic `HTTPSDialer`.

This work is part of https://github.com/ooni/probe/issues/2531.
