### PR TITLE
refactor(enginenetx): make static-policy API private

### DIFF
--- a/internal/enginenetx/beacons.go
+++ b/internal/enginenetx/beacons.go
@@ -1,5 +1,10 @@
 package enginenetx
 
+//
+// beacons policy - a policy where we treat some IP addresses as special for
+// some domains, bypassing DNS lookups and using custom SNIs
+//
+
 import (
 	"context"
 	"math/rand"

--- a/internal/enginenetx/network.go
+++ b/internal/enginenetx/network.go
@@ -1,5 +1,10 @@
 package enginenetx
 
+//
+// Network - the top-level object of this package, used by the
+// OONI engine to communicate with several backends
+//
+
 import (
 	"net/http"
 	"net/http/cookiejar"
@@ -141,7 +146,7 @@ func newHTTPSDialerPolicy(kvStore model.KeyValueStore, logger model.Logger, reso
 	}
 
 	// make sure we honor a user-provided policy
-	policy, err := NewHTTPSDialerStaticPolicy(kvStore, fallback)
+	policy, err := newStaticPolicy(kvStore, fallback)
 	if err != nil {
 		return fallback
 	}

--- a/internal/enginenetx/network_internal_test.go
+++ b/internal/enginenetx/network_internal_test.go
@@ -1,12 +1,20 @@
 package enginenetx
 
 import (
+	"context"
+	"encoding/json"
 	"sync"
 	"testing"
 
+	"github.com/apex/log"
+	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/probe-cli/v3/internal/bytecounter"
 	"github.com/ooni/probe-cli/v3/internal/kvstore"
 	"github.com/ooni/probe-cli/v3/internal/mocks"
 	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/netemx"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
 func TestNetworkUnit(t *testing.T) {
@@ -73,6 +81,90 @@ func TestNetworkUnit(t *testing.T) {
 		}
 		if !called {
 			t.Fatal("did not call the transport's CloseIdleConnections")
+		}
+	})
+
+	t.Run("NewNetwork uses the correct HTTPSDialerPolicy", func(t *testing.T) {
+		// testcase is a test case run by this func
+		type testcase struct {
+			name         string
+			kvStore      func() model.KeyValueStore
+			expectStatus int
+			expectBody   []byte
+		}
+
+		cases := []testcase{
+			// Without a policy accessing www.example.com should lead to 200 as status
+			// code and the expected web page when we're using netem
+			{
+				name: "when there is no user-provided policy",
+				kvStore: func() model.KeyValueStore {
+					return &kvstore.Memory{}
+				},
+				expectStatus: 200,
+				expectBody:   []byte(netemx.ExampleWebPage),
+			},
+
+			// But we can create a policy that can land us on a different website (not the
+			// typical use case of the policy, but definitely demonstrating it works)
+			{
+				name: "when there's a user-provided policy",
+				kvStore: func() model.KeyValueStore {
+					policy := &staticPolicyRoot{
+						DomainEndpoints: map[string][]*HTTPSDialerTactic{
+							"www.example.com:443": {{
+								Address:        netemx.AddressApiOONIIo,
+								InitialDelay:   0,
+								Port:           "443",
+								SNI:            "www.example.com",
+								VerifyHostname: "api.ooni.io",
+							}},
+						},
+						Version: staticPolicyVersion,
+					}
+					rawPolicy := runtimex.Try1(json.Marshal(policy))
+					kvStore := &kvstore.Memory{}
+					runtimex.Try0(kvStore.Set(staticPolicyKey, rawPolicy))
+					return kvStore
+				},
+				expectStatus: 404,
+				expectBody:   []byte{},
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				env := netemx.MustNewScenario(netemx.InternetScenario)
+				defer env.Close()
+
+				env.Do(func() {
+					netx := NewNetwork(
+						bytecounter.New(),
+						tc.kvStore(),
+						log.Log,
+						nil, // proxy URL
+						netxlite.NewStdlibResolver(log.Log),
+					)
+					defer netx.Close()
+
+					client := netx.NewHTTPClient()
+					resp, err := client.Get("https://www.example.com/")
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer resp.Body.Close()
+					if resp.StatusCode != tc.expectStatus {
+						t.Fatal("StatusCode: expected", tc.expectStatus, "got", resp.StatusCode)
+					}
+					data, err := netxlite.ReadAllContext(context.Background(), resp.Body)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if diff := cmp.Diff(tc.expectBody, data); diff != "" {
+						t.Fatal(diff)
+					}
+				})
+			})
 		}
 	})
 }

--- a/internal/enginenetx/network_test.go
+++ b/internal/enginenetx/network_test.go
@@ -2,7 +2,6 @@ package enginenetx_test
 
 import (
 	"context"
-	"encoding/json"
 	"net"
 	"net/http"
 	"net/url"
@@ -10,15 +9,12 @@ import (
 	"time"
 
 	"github.com/apex/log"
-	"github.com/google/go-cmp/cmp"
 	"github.com/ooni/probe-cli/v3/internal/bytecounter"
 	"github.com/ooni/probe-cli/v3/internal/enginenetx"
 	"github.com/ooni/probe-cli/v3/internal/kvstore"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
-	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netemx"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
-	"github.com/ooni/probe-cli/v3/internal/runtimex"
 	"github.com/ooni/probe-cli/v3/internal/testingsocks5"
 	"github.com/ooni/probe-cli/v3/internal/testingx"
 )
@@ -271,90 +267,6 @@ func TestNetworkQA(t *testing.T) {
 		client := txp.NewHTTPClient()
 		if client.Jar == nil {
 			t.Fatal("expected non-nil cookie jar")
-		}
-	})
-
-	t.Run("NewNetwork uses the correct HTTPSDialerPolicy", func(t *testing.T) {
-		// testcase is a test case run by this func
-		type testcase struct {
-			name         string
-			kvStore      func() model.KeyValueStore
-			expectStatus int
-			expectBody   []byte
-		}
-
-		cases := []testcase{
-			// Without a policy accessing www.example.com should lead to 200 as status
-			// code and the expected web page when we're using netem
-			{
-				name: "when there is no user-provided policy",
-				kvStore: func() model.KeyValueStore {
-					return &kvstore.Memory{}
-				},
-				expectStatus: 200,
-				expectBody:   []byte(netemx.ExampleWebPage),
-			},
-
-			// But we can create a policy that can land us on a different website (not the
-			// typical use case of the policy, but definitely demonstrating it works)
-			{
-				name: "when there's a user-provided policy",
-				kvStore: func() model.KeyValueStore {
-					policy := &enginenetx.HTTPSDialerStaticPolicyRoot{
-						DomainEndpoints: map[string][]*enginenetx.HTTPSDialerTactic{
-							"www.example.com:443": {{
-								Address:        netemx.AddressApiOONIIo,
-								InitialDelay:   0,
-								Port:           "443",
-								SNI:            "www.example.com",
-								VerifyHostname: "api.ooni.io",
-							}},
-						},
-						Version: enginenetx.HTTPSDialerStaticPolicyVersion,
-					}
-					rawPolicy := runtimex.Try1(json.Marshal(policy))
-					kvStore := &kvstore.Memory{}
-					runtimex.Try0(kvStore.Set(enginenetx.HTTPSDialerStaticPolicyKey, rawPolicy))
-					return kvStore
-				},
-				expectStatus: 404,
-				expectBody:   []byte{},
-			},
-		}
-
-		for _, tc := range cases {
-			t.Run(tc.name, func(t *testing.T) {
-				env := netemx.MustNewScenario(netemx.InternetScenario)
-				defer env.Close()
-
-				env.Do(func() {
-					netx := enginenetx.NewNetwork(
-						bytecounter.New(),
-						tc.kvStore(),
-						log.Log,
-						nil, // proxy URL
-						netxlite.NewStdlibResolver(log.Log),
-					)
-					defer netx.Close()
-
-					client := netx.NewHTTPClient()
-					resp, err := client.Get("https://www.example.com/")
-					if err != nil {
-						t.Fatal(err)
-					}
-					defer resp.Body.Close()
-					if resp.StatusCode != tc.expectStatus {
-						t.Fatal("StatusCode: expected", tc.expectStatus, "got", resp.StatusCode)
-					}
-					data, err := netxlite.ReadAllContext(context.Background(), resp.Body)
-					if err != nil {
-						t.Fatal(err)
-					}
-					if diff := cmp.Diff(tc.expectBody, data); diff != "" {
-						t.Fatal(diff)
-					}
-				})
-			})
 		}
 	})
 }

--- a/internal/enginenetx/stats.go
+++ b/internal/enginenetx/stats.go
@@ -1,5 +1,10 @@
 package enginenetx
 
+//
+// Code to keep statistics about the TLS dialing
+// tactics that work and the ones that don't
+//
+
 import (
 	"context"
 	"encoding/json"

--- a/internal/enginenetx/stats_test.go
+++ b/internal/enginenetx/stats_test.go
@@ -55,7 +55,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 			name: "with TCP connect failure",
 			URL:  "https://api.ooni.io/",
 			initialPolicy: func() []byte {
-				p0 := &HTTPSDialerStaticPolicyRoot{
+				p0 := &staticPolicyRoot{
 					DomainEndpoints: map[string][]*HTTPSDialerTactic{
 						// This policy has a different SNI and VerifyHostname, which gives
 						// us confidence that the stats are using the latter
@@ -67,7 +67,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 							VerifyHostname: "api.ooni.io",
 						}},
 					},
-					Version: HTTPSDialerStaticPolicyVersion,
+					Version: staticPolicyVersion,
 				}
 				return runtimex.Try1(json.Marshal(p0))
 			},
@@ -107,7 +107,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 			name: "with TLS handshake failure",
 			URL:  "https://api.ooni.io/",
 			initialPolicy: func() []byte {
-				p0 := &HTTPSDialerStaticPolicyRoot{
+				p0 := &staticPolicyRoot{
 					DomainEndpoints: map[string][]*HTTPSDialerTactic{
 						// This policy has a different SNI and VerifyHostname, which gives
 						// us confidence that the stats are using the latter
@@ -119,7 +119,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 							VerifyHostname: "api.ooni.io",
 						}},
 					},
-					Version: HTTPSDialerStaticPolicyVersion,
+					Version: staticPolicyVersion,
 				}
 				return runtimex.Try1(json.Marshal(p0))
 			},
@@ -158,7 +158,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 			name: "with TLS verification failure",
 			URL:  "https://api.ooni.io/",
 			initialPolicy: func() []byte {
-				p0 := &HTTPSDialerStaticPolicyRoot{
+				p0 := &staticPolicyRoot{
 					DomainEndpoints: map[string][]*HTTPSDialerTactic{
 						// This policy has a different SNI and VerifyHostname, which gives
 						// us confidence that the stats are using the latter
@@ -170,7 +170,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 							VerifyHostname: "api.ooni.io",
 						}},
 					},
-					Version: HTTPSDialerStaticPolicyVersion,
+					Version: staticPolicyVersion,
 				}
 				return runtimex.Try1(json.Marshal(p0))
 			},
@@ -216,7 +216,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 
 			initialPolicy := tc.initialPolicy()
 			t.Logf("initialPolicy: %s", string(initialPolicy))
-			if err := kvStore.Set(HTTPSDialerStaticPolicyKey, initialPolicy); err != nil {
+			if err := kvStore.Set(staticPolicyKey, initialPolicy); err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
Now that we've more or less reached the point where we wanted to be with https://github.com/ooni/probe/issues/2531, let's spend some time to refactor the implementation, now that we know very well how it works, such that modifying it in the future would be easier.

The first order of business here seems to hide implementation details and get rid of too many HTTPSDialer prefixes which only cause confusion when looking at the available structs.

Here, in particular, we deal with the static-policy API. To this end, we also need to more some tests around because they need internals.

Also, while there, add a top-level description to some files, so that newcomers have an idea of what each file is about.
