### PR TITLE
fix(enginenetx): use dns policy with proxy (+renames)

### DIFF
--- a/internal/enginenetx/httpsdialer.go
+++ b/internal/enginenetx/httpsdialer.go
@@ -71,7 +71,7 @@ func (dt *httpsDialerTactic) String() string {
 // `sni=` before the SNI and `verify=` before the verify hostname.
 //
 // We should be careful not to change this format unless we also change the
-// format version used by static policies and by the state management.
+// format version used by user policies and by the state management.
 func (dt *httpsDialerTactic) tacticSummaryKey() string {
 	return fmt.Sprintf(
 		"%v sni=%v verify=%v",

--- a/internal/enginenetx/statsmanager_test.go
+++ b/internal/enginenetx/statsmanager_test.go
@@ -58,7 +58,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 			name: "with TCP connect failure",
 			URL:  "https://api.ooni.io/",
 			initialPolicy: func() []byte {
-				p0 := &staticPolicyRoot{
+				p0 := &userPolicyRoot{
 					DomainEndpoints: map[string][]*httpsDialerTactic{
 						// This policy has a different SNI and VerifyHostname, which gives
 						// us confidence that the stats are using the latter
@@ -70,7 +70,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 							VerifyHostname: "api.ooni.io",
 						}},
 					},
-					Version: staticPolicyVersion,
+					Version: userPolicyVersion,
 				}
 				return runtimex.Try1(json.Marshal(p0))
 			},
@@ -110,7 +110,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 			name: "with TLS handshake failure",
 			URL:  "https://api.ooni.io/",
 			initialPolicy: func() []byte {
-				p0 := &staticPolicyRoot{
+				p0 := &userPolicyRoot{
 					DomainEndpoints: map[string][]*httpsDialerTactic{
 						// This policy has a different SNI and VerifyHostname, which gives
 						// us confidence that the stats are using the latter
@@ -122,7 +122,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 							VerifyHostname: "api.ooni.io",
 						}},
 					},
-					Version: staticPolicyVersion,
+					Version: userPolicyVersion,
 				}
 				return runtimex.Try1(json.Marshal(p0))
 			},
@@ -161,7 +161,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 			name: "with TLS verification failure",
 			URL:  "https://api.ooni.io/",
 			initialPolicy: func() []byte {
-				p0 := &staticPolicyRoot{
+				p0 := &userPolicyRoot{
 					DomainEndpoints: map[string][]*httpsDialerTactic{
 						// This policy has a different SNI and VerifyHostname, which gives
 						// us confidence that the stats are using the latter
@@ -173,7 +173,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 							VerifyHostname: "api.ooni.io",
 						}},
 					},
-					Version: staticPolicyVersion,
+					Version: userPolicyVersion,
 				}
 				return runtimex.Try1(json.Marshal(p0))
 			},
@@ -219,7 +219,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 
 			initialPolicy := tc.initialPolicy()
 			t.Logf("initialPolicy: %s", string(initialPolicy))
-			if err := kvStore.Set(staticPolicyKey, initialPolicy); err != nil {
+			if err := kvStore.Set(userPolicyKey, initialPolicy); err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
This diff modifies how we construct a `*Network` to use a very simple DNS-only policy when using a proxy.

We don't need to try anything fancy when we're using a proxy because we assume the proxy knows how to do circumvention and we don't to get in the proxy way.

While there, recognize that the static policy was named very similarly to the stats policy, so rename the former user policy, such that there is more lexicographical difference.

Part of https://github.com/ooni/probe/issues/2531

