### PR TITLE
fix(enginenetx): refine the happy-eyeballs algorithm

### DIFF
--- a/internal/enginenetx/happyeyeballs.go
+++ b/internal/enginenetx/happyeyeballs.go
@@ -1,0 +1,30 @@
+package enginenetx
+
+import "time"
+
+// happyEyeballsDelay implements an happy-eyeballs like algorithm with the
+// given base delay and with the given index. The index is the attempt number
+// and the first attempt should have zero as its index.
+//
+// The algorithm should emit 0 as the first delay, the baseDelay as the
+// second delay, and then it should double the base delay at each attempt,
+// until we reach the 30 seconds, after which the delay is constant.
+//
+// By doubling the base delay, we account for the case where there are
+// actual issues inside the network. By using this algorithm, we are still
+// able to overlap and pack more dialing attempts overall.
+func happyEyeballsDelay(baseDelay time.Duration, idx int) time.Duration {
+	const cutoff = 30 * time.Second
+	switch {
+	case idx <= 0:
+		return 0
+	case idx == 1:
+		return baseDelay
+	default:
+		delay := baseDelay << (idx - 1)
+		if delay > cutoff {
+			delay = cutoff
+		}
+		return delay
+	}
+}

--- a/internal/enginenetx/happyeyeballs_test.go
+++ b/internal/enginenetx/happyeyeballs_test.go
@@ -1,0 +1,40 @@
+package enginenetx
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestHappyEyeballsDelay(t *testing.T) {
+	type testcase struct {
+		idx    int
+		expect time.Duration
+	}
+
+	const delay = 900 * time.Millisecond
+
+	cases := []testcase{
+		{0, 0},
+		{1, delay},
+		{2, delay * 2},
+		{3, delay * 4},
+		{4, delay * 8},
+		{5, delay * 16},
+		{6, delay * 32},
+		{7, 30 * time.Second},
+		{8, 30 * time.Second},
+		{9, 30 * time.Second},
+		{10, 30 * time.Second},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("delay=%v tc.idx=%v", delay, tc.idx), func(t *testing.T) {
+			got := happyEyeballsDelay(delay, tc.idx)
+			if got != tc.expect {
+				t.Fatalf("with delay=%v tc.idx=%v we got %v but expected %v", delay, tc.idx, got, tc.expect)
+			}
+			t.Logf("with delay=%v tc.idx=%v: got %v", delay, tc.idx, got)
+		})
+	}
+}

--- a/internal/enginenetx/happyeyeballs_test.go
+++ b/internal/enginenetx/happyeyeballs_test.go
@@ -15,6 +15,7 @@ func TestHappyEyeballsDelay(t *testing.T) {
 	const delay = 900 * time.Millisecond
 
 	cases := []testcase{
+		{-1, 0}, // make sure we gracefully handle negative numbers (i.e., we don't crash)
 		{0, 0},
 		{1, delay},
 		{2, delay * 2},


### PR DESCRIPTION
We want to pack attempts in parallel, which we also did before when the interval between attempts was linear.

We need to take into account possible congestion, so we should push back exponentially, even though the common case for us is probably censorship (but it is better to do the right thing anyway).

So, let's scale exponentially until we reach 30s. After that, it's fine to keep attempts evenly spaces, because 30s is quite definitely a huge interval if we're reasoning in internet time.

Also, change the base value used for TLS handshaking to be 900ms rather than 300ms, because a TLS handshake is ~3 round trips.

Part of https://github.com/ooni/probe/issues/2531
