### PR TITLE
fix(enginenetx): store endpoint into the tactic

### DIFF
--- a/internal/enginenetx/httpsdialer_internal_test.go
+++ b/internal/enginenetx/httpsdialer_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"net"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -29,7 +30,7 @@ func TestHTTPSDialerTacticsEmitter(t *testing.T) {
 		var tactics []*HTTPSDialerTactic
 		for idx := 0; idx < 255; idx++ {
 			tactics = append(tactics, &HTTPSDialerTactic{
-				IPAddr:         fmt.Sprintf("10.0.0.%d", idx),
+				Endpoint:       net.JoinHostPort(fmt.Sprintf("10.0.0.%d", idx), "443"),
 				InitialDelay:   0,
 				SNI:            "www.example.com",
 				VerifyHostname: "www.example.com",

--- a/internal/enginenetx/httpsdialer_test.go
+++ b/internal/enginenetx/httpsdialer_test.go
@@ -588,4 +588,18 @@ func TestHTTPSDialerTactic(t *testing.T) {
 			t.Fatal(diff)
 		}
 	})
+
+	t.Run("Summary", func(t *testing.T) {
+		expected := `162.55.247.208:443 sni=www.example.com verify=api.ooni.io`
+		ldt := &enginenetx.HTTPSDialerTactic{
+			Endpoint:       "162.55.247.208:443",
+			InitialDelay:   150 * time.Millisecond,
+			SNI:            "www.example.com",
+			VerifyHostname: "api.ooni.io",
+		}
+		got := ldt.Summary()
+		if diff := cmp.Diff(expected, got); diff != "" {
+			t.Fatal(diff)
+		}
+	})
 }

--- a/internal/enginenetx/httpsdialer_test.go
+++ b/internal/enginenetx/httpsdialer_test.go
@@ -476,27 +476,27 @@ func TestLoadHTTPSDialerPolicy(t *testing.T) {
 			return runtimex.Try1(json.Marshal(&enginenetx.HTTPSDialerLoadablePolicy{
 				Domains: map[string][]*enginenetx.HTTPSDialerTactic{
 					"api.ooni.io": {{
-						IPAddr:         "162.55.247.208",
+						Endpoint:       "162.55.247.208:443",
 						InitialDelay:   0,
 						SNI:            "api.ooni.io",
 						VerifyHostname: "api.ooni.io",
 					}, {
-						IPAddr:         "46.101.82.151",
+						Endpoint:       "46.101.82.151:443",
 						InitialDelay:   300 * time.Millisecond,
 						SNI:            "api.ooni.io",
 						VerifyHostname: "api.ooni.io",
 					}, {
-						IPAddr:         "2a03:b0c0:1:d0::ec4:9001",
+						Endpoint:       "[2a03:b0c0:1:d0::ec4:9001]:443",
 						InitialDelay:   600 * time.Millisecond,
 						SNI:            "api.ooni.io",
 						VerifyHostname: "api.ooni.io",
 					}, {
-						IPAddr:         "46.101.82.151",
+						Endpoint:       "46.101.82.151:443",
 						InitialDelay:   3000 * time.Millisecond,
 						SNI:            "www.example.com",
 						VerifyHostname: "api.ooni.io",
 					}, {
-						IPAddr:         "2a03:b0c0:1:d0::ec4:9001",
+						Endpoint:       "[2a03:b0c0:1:d0::ec4:9001]:443",
 						InitialDelay:   3300 * time.Millisecond,
 						SNI:            "www.example.com",
 						VerifyHostname: "api.ooni.io",
@@ -508,27 +508,27 @@ func TestLoadHTTPSDialerPolicy(t *testing.T) {
 		expectedPolicy: &enginenetx.HTTPSDialerLoadablePolicy{
 			Domains: map[string][]*enginenetx.HTTPSDialerTactic{
 				"api.ooni.io": {{
-					IPAddr:         "162.55.247.208",
+					Endpoint:       "162.55.247.208:443",
 					InitialDelay:   0,
 					SNI:            "api.ooni.io",
 					VerifyHostname: "api.ooni.io",
 				}, {
-					IPAddr:         "46.101.82.151",
+					Endpoint:       "46.101.82.151:443",
 					InitialDelay:   300 * time.Millisecond,
 					SNI:            "api.ooni.io",
 					VerifyHostname: "api.ooni.io",
 				}, {
-					IPAddr:         "2a03:b0c0:1:d0::ec4:9001",
+					Endpoint:       "[2a03:b0c0:1:d0::ec4:9001]:443",
 					InitialDelay:   600 * time.Millisecond,
 					SNI:            "api.ooni.io",
 					VerifyHostname: "api.ooni.io",
 				}, {
-					IPAddr:         "46.101.82.151",
+					Endpoint:       "46.101.82.151:443",
 					InitialDelay:   3000 * time.Millisecond,
 					SNI:            "www.example.com",
 					VerifyHostname: "api.ooni.io",
 				}, {
-					IPAddr:         "2a03:b0c0:1:d0::ec4:9001",
+					Endpoint:       "[2a03:b0c0:1:d0::ec4:9001]:443",
 					InitialDelay:   3300 * time.Millisecond,
 					SNI:            "www.example.com",
 					VerifyHostname: "api.ooni.io",
@@ -566,15 +566,25 @@ func TestLoadHTTPSDialerPolicy(t *testing.T) {
 
 func TestHTTPSDialerTactic(t *testing.T) {
 	t.Run("String", func(t *testing.T) {
-		expected := `{"IPAddr":"162.55.247.208","InitialDelay":150000000,"SNI":"www.example.com","VerifyHostname":"api.ooni.io"}`
+		expected := `{"Endpoint":"162.55.247.208:443","InitialDelay":150000000,"SNI":"www.example.com","VerifyHostname":"api.ooni.io"}`
 		ldt := &enginenetx.HTTPSDialerTactic{
-			IPAddr:         "162.55.247.208",
+			Endpoint:       "162.55.247.208:443",
 			InitialDelay:   150 * time.Millisecond,
 			SNI:            "www.example.com",
 			VerifyHostname: "api.ooni.io",
 		}
 		got := ldt.String()
 		if diff := cmp.Diff(expected, got); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
+	t.Run("Clone", func(t *testing.T) {
+		ff := &testingx.FakeFiller{}
+		var expect enginenetx.HTTPSDialerTactic
+		ff.Fill(&expect)
+		got := expect.Clone()
+		if diff := cmp.Diff(expect.String(), got.String()); diff != "" {
 			t.Fatal(diff)
 		}
 	})

--- a/internal/enginenetx/httpsdialernull.go
+++ b/internal/enginenetx/httpsdialernull.go
@@ -2,6 +2,7 @@ package enginenetx
 
 import (
 	"context"
+	"net"
 	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/model"
@@ -23,7 +24,7 @@ var _ HTTPSDialerPolicy = &HTTPSDialerNullPolicy{}
 
 // LookupTactics implements HTTPSDialerPolicy.
 func (*HTTPSDialerNullPolicy) LookupTactics(
-	ctx context.Context, domain string, reso model.Resolver) ([]*HTTPSDialerTactic, error) {
+	ctx context.Context, domain, port string, reso model.Resolver) ([]*HTTPSDialerTactic, error) {
 	addrs, err := reso.LookupHost(ctx, domain)
 	if err != nil {
 		return nil, err
@@ -33,7 +34,7 @@ func (*HTTPSDialerNullPolicy) LookupTactics(
 	var tactics []*HTTPSDialerTactic
 	for idx, addr := range addrs {
 		tactics = append(tactics, &HTTPSDialerTactic{
-			IPAddr:         addr,
+			Endpoint:       net.JoinHostPort(addr, port),
 			InitialDelay:   time.Duration(idx) * delay, // zero for the first dial
 			SNI:            domain,
 			VerifyHostname: domain,


### PR DESCRIPTION
We cannot evaluate tactics on an IP address basis because different ports may cause tactics to fail. In principle we will probably only use port 443/tcp here, though it is better to avoid keeping lame code around.

While there, start preparing for inserting the tactics into a map to keep statistics.

Part of https://github.com/ooni/probe/issues/2531

