### PR TITLE
fix(enginenetx): gracefully handle more nil cases

### DIFF
--- a/internal/enginenetx/statsmanager.go
+++ b/internal/enginenetx/statsmanager.go
@@ -211,7 +211,7 @@ func statsContainerRemoveOldEntries(input *statsContainer) (output *statsContain
 // At the name implies, this function MUST be called while holding the [*statsManager] mutex.
 func (c *statsContainer) GetStatsTacticLocked(tactic *httpsDialerTactic) (*statsTactic, bool) {
 	domainEpntRecord, found := c.DomainEndpoints[tactic.domainEndpointKey()]
-	if !found {
+	if !found || domainEpntRecord == nil {
 		return nil, false
 	}
 	tacticRecord, found := domainEpntRecord.Tactics[tactic.tacticSummaryKey()]

--- a/internal/enginenetx/statsmanager_test.go
+++ b/internal/enginenetx/statsmanager_test.go
@@ -1016,3 +1016,30 @@ func TestStatsSafeIncrementMapStringInt64(t *testing.T) {
 		}
 	})
 }
+
+func TestStatsContainer(t *testing.T) {
+	t.Run("GetStatsTacticLocked", func(t *testing.T) {
+		t.Run("is robust with respect to c.DomainEndpoints containing a nil entry", func(t *testing.T) {
+			sc := &statsContainer{
+				DomainEndpoints: map[string]*statsDomainEndpoint{
+					"api.ooni.io:443": nil,
+				},
+				Version: statsContainerVersion,
+			}
+			tactic := &httpsDialerTactic{
+				Address:        "162.55.247.208",
+				InitialDelay:   0,
+				Port:           "443",
+				SNI:            "www.example.com",
+				VerifyHostname: "api.ooni.io",
+			}
+			record, good := sc.GetStatsTacticLocked(tactic)
+			if good {
+				t.Fatal("expected not good")
+			}
+			if record != nil {
+				t.Fatal("expected nil")
+			}
+		})
+	})
+}

--- a/internal/enginenetx/statspolicy_test.go
+++ b/internal/enginenetx/statspolicy_test.go
@@ -317,14 +317,14 @@ func (p *mocksPolicy) LookupTactics(ctx context.Context, domain string, port str
 }
 
 func TestStatsPolicyPostProcessTactics(t *testing.T) {
-	t.Run("we do nothing when bool is false", func(t *testing.T) {
+	t.Run("we do nothing when good is false", func(t *testing.T) {
 		tactics := statsPolicyPostProcessTactics(nil, false)
 		if len(tactics) != 0 {
 			t.Fatal("expected zero-lenght return value")
 		}
 	})
 
-	t.Run("we filter out cases in which a .Tactic field is nil", func(t *testing.T) {
+	t.Run("we filter out cases in which t or t.Tactic are nil", func(t *testing.T) {
 		expected := &statsTactic{}
 		ff := &testingx.FakeFiller{}
 		ff.Fill(&expected)


### PR DESCRIPTION
This diff adjusts code inside the enginenetx package such that we gracefully deal with nil values in more cases.

Part of https://github.com/ooni/probe/issues/2531
