### PR TITLE
chore(enginenetx): more tests and robustness checks

### DIFF
--- a/internal/enginenetx/beaconspolicy.go
+++ b/internal/enginenetx/beaconspolicy.go
@@ -33,7 +33,7 @@ func (p *beaconsPolicy) LookupTactics(ctx context.Context, domain, port string) 
 		defer close(out) // tell the parent when we're done
 		index := 0
 
-		// emit beacons related tactics first which is empty if there are
+		// emit beacons related tactics first which are empty if there are
 		// no beacons for the givend domain and port
 		for tx := range p.tacticsForDomain(domain, port) {
 			tx.InitialDelay = happyEyeballsDelay(index)
@@ -42,7 +42,7 @@ func (p *beaconsPolicy) LookupTactics(ctx context.Context, domain, port string) 
 		}
 
 		// now fallback to get more tactics (typically here the fallback
-		// uses the DNS and obtains some extra tactic)
+		// uses the DNS and obtains some extra tactics)
 		for tx := range p.Fallback.LookupTactics(ctx, domain, port) {
 			tx.InitialDelay = happyEyeballsDelay(index)
 			index += 1

--- a/internal/enginenetx/beaconspolicy.go
+++ b/internal/enginenetx/beaconspolicy.go
@@ -30,17 +30,19 @@ func (p *beaconsPolicy) LookupTactics(ctx context.Context, domain, port string) 
 	out := make(chan *httpsDialerTactic)
 
 	go func() {
-		defer close(out)
+		defer close(out) // tell the parent when we're done
 		index := 0
 
-		// emit beacons related tactics first
+		// emit beacons related tactics first which is empty if there are
+		// no beacons for the givend domain and port
 		for tx := range p.tacticsForDomain(domain, port) {
 			tx.InitialDelay = happyEyeballsDelay(index)
 			index += 1
 			out <- tx
 		}
 
-		// now emit tactics using the DNS
+		// now fallback to get more tactics (typically here the fallback
+		// uses the DNS and obtains some extra tactic)
 		for tx := range p.Fallback.LookupTactics(ctx, domain, port) {
 			tx.InitialDelay = happyEyeballsDelay(index)
 			index += 1
@@ -55,7 +57,7 @@ func (p *beaconsPolicy) tacticsForDomain(domain, port string) <-chan *httpsDiale
 	out := make(chan *httpsDialerTactic)
 
 	go func() {
-		defer close(out)
+		defer close(out) // tell the parent when we're done
 
 		// we currently only have beacons for api.ooni.io
 		if domain != "api.ooni.io" {
@@ -68,9 +70,7 @@ func (p *beaconsPolicy) tacticsForDomain(domain, port string) <-chan *httpsDiale
 			snis[i], snis[j] = snis[j], snis[i]
 		})
 
-		ipAddrs := p.beaconsAddrs()
-
-		for _, ipAddr := range ipAddrs {
+		for _, ipAddr := range p.beaconsAddrs() {
 			for _, sni := range snis {
 				out <- &httpsDialerTactic{
 					Address:        ipAddr,

--- a/internal/enginenetx/dnspolicy.go
+++ b/internal/enginenetx/dnspolicy.go
@@ -35,6 +35,7 @@ func (p *dnsPolicy) LookupTactics(
 
 	go func() {
 		// make sure we close the output channel when done
+		// so the reader knows that we're done
 		defer close(out)
 
 		// Do not even start the DNS lookup if the context has already been canceled, which
@@ -54,6 +55,7 @@ func (p *dnsPolicy) LookupTactics(
 			return
 		}
 
+		// The tactics we generate here have SNI == VerifyHostname == domain
 		for idx, addr := range addrs {
 			tactic := &httpsDialerTactic{
 				Address:        addr,

--- a/internal/enginenetx/httpsdialer.go
+++ b/internal/enginenetx/httpsdialer.go
@@ -83,7 +83,7 @@ func (dt *httpsDialerTactic) tacticSummaryKey() string {
 
 // domainEndpointKey returns a string consisting of the domain endpoint only.
 //
-// We always use the VerifyHostname to construct the domain endpoint.
+// We always use the VerifyHostname and the Port to construct the domain endpoint.
 func (dt *httpsDialerTactic) domainEndpointKey() string {
 	return net.JoinHostPort(dt.VerifyHostname, dt.Port)
 }
@@ -286,7 +286,7 @@ func (hd *httpsDialer) worker(
 		// perform the actual dial
 		conn, err := hd.dialTLS(ctx, prefixLogger, t0, tactic)
 
-		// send result to the parent
+		// send results to the parent
 		writer <- &httpsDialerErrorOrConn{Conn: conn, Err: err}
 	}
 }

--- a/internal/enginenetx/httpsdialer.go
+++ b/internal/enginenetx/httpsdialer.go
@@ -55,8 +55,7 @@ func (dt *httpsDialerTactic) String() string {
 	return string(runtimex.Try1(json.Marshal(dt)))
 }
 
-// tacticSummaryKey returns a string summarizing this [httpsDialerTactic] for
-// the specific purpose of inserting the struct into a map.
+// tacticSummaryKey returns a string summarizing the tactic's features.
 //
 // The fields used to compute the summary are:
 //
@@ -68,33 +67,45 @@ func (dt *httpsDialerTactic) String() string {
 //
 // - VerifyHostname
 //
-// The returned string contains the above fields separated by space.
+// The returned string contains the above fields separated by space with
+// `sni=` before the SNI and `verify=` before the verify hostname.
+//
+// We should be careful not to change this format unless we also change the
+// format version used by static policies and by the state management.
 func (dt *httpsDialerTactic) tacticSummaryKey() string {
-	return fmt.Sprintf("%v sni=%v verify=%v", net.JoinHostPort(dt.Address, dt.Port), dt.SNI, dt.VerifyHostname)
+	return fmt.Sprintf(
+		"%v sni=%v verify=%v",
+		net.JoinHostPort(dt.Address, dt.Port),
+		dt.SNI,
+		dt.VerifyHostname,
+	)
 }
 
-// domainEndpointKey returns the domain's endpoint string key for storing into a map.
+// domainEndpointKey returns a string consisting of the domain endpoint only.
+//
+// We always use the VerifyHostname to construct the domain endpoint.
 func (dt *httpsDialerTactic) domainEndpointKey() string {
 	return net.JoinHostPort(dt.VerifyHostname, dt.Port)
 }
 
-// httpsDialerPolicy describes the policy used by the [*httpsDialer].
+// httpsDialerPolicy is a policy used by the [*httpsDialer].
 type httpsDialerPolicy interface {
-	// LookupTactics returns zero or more tactics for the given host and port.
+	// LookupTactics emits zero or more tactics for the given host and port
+	// through the returned channel, which is closed when done.
 	LookupTactics(ctx context.Context, domain, port string) <-chan *httpsDialerTactic
 }
 
-// httpsDialerStatsTracker tracks what happens while dialing TLS connections.
-type httpsDialerStatsTracker interface {
+// httpsDialerEventsHandler handles events occurring while we try dialing TLS.
+type httpsDialerEventsHandler interface {
 	// These callbacks are invoked during the TLS handshake to inform this
-	// tactic about events that occurred. A tactic SHOULD keep track of which
+	// interface about events that occurred. A policy SHOULD keep track of which
 	// addresses, SNIs, etc. work and return them more frequently.
 	//
 	// Callbacks that take an error as argument also take a context as
 	// argument and MUST check whether the context has been canceled or
 	// its timeout has expired (i.e., using ctx.Err()) to determine
 	// whether the operation failed or was merely canceled. In the latter
-	// case, obviously, the policy MUST NOT consider the tactic failed.
+	// case, obviously, you MUST NOT consider the tactic failed.
 	OnStarting(tactic *httpsDialerTactic)
 	OnTCPConnectError(ctx context.Context, tactic *httpsDialerTactic, err error)
 	OnTLSHandshakeError(ctx context.Context, tactic *httpsDialerTactic, err error)
@@ -125,7 +136,7 @@ type httpsDialer struct {
 	rootCAs *x509.CertPool
 
 	// stats tracks what happens while dialing.
-	stats httpsDialerStatsTracker
+	stats httpsDialerEventsHandler
 }
 
 // newHTTPSDialer constructs a new [*httpsDialer] instance.
@@ -146,7 +157,7 @@ func newHTTPSDialer(
 	logger model.Logger,
 	netx *netxlite.Netx,
 	policy httpsDialerPolicy,
-	stats httpsDialerStatsTracker,
+	stats httpsDialerEventsHandler,
 ) *httpsDialer {
 	return &httpsDialer{
 		idGenerator: &atomic.Int64{},
@@ -196,8 +207,8 @@ func (hd *httpsDialer) DialTLSContext(ctx context.Context, network string, endpo
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// The emitter will emit tactics and then close the channel when done. We spawn 1+ workers
-	// that handle tactics in paralellel and posts on the collector channel.
+	// The emitter will emit tactics and then close the channel when done. We spawn 16 workers
+	// that handle tactics in parallel and post results on the collector channel.
 	emitter := hd.policy.LookupTactics(ctx, hostname, port)
 	collector := make(chan *httpsDialerErrorOrConn)
 	joiner := make(chan any)
@@ -252,8 +263,10 @@ func httpsDialerReduceResult(connv []model.TLSConn, errorv []error) (model.TLSCo
 	}
 }
 
-// worker attempts to establish a TLS connection using and emits a single
-// [*httpsDialerErrorOrConn] for each tactic.
+// worker attempts to establish a TLS connection and emits the result using
+// a [*httpsDialerErrorOrConn] for each tactic, until there are no more tactics
+// and the reader channel is closed. At which point it posts on joiner to let
+// the parent know that this goroutine has done its job.
 func (hd *httpsDialer) worker(
 	ctx context.Context,
 	joiner chan<- any,
@@ -270,8 +283,10 @@ func (hd *httpsDialer) worker(
 			Logger: hd.logger,
 		}
 
+		// perform the actual dial
 		conn, err := hd.dialTLS(ctx, prefixLogger, t0, tactic)
 
+		// send result to the parent
 		writer <- &httpsDialerErrorOrConn{Conn: conn, Err: err}
 	}
 }
@@ -283,12 +298,12 @@ func (hd *httpsDialer) dialTLS(
 	t0 time.Time,
 	tactic *httpsDialerTactic,
 ) (model.TLSConn, error) {
-	// wait for the tactic to be ready to run
+	// honor happy-eyeballs delays and wait for the tactic to be ready to run
 	if err := httpsDialerTacticWaitReady(ctx, t0, tactic); err != nil {
 		return nil, err
 	}
 
-	// tell the tactic that we're starting
+	// tell the observer that we're starting
 	hd.stats.OnStarting(tactic)
 
 	// create dialer and establish TCP connection
@@ -306,7 +321,7 @@ func (hd *httpsDialer) dialTLS(
 
 	// create TLS configuration
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: true, // Note: we're going to verify at the end of the func
+		InsecureSkipVerify: true, // Note: we're going to verify at the end of the func!
 		NextProtos:         []string{"h2", "http/1.1"},
 		RootCAs:            hd.rootCAs,
 		ServerName:         tactic.SNI,
@@ -343,7 +358,7 @@ func (hd *httpsDialer) dialTLS(
 		return nil, err
 	}
 
-	// make sure the tactic know it worked
+	// make sure the observer knows it worked
 	hd.stats.OnSuccess(tactic)
 
 	return tlsConn, nil

--- a/internal/enginenetx/network.go
+++ b/internal/enginenetx/network.go
@@ -18,18 +18,20 @@ import (
 )
 
 // Network is the network abstraction used by the OONI engine.
+//
+// The zero value is invalid; construct using the [NewNetwork] func.
 type Network struct {
 	reso  model.Resolver
 	stats *statsManager
 	txp   model.HTTPTransport
 }
 
-// HTTPTransport returns the [model.HTTPTransport] that the engine should use.
+// HTTPTransport returns the underlying [model.HTTPTransport].
 func (n *Network) HTTPTransport() model.HTTPTransport {
 	return n.txp
 }
 
-// NewHTTPClient is a convenience function for building a [model.HTTPClient] using
+// NewHTTPClient is a convenience function for building an [*http.Client] using
 // the underlying [model.HTTPTransport] and the correct cookies configuration.
 func (n *Network) NewHTTPClient() *http.Client {
 	// Note: cookiejar.New cannot fail, so we're using runtimex.Try1 here
@@ -43,7 +45,8 @@ func (n *Network) NewHTTPClient() *http.Client {
 
 // Close ensures that we close idle connections and persist statistics.
 func (n *Network) Close() error {
-	// TODO(bassosimone): do we want to introduce "once" semantics in this method?
+	// TODO(bassosimone): do we want to introduce "once" semantics in this method? It
+	// does not seem necessary since there's no resource we can close just once.
 
 	// make sure we close the transport's idle connections
 	n.txp.CloseIdleConnections()
@@ -63,7 +66,7 @@ func (n *Network) Close() error {
 //
 // Arguments:
 //
-// - counter is the [*bytecounter.Counter] to use.
+// - counter is the [*bytecounter.Counter] to use;
 //
 // - kvStore is a [model.KeyValueStore] for persisting stats;
 //
@@ -73,7 +76,7 @@ func (n *Network) Close() error {
 //
 // - resolver is the [model.Resolver] to use.
 //
-// The presence of the proxyURL will cause this function to possibly build a
+// The presence of the proxyURL MAY cause this function to possibly build a
 // network with different behavior with respect to circumvention. If there is
 // an upstream proxy we're going to trust it is doing circumvention for us.
 func NewNetwork(
@@ -90,6 +93,9 @@ func NewNetwork(
 
 	// Create manager for keeping track of statistics
 	stats := newStatsManager(kvStore, logger)
+
+	// TODO(bassosimone): the documentation says we MAY avoid specific policies
+	// when using a proxy, should we actually implement that?
 
 	// Create a TLS dialer ONLY used for dialing TLS connections. This dialer will use
 	// happy-eyeballs and possibly custom policies for dialing TLS connections.

--- a/internal/enginenetx/staticpolicy.go
+++ b/internal/enginenetx/staticpolicy.go
@@ -90,7 +90,7 @@ var _ httpsDialerPolicy = &staticPolicy{}
 // LookupTactics implements httpsDialerPolicy.
 func (ldp *staticPolicy) LookupTactics(
 	ctx context.Context, domain string, port string) <-chan *httpsDialerTactic {
-	// check whether an entry exists in the user-provided map
+	// check whether an entry exists in the user-provided map, which MAY be nil
 	tactics, found := ldp.Root.DomainEndpoints[net.JoinHostPort(domain, port)]
 	if !found {
 		return ldp.Fallback.LookupTactics(ctx, domain, port)

--- a/internal/enginenetx/staticpolicy.go
+++ b/internal/enginenetx/staticpolicy.go
@@ -91,8 +91,16 @@ var _ httpsDialerPolicy = &staticPolicy{}
 func (ldp *staticPolicy) LookupTactics(
 	ctx context.Context, domain string, port string) <-chan *httpsDialerTactic {
 	// check whether an entry exists in the user-provided map, which MAY be nil
+	// if/when the user has chosen the static policy to be as such
 	tactics, found := ldp.Root.DomainEndpoints[net.JoinHostPort(domain, port)]
 	if !found {
+		return ldp.Fallback.LookupTactics(ctx, domain, port)
+	}
+
+	// note that we also need to fallback when the tactics contains an empty list
+	// or a list that only contains nil entries
+	tactics = staticPolicyRemoveNilEntries(tactics)
+	if len(tactics) <= 0 {
 		return ldp.Fallback.LookupTactics(ctx, domain, port)
 	}
 
@@ -101,15 +109,17 @@ func (ldp *staticPolicy) LookupTactics(
 	go func() {
 		defer close(out) // let the caller know we're done
 		for _, tactic := range tactics {
-
-			// We read this data from disk, we se cannot exclude the case where a user
-			// provides a file containing an explicitly nil tactic
-			if tactic == nil {
-				continue
-			}
-
 			out <- tactic
 		}
 	}()
 	return out
+}
+
+func staticPolicyRemoveNilEntries(input []*httpsDialerTactic) (output []*httpsDialerTactic) {
+	for _, entry := range input {
+		if entry != nil {
+			output = append(output, entry)
+		}
+	}
+	return
 }

--- a/internal/enginenetx/staticpolicy_test.go
+++ b/internal/enginenetx/staticpolicy_test.go
@@ -65,13 +65,16 @@ func TestStaticPolicy(t *testing.T) {
 			input: (func() []byte {
 				return runtimex.Try1(json.Marshal(&staticPolicyRoot{
 					DomainEndpoints: map[string][]*httpsDialerTactic{
+
+						// Please, note how the input includes explicitly nil entries
+						// with the purpose of making sure the code can handle them
 						"api.ooni.io:443": {{
 							Address:        "162.55.247.208",
 							InitialDelay:   0,
 							Port:           "443",
 							SNI:            "api.ooni.io",
 							VerifyHostname: "api.ooni.io",
-						}, {
+						}, nil, {
 							Address:        "46.101.82.151",
 							InitialDelay:   300 * time.Millisecond,
 							Port:           "443",
@@ -83,7 +86,7 @@ func TestStaticPolicy(t *testing.T) {
 							Port:           "443",
 							SNI:            "api.ooni.io",
 							VerifyHostname: "api.ooni.io",
-						}, {
+						}, nil, {
 							Address:        "46.101.82.151",
 							InitialDelay:   3000 * time.Millisecond,
 							Port:           "443",
@@ -95,7 +98,9 @@ func TestStaticPolicy(t *testing.T) {
 							Port:           "443",
 							SNI:            "www.example.com",
 							VerifyHostname: "api.ooni.io",
-						}},
+						}, nil},
+						//
+
 					},
 					Version: staticPolicyVersion,
 				}))
@@ -111,7 +116,7 @@ func TestStaticPolicy(t *testing.T) {
 							Port:           "443",
 							SNI:            "api.ooni.io",
 							VerifyHostname: "api.ooni.io",
-						}, {
+						}, nil, {
 							Address:        "46.101.82.151",
 							InitialDelay:   300 * time.Millisecond,
 							Port:           "443",
@@ -123,7 +128,7 @@ func TestStaticPolicy(t *testing.T) {
 							Port:           "443",
 							SNI:            "api.ooni.io",
 							VerifyHostname: "api.ooni.io",
-						}, {
+						}, nil, {
 							Address:        "46.101.82.151",
 							InitialDelay:   3000 * time.Millisecond,
 							Port:           "443",
@@ -135,7 +140,7 @@ func TestStaticPolicy(t *testing.T) {
 							Port:           "443",
 							SNI:            "www.example.com",
 							VerifyHostname: "api.ooni.io",
-						}},
+						}, nil},
 					},
 					Version: staticPolicyVersion,
 				},
@@ -182,7 +187,13 @@ func TestStaticPolicy(t *testing.T) {
 		}
 		staticPolicyRoot := &staticPolicyRoot{
 			DomainEndpoints: map[string][]*httpsDialerTactic{
-				"api.ooni.io:443": {expectedTactic},
+				// Note that here we're adding explicitly nil entries
+				// to make sure that the code correctly handles 'em
+				"api.ooni.io:443": {
+					nil,
+					expectedTactic,
+					nil,
+				},
 			},
 			Version: staticPolicyVersion,
 		}

--- a/internal/enginenetx/statspolicy.go
+++ b/internal/enginenetx/statspolicy.go
@@ -104,7 +104,7 @@ func (p *statsPolicy) statsLookupTactics(domain string, port string) (out []*htt
 		// fallback policy to generate new tactics to test
 		//
 		// additionally, as a precautionary and defensive measure, make sure t.Tactic
-		// is nil before adding the real tactic to the return list
+		// is not nil before adding the real tactic to the return list
 		if t.CountSuccess > 0 && t.Tactic != nil {
 			out = append(out, t.Tactic)
 		}

--- a/internal/enginenetx/statspolicy.go
+++ b/internal/enginenetx/statspolicy.go
@@ -32,19 +32,28 @@ func (p *statsPolicy) LookupTactics(ctx context.Context, domain string, port str
 	out := make(chan *httpsDialerTactic)
 
 	go func() {
+		defer close(out) // make sure the parent knows when we're done
 		index := 0
-		defer close(out)
 
-		// make sure we don't emit two equal policy in a single run
+		// useful to make sure we don't emit two equal policy in a single run
 		uniq := make(map[string]int)
 
 		// function that emits a given tactic unless we already emitted it
 		maybeEmitTactic := func(t *httpsDialerTactic) {
+			// as a safety mechanism let's gracefully handle the
+			// case in which the tactic is nil
+			if t == nil {
+				return
+			}
+
+			// handle the case in which we already emitted a policy
 			key := t.tacticSummaryKey()
 			if uniq[key] > 0 {
 				return
 			}
 			uniq[key]++
+
+			// 🚀!!!
 			t.InitialDelay = happyEyeballsDelay(index)
 			index += 1
 			out <- t
@@ -65,11 +74,15 @@ func (p *statsPolicy) LookupTactics(ctx context.Context, domain string, port str
 }
 
 func (p *statsPolicy) statsLookupTactics(domain string, port string) (out []*httpsDialerTactic) {
+
+	// obtain information from the stats--here the result may be false if the
+	// stats do not contain any information about the domain and port
 	tactics, good := p.Stats.LookupTactics(domain, port)
 	if !good {
 		return
 	}
 
+	// successRate is a convenience function for computing the success rate
 	successRate := func(t *statsTactic) (rate float64) {
 		if t.CountStarted > 0 {
 			rate = float64(t.CountSuccess) / float64(t.CountStarted)
@@ -77,10 +90,9 @@ func (p *statsPolicy) statsLookupTactics(domain string, port string) (out []*htt
 		return
 	}
 
+	// Implementation note: the function should implement the "less" semantics
+	// but we want descending sort, so we're using a "more" semantics
 	sort.SliceStable(tactics, func(i, j int) bool {
-		// Implementation note: the function should implement the "less" semantics
-		// but we want descending sort, so we're using a "more" semantics
-		//
 		// TODO(bassosimone): should we also consider the number of samples
 		// we have and how recent a sample is?
 		return successRate(tactics[i]) > successRate(tactics[j])
@@ -90,7 +102,10 @@ func (p *statsPolicy) statsLookupTactics(domain string, port string) (out []*htt
 		// make sure we only include samples with 1+ successes; we don't want this policy
 		// to return what we already know it's not working and it will be the purpose of the
 		// fallback policy to generate new tactics to test
-		if t.CountSuccess > 0 {
+		//
+		// additionally, as a precautionary and defensive measure, make sure t.Tactic
+		// is nil before adding the real tactic to the return list
+		if t.CountSuccess > 0 && t.Tactic != nil {
 			out = append(out, t.Tactic)
 		}
 	}


### PR DESCRIPTION
This diff attempts to improve the code quality of enginenetx by identifying cases where the code could be made to crash with specially written input and adds regress tests and checks to avoid these kind of crashes to happen.

While there, perform a code review and improve comments and naming.

Part of https://github.com/ooni/probe/issues/2531