### PR TITLE
refactor(enginenetx): make https-dialer API private

### DIFF
--- a/internal/enginenetx/beacons.go
+++ b/internal/enginenetx/beacons.go
@@ -20,14 +20,14 @@ import (
 // The zero value is invalid; please, init MANDATORY fields.
 type beaconsPolicy struct {
 	// Fallback is the MANDATORY fallback policy.
-	Fallback HTTPSDialerPolicy
+	Fallback httpsDialerPolicy
 }
 
-var _ HTTPSDialerPolicy = &beaconsPolicy{}
+var _ httpsDialerPolicy = &beaconsPolicy{}
 
-// LookupTactics implements HTTPSDialerPolicy.
-func (p *beaconsPolicy) LookupTactics(ctx context.Context, domain, port string) <-chan *HTTPSDialerTactic {
-	out := make(chan *HTTPSDialerTactic)
+// LookupTactics implements httpsDialerPolicy.
+func (p *beaconsPolicy) LookupTactics(ctx context.Context, domain, port string) <-chan *httpsDialerTactic {
+	out := make(chan *httpsDialerTactic)
 
 	go func() {
 		defer close(out)
@@ -51,8 +51,8 @@ func (p *beaconsPolicy) LookupTactics(ctx context.Context, domain, port string) 
 	return out
 }
 
-func (p *beaconsPolicy) tacticsForDomain(domain, port string) <-chan *HTTPSDialerTactic {
-	out := make(chan *HTTPSDialerTactic)
+func (p *beaconsPolicy) tacticsForDomain(domain, port string) <-chan *httpsDialerTactic {
+	out := make(chan *httpsDialerTactic)
 
 	go func() {
 		defer close(out)
@@ -72,7 +72,7 @@ func (p *beaconsPolicy) tacticsForDomain(domain, port string) <-chan *HTTPSDiale
 
 		for _, ipAddr := range ipAddrs {
 			for _, sni := range snis {
-				out <- &HTTPSDialerTactic{
+				out <- &httpsDialerTactic{
 					Address:        ipAddr,
 					InitialDelay:   0,
 					Port:           port,

--- a/internal/enginenetx/dnspolicy.go
+++ b/internal/enginenetx/dnspolicy.go
@@ -26,12 +26,12 @@ type dnsPolicy struct {
 	Resolver model.Resolver
 }
 
-var _ HTTPSDialerPolicy = &dnsPolicy{}
+var _ httpsDialerPolicy = &dnsPolicy{}
 
-// LookupTactics implements HTTPSDialerPolicy.
+// LookupTactics implements httpsDialerPolicy.
 func (p *dnsPolicy) LookupTactics(
-	ctx context.Context, domain, port string) <-chan *HTTPSDialerTactic {
-	out := make(chan *HTTPSDialerTactic)
+	ctx context.Context, domain, port string) <-chan *httpsDialerTactic {
+	out := make(chan *httpsDialerTactic)
 
 	go func() {
 		// make sure we close the output channel when done
@@ -40,7 +40,7 @@ func (p *dnsPolicy) LookupTactics(
 		// Do not even start the DNS lookup if the context has already been canceled, which
 		// happens if some policy running before us had successfully connected
 		if err := ctx.Err(); err != nil {
-			p.Logger.Debugf("HTTPSDialerNullPolicy: LookupTactics: %s", err.Error())
+			p.Logger.Debugf("dnsPolicy: LookupTactics: %s", err.Error())
 			return
 		}
 
@@ -55,7 +55,7 @@ func (p *dnsPolicy) LookupTactics(
 		}
 
 		for idx, addr := range addrs {
-			tactic := &HTTPSDialerTactic{
+			tactic := &httpsDialerTactic{
 				Address:        addr,
 				InitialDelay:   happyEyeballsDelay(idx),
 				Port:           port,

--- a/internal/enginenetx/dnspolicy_test.go
+++ b/internal/enginenetx/dnspolicy_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
 
-func TestHTTPSDialerNullPolicy(t *testing.T) {
+func TestDNSPolicy(t *testing.T) {
 	t.Run("LookupTactics with canceled context", func(t *testing.T) {
 		var called int
 

--- a/internal/enginenetx/network.go
+++ b/internal/enginenetx/network.go
@@ -93,7 +93,7 @@ func NewNetwork(
 
 	// Create a TLS dialer ONLY used for dialing TLS connections. This dialer will use
 	// happy-eyeballs and possibly custom policies for dialing TLS connections.
-	httpsDialer := NewHTTPSDialer(
+	httpsDialer := newHTTPSDialer(
 		logger,
 		&netxlite.Netx{Underlying: nil}, // nil means using netxlite's singleton
 		newHTTPSDialerPolicy(kvStore, logger, resolver),
@@ -139,7 +139,7 @@ func NewNetwork(
 }
 
 // newHTTPSDialerPolicy contains the logic to select the [HTTPSDialerPolicy] to use.
-func newHTTPSDialerPolicy(kvStore model.KeyValueStore, logger model.Logger, resolver model.Resolver) HTTPSDialerPolicy {
+func newHTTPSDialerPolicy(kvStore model.KeyValueStore, logger model.Logger, resolver model.Resolver) httpsDialerPolicy {
 	// create a composed fallback TLS dialer policy
 	fallback := &beaconsPolicy{
 		Fallback: &dnsPolicy{logger, resolver},

--- a/internal/enginenetx/network_internal_test.go
+++ b/internal/enginenetx/network_internal_test.go
@@ -84,7 +84,7 @@ func TestNetworkUnit(t *testing.T) {
 		}
 	})
 
-	t.Run("NewNetwork uses the correct HTTPSDialerPolicy", func(t *testing.T) {
+	t.Run("NewNetwork uses the correct httpsDialerPolicy", func(t *testing.T) {
 		// testcase is a test case run by this func
 		type testcase struct {
 			name         string
@@ -111,7 +111,7 @@ func TestNetworkUnit(t *testing.T) {
 				name: "when there's a user-provided policy",
 				kvStore: func() model.KeyValueStore {
 					policy := &staticPolicyRoot{
-						DomainEndpoints: map[string][]*HTTPSDialerTactic{
+						DomainEndpoints: map[string][]*httpsDialerTactic{
 							"www.example.com:443": {{
 								Address:        netemx.AddressApiOONIIo,
 								InitialDelay:   0,

--- a/internal/enginenetx/static.go
+++ b/internal/enginenetx/static.go
@@ -18,14 +18,14 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
 
-// staticPolicy is an [HTTPSDialerPolicy] incorporating verbatim
+// staticPolicy is an [httpsDialerPolicy] incorporating verbatim
 // a static policy loaded from the engine's key-value store.
 //
 // This policy is very useful for exploration and experimentation.
 type staticPolicy struct {
 	// Fallback is the fallback policy in case the static one does not
 	// contain a rule for a specific domain.
-	Fallback HTTPSDialerPolicy
+	Fallback httpsDialerPolicy
 
 	// Root is the root of the statically loaded policy.
 	Root *staticPolicyRoot
@@ -41,7 +41,7 @@ var errStaticPolicyWrongVersion = errors.New("wrong static policy version")
 // policy and either returns a good policy or an error. The typical error case is the one
 // in which there's no httpsDialerStaticPolicyKey in the key-value store.
 func newStaticPolicy(
-	kvStore model.KeyValueStore, fallback HTTPSDialerPolicy) (*staticPolicy, error) {
+	kvStore model.KeyValueStore, fallback httpsDialerPolicy) (*staticPolicy, error) {
 	// attempt to read the static policy bytes from the kvstore
 	data, err := kvStore.Get(staticPolicyKey)
 	if err != nil {
@@ -79,23 +79,23 @@ const staticPolicyVersion = 3
 // staticPolicyRoot is the root of a statically loaded policy.
 type staticPolicyRoot struct {
 	// DomainEndpoints maps each domain endpoint to its policies.
-	DomainEndpoints map[string][]*HTTPSDialerTactic
+	DomainEndpoints map[string][]*httpsDialerTactic
 
 	// Version is the data structure version.
 	Version int
 }
 
-var _ HTTPSDialerPolicy = &staticPolicy{}
+var _ httpsDialerPolicy = &staticPolicy{}
 
-// LookupTactics implements HTTPSDialerPolicy.
+// LookupTactics implements httpsDialerPolicy.
 func (ldp *staticPolicy) LookupTactics(
-	ctx context.Context, domain string, port string) <-chan *HTTPSDialerTactic {
+	ctx context.Context, domain string, port string) <-chan *httpsDialerTactic {
 	tactics, found := ldp.Root.DomainEndpoints[net.JoinHostPort(domain, port)]
 	if !found {
 		return ldp.Fallback.LookupTactics(ctx, domain, port)
 	}
 
-	out := make(chan *HTTPSDialerTactic)
+	out := make(chan *httpsDialerTactic)
 	go func() {
 		defer close(out)
 		for _, tactic := range tactics {

--- a/internal/enginenetx/static_test.go
+++ b/internal/enginenetx/static_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
-func TestHTTPSDialerStaticPolicy(t *testing.T) {
-	t.Run("NewHTTPSDialerStaticPolicy", func(t *testing.T) {
+func TestStaticPolicy(t *testing.T) {
+	t.Run("newStaticPolicy", func(t *testing.T) {
 		// testcase is a test case implemented by this function
 		type testcase struct {
 			// name is the test case name
@@ -64,7 +64,7 @@ func TestHTTPSDialerStaticPolicy(t *testing.T) {
 			key:  staticPolicyKey,
 			input: (func() []byte {
 				return runtimex.Try1(json.Marshal(&staticPolicyRoot{
-					DomainEndpoints: map[string][]*HTTPSDialerTactic{
+					DomainEndpoints: map[string][]*httpsDialerTactic{
 						"api.ooni.io:443": {{
 							Address:        "162.55.247.208",
 							InitialDelay:   0,
@@ -104,7 +104,7 @@ func TestHTTPSDialerStaticPolicy(t *testing.T) {
 			expectedPolicy: &staticPolicy{
 				Fallback: fallback,
 				Root: &staticPolicyRoot{
-					DomainEndpoints: map[string][]*HTTPSDialerTactic{
+					DomainEndpoints: map[string][]*httpsDialerTactic{
 						"api.ooni.io:443": {{
 							Address:        "162.55.247.208",
 							InitialDelay:   0,
@@ -173,7 +173,7 @@ func TestHTTPSDialerStaticPolicy(t *testing.T) {
 	})
 
 	t.Run("LookupTactics", func(t *testing.T) {
-		expectedTactic := &HTTPSDialerTactic{
+		expectedTactic := &httpsDialerTactic{
 			Address:        "162.55.247.208",
 			InitialDelay:   0,
 			Port:           "443",
@@ -181,7 +181,7 @@ func TestHTTPSDialerStaticPolicy(t *testing.T) {
 			VerifyHostname: "api.ooni.io",
 		}
 		staticPolicyRoot := &staticPolicyRoot{
-			DomainEndpoints: map[string][]*HTTPSDialerTactic{
+			DomainEndpoints: map[string][]*httpsDialerTactic{
 				"api.ooni.io:443": {expectedTactic},
 			},
 			Version: staticPolicyVersion,
@@ -201,13 +201,13 @@ func TestHTTPSDialerStaticPolicy(t *testing.T) {
 			}
 
 			tactics := policy.LookupTactics(ctx, "api.ooni.io", "443")
-			got := []*HTTPSDialerTactic{}
+			got := []*httpsDialerTactic{}
 			for tactic := range tactics {
 				t.Logf("%+v", tactic)
 				got = append(got, tactic)
 			}
 
-			expect := []*HTTPSDialerTactic{expectedTactic}
+			expect := []*httpsDialerTactic{expectedTactic}
 
 			if diff := cmp.Diff(expect, got); diff != "" {
 				t.Fatal(diff)
@@ -232,13 +232,13 @@ func TestHTTPSDialerStaticPolicy(t *testing.T) {
 			}
 
 			tactics := policy.LookupTactics(ctx, "www.example.com", "443")
-			got := []*HTTPSDialerTactic{}
+			got := []*httpsDialerTactic{}
 			for tactic := range tactics {
 				t.Logf("%+v", tactic)
 				got = append(got, tactic)
 			}
 
-			expect := []*HTTPSDialerTactic{{
+			expect := []*httpsDialerTactic{{
 				Address:        "93.184.216.34",
 				InitialDelay:   0,
 				Port:           "443",

--- a/internal/enginenetx/stats_test.go
+++ b/internal/enginenetx/stats_test.go
@@ -56,7 +56,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 			URL:  "https://api.ooni.io/",
 			initialPolicy: func() []byte {
 				p0 := &staticPolicyRoot{
-					DomainEndpoints: map[string][]*HTTPSDialerTactic{
+					DomainEndpoints: map[string][]*httpsDialerTactic{
 						// This policy has a different SNI and VerifyHostname, which gives
 						// us confidence that the stats are using the latter
 						"api.ooni.io:443": {{
@@ -93,7 +93,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 				HistoTLSHandshakeError:    map[string]int64{},
 				HistoTLSVerificationError: map[string]int64{},
 				LastUpdated:               time.Time{},
-				Tactic: &HTTPSDialerTactic{
+				Tactic: &httpsDialerTactic{
 					Address:        "162.55.247.208",
 					InitialDelay:   0,
 					Port:           "443",
@@ -108,7 +108,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 			URL:  "https://api.ooni.io/",
 			initialPolicy: func() []byte {
 				p0 := &staticPolicyRoot{
-					DomainEndpoints: map[string][]*HTTPSDialerTactic{
+					DomainEndpoints: map[string][]*httpsDialerTactic{
 						// This policy has a different SNI and VerifyHostname, which gives
 						// us confidence that the stats are using the latter
 						"api.ooni.io:443": {{
@@ -144,7 +144,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 				},
 				HistoTLSVerificationError: map[string]int64{},
 				LastUpdated:               time.Time{},
-				Tactic: &HTTPSDialerTactic{
+				Tactic: &httpsDialerTactic{
 					Address:        "162.55.247.208",
 					InitialDelay:   0,
 					Port:           "443",
@@ -159,7 +159,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 			URL:  "https://api.ooni.io/",
 			initialPolicy: func() []byte {
 				p0 := &staticPolicyRoot{
-					DomainEndpoints: map[string][]*HTTPSDialerTactic{
+					DomainEndpoints: map[string][]*httpsDialerTactic{
 						// This policy has a different SNI and VerifyHostname, which gives
 						// us confidence that the stats are using the latter
 						"api.ooni.io:443": {{
@@ -192,7 +192,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 					"ssl_invalid_hostname": 1,
 				},
 				LastUpdated: time.Time{},
-				Tactic: &HTTPSDialerTactic{
+				Tactic: &httpsDialerTactic{
 					Address:        "104.154.89.105",
 					InitialDelay:   0,
 					Port:           "443",
@@ -350,7 +350,7 @@ func TestLoadStatsContainer(t *testing.T) {
 									"ssl_invalid_hostname": 1,
 								},
 								LastUpdated: fourtyFiveMinutesAgo,
-								Tactic: &HTTPSDialerTactic{
+								Tactic: &httpsDialerTactic{
 									Address:        "162.55.247.208",
 									InitialDelay:   0,
 									Port:           "443",
@@ -374,7 +374,7 @@ func TestLoadStatsContainer(t *testing.T) {
 									"ssl_invalid_hostname": 1,
 								},
 								LastUpdated: twoWeeksAgo,
-								Tactic: &HTTPSDialerTactic{
+								Tactic: &httpsDialerTactic{
 									Address:        "162.55.247.208",
 									InitialDelay:   0,
 									Port:           "443",
@@ -402,7 +402,7 @@ func TestLoadStatsContainer(t *testing.T) {
 									"ssl_invalid_hostname": 1,
 								},
 								LastUpdated: twoWeeksAgo,
-								Tactic: &HTTPSDialerTactic{
+								Tactic: &httpsDialerTactic{
 									Address:        "162.55.247.208",
 									InitialDelay:   0,
 									Port:           "443",
@@ -438,7 +438,7 @@ func TestLoadStatsContainer(t *testing.T) {
 								"ssl_invalid_hostname": 1,
 							},
 							LastUpdated: fourtyFiveMinutesAgo,
-							Tactic: &HTTPSDialerTactic{
+							Tactic: &httpsDialerTactic{
 								Address:        "162.55.247.208",
 								InitialDelay:   0,
 								Port:           "443",
@@ -510,7 +510,7 @@ func TestStatsManagerCallbacks(t *testing.T) {
 							"162.55.247.208:443 sni=www.example.com verify=api.ooni.io": {
 								CountStarted: 1,
 								LastUpdated:  fourtyFiveMinutesAgo,
-								Tactic:       &HTTPSDialerTactic{}, // only required for cloning
+								Tactic:       &httpsDialerTactic{}, // only required for cloning
 							},
 						},
 					},
@@ -521,7 +521,7 @@ func TestStatsManagerCallbacks(t *testing.T) {
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel() // immediately!
 
-				tactic := &HTTPSDialerTactic{
+				tactic := &httpsDialerTactic{
 					Address:        "162.55.247.208",
 					InitialDelay:   0,
 					Port:           "443",
@@ -540,7 +540,7 @@ func TestStatsManagerCallbacks(t *testing.T) {
 							"162.55.247.208:443 sni=www.example.com verify=api.ooni.io": {
 								CountStarted:             1,
 								CountTCPConnectInterrupt: 1,
-								Tactic:                   &HTTPSDialerTactic{},
+								Tactic:                   &httpsDialerTactic{},
 							},
 						},
 					},
@@ -559,7 +559,7 @@ func TestStatsManagerCallbacks(t *testing.T) {
 			do: func(stats *statsManager) {
 				ctx := context.Background()
 
-				tactic := &HTTPSDialerTactic{
+				tactic := &httpsDialerTactic{
 					Address:        "162.55.247.208",
 					InitialDelay:   0,
 					Port:           "443",
@@ -587,7 +587,7 @@ func TestStatsManagerCallbacks(t *testing.T) {
 							"162.55.247.208:443 sni=www.example.com verify=api.ooni.io": {
 								CountStarted: 1,
 								LastUpdated:  fourtyFiveMinutesAgo,
-								Tactic:       &HTTPSDialerTactic{}, // only for cloning
+								Tactic:       &httpsDialerTactic{}, // only for cloning
 							},
 						},
 					},
@@ -598,7 +598,7 @@ func TestStatsManagerCallbacks(t *testing.T) {
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel() // immediately!
 
-				tactic := &HTTPSDialerTactic{
+				tactic := &httpsDialerTactic{
 					Address:        "162.55.247.208",
 					InitialDelay:   0,
 					Port:           "443",
@@ -617,7 +617,7 @@ func TestStatsManagerCallbacks(t *testing.T) {
 							"162.55.247.208:443 sni=www.example.com verify=api.ooni.io": {
 								CountStarted:               1,
 								CountTLSHandshakeInterrupt: 1,
-								Tactic:                     &HTTPSDialerTactic{},
+								Tactic:                     &httpsDialerTactic{},
 							},
 						},
 					},
@@ -636,7 +636,7 @@ func TestStatsManagerCallbacks(t *testing.T) {
 			do: func(stats *statsManager) {
 				ctx := context.Background()
 
-				tactic := &HTTPSDialerTactic{
+				tactic := &httpsDialerTactic{
 					Address:        "162.55.247.208",
 					InitialDelay:   0,
 					Port:           "443",
@@ -662,7 +662,7 @@ func TestStatsManagerCallbacks(t *testing.T) {
 				Version:         statsContainerVersion,
 			},
 			do: func(stats *statsManager) {
-				tactic := &HTTPSDialerTactic{
+				tactic := &httpsDialerTactic{
 					Address:        "162.55.247.208",
 					InitialDelay:   0,
 					Port:           "443",
@@ -688,7 +688,7 @@ func TestStatsManagerCallbacks(t *testing.T) {
 				Version:         statsContainerVersion,
 			},
 			do: func(stats *statsManager) {
-				tactic := &HTTPSDialerTactic{
+				tactic := &httpsDialerTactic{
 					Address:        "162.55.247.208",
 					InitialDelay:   0,
 					Port:           "443",


### PR DESCRIPTION
What needs to be public is the network API, while all the rest can and should instead be private.

Part of https://github.com/ooni/probe/issues/2531
