### PR TITLE
refactor(enginenetx): make beacons API private

### DIFF
--- a/internal/enginenetx/beacons.go
+++ b/internal/enginenetx/beacons.go
@@ -7,22 +7,22 @@ import (
 	"time"
 )
 
-// BeaconsPolicy is a policy where we use beacons for communicating
+// beaconsPolicy is a policy where we use beacons for communicating
 // with the OONI backend, i.e., api.ooni.io.
 //
 // A beacon is an IP address that can route traffic from and to
 // the OONI backend and accepts any SNI.
 //
 // The zero value is invalid; please, init MANDATORY fields.
-type BeaconsPolicy struct {
+type beaconsPolicy struct {
 	// Fallback is the MANDATORY fallback policy.
 	Fallback HTTPSDialerPolicy
 }
 
-var _ HTTPSDialerPolicy = &BeaconsPolicy{}
+var _ HTTPSDialerPolicy = &beaconsPolicy{}
 
 // LookupTactics implements HTTPSDialerPolicy.
-func (p *BeaconsPolicy) LookupTactics(ctx context.Context, domain, port string) <-chan *HTTPSDialerTactic {
+func (p *beaconsPolicy) LookupTactics(ctx context.Context, domain, port string) <-chan *HTTPSDialerTactic {
 	out := make(chan *HTTPSDialerTactic)
 
 	go func() {
@@ -47,7 +47,7 @@ func (p *BeaconsPolicy) LookupTactics(ctx context.Context, domain, port string) 
 	return out
 }
 
-func (p *BeaconsPolicy) tacticsForDomain(domain, port string) <-chan *HTTPSDialerTactic {
+func (p *beaconsPolicy) tacticsForDomain(domain, port string) <-chan *HTTPSDialerTactic {
 	out := make(chan *HTTPSDialerTactic)
 
 	go func() {
@@ -81,14 +81,14 @@ func (p *BeaconsPolicy) tacticsForDomain(domain, port string) <-chan *HTTPSDiale
 	return out
 }
 
-func (p *BeaconsPolicy) beaconsAddrs() (out []string) {
+func (p *beaconsPolicy) beaconsAddrs() (out []string) {
 	return append(
 		out,
 		"162.55.247.208",
 	)
 }
 
-func (p *BeaconsPolicy) beaconsDomains() (out []string) {
+func (p *beaconsPolicy) beaconsDomains() (out []string) {
 	// See https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/issues/40273
 	return append(
 		out,

--- a/internal/enginenetx/beacons_test.go
+++ b/internal/enginenetx/beacons_test.go
@@ -13,7 +13,7 @@ import (
 func TestBeaconsPolicy(t *testing.T) {
 	t.Run("for domains for which we don't have beacons and DNS failure", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		policy := &BeaconsPolicy{
+		policy := &beaconsPolicy{
 			Fallback: &HTTPSDialerNullPolicy{
 				Logger: model.DiscardLogger,
 				Resolver: &mocks.Resolver{
@@ -38,7 +38,7 @@ func TestBeaconsPolicy(t *testing.T) {
 	})
 
 	t.Run("for domains for which we don't have beacons and DNS success", func(t *testing.T) {
-		policy := &BeaconsPolicy{
+		policy := &beaconsPolicy{
 			Fallback: &HTTPSDialerNullPolicy{
 				Logger: model.DiscardLogger,
 				Resolver: &mocks.Resolver{
@@ -83,7 +83,7 @@ func TestBeaconsPolicy(t *testing.T) {
 
 	t.Run("for the api.ooni.io domain", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		policy := &BeaconsPolicy{
+		policy := &beaconsPolicy{
 			Fallback: &HTTPSDialerNullPolicy{
 				Logger: model.DiscardLogger,
 				Resolver: &mocks.Resolver{

--- a/internal/enginenetx/network.go
+++ b/internal/enginenetx/network.go
@@ -136,7 +136,7 @@ func NewNetwork(
 // newHTTPSDialerPolicy contains the logic to select the [HTTPSDialerPolicy] to use.
 func newHTTPSDialerPolicy(kvStore model.KeyValueStore, logger model.Logger, resolver model.Resolver) HTTPSDialerPolicy {
 	// create a composed fallback TLS dialer policy
-	fallback := &BeaconsPolicy{
+	fallback := &beaconsPolicy{
 		Fallback: &HTTPSDialerNullPolicy{logger, resolver},
 	}
 


### PR DESCRIPTION
Now that we've more or less reached the point where we wanted to be with https://github.com/ooni/probe/issues/2531, let's spend some time to refactor the implementation, now that we know very well how to works, such that modifying it in the future would be easier.

The first order of business here seems to hide implementation details and get rid of too many HTTPSDialer prefixes which only cause confusion when looking at the available structs.

