### PR TITLE
refactor(enginenetx): store address and port separately

### DIFF
--- a/internal/enginenetx/beacons.go
+++ b/internal/enginenetx/beacons.go
@@ -3,7 +3,6 @@ package enginenetx
 import (
 	"context"
 	"math/rand"
-	"net"
 	"time"
 )
 
@@ -69,8 +68,9 @@ func (p *beaconsPolicy) tacticsForDomain(domain, port string) <-chan *HTTPSDiale
 		for _, ipAddr := range ipAddrs {
 			for _, sni := range snis {
 				out <- &HTTPSDialerTactic{
-					Endpoint:       net.JoinHostPort(ipAddr, port),
+					Address:        ipAddr,
 					InitialDelay:   0,
+					Port:           port,
 					SNI:            sni,
 					VerifyHostname: domain,
 				}

--- a/internal/enginenetx/beacons_test.go
+++ b/internal/enginenetx/beacons_test.go
@@ -3,7 +3,6 @@ package enginenetx
 import (
 	"context"
 	"errors"
-	"net"
 	"testing"
 
 	"github.com/ooni/probe-cli/v3/internal/mocks"
@@ -56,14 +55,10 @@ func TestBeaconsPolicy(t *testing.T) {
 		for tactic := range tactics {
 			count++
 
-			host, port, err := net.SplitHostPort(tactic.Endpoint)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if port != "443" {
+			if tactic.Port != "443" {
 				t.Fatal("the port should always be 443")
 			}
-			if host != "93.184.216.34" {
+			if tactic.Address != "93.184.216.34" {
 				t.Fatal("the host should always be 93.184.216.34")
 			}
 
@@ -101,14 +96,10 @@ func TestBeaconsPolicy(t *testing.T) {
 		for tactic := range tactics {
 			count++
 
-			host, port, err := net.SplitHostPort(tactic.Endpoint)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if port != "443" {
+			if tactic.Port != "443" {
 				t.Fatal("the port should always be 443")
 			}
-			if host != "162.55.247.208" {
+			if tactic.Address != "162.55.247.208" {
 				t.Fatal("the host should always be 162.55.247.208")
 			}
 

--- a/internal/enginenetx/httpsdialer_test.go
+++ b/internal/enginenetx/httpsdialer_test.go
@@ -437,8 +437,9 @@ func TestHTTPSDialerTactic(t *testing.T) {
 	t.Run("String", func(t *testing.T) {
 		expected := `{"Endpoint":"162.55.247.208:443","InitialDelay":150000000,"SNI":"www.example.com","VerifyHostname":"api.ooni.io"}`
 		ldt := &enginenetx.HTTPSDialerTactic{
-			Endpoint:       "162.55.247.208:443",
+			Address:        "162.55.247.208",
 			InitialDelay:   150 * time.Millisecond,
+			Port:           "443",
 			SNI:            "www.example.com",
 			VerifyHostname: "api.ooni.io",
 		}
@@ -461,8 +462,9 @@ func TestHTTPSDialerTactic(t *testing.T) {
 	t.Run("Summary", func(t *testing.T) {
 		expected := `162.55.247.208:443 sni=www.example.com verify=api.ooni.io`
 		ldt := &enginenetx.HTTPSDialerTactic{
-			Endpoint:       "162.55.247.208:443",
+			Address:        "162.55.247.208",
 			InitialDelay:   150 * time.Millisecond,
+			Port:           "443",
 			SNI:            "www.example.com",
 			VerifyHostname: "api.ooni.io",
 		}

--- a/internal/enginenetx/httpsdialer_test.go
+++ b/internal/enginenetx/httpsdialer_test.go
@@ -435,7 +435,7 @@ func TestHTTPSDialerNetemQA(t *testing.T) {
 
 func TestHTTPSDialerTactic(t *testing.T) {
 	t.Run("String", func(t *testing.T) {
-		expected := `{"Endpoint":"162.55.247.208:443","InitialDelay":150000000,"SNI":"www.example.com","VerifyHostname":"api.ooni.io"}`
+		expected := `{"Address":"162.55.247.208","InitialDelay":150000000,"Port":"443","SNI":"www.example.com","VerifyHostname":"api.ooni.io"}`
 		ldt := &enginenetx.HTTPSDialerTactic{
 			Address:        "162.55.247.208",
 			InitialDelay:   150 * time.Millisecond,

--- a/internal/enginenetx/httpsdialercore.go
+++ b/internal/enginenetx/httpsdialercore.go
@@ -68,7 +68,7 @@ func (dt *HTTPSDialerTactic) String() string {
 //
 // The returned string contains the above fields separated by space.
 func (dt *HTTPSDialerTactic) Summary() string {
-	return fmt.Sprintf("%v port=%v sni=%v verify=%v", dt.Address, dt.Port, dt.SNI, dt.VerifyHostname)
+	return fmt.Sprintf("%v:%v sni=%v verify=%v", dt.Address, dt.Port, dt.SNI, dt.VerifyHostname)
 }
 
 // HTTPSDialerPolicy describes the policy used by the [*HTTPSDialer].

--- a/internal/enginenetx/httpsdialercore.go
+++ b/internal/enginenetx/httpsdialercore.go
@@ -68,7 +68,7 @@ func (dt *HTTPSDialerTactic) String() string {
 //
 // The returned string contains the above fields separated by space.
 func (dt *HTTPSDialerTactic) Summary() string {
-	return fmt.Sprintf("%v:%v sni=%v verify=%v", dt.Address, dt.Port, dt.SNI, dt.VerifyHostname)
+	return fmt.Sprintf("%v sni=%v verify=%v", net.JoinHostPort(dt.Address, dt.Port), dt.SNI, dt.VerifyHostname)
 }
 
 // HTTPSDialerPolicy describes the policy used by the [*HTTPSDialer].

--- a/internal/enginenetx/httpsdialercore.go
+++ b/internal/enginenetx/httpsdialercore.go
@@ -19,12 +19,15 @@ import (
 
 // HTTPSDialerTactic is a tactic to establish a TLS connection.
 type HTTPSDialerTactic struct {
-	// Endpoint is the TCP endpoint to use for dialing.
-	Endpoint string
+	// Address is the IPv4/IPv6 address for dialing.
+	Address string
 
 	// InitialDelay is the time in nanoseconds after which
 	// you would like to start this policy.
 	InitialDelay time.Duration
+
+	// Port is the TCP port for dialing.
+	Port string
 
 	// SNI is the TLS ServerName to send over the wire.
 	SNI string
@@ -39,8 +42,9 @@ var _ fmt.Stringer = &HTTPSDialerTactic{}
 // Clone makes a deep copy of this [HTTPSDialerTactic].
 func (dt *HTTPSDialerTactic) Clone() *HTTPSDialerTactic {
 	return &HTTPSDialerTactic{
-		Endpoint:       dt.Endpoint,
+		Address:        dt.Address,
 		InitialDelay:   dt.InitialDelay,
+		Port:           dt.Port,
 		SNI:            dt.SNI,
 		VerifyHostname: dt.VerifyHostname,
 	}
@@ -64,7 +68,7 @@ func (dt *HTTPSDialerTactic) String() string {
 //
 // The returned string contains the above fields separated by space.
 func (dt *HTTPSDialerTactic) Summary() string {
-	return fmt.Sprintf("%v sni=%v verify=%v", dt.Endpoint, dt.SNI, dt.VerifyHostname)
+	return fmt.Sprintf("%v port=%v sni=%v verify=%v", dt.Address, dt.Port, dt.SNI, dt.VerifyHostname)
 }
 
 // HTTPSDialerPolicy describes the policy used by the [*HTTPSDialer].
@@ -281,9 +285,10 @@ func (hd *HTTPSDialer) dialTLS(
 	hd.stats.OnStarting(tactic)
 
 	// create dialer and establish TCP connection
-	ol := logx.NewOperationLogger(logger, "TCPConnect %s", tactic.Endpoint)
+	endpoint := net.JoinHostPort(tactic.Address, tactic.Port)
+	ol := logx.NewOperationLogger(logger, "TCPConnect %s", endpoint)
 	dialer := hd.netx.NewDialerWithoutResolver(logger)
-	tcpConn, err := dialer.DialContext(ctx, "tcp", tactic.Endpoint)
+	tcpConn, err := dialer.DialContext(ctx, "tcp", endpoint)
 	ol.Stop(err)
 
 	// handle a dialing error
@@ -304,7 +309,7 @@ func (hd *HTTPSDialer) dialTLS(
 	ol = logx.NewOperationLogger(
 		logger,
 		"TLSHandshake with %s SNI=%s ALPN=%v",
-		tactic.Endpoint,
+		endpoint,
 		tlsConfig.ServerName,
 		tlsConfig.NextProtos,
 	)

--- a/internal/enginenetx/httpsdialernull.go
+++ b/internal/enginenetx/httpsdialernull.go
@@ -2,7 +2,6 @@ package enginenetx
 
 import (
 	"context"
-	"net"
 
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
@@ -56,8 +55,9 @@ func (p *HTTPSDialerNullPolicy) LookupTactics(
 
 		for idx, addr := range addrs {
 			tactic := &HTTPSDialerTactic{
-				Endpoint:       net.JoinHostPort(addr, port),
+				Address:        addr,
 				InitialDelay:   happyEyeballsDelay(idx),
+				Port:           port,
 				SNI:            domain,
 				VerifyHostname: domain,
 			}

--- a/internal/enginenetx/httpsdialernull_test.go
+++ b/internal/enginenetx/httpsdialernull_test.go
@@ -51,7 +51,10 @@ func TestHTTPSDialerNullPolicy(t *testing.T) {
 		for tactic := range tactics {
 			count++
 
-			if tactic.Endpoint != "130.192.91.211:443" {
+			if tactic.Address != "130.192.91.211" {
+				t.Fatal("invalid endpoint")
+			}
+			if tactic.Port != "443" {
 				t.Fatal("invalid endpoint")
 			}
 			if tactic.SNI != "130.192.91.211" {

--- a/internal/enginenetx/httpsdialernull_test.go
+++ b/internal/enginenetx/httpsdialernull_test.go
@@ -52,10 +52,10 @@ func TestHTTPSDialerNullPolicy(t *testing.T) {
 			count++
 
 			if tactic.Address != "130.192.91.211" {
-				t.Fatal("invalid endpoint")
+				t.Fatal("invalid endpoint address")
 			}
 			if tactic.Port != "443" {
-				t.Fatal("invalid endpoint")
+				t.Fatal("invalid endpoint port")
 			}
 			if tactic.SNI != "130.192.91.211" {
 				t.Fatal("invalid SNI")

--- a/internal/enginenetx/httpsdialerstatic.go
+++ b/internal/enginenetx/httpsdialerstatic.go
@@ -65,7 +65,7 @@ func NewHTTPSDialerStaticPolicy(
 }
 
 // HTTPSDialerStaticPolicyVersion is the current version of the static policy file.
-const HTTPSDialerStaticPolicyVersion = 1
+const HTTPSDialerStaticPolicyVersion = 2
 
 // HTTPSDialerStaticPolicyRoot is the root of a statically loaded policy.
 type HTTPSDialerStaticPolicyRoot struct {

--- a/internal/enginenetx/httpsdialerstatic_test.go
+++ b/internal/enginenetx/httpsdialerstatic_test.go
@@ -66,28 +66,33 @@ func TestHTTPSDialerStaticPolicy(t *testing.T) {
 				return runtimex.Try1(json.Marshal(&HTTPSDialerStaticPolicyRoot{
 					Domains: map[string][]*HTTPSDialerTactic{
 						"api.ooni.io": {{
-							Endpoint:       "162.55.247.208:443",
+							Address:        "162.55.247.208",
 							InitialDelay:   0,
+							Port:           "443",
 							SNI:            "api.ooni.io",
 							VerifyHostname: "api.ooni.io",
 						}, {
-							Endpoint:       "46.101.82.151:443",
+							Address:        "46.101.82.151",
 							InitialDelay:   300 * time.Millisecond,
+							Port:           "443",
 							SNI:            "api.ooni.io",
 							VerifyHostname: "api.ooni.io",
 						}, {
-							Endpoint:       "[2a03:b0c0:1:d0::ec4:9001]:443",
+							Address:        "2a03:b0c0:1:d0::ec4:9001",
 							InitialDelay:   600 * time.Millisecond,
+							Port:           "443",
 							SNI:            "api.ooni.io",
 							VerifyHostname: "api.ooni.io",
 						}, {
-							Endpoint:       "46.101.82.151:443",
+							Address:        "46.101.82.151",
 							InitialDelay:   3000 * time.Millisecond,
+							Port:           "443",
 							SNI:            "www.example.com",
 							VerifyHostname: "api.ooni.io",
 						}, {
-							Endpoint:       "[2a03:b0c0:1:d0::ec4:9001]:443",
+							Address:        "2a03:b0c0:1:d0::ec4:9001",
 							InitialDelay:   3300 * time.Millisecond,
+							Port:           "443",
 							SNI:            "www.example.com",
 							VerifyHostname: "api.ooni.io",
 						}},
@@ -101,28 +106,33 @@ func TestHTTPSDialerStaticPolicy(t *testing.T) {
 				Root: &HTTPSDialerStaticPolicyRoot{
 					Domains: map[string][]*HTTPSDialerTactic{
 						"api.ooni.io": {{
-							Endpoint:       "162.55.247.208:443",
+							Address:        "162.55.247.208",
 							InitialDelay:   0,
+							Port:           "443",
 							SNI:            "api.ooni.io",
 							VerifyHostname: "api.ooni.io",
 						}, {
-							Endpoint:       "46.101.82.151:443",
+							Address:        "46.101.82.151",
 							InitialDelay:   300 * time.Millisecond,
+							Port:           "443",
 							SNI:            "api.ooni.io",
 							VerifyHostname: "api.ooni.io",
 						}, {
-							Endpoint:       "[2a03:b0c0:1:d0::ec4:9001]:443",
+							Address:        "2a03:b0c0:1:d0::ec4:9001",
 							InitialDelay:   600 * time.Millisecond,
+							Port:           "443",
 							SNI:            "api.ooni.io",
 							VerifyHostname: "api.ooni.io",
 						}, {
-							Endpoint:       "46.101.82.151:443",
+							Address:        "46.101.82.151",
 							InitialDelay:   3000 * time.Millisecond,
+							Port:           "443",
 							SNI:            "www.example.com",
 							VerifyHostname: "api.ooni.io",
 						}, {
-							Endpoint:       "[2a03:b0c0:1:d0::ec4:9001]:443",
+							Address:        "2a03:b0c0:1:d0::ec4:9001",
 							InitialDelay:   3300 * time.Millisecond,
+							Port:           "443",
 							SNI:            "www.example.com",
 							VerifyHostname: "api.ooni.io",
 						}},
@@ -164,8 +174,9 @@ func TestHTTPSDialerStaticPolicy(t *testing.T) {
 
 	t.Run("LookupTactics", func(t *testing.T) {
 		expectedTactic := &HTTPSDialerTactic{
-			Endpoint:       "162.55.247.208:443",
+			Address:        "162.55.247.208",
 			InitialDelay:   0,
+			Port:           "443",
 			SNI:            "www.example.com",
 			VerifyHostname: "api.ooni.io",
 		}
@@ -228,8 +239,9 @@ func TestHTTPSDialerStaticPolicy(t *testing.T) {
 			}
 
 			expect := []*HTTPSDialerTactic{{
-				Endpoint:       "93.184.216.34:443",
+				Address:        "93.184.216.34",
 				InitialDelay:   0,
+				Port:           "443",
 				SNI:            "www.example.com",
 				VerifyHostname: "www.example.com",
 			}}

--- a/internal/enginenetx/httpsdialerstatic_test.go
+++ b/internal/enginenetx/httpsdialerstatic_test.go
@@ -57,7 +57,7 @@ func TestHTTPSDialerStaticPolicy(t *testing.T) {
 			name:           "with empty JSON",
 			key:            HTTPSDialerStaticPolicyKey,
 			input:          []byte(`{}`),
-			expectErr:      "httpsdialerstatic.conf: wrong static policy version: expected=1 got=0",
+			expectErr:      "httpsdialerstatic.conf: wrong static policy version: expected=2 got=0",
 			expectedPolicy: nil,
 		}, {
 			name: "with real serialized policy",

--- a/internal/enginenetx/network_test.go
+++ b/internal/enginenetx/network_test.go
@@ -303,8 +303,9 @@ func TestNetworkQA(t *testing.T) {
 					policy := &enginenetx.HTTPSDialerStaticPolicyRoot{
 						Domains: map[string][]*enginenetx.HTTPSDialerTactic{
 							"www.example.com": {{
-								Endpoint:       net.JoinHostPort(netemx.AddressApiOONIIo, "443"),
+								Address:        netemx.AddressApiOONIIo,
 								InitialDelay:   0,
+								Port:           "443",
 								SNI:            "www.example.com",
 								VerifyHostname: "api.ooni.io",
 							}},

--- a/internal/enginenetx/stats.go
+++ b/internal/enginenetx/stats.go
@@ -101,7 +101,7 @@ func statsDomainRemoveOldEntries(input *statsDomain) (output *statsDomain) {
 }
 
 // statsContainerVersion is the current version of [statsContainer].
-const statsContainerVersion = 3
+const statsContainerVersion = 4
 
 // statsContainer is the root container for the stats.
 //

--- a/internal/enginenetx/stats.go
+++ b/internal/enginenetx/stats.go
@@ -101,7 +101,7 @@ func statsDomainRemoveOldEntries(input *statsDomain) (output *statsDomain) {
 }
 
 // statsContainerVersion is the current version of [statsContainer].
-const statsContainerVersion = 2
+const statsContainerVersion = 3
 
 // statsContainer is the root container for the stats.
 //

--- a/internal/enginenetx/stats_test.go
+++ b/internal/enginenetx/stats_test.go
@@ -325,7 +325,7 @@ func TestLoadStatsContainer(t *testing.T) {
 		input: func() []byte {
 			return []byte(`{"Version":1}`)
 		},
-		expectErr:  "httpsdialerstats.state: wrong stats container version: expected=2 got=1",
+		expectErr:  "httpsdialerstats.state: wrong stats container version: expected=4 got=1",
 		expectRoot: nil,
 	}, {
 		name: "on success including correct entries pruning",

--- a/internal/enginenetx/stats_test.go
+++ b/internal/enginenetx/stats_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"net"
 	"testing"
 	"time"
 
@@ -61,8 +60,9 @@ func TestNetworkCollectsStats(t *testing.T) {
 						// This policy has a different SNI and VerifyHostname, which gives
 						// us confidence that the stats are using the latter
 						"api.ooni.io": {{
-							Endpoint:       net.JoinHostPort(netemx.AddressApiOONIIo, "443"),
+							Address:        netemx.AddressApiOONIIo,
 							InitialDelay:   0,
+							Port:           "443",
 							SNI:            "www.example.com",
 							VerifyHostname: "api.ooni.io",
 						}},
@@ -94,8 +94,9 @@ func TestNetworkCollectsStats(t *testing.T) {
 				HistoTLSVerificationError: map[string]int64{},
 				LastUpdated:               time.Time{},
 				Tactic: &HTTPSDialerTactic{
-					Endpoint:       "162.55.247.208:443",
+					Address:        "162.55.247.208",
 					InitialDelay:   0,
+					Port:           "443",
 					SNI:            "www.example.com",
 					VerifyHostname: "api.ooni.io",
 				},
@@ -111,8 +112,9 @@ func TestNetworkCollectsStats(t *testing.T) {
 						// This policy has a different SNI and VerifyHostname, which gives
 						// us confidence that the stats are using the latter
 						"api.ooni.io": {{
-							Endpoint:       net.JoinHostPort(netemx.AddressApiOONIIo, "443"),
+							Address:        netemx.AddressApiOONIIo,
 							InitialDelay:   0,
+							Port:           "443",
 							SNI:            "www.example.com",
 							VerifyHostname: "api.ooni.io",
 						}},
@@ -143,8 +145,9 @@ func TestNetworkCollectsStats(t *testing.T) {
 				HistoTLSVerificationError: map[string]int64{},
 				LastUpdated:               time.Time{},
 				Tactic: &HTTPSDialerTactic{
-					Endpoint:       "162.55.247.208:443",
+					Address:        "162.55.247.208",
 					InitialDelay:   0,
+					Port:           "443",
 					SNI:            "www.example.com",
 					VerifyHostname: "api.ooni.io",
 				},
@@ -160,8 +163,9 @@ func TestNetworkCollectsStats(t *testing.T) {
 						// This policy has a different SNI and VerifyHostname, which gives
 						// us confidence that the stats are using the latter
 						"api.ooni.io": {{
-							Endpoint:       net.JoinHostPort(netemx.AddressBadSSLCom, "443"),
+							Address:        netemx.AddressBadSSLCom,
 							InitialDelay:   0,
+							Port:           "443",
 							SNI:            "untrusted-root.badssl.com",
 							VerifyHostname: "api.ooni.io",
 						}},
@@ -189,8 +193,9 @@ func TestNetworkCollectsStats(t *testing.T) {
 				},
 				LastUpdated: time.Time{},
 				Tactic: &HTTPSDialerTactic{
-					Endpoint:       "104.154.89.105:443",
+					Address:        "104.154.89.105",
 					InitialDelay:   0,
+					Port:           "443",
 					SNI:            "untrusted-root.badssl.com",
 					VerifyHostname: "api.ooni.io",
 				},
@@ -346,8 +351,9 @@ func TestLoadStatsContainer(t *testing.T) {
 								},
 								LastUpdated: fourtyFiveMinutesAgo,
 								Tactic: &HTTPSDialerTactic{
-									Endpoint:       "162.55.247.208:443",
+									Address:        "162.55.247.208",
 									InitialDelay:   0,
+									Port:           "443",
 									SNI:            "www.example.com",
 									VerifyHostname: "api.ooni.io",
 								},
@@ -369,8 +375,9 @@ func TestLoadStatsContainer(t *testing.T) {
 								},
 								LastUpdated: twoWeeksAgo,
 								Tactic: &HTTPSDialerTactic{
-									Endpoint:       "162.55.247.208:443",
+									Address:        "162.55.247.208",
 									InitialDelay:   0,
+									Port:           "443",
 									SNI:            "www.example.org",
 									VerifyHostname: "api.ooni.io",
 								},
@@ -396,8 +403,9 @@ func TestLoadStatsContainer(t *testing.T) {
 								},
 								LastUpdated: twoWeeksAgo,
 								Tactic: &HTTPSDialerTactic{
-									Endpoint:       "162.55.247.208:443",
+									Address:        "162.55.247.208",
 									InitialDelay:   0,
+									Port:           "443",
 									SNI:            "www.example.com",
 									VerifyHostname: "www.kernel.org",
 								},
@@ -431,8 +439,9 @@ func TestLoadStatsContainer(t *testing.T) {
 							},
 							LastUpdated: fourtyFiveMinutesAgo,
 							Tactic: &HTTPSDialerTactic{
-								Endpoint:       "162.55.247.208:443",
+								Address:        "162.55.247.208",
 								InitialDelay:   0,
+								Port:           "443",
 								SNI:            "www.example.com",
 								VerifyHostname: "api.ooni.io",
 							},
@@ -513,8 +522,9 @@ func TestStatsManagerCallbacks(t *testing.T) {
 				cancel() // immediately!
 
 				tactic := &HTTPSDialerTactic{
-					Endpoint:       "162.55.247.208:443",
+					Address:        "162.55.247.208",
 					InitialDelay:   0,
+					Port:           "443",
 					SNI:            "www.example.com",
 					VerifyHostname: "api.ooni.io",
 				}
@@ -550,8 +560,9 @@ func TestStatsManagerCallbacks(t *testing.T) {
 				ctx := context.Background()
 
 				tactic := &HTTPSDialerTactic{
-					Endpoint:       "162.55.247.208:443",
+					Address:        "162.55.247.208",
 					InitialDelay:   0,
+					Port:           "443",
 					SNI:            "www.example.com",
 					VerifyHostname: "api.ooni.io",
 				}
@@ -588,8 +599,9 @@ func TestStatsManagerCallbacks(t *testing.T) {
 				cancel() // immediately!
 
 				tactic := &HTTPSDialerTactic{
-					Endpoint:       "162.55.247.208:443",
+					Address:        "162.55.247.208",
 					InitialDelay:   0,
+					Port:           "443",
 					SNI:            "www.example.com",
 					VerifyHostname: "api.ooni.io",
 				}
@@ -625,8 +637,9 @@ func TestStatsManagerCallbacks(t *testing.T) {
 				ctx := context.Background()
 
 				tactic := &HTTPSDialerTactic{
-					Endpoint:       "162.55.247.208:443",
+					Address:        "162.55.247.208",
 					InitialDelay:   0,
+					Port:           "443",
 					SNI:            "www.example.com",
 					VerifyHostname: "api.ooni.io",
 				}
@@ -650,8 +663,9 @@ func TestStatsManagerCallbacks(t *testing.T) {
 			},
 			do: func(stats *statsManager) {
 				tactic := &HTTPSDialerTactic{
-					Endpoint:       "162.55.247.208:443",
+					Address:        "162.55.247.208",
 					InitialDelay:   0,
+					Port:           "443",
 					SNI:            "www.example.com",
 					VerifyHostname: "api.ooni.io",
 				}
@@ -675,8 +689,9 @@ func TestStatsManagerCallbacks(t *testing.T) {
 			},
 			do: func(stats *statsManager) {
 				tactic := &HTTPSDialerTactic{
-					Endpoint:       "162.55.247.208:443",
+					Address:        "162.55.247.208",
 					InitialDelay:   0,
+					Port:           "443",
 					SNI:            "www.example.com",
 					VerifyHostname: "api.ooni.io",
 				}


### PR DESCRIPTION
This diff modifies the `HTTPSDialerTactic` struct to store the address and port separately rather than storing the endpoint as the concatenation of the address and the port.

By storing these two fields separately, we're more flexible as we will soon see with subsequent diffs.

Reference issue: https://github.com/ooni/probe/issues/2531
