### PR TITLE
fix(enginenetx): periodically trim statistics

### DIFF
--- a/internal/enginenetx/network.go
+++ b/internal/enginenetx/network.go
@@ -55,7 +55,7 @@ func (n *Network) Close() error {
 	// same as above but for the resolver's connections
 	n.reso.CloseIdleConnections()
 
-	// make sure we sync stats to disk
+	// make sure we sync stats to disk and shutdown the background trimmer
 	return n.stats.Close()
 }
 

--- a/internal/enginenetx/network.go
+++ b/internal/enginenetx/network.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/bytecounter"
 	"github.com/ooni/probe-cli/v3/internal/model"
@@ -92,7 +93,8 @@ func NewNetwork(
 	dialer := netxlite.NewDialerWithResolver(logger, resolver)
 
 	// Create manager for keeping track of statistics
-	stats := newStatsManager(kvStore, logger)
+	const trimInterval = 30 * time.Second
+	stats := newStatsManager(kvStore, logger, trimInterval)
 
 	// Create a TLS dialer ONLY used for dialing TLS connections. This dialer will use
 	// happy-eyeballs and possibly custom policies for dialing TLS connections.

--- a/internal/enginenetx/network_internal_test.go
+++ b/internal/enginenetx/network_internal_test.go
@@ -88,7 +88,7 @@ func TestNetworkUnit(t *testing.T) {
 		}
 	})
 
-	t.Run("Close calls the .cancel field of the statsManager", func(t *testing.T) {
+	t.Run("Close calls the .cancel field of the statsManager as a side effect", func(t *testing.T) {
 		var called bool
 		netx := &Network{
 			reso: &mocks.Resolver{

--- a/internal/enginenetx/network_internal_test.go
+++ b/internal/enginenetx/network_internal_test.go
@@ -43,10 +43,13 @@ func TestNetworkUnit(t *testing.T) {
 			},
 			stats: &statsManager{
 				cancel:    func() { /* nothing */ },
+				closeOnce: sync.Once{},
 				container: &statsContainer{},
 				kvStore:   &kvstore.Memory{},
 				logger:    model.DiscardLogger,
 				mu:        sync.Mutex{},
+				pruned:    make(chan any),
+				wg:        &sync.WaitGroup{},
 			},
 			txp: expected,
 		}
@@ -69,10 +72,13 @@ func TestNetworkUnit(t *testing.T) {
 			reso: expected,
 			stats: &statsManager{
 				cancel:    func() { /* nothing */ },
+				closeOnce: sync.Once{},
 				container: &statsContainer{},
 				kvStore:   &kvstore.Memory{},
 				logger:    model.DiscardLogger,
 				mu:        sync.Mutex{},
+				pruned:    make(chan any),
+				wg:        &sync.WaitGroup{},
 			},
 			txp: &mocks.HTTPTransport{
 				MockCloseIdleConnections: func() {
@@ -100,10 +106,13 @@ func TestNetworkUnit(t *testing.T) {
 				cancel: func() {
 					called = true
 				},
+				closeOnce: sync.Once{},
 				container: &statsContainer{},
 				kvStore:   &kvstore.Memory{},
 				logger:    model.DiscardLogger,
 				mu:        sync.Mutex{},
+				pruned:    make(chan any),
+				wg:        &sync.WaitGroup{},
 			},
 			txp: &mocks.HTTPTransport{
 				MockCloseIdleConnections: func() {

--- a/internal/enginenetx/statsmanager.go
+++ b/internal/enginenetx/statsmanager.go
@@ -89,10 +89,10 @@ type statsTactic struct {
 }
 
 // statsNilSafeSuccessRate is a convenience function for computing the success rate
-// which returns zero as the success rate if CountStarted is zero
+// which returns zero as the success rate if CountStarted is zero.
 //
-// for robustness, be paranoid about nils here because the stats are
-// written on the disk and a user could potentially edit them
+// For robustness, be paranoid about nils here because the stats are
+// written on the disk and a user could potentially edit them.
 func statsNilSafeSuccessRate(t *statsTactic) (rate float64) {
 	if t != nil && t.CountStarted > 0 {
 		rate = float64(t.CountSuccess) / float64(t.CountStarted)
@@ -379,10 +379,10 @@ type statsManager struct {
 	mu sync.Mutex
 
 	// pruned is a channel pruned on a best effort basis
-	// by the background goroutine that prunes
+	// by the background goroutine that prunes.
 	pruned chan any
 
-	// wg tells us when the background goroutine joined
+	// wg tells us when the background goroutine joined.
 	wg *sync.WaitGroup
 }
 
@@ -629,7 +629,7 @@ func (mt *statsManager) trim(ctx context.Context, interval time.Duration) {
 			mt.mu.Unlock()
 
 			// notify whoever's concerned that we pruned
-			// on a best effort basis
+			// and do that best effort because it may be that nobody is concerned
 			select {
 			case mt.pruned <- true:
 			default:

--- a/internal/enginenetx/statsmanager.go
+++ b/internal/enginenetx/statsmanager.go
@@ -149,10 +149,10 @@ func statsDefensivelySortTacticsByDescendingSuccessRateWithAcceptPredicate(
 		if statsNilSafeSuccessRate(work[i]) > statsNilSafeSuccessRate(work[j]) {
 			return true
 		}
-		if statsNilSafeLastUpdated(work[i]).Sub(statsNilSafeLastUpdated(work[j])) > 0 {
+		if statsNilSafeCountSuccess(work[i]) > statsNilSafeCountSuccess(work[j]) {
 			return true
 		}
-		if statsNilSafeCountSuccess(work[i]) > statsNilSafeCountSuccess(work[j]) {
+		if statsNilSafeLastUpdated(work[i]).Sub(statsNilSafeLastUpdated(work[j])) > 0 {
 			return true
 		}
 		return false

--- a/internal/enginenetx/statsmanager.go
+++ b/internal/enginenetx/statsmanager.go
@@ -243,8 +243,8 @@ func statsDomainEndpointPruneEntries(input *statsDomainEndpoint) *statsDomainEnd
 	// a given threshold. Note that we need to be defensive here because we are dealing
 	// with data stored on disk that might have been modified to crash us.
 	//
-	// Note that statsDefensivelySortTacticsByDescendingSuccessRateWithPredicate operates
-	// and returns a DEEP COPY of the original list.
+	// Note that statsDefensivelySortTacticsByDescendingSuccessRateWithAcceptPredicate
+	// operates on and returns a DEEP COPY of the original list.
 	tactics = statsDefensivelySortTacticsByDescendingSuccessRateWithAcceptPredicate(tactics, func(st *statsTactic) bool {
 		// When .LastUpdated is the zero time.Time value, the check is going to fail
 		// exactly like the time was 1 or 5 or 10 years ago instead.

--- a/internal/enginenetx/statsmanager.go
+++ b/internal/enginenetx/statsmanager.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sort"
 	"sync"
 	"time"
 
@@ -87,6 +88,85 @@ type statsTactic struct {
 	Tactic *httpsDialerTactic
 }
 
+// statsNilSafeSuccessRate is a convenience function for computing the success rate
+// which returns zero as the success rate if CountStarted is zero
+//
+// for robustness, be paranoid about nils here because the stats are
+// written on the disk and a user could potentially edit them
+func statsNilSafeSuccessRate(t *statsTactic) (rate float64) {
+	if t != nil && t.CountStarted > 0 {
+		rate = float64(t.CountSuccess) / float64(t.CountStarted)
+	}
+	return
+}
+
+// statsNilSafeLastUpdated is a convenience function for getting the .LastUpdated
+// field that takes into account the case where t is nil.
+func statsNilSafeLastUpdated(t *statsTactic) (output time.Time) {
+	if t != nil {
+		output = t.LastUpdated
+	}
+	return
+}
+
+// statsNilSafeCountSuccess is a convenience function for getting the .CountSuccess
+// counter that takes into account the case where t is nil.
+func statsNilSafeCountSuccess(t *statsTactic) (output int64) {
+	if t != nil {
+		output = t.CountSuccess
+	}
+	return
+}
+
+// statsDefensivelySortTacticsByDescendingSuccessRateWithAcceptPredicate sorts the input list
+// by success rate taking into account that several entries could be malformed, and then
+// filters the sorted list using the given boolean predicate to accept elements.
+//
+// The sorting criteria takes into account:
+//
+// 1. the success rate; or
+//
+// 2. the last updated time; or
+//
+// 3. the number of successes.
+//
+// The predicate allows to further restrict the returned list.
+//
+// This function operates on a deep copy of the input list, so it does not create data races.
+func statsDefensivelySortTacticsByDescendingSuccessRateWithAcceptPredicate(
+	input []*statsTactic, acceptp func(*statsTactic) bool) (output []*statsTactic) {
+	// first let's create a working list such that we don't modify
+	// the input in place thus avoiding any data race
+	work := []*statsTactic{}
+	for _, t := range input {
+		if t != nil && t.Tactic != nil {
+			work = append(work, t.Clone()) // DEEP COPY!
+		}
+	}
+
+	// now let's sort work in place
+	sort.SliceStable(work, func(i, j int) bool {
+		if statsNilSafeSuccessRate(work[i]) > statsNilSafeSuccessRate(work[j]) {
+			return true
+		}
+		if statsNilSafeLastUpdated(work[i]).Sub(statsNilSafeLastUpdated(work[j])) > 0 {
+			return true
+		}
+		if statsNilSafeCountSuccess(work[i]) > statsNilSafeCountSuccess(work[j]) {
+			return true
+		}
+		return false
+	})
+
+	// finally let's apply the predicate to produce output
+	for _, t := range work {
+		if acceptp(t) {
+			output = append(output, t)
+		}
+	}
+	return
+}
+
 func statsMaybeCloneMapStringInt64(input map[string]int64) (output map[string]int64) {
 	// distinguish and preserve nil versus empty
 	if input == nil {
@@ -135,35 +215,59 @@ type statsDomainEndpoint struct {
 	Tactics map[string]*statsTactic
 }
 
-// statsDomainEndpointRemoveOldEntries returns a copy of a [*statsDomainEndpoint] with old entries removed.
-func statsDomainEndpointRemoveOldEntries(input *statsDomainEndpoint) (output *statsDomainEndpoint) {
-	output = &statsDomainEndpoint{
-		Tactics: map[string]*statsTactic{},
-	}
-	oneWeek := 7 * 24 * time.Hour
+// statsDomainEndpointPruneEntries returns a copy of a [*statsDomainEndpoint] with old
+// and excess entries removed, such that the overall size is not unbounded.
+func statsDomainEndpointPruneEntries(input *statsDomainEndpoint) *statsDomainEndpoint {
+	tactics := []*statsTactic{}
 	now := time.Now()
 
 	// if .Tactics is empty here we're just going to do nothing
 	for summary, tactic := range input.Tactics {
-
 		// we serialize stats to disk, so we cannot rule out the case where the user
 		// explicitly edits the stats to include a malformed entry
-		if tactic == nil || tactic.Tactic == nil {
+		if summary == "" || tactic == nil || tactic.Tactic == nil {
 			continue
 		}
+		tactics = append(tactics, tactic)
+	}
 
+	// oneWeek is a constant representing one week of data.
+	const oneWeek = 7 * 24 * time.Hour
+
+	// maxEntriesPerDomainEndpoint is the maximum number of entries per
+	// domain endpoint that we would like to keep overall.
+	const maxEntriesPerDomainEndpoint = 10
+
+	// Sort by descending success rate and cut all the entries that are older than
+	// a given threshold. Note that we need to be defensive here because we are dealing
+	// with data stored on disk that might have been modified to crash us.
+	//
+	// Note that statsDefensivelySortTacticsByDescendingSuccessRateWithPredicate operates
+	// and returns a DEEP COPY of the original list.
+	tactics = statsDefensivelySortTacticsByDescendingSuccessRateWithAcceptPredicate(tactics, func(st *statsTactic) bool {
 		// When .LastUpdated is the zero time.Time value, the check is going to fail
 		// exactly like the time was 1 or 5 or 10 years ago instead.
 		//
 		// See https://go.dev/play/p/HGQT17ueIkq where we show that the zero time
 		// is handled exactly like any time in the past (it was kinda obvious, but
 		// sometimes it also make sense to double check assumptions!)
-		if delta := now.Sub(tactic.LastUpdated); delta > oneWeek {
-			continue
-		}
-		output.Tactics[summary] = tactic.Clone()
+		delta := now.Sub(statsNilSafeLastUpdated(st))
+		return delta < oneWeek
+	})
+
+	// Cut excess entries, if needed
+	if len(tactics) > maxEntriesPerDomainEndpoint {
+		tactics = tactics[:maxEntriesPerDomainEndpoint]
 	}
-	return
+
+	// return a new statsDomainEndpoint to the caller
+	output := &statsDomainEndpoint{
+		Tactics: map[string]*statsTactic{},
+	}
+	for _, t := range tactics {
+		output.Tactics[t.Tactic.tacticSummaryKey()] = t
+	}
+	return output
 }
 
 // statsContainerVersion is the current version of [statsContainer].
@@ -180,8 +284,8 @@ type statsContainer struct {
 	Version int
 }
 
-// statsDomainRemoveOldEntries returns a copy of a [*statsContainer] with old entries removed.
-func statsContainerRemoveOldEntries(input *statsContainer) (output *statsContainer) {
+// statsDomainPruneEntries returns a copy of a [*statsContainer] with old entries removed.
+func statsContainerPruneEntries(input *statsContainer) (output *statsContainer) {
 	output = newStatsContainer()
 
 	// if .DomainEndpoints is nil here we're just going to do nothing
@@ -189,11 +293,11 @@ func statsContainerRemoveOldEntries(input *statsContainer) (output *statsContain
 
 		// We serialize this data to disk, so we need to account for the case
 		// where a user has manually edited the JSON to add a nil value
-		if inputStats == nil {
+		if domainEpnt == "" || inputStats == nil || len(inputStats.Tactics) <= 0 {
 			continue
 		}
 
-		prunedStats := statsDomainEndpointRemoveOldEntries(inputStats)
+		prunedStats := statsDomainEndpointPruneEntries(inputStats)
 
 		// We don't want to include an entry when it's empty because all the
 		// stats inside it have just been pruned
@@ -208,7 +312,7 @@ func statsContainerRemoveOldEntries(input *statsContainer) (output *statsContain
 
 // GetStatsTacticLocked returns the tactic record for the given [*statsTactic] instance.
 //
-// At the name implies, this function MUST be called while holding the [*statsManager] mutex.
+// As the name implies, this function MUST be called while holding the [*statsManager] mutex.
 func (c *statsContainer) GetStatsTacticLocked(tactic *httpsDialerTactic) (*statsTactic, bool) {
 	domainEpntRecord, found := c.DomainEndpoints[tactic.domainEndpointKey()]
 	if !found || domainEpntRecord == nil {
@@ -220,7 +324,7 @@ func (c *statsContainer) GetStatsTacticLocked(tactic *httpsDialerTactic) (*stats
 
 // SetStatsTacticLocked sets the tactic record for the given the given [*statsTactic] instance.
 //
-// At the name implies, this function MUST be called while holding the [*statsManager] mutex.
+// As the name implies, this function MUST be called while holding the [*statsManager] mutex.
 func (c *statsContainer) SetStatsTacticLocked(tactic *httpsDialerTactic, record *statsTactic) {
 	domainEpntRecord, found := c.DomainEndpoints[tactic.domainEndpointKey()]
 	if !found {
@@ -254,6 +358,9 @@ func newStatsContainer() *statsContainer {
 // The zero value of this structure is not ready to use; please, use the
 // [newStatsManager] factory to create a new instance.
 type statsManager struct {
+	// cancel allows canceling the background stats pruner.
+	cancel context.CancelFunc
+
 	// container is the container container for stats
 	container *statsContainer
 
@@ -299,8 +406,8 @@ func loadStatsContainer(kvStore model.KeyValueStore) (*statsContainer, error) {
 		return nil, err
 	}
 
-	// make sure we remove old entries
-	pruned := statsContainerRemoveOldEntries(&container)
+	// make sure we prune the data structure
+	pruned := statsContainerPruneEntries(&container)
 	return pruned, nil
 }
 
@@ -311,12 +418,21 @@ func newStatsManager(kvStore model.KeyValueStore, logger model.Logger) *statsMan
 		root = newStatsContainer()
 	}
 
-	return &statsManager{
+	ctx, cancel := context.WithCancel(context.Background())
+
+	mt := &statsManager{
+		cancel:    cancel,
 		container: root,
 		kvStore:   kvStore,
 		logger:    logger,
 		mu:        sync.Mutex{},
 	}
+
+	// run a background goroutine that trims the stats by removing excessive
+	// entries until the programmer calls (*statsManager).Close
+	go mt.trim(ctx)
+
+	return mt
 }
 
 var _ httpsDialerEventsHandler = &statsManager{}
@@ -453,12 +569,39 @@ func (mt *statsManager) Close() error {
 	// TODO(bassosimone): do we need to apply a "once" semantics to this method? Perhaps no
 	// given that there is no resource that we can close only once...
 
+	// interrupt the background goroutine
+	mt.cancel()
+
 	// get exclusive access
 	defer mt.mu.Unlock()
 	mt.mu.Lock()
 
+	// make sure we remove the unneeded entries one last time before saving them
+	container := statsContainerPruneEntries(mt.container)
+
 	// write updated stats into the underlying key-value store
-	return mt.kvStore.Set(statsKey, runtimex.Try1(json.Marshal(mt.container)))
+	return mt.kvStore.Set(statsKey, runtimex.Try1(json.Marshal(container)))
+}
+
+// trim runs in the background and trims the mt.container struct
+func (mt *statsManager) trim(ctx context.Context) {
+	const interval = 30 * time.Second
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-t.C:
+
+			// get exclusive access and edit the container
+			mt.mu.Lock()
+			mt.container = statsContainerPruneEntries(mt.container)
+			mt.mu.Unlock()
+
+		}
+	}
 }
 
 // LookupTacticsStats returns stats about tactics for a given domain and port. The returned

--- a/internal/enginenetx/statsmanager.go
+++ b/internal/enginenetx/statsmanager.go
@@ -245,16 +245,17 @@ func statsDomainEndpointPruneEntries(input *statsDomainEndpoint) *statsDomainEnd
 	//
 	// Note that statsDefensivelySortTacticsByDescendingSuccessRateWithAcceptPredicate
 	// operates on and returns a DEEP COPY of the original list.
-	tactics = statsDefensivelySortTacticsByDescendingSuccessRateWithAcceptPredicate(tactics, func(st *statsTactic) bool {
-		// When .LastUpdated is the zero time.Time value, the check is going to fail
-		// exactly like the time was 1 or 5 or 10 years ago instead.
-		//
-		// See https://go.dev/play/p/HGQT17ueIkq where we show that the zero time
-		// is handled exactly like any time in the past (it was kinda obvious, but
-		// sometimes it also make sense to double check assumptions!)
-		delta := now.Sub(statsNilSafeLastUpdated(st))
-		return delta < oneWeek
-	})
+	tactics = statsDefensivelySortTacticsByDescendingSuccessRateWithAcceptPredicate(
+		tactics, func(st *statsTactic) bool {
+			// When .LastUpdated is the zero time.Time value, the check is going to fail
+			// exactly like the time was 1 or 5 or 10 years ago instead.
+			//
+			// See https://go.dev/play/p/HGQT17ueIkq where we show that the zero time
+			// is handled exactly like any time in the past (it was kinda obvious, but
+			// sometimes it also make sense to double check assumptions!)
+			delta := now.Sub(statsNilSafeLastUpdated(st))
+			return delta < oneWeek
+		})
 
 	// Cut excess entries, if needed
 	if len(tactics) > maxEntriesPerDomainEndpoint {

--- a/internal/enginenetx/statsmanager.go
+++ b/internal/enginenetx/statsmanager.go
@@ -286,7 +286,7 @@ type statsContainer struct {
 	Version int
 }
 
-// statsDomainPruneEntries returns a DEEP COPY of a [*statsContainer] with old entries removed.
+// statsContainerPruneEntries returns a DEEP COPY of a [*statsContainer] with old entries removed.
 func statsContainerPruneEntries(input *statsContainer) (output *statsContainer) {
 	output = newStatsContainer()
 

--- a/internal/enginenetx/statsmanager.go
+++ b/internal/enginenetx/statsmanager.go
@@ -134,7 +134,7 @@ func statsNilSafeCountSuccess(t *statsTactic) (output int64) {
 //
 // This function operates on a deep copy of the input list, so it does not create data races.
 func statsDefensivelySortTacticsByDescendingSuccessRateWithAcceptPredicate(
-	input []*statsTactic, acceptp func(*statsTactic) bool) (output []*statsTactic) {
+	input []*statsTactic, acceptfunc func(*statsTactic) bool) []*statsTactic {
 	// first let's create a working list such that we don't modify
 	// the input in place thus avoiding any data race
 	work := []*statsTactic{}
@@ -159,12 +159,13 @@ func statsDefensivelySortTacticsByDescendingSuccessRateWithAcceptPredicate(
 	})
 
 	// finally let's apply the predicate to produce output
+	output := []*statsTactic{}
 	for _, t := range work {
-		if acceptp(t) {
+		if acceptfunc(t) {
 			output = append(output, t)
 		}
 	}
-	return
+	return output
 }
 
 func statsMaybeCloneMapStringInt64(input map[string]int64) (output map[string]int64) {

--- a/internal/enginenetx/statsmanager.go
+++ b/internal/enginenetx/statsmanager.go
@@ -216,7 +216,7 @@ type statsDomainEndpoint struct {
 	Tactics map[string]*statsTactic
 }
 
-// statsDomainEndpointPruneEntries returns a copy of a [*statsDomainEndpoint] with old
+// statsDomainEndpointPruneEntries returns a DEEP COPY of a [*statsDomainEndpoint] with old
 // and excess entries removed, such that the overall size is not unbounded.
 func statsDomainEndpointPruneEntries(input *statsDomainEndpoint) *statsDomainEndpoint {
 	tactics := []*statsTactic{}
@@ -285,7 +285,7 @@ type statsContainer struct {
 	Version int
 }
 
-// statsDomainPruneEntries returns a copy of a [*statsContainer] with old entries removed.
+// statsDomainPruneEntries returns a DEEP COPY of a [*statsContainer] with old entries removed.
 func statsContainerPruneEntries(input *statsContainer) (output *statsContainer) {
 	output = newStatsContainer()
 

--- a/internal/enginenetx/statsmanager_test.go
+++ b/internal/enginenetx/statsmanager_test.go
@@ -795,7 +795,9 @@ func TestStatsManagerCallbacks(t *testing.T) {
 			}
 
 			// create the stats manager
-			stats := newStatsManager(kvStore, logger)
+			const trimInterval = 30 * time.Second
+			stats := newStatsManager(kvStore, logger, trimInterval)
+			defer stats.Close()
 
 			// invoke the proper stats callback
 			tc.do(stats)
@@ -916,7 +918,9 @@ func TestStatsManagerLookupTactics(t *testing.T) {
 	}
 
 	// create the stats manager
-	stats := newStatsManager(kvStore, log.Log)
+	const trimInterval = 30 * time.Second
+	stats := newStatsManager(kvStore, log.Log, trimInterval)
+	defer stats.Close()
 
 	t.Run("when we're searching for a domain endpoint we know about", func(t *testing.T) {
 		// obtain tactics

--- a/internal/enginenetx/statsmanager_test.go
+++ b/internal/enginenetx/statsmanager_test.go
@@ -1113,7 +1113,7 @@ func TestStatsNilSafeLastUpdated(t *testing.T) {
 	})
 }
 
-func TestStatsNilSafeCounSuccess(t *testing.T) {
+func TestStatsNilSafeCountSuccess(t *testing.T) {
 	t.Run("with nil entry", func(t *testing.T) {
 		var st *statsTactic
 		if statsNilSafeCountSuccess(st) != 0 {
@@ -1487,7 +1487,7 @@ func TestStatsContainerPruneEntries(t *testing.T) {
 		}
 	})
 
-	t.Run("we avoid including into the results empty .Tactics", func(t *testing.T) {
+	t.Run("we avoid including into the results expired entries", func(t *testing.T) {
 		input := &statsContainer{
 			DomainEndpoints: map[string]*statsDomainEndpoint{
 				"shelob.polito.it:443": {
@@ -1580,7 +1580,7 @@ func TestStatsContainerPruneEntries(t *testing.T) {
 }
 
 func TestStatsManagerTrimEntriesConcurrently(t *testing.T) {
-	// start stats manger that trims very frequently
+	// start stats manager that trims very frequently
 	store := &kvstore.Memory{}
 	sm := newStatsManager(store, model.DiscardLogger, 1*time.Second)
 
@@ -1623,13 +1623,13 @@ func TestStatsManagerTrimEntriesConcurrently(t *testing.T) {
 	}
 
 	// now check what actually ended up being written; note that we expect
-	// to see empty domain endpoitns because we added a too old entry
-	expecteData := []byte(`{"DomainEndpoints":{},"Version":5}`)
+	// to see empty domain endpoints because we added a too old entry
+	expectedData := []byte(`{"DomainEndpoints":{},"Version":5}`)
 	data, err := store.Get(statsKey)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if diff := cmp.Diff(expecteData, data); diff != "" {
+	if diff := cmp.Diff(expectedData, data); diff != "" {
 		t.Fatal(diff)
 	}
 }

--- a/internal/enginenetx/statsmanager_test.go
+++ b/internal/enginenetx/statsmanager_test.go
@@ -558,7 +558,13 @@ func TestStatsManagerCallbacks(t *testing.T) {
 							"162.55.247.208:443 sni=www.example.com verify=api.ooni.io": {
 								CountStarted: 1,
 								LastUpdated:  fourtyFiveMinutesAgo,
-								Tactic:       &httpsDialerTactic{}, // only required for cloning
+								Tactic: &httpsDialerTactic{
+									Address:        "162.55.247.208",
+									InitialDelay:   0,
+									Port:           "443",
+									SNI:            "www.example.com",
+									VerifyHostname: "api.ooni.io",
+								},
 							},
 						},
 					},
@@ -588,40 +594,18 @@ func TestStatsManagerCallbacks(t *testing.T) {
 							"162.55.247.208:443 sni=www.example.com verify=api.ooni.io": {
 								CountStarted:             1,
 								CountTCPConnectInterrupt: 1,
-								Tactic:                   &httpsDialerTactic{},
+								Tactic: &httpsDialerTactic{
+									Address:        "162.55.247.208",
+									InitialDelay:   0,
+									Port:           "443",
+									SNI:            "www.example.com",
+									VerifyHostname: "api.ooni.io",
+								},
 							},
 						},
 					},
 				},
 				Version: statsContainerVersion,
-			},
-		},
-
-		// When TCP connect fails and we don't already have a policy record
-		{
-			name: "OnTCPConnectError when we are missing the stats record for the domain",
-			initialRoot: &statsContainer{
-				DomainEndpoints: map[string]*statsDomainEndpoint{},
-				Version:         statsContainerVersion,
-			},
-			do: func(stats *statsManager) {
-				ctx := context.Background()
-
-				tactic := &httpsDialerTactic{
-					Address:        "162.55.247.208",
-					InitialDelay:   0,
-					Port:           "443",
-					SNI:            "www.example.com",
-					VerifyHostname: "api.ooni.io",
-				}
-				err := errors.New("generic_timeout_error")
-
-				stats.OnTCPConnectError(ctx, tactic, err)
-			},
-			expectWarnf: 1,
-			expectRoot: &statsContainer{
-				DomainEndpoints: map[string]*statsDomainEndpoint{},
-				Version:         statsContainerVersion,
 			},
 		},
 
@@ -635,7 +619,13 @@ func TestStatsManagerCallbacks(t *testing.T) {
 							"162.55.247.208:443 sni=www.example.com verify=api.ooni.io": {
 								CountStarted: 1,
 								LastUpdated:  fourtyFiveMinutesAgo,
-								Tactic:       &httpsDialerTactic{}, // only for cloning
+								Tactic: &httpsDialerTactic{
+									Address:        "162.55.247.208",
+									InitialDelay:   0,
+									Port:           "443",
+									SNI:            "www.example.com",
+									VerifyHostname: "api.ooni.io",
+								},
 							},
 						},
 					},
@@ -665,7 +655,13 @@ func TestStatsManagerCallbacks(t *testing.T) {
 							"162.55.247.208:443 sni=www.example.com verify=api.ooni.io": {
 								CountStarted:               1,
 								CountTLSHandshakeInterrupt: 1,
-								Tactic:                     &httpsDialerTactic{},
+								Tactic: &httpsDialerTactic{
+									Address:        "162.55.247.208",
+									InitialDelay:   0,
+									Port:           "443",
+									SNI:            "www.example.com",
+									VerifyHostname: "api.ooni.io",
+								},
 							},
 						},
 					},

--- a/internal/enginenetx/statsmanager_test.go
+++ b/internal/enginenetx/statsmanager_test.go
@@ -609,6 +609,34 @@ func TestStatsManagerCallbacks(t *testing.T) {
 			},
 		},
 
+		// When TCP connect fails and we don't already have a policy record
+		{
+			name: "OnTCPConnectError when we are missing the stats record for the domain",
+			initialRoot: &statsContainer{
+				DomainEndpoints: map[string]*statsDomainEndpoint{},
+				Version:         statsContainerVersion,
+			},
+			do: func(stats *statsManager) {
+				ctx := context.Background()
+
+				tactic := &httpsDialerTactic{
+					Address:        "162.55.247.208",
+					InitialDelay:   0,
+					Port:           "443",
+					SNI:            "www.example.com",
+					VerifyHostname: "api.ooni.io",
+				}
+				err := errors.New("generic_timeout_error")
+
+				stats.OnTCPConnectError(ctx, tactic, err)
+			},
+			expectWarnf: 1,
+			expectRoot: &statsContainer{
+				DomainEndpoints: map[string]*statsDomainEndpoint{},
+				Version:         statsContainerVersion,
+			},
+		},
+
 		// When TLS handshake fails and the reason is a canceled context
 		{
 			name: "OnTLSHandshakeError with ctx.Error() != nil",

--- a/internal/enginenetx/statspolicy_test.go
+++ b/internal/enginenetx/statspolicy_test.go
@@ -135,12 +135,14 @@ func TestStatsPolicyWorkingAsIntended(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		return newStatsManager(kvStore, log.Log)
+		const trimInterval = 30 * time.Second
+		return newStatsManager(kvStore, log.Log, trimInterval)
 	}
 
 	t.Run("when we have unique statistics", func(t *testing.T) {
 		// create stats manager
 		stats := createStatsManager("api.ooni.io:443", expectTacticsStats...)
+		defer stats.Close()
 
 		// create the composed policy
 		policy := &statsPolicy{
@@ -204,6 +206,7 @@ func TestStatsPolicyWorkingAsIntended(t *testing.T) {
 
 		// create stats manager
 		stats := createStatsManager("api.ooni.io:443", statsWithDupes...)
+		defer stats.Close()
 
 		// create the composed policy
 		policy := &statsPolicy{
@@ -261,6 +264,7 @@ func TestStatsPolicyWorkingAsIntended(t *testing.T) {
 	t.Run("we avoid manipulating nil tactics", func(t *testing.T) {
 		// create stats manager
 		stats := createStatsManager("api.ooni.io:443", expectTacticsStats...)
+		defer stats.Close()
 
 		// create the composed policy
 		policy := &statsPolicy{


### PR DESCRIPTION
If we're running the enginenetx code inside an environment that sprays ~random IP addresses during DNS lookup, we're going to end up using quite a large amount of statistics. While this amount of statistics could potentially be great in general, we need to be mindful of memory and disk occupation as well as of the overhead of serializing and deserializing.

To address these concerns, add the arbitrary rule that we don't want more than ten domain-endpoint entries and implement code to zap old and/or always-failing entries. The code will run when loading the entries, when serializing them, and periodically while the `*Network` is up and running.

See https://github.com/ooni/probe/issues/2531
