### PR TITLE
refactor(enginenetx): introduce stats

### DIFF
--- a/internal/enginenetx/httpsdialer_internal_test.go
+++ b/internal/enginenetx/httpsdialer_internal_test.go
@@ -26,15 +26,13 @@ func TestHTTPSDialerTacticsEmitter(t *testing.T) {
 			wg:          &sync.WaitGroup{},
 		}
 
-		var tactics []HTTPSDialerTactic
+		var tactics []*HTTPSDialerTactic
 		for idx := 0; idx < 255; idx++ {
-			tactics = append(tactics, &HTTPSDialerLoadableTacticWrapper{
-				Tactic: &HTTPSDialerLoadableTactic{
-					IPAddr:         fmt.Sprintf("10.0.0.%d", idx),
-					InitialDelay:   0,
-					SNI:            "www.example.com",
-					VerifyHostname: "www.example.com",
-				},
+			tactics = append(tactics, &HTTPSDialerTactic{
+				IPAddr:         fmt.Sprintf("10.0.0.%d", idx),
+				InitialDelay:   0,
+				SNI:            "www.example.com",
+				VerifyHostname: "www.example.com",
 			})
 		}
 

--- a/internal/enginenetx/httpsdialerloadable.go
+++ b/internal/enginenetx/httpsdialerloadable.go
@@ -1,13 +1,7 @@
 package enginenetx
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
-	"time"
-
-	"github.com/ooni/probe-cli/v3/internal/model"
-	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
 // HTTPSDialerLoadablePolicy is an [HTTPSDialerPolicy] that you
@@ -15,8 +9,8 @@ import (
 type HTTPSDialerLoadablePolicy struct {
 	// Domains maps each domain to its policy. When there is
 	// no domain, the code falls back to the default "null" policy
-	// implemented by HTTPSDialerNullPolicy.
-	Domains map[string][]*HTTPSDialerLoadableTactic
+	// implemented by the HTTPSDialerNullPolicy struct.
+	Domains map[string][]*HTTPSDialerTactic
 }
 
 // LoadHTTPSDialerPolicy loads the [HTTPSDialerPolicy] from
@@ -27,83 +21,4 @@ func LoadHTTPSDialerPolicy(data []byte) (*HTTPSDialerLoadablePolicy, error) {
 		return nil, err
 	}
 	return &p, nil
-}
-
-// HTTPSDialerLoadableTactic is an [HTTPSDialerTactic] that you
-// can load from JSON as part of [HTTPSDialerLoadablePolicy].
-type HTTPSDialerLoadableTactic struct {
-	// IPAddr is the IP address to use for dialing.
-	IPAddr string
-
-	// InitialDelay is the time in nanoseconds after which
-	// you would like to start this policy.
-	InitialDelay time.Duration
-
-	// SNI is the TLS ServerName to send over the wire.
-	SNI string
-
-	// VerifyHostname is the hostname using during
-	// the X.509 certificate verification.
-	VerifyHostname string
-}
-
-// HTTPSDialerLoadableTacticWrapper wraps [HTTPSDialerLoadableTactic]
-// to make it implements the [HTTPSDialerTactic] interface.
-type HTTPSDialerLoadableTacticWrapper struct {
-	Tactic *HTTPSDialerLoadableTactic
-}
-
-// IPAddr implements HTTPSDialerTactic.
-func (ldt *HTTPSDialerLoadableTacticWrapper) IPAddr() string {
-	return ldt.Tactic.IPAddr
-}
-
-// InitialDelay implements HTTPSDialerTactic.
-func (ldt *HTTPSDialerLoadableTacticWrapper) InitialDelay() time.Duration {
-	return ldt.Tactic.InitialDelay
-}
-
-// NewTLSHandshaker implements HTTPSDialerTactic.
-func (ldt *HTTPSDialerLoadableTacticWrapper) NewTLSHandshaker(netx *netxlite.Netx, logger model.Logger) model.TLSHandshaker {
-	return netxlite.NewTLSHandshakerStdlib(logger)
-}
-
-// OnStarting implements HTTPSDialerTactic.
-func (ldt *HTTPSDialerLoadableTacticWrapper) OnStarting() {
-	// TODO(bassosimone): implement
-}
-
-// OnSuccess implements HTTPSDialerTactic.
-func (ldt *HTTPSDialerLoadableTacticWrapper) OnSuccess() {
-	// TODO(bassosimone): implement
-}
-
-// OnTCPConnectError implements HTTPSDialerTactic.
-func (ldt *HTTPSDialerLoadableTacticWrapper) OnTCPConnectError(ctx context.Context, err error) {
-	// TODO(bassosimone): implement
-}
-
-// OnTLSHandshakeError implements HTTPSDialerTactic.
-func (ldt *HTTPSDialerLoadableTacticWrapper) OnTLSHandshakeError(ctx context.Context, err error) {
-	// TODO(bassosimone): implement
-}
-
-// OnTLSVerifyError implements HTTPSDialerTactic.
-func (ldt *HTTPSDialerLoadableTacticWrapper) OnTLSVerifyError(ctz context.Context, err error) {
-	// TODO(bassosimone): implement
-}
-
-// SNI implements HTTPSDialerTactic.
-func (ldt *HTTPSDialerLoadableTacticWrapper) SNI() string {
-	return ldt.Tactic.SNI
-}
-
-// String implements HTTPSDialerTactic.
-func (ldt *HTTPSDialerLoadableTacticWrapper) String() string {
-	return fmt.Sprintf("%+v", ldt.Tactic)
-}
-
-// VerifyHostname implements HTTPSDialerTactic.
-func (ldt *HTTPSDialerLoadableTacticWrapper) VerifyHostname() string {
-	return ldt.Tactic.VerifyHostname
 }

--- a/internal/enginenetx/httpsdialernull.go
+++ b/internal/enginenetx/httpsdialernull.go
@@ -23,22 +23,20 @@ var _ HTTPSDialerPolicy = &HTTPSDialerNullPolicy{}
 
 // LookupTactics implements HTTPSDialerPolicy.
 func (*HTTPSDialerNullPolicy) LookupTactics(
-	ctx context.Context, domain string, reso model.Resolver) ([]HTTPSDialerTactic, error) {
+	ctx context.Context, domain string, reso model.Resolver) ([]*HTTPSDialerTactic, error) {
 	addrs, err := reso.LookupHost(ctx, domain)
 	if err != nil {
 		return nil, err
 	}
 
 	const delay = 300 * time.Millisecond
-	var tactics []HTTPSDialerTactic
+	var tactics []*HTTPSDialerTactic
 	for idx, addr := range addrs {
-		tactics = append(tactics, &HTTPSDialerLoadableTacticWrapper{
-			Tactic: &HTTPSDialerLoadableTactic{
-				IPAddr:         addr,
-				InitialDelay:   time.Duration(idx) * delay, // zero for the first dial
-				SNI:            domain,
-				VerifyHostname: domain,
-			},
+		tactics = append(tactics, &HTTPSDialerTactic{
+			IPAddr:         addr,
+			InitialDelay:   time.Duration(idx) * delay, // zero for the first dial
+			SNI:            domain,
+			VerifyHostname: domain,
 		})
 	}
 
@@ -48,4 +46,34 @@ func (*HTTPSDialerNullPolicy) LookupTactics(
 // Parallelism implements HTTPSDialerPolicy.
 func (*HTTPSDialerNullPolicy) Parallelism() int {
 	return 16
+}
+
+// HTTPSDialerNullStatsTracker is the "null" [HTTPSDialerStatsTracker].
+type HTTPSDialerNullStatsTracker struct{}
+
+var _ HTTPSDialerStatsTracker = &HTTPSDialerNullStatsTracker{}
+
+// OnStarting implements HTTPSDialerStatsTracker.
+func (*HTTPSDialerNullStatsTracker) OnStarting(tactic *HTTPSDialerTactic) {
+	// nothing
+}
+
+// OnSuccess implements HTTPSDialerStatsTracker.
+func (*HTTPSDialerNullStatsTracker) OnSuccess(tactic *HTTPSDialerTactic) {
+	// nothing
+}
+
+// OnTCPConnectError implements HTTPSDialerStatsTracker.
+func (*HTTPSDialerNullStatsTracker) OnTCPConnectError(ctx context.Context, tactic *HTTPSDialerTactic, err error) {
+	// nothing
+}
+
+// OnTLSHandshakeError implements HTTPSDialerStatsTracker.
+func (*HTTPSDialerNullStatsTracker) OnTLSHandshakeError(ctx context.Context, tactic *HTTPSDialerTactic, err error) {
+	// nothing
+}
+
+// OnTLSVerifyError implements HTTPSDialerStatsTracker.
+func (*HTTPSDialerNullStatsTracker) OnTLSVerifyError(ctz context.Context, tactic *HTTPSDialerTactic, err error) {
+	// nothing
 }


### PR DESCRIPTION
This diff refactors the code to introduce a stats interface and to make the tactic a struct ~without methods attached.

We transform the tactic into a struct because we're planning on storing the tactics on disk and loading them.

We need stats to track what is working and choose which is the best tactic that we should employ.

In light of these two needs, it makes sense to transfer the reporting methods that previously were part of the tactic interface to stats.

Part of https://github.com/ooni/probe/issues/2531
