### PR TITLE
feat(enginenetx): prune old entries from stats

### DIFF
--- a/internal/enginenetx/network_internal_test.go
+++ b/internal/enginenetx/network_internal_test.go
@@ -32,10 +32,10 @@ func TestNetworkUnit(t *testing.T) {
 				},
 			},
 			stats: &statsManager{
-				kvStore: &kvstore.Memory{},
-				logger:  model.DiscardLogger,
-				mu:      sync.Mutex{},
-				root:    &statsContainer{},
+				container: &statsContainer{},
+				kvStore:   &kvstore.Memory{},
+				logger:    model.DiscardLogger,
+				mu:        sync.Mutex{},
 			},
 			txp: expected,
 		}
@@ -57,10 +57,10 @@ func TestNetworkUnit(t *testing.T) {
 		netx := &Network{
 			reso: expected,
 			stats: &statsManager{
-				kvStore: &kvstore.Memory{},
-				logger:  model.DiscardLogger,
-				mu:      sync.Mutex{},
-				root:    &statsContainer{},
+				container: &statsContainer{},
+				kvStore:   &kvstore.Memory{},
+				logger:    model.DiscardLogger,
+				mu:        sync.Mutex{},
 			},
 			txp: &mocks.HTTPTransport{
 				MockCloseIdleConnections: func() {

--- a/internal/enginenetx/stats.go
+++ b/internal/enginenetx/stats.go
@@ -52,8 +52,10 @@ type statsTactic struct {
 }
 
 func statsCloneMapStringInt64(input map[string]int64) (output map[string]int64) {
-	output = make(map[string]int64)
 	for key, value := range input {
+		if output == nil {
+			output = make(map[string]int64) // the idea here is to clone a nil map to a nil map
+		}
 		output[key] = value
 	}
 	return

--- a/internal/enginenetx/stats_test.go
+++ b/internal/enginenetx/stats_test.go
@@ -487,6 +487,8 @@ func TestStatsManagerCallbacks(t *testing.T) {
 		expectRoot  *statsContainer
 	}
 
+	fourtyFiveMinutesAgo := time.Now().Add(-45 * time.Minute)
+
 	cases := []testcase{
 
 		// When TCP connect fails and the reason is a canceled context
@@ -498,6 +500,8 @@ func TestStatsManagerCallbacks(t *testing.T) {
 						Tactics: map[string]*statsTactic{
 							"162.55.247.208:443 sni=www.example.com verify=api.ooni.io": {
 								CountStarted: 1,
+								LastUpdated:  fourtyFiveMinutesAgo,
+								Tactic:       &HTTPSDialerTactic{}, // only required for cloning
 							},
 						},
 					},
@@ -526,6 +530,7 @@ func TestStatsManagerCallbacks(t *testing.T) {
 							"162.55.247.208:443 sni=www.example.com verify=api.ooni.io": {
 								CountStarted:             1,
 								CountTCPConnectInterrupt: 1,
+								Tactic:                   &HTTPSDialerTactic{},
 							},
 						},
 					},
@@ -570,6 +575,8 @@ func TestStatsManagerCallbacks(t *testing.T) {
 						Tactics: map[string]*statsTactic{
 							"162.55.247.208:443 sni=www.example.com verify=api.ooni.io": {
 								CountStarted: 1,
+								LastUpdated:  fourtyFiveMinutesAgo,
+								Tactic:       &HTTPSDialerTactic{}, // only for cloning
 							},
 						},
 					},
@@ -598,6 +605,7 @@ func TestStatsManagerCallbacks(t *testing.T) {
 							"162.55.247.208:443 sni=www.example.com verify=api.ooni.io": {
 								CountStarted:               1,
 								CountTLSHandshakeInterrupt: 1,
+								Tactic:                     &HTTPSDialerTactic{},
 							},
 						},
 					},

--- a/internal/enginenetx/stats_test.go
+++ b/internal/enginenetx/stats_test.go
@@ -371,7 +371,7 @@ func TestLoadStatsContainer(t *testing.T) {
 								Tactic: &HTTPSDialerTactic{
 									Endpoint:       "162.55.247.208:443",
 									InitialDelay:   0,
-									SNI:            "www.example.com",
+									SNI:            "www.example.org",
 									VerifyHostname: "api.ooni.io",
 								},
 							},
@@ -399,7 +399,7 @@ func TestLoadStatsContainer(t *testing.T) {
 									Endpoint:       "162.55.247.208:443",
 									InitialDelay:   0,
 									SNI:            "www.example.com",
-									VerifyHostname: "api.ooni.io",
+									VerifyHostname: "www.kernel.org",
 								},
 							},
 						},

--- a/internal/enginenetx/stats_test.go
+++ b/internal/enginenetx/stats_test.go
@@ -296,6 +296,10 @@ func TestLoadStatsContainer(t *testing.T) {
 		expectRoot *statsContainer
 	}
 
+	fourtyFiveMinutesAgo := time.Now().Add(-45 * time.Minute)
+
+	twoWeeksAgo := time.Now().Add(-14 * 24 * time.Hour)
+
 	cases := []testcase{{
 		name: "when the key-value store does not contain any data",
 		input: func() []byte {
@@ -319,7 +323,7 @@ func TestLoadStatsContainer(t *testing.T) {
 		expectErr:  "httpsdialerstats.state: wrong stats container version: expected=2 got=1",
 		expectRoot: nil,
 	}, {
-		name: "on success",
+		name: "on success including correct entries pruning",
 		input: func() []byte {
 			root := &statsContainer{
 				Domains: map[string]*statsDomain{
@@ -340,7 +344,57 @@ func TestLoadStatsContainer(t *testing.T) {
 								HistoTLSVerificationError: map[string]int64{
 									"ssl_invalid_hostname": 1,
 								},
-								LastUpdated: time.Date(2023, 9, 25, 0, 0, 0, 0, time.UTC),
+								LastUpdated: fourtyFiveMinutesAgo,
+								Tactic: &HTTPSDialerTactic{
+									Endpoint:       "162.55.247.208:443",
+									InitialDelay:   0,
+									SNI:            "www.example.com",
+									VerifyHostname: "api.ooni.io",
+								},
+							},
+							"162.55.247.208:443 sni=www.example.org verify=api.ooni.io": { // should be skipped b/c it's old
+								CountStarted:              4,
+								CountTCPConnectError:      1,
+								CountTLSHandshakeError:    1,
+								CountTLSVerificationError: 1,
+								CountSuccess:              1,
+								HistoTCPConnectError: map[string]int64{
+									"connection_refused": 1,
+								},
+								HistoTLSHandshakeError: map[string]int64{
+									"generic_timeout_error": 1,
+								},
+								HistoTLSVerificationError: map[string]int64{
+									"ssl_invalid_hostname": 1,
+								},
+								LastUpdated: twoWeeksAgo,
+								Tactic: &HTTPSDialerTactic{
+									Endpoint:       "162.55.247.208:443",
+									InitialDelay:   0,
+									SNI:            "www.example.com",
+									VerifyHostname: "api.ooni.io",
+								},
+							},
+						},
+					},
+					"www.kernel.org": { // this whole entry should be skipped because it's too old
+						Tactics: map[string]*statsTactic{
+							"162.55.247.208:443 sni=www.example.com verify=www.kernel.org": {
+								CountStarted:              4,
+								CountTCPConnectError:      1,
+								CountTLSHandshakeError:    1,
+								CountTLSVerificationError: 1,
+								CountSuccess:              1,
+								HistoTCPConnectError: map[string]int64{
+									"connection_refused": 1,
+								},
+								HistoTLSHandshakeError: map[string]int64{
+									"generic_timeout_error": 1,
+								},
+								HistoTLSVerificationError: map[string]int64{
+									"ssl_invalid_hostname": 1,
+								},
+								LastUpdated: twoWeeksAgo,
 								Tactic: &HTTPSDialerTactic{
 									Endpoint:       "162.55.247.208:443",
 									InitialDelay:   0,
@@ -375,7 +429,7 @@ func TestLoadStatsContainer(t *testing.T) {
 							HistoTLSVerificationError: map[string]int64{
 								"ssl_invalid_hostname": 1,
 							},
-							LastUpdated: time.Date(2023, 9, 25, 0, 0, 0, 0, time.UTC),
+							LastUpdated: fourtyFiveMinutesAgo,
 							Tactic: &HTTPSDialerTactic{
 								Endpoint:       "162.55.247.208:443",
 								InitialDelay:   0,


### PR DESCRIPTION
If an entry is older than one week ago, we remove it from the stats.

This helps ensuring the stats cache does not grow too large.

Additionally, this helps ensuring we are not going to try tactics that worked long time ago and it may be pointless trying now.

Part of https://github.com/ooni/probe/issues/2531
