### PR TITLE
feat(enginenetx): enable the stats-based policy

### DIFF
--- a/internal/enginenetx/network.go
+++ b/internal/enginenetx/network.go
@@ -96,7 +96,7 @@ func NewNetwork(
 	httpsDialer := newHTTPSDialer(
 		logger,
 		&netxlite.Netx{Underlying: nil}, // nil means using netxlite's singleton
-		newHTTPSDialerPolicy(kvStore, logger, resolver),
+		newHTTPSDialerPolicy(kvStore, logger, resolver, stats),
 		stats,
 	)
 
@@ -139,10 +139,16 @@ func NewNetwork(
 }
 
 // newHTTPSDialerPolicy contains the logic to select the [HTTPSDialerPolicy] to use.
-func newHTTPSDialerPolicy(kvStore model.KeyValueStore, logger model.Logger, resolver model.Resolver) httpsDialerPolicy {
+func newHTTPSDialerPolicy(
+	kvStore model.KeyValueStore,
+	logger model.Logger,
+	resolver model.Resolver,
+	stats *statsManager,
+) httpsDialerPolicy {
 	// create a composed fallback TLS dialer policy
-	fallback := &beaconsPolicy{
-		Fallback: &dnsPolicy{logger, resolver},
+	fallback := &statsPolicy{
+		Fallback: &beaconsPolicy{Fallback: &dnsPolicy{logger, resolver}},
+		Stats:    stats,
 	}
 
 	// make sure we honor a user-provided policy

--- a/internal/enginenetx/statspolicy.go
+++ b/internal/enginenetx/statspolicy.go
@@ -65,7 +65,10 @@ func (p *statsPolicy) LookupTactics(ctx context.Context, domain string, port str
 }
 
 func (p *statsPolicy) statsLookupTactics(domain string, port string) (out []*httpsDialerTactic) {
-	tactics := p.Stats.LookupTactics(domain, port)
+	tactics, good := p.Stats.LookupTactics(domain, port)
+	if !good {
+		return
+	}
 
 	successRate := func(t *statsTactic) (rate float64) {
 		if t.CountStarted > 0 {


### PR DESCRIPTION
This commit modifies the https-dialer policy we create to take into account stats to generate tactics. As of this commit, the overall policy is as follows:

1. if `$OONI_HOME/$engine_dir/httpsdialerstatic.conf` exists and contains entries for the endpoint's domain (e.g., "www.example.com:443"), then we unconditionally use it to generate tactics, otherwise;

2. we generate tactics using existing stats and filter only the tactics that are less than one week old (filtering done when loading from the kvstore) and have worked at least once, otherwise;

3. we generate tactics using known beacons and candidate SNIs with the extra caveat that we're not going to generate a tactic we have generate already in the previous step, otherwise;

4. we use whatever resolver is configured to lookup for the domain name and generate tactics doing the boring thing of using the resolved IP addrs along with the SNI being equal to the original domain.

Note that this diff fixes a previously untested for bug caused by trying to obtain statistics for an unknow endpoint domain.

Part of https://github.com/ooni/probe/issues/2531
