### PR TITLE
cleanup(model): use ArchivalMaybeBinaryString for HTTP bodies

### DIFF
--- a/internal/experiment/hhfm/hhfm.go
+++ b/internal/experiment/hhfm/hhfm.go
@@ -274,7 +274,7 @@ func NewRequestEntryList(req *http.Request, headers map[string]string) (out []tr
 // specific *http.Response instance and its body.
 func NewHTTPResponse(resp *http.Response, data []byte) (out tracex.HTTPResponse) {
 	out = tracex.HTTPResponse{
-		Body:        tracex.HTTPBody{Value: string(data)},
+		Body:        model.ArchivalMaybeBinaryString(data),
 		Code:        int64(resp.StatusCode),
 		Headers:     make(map[string]tracex.MaybeBinaryValue),
 		HeadersList: []tracex.HTTPHeader{},

--- a/internal/experiment/hhfm/hhfm_test.go
+++ b/internal/experiment/hhfm/hhfm_test.go
@@ -68,7 +68,7 @@ func TestSuccess(t *testing.T) {
 	if request.Failure != nil {
 		t.Fatal("invalid Requests[0].Failure")
 	}
-	if request.Request.Body.Value != "" {
+	if request.Request.Body != "" {
 		t.Fatal("invalid Requests[0].Request.Body.Value")
 	}
 	if request.Request.BodyIsTruncated != false {
@@ -99,7 +99,7 @@ func TestSuccess(t *testing.T) {
 	if request.Request.URL != ths[0].Address {
 		t.Fatal("invalid Requests[0].Request.URL")
 	}
-	if len(request.Response.Body.Value) < 1 {
+	if len(request.Response.Body) < 1 {
 		t.Fatal("invalid Requests[0].Response.Body.Value length")
 	}
 	if request.Response.BodyIsTruncated != false {
@@ -181,7 +181,7 @@ func TestCancelledContext(t *testing.T) {
 	if *request.Failure != netxlite.FailureInterrupted {
 		t.Fatal("invalid Requests[0].Failure")
 	}
-	if request.Request.Body.Value != "" {
+	if request.Request.Body != "" {
 		t.Fatal("invalid Requests[0].Request.Body.Value")
 	}
 	if request.Request.BodyIsTruncated != false {
@@ -212,7 +212,7 @@ func TestCancelledContext(t *testing.T) {
 	if request.Request.URL != ths[0].Address {
 		t.Fatal("invalid Requests[0].Request.URL")
 	}
-	if len(request.Response.Body.Value) != 0 {
+	if len(request.Response.Body) != 0 {
 		t.Fatal("invalid Requests[0].Response.Body.Value length")
 	}
 	if request.Response.BodyIsTruncated != false {
@@ -811,7 +811,7 @@ func TestNewHTTPResponse(t *testing.T) {
 			data: []byte("deadbeef"),
 		},
 		wantOut: tracex.HTTPResponse{
-			Body: tracex.MaybeBinaryValue{Value: "deadbeef"},
+			Body: model.ArchivalMaybeBinaryString("deadbeef"),
 			Code: 200,
 			HeadersList: []tracex.HTTPHeader{{
 				Key:   "Content-Type",
@@ -831,7 +831,7 @@ func TestNewHTTPResponse(t *testing.T) {
 			resp: &http.Response{StatusCode: 200},
 		},
 		wantOut: tracex.HTTPResponse{
-			Body:        tracex.MaybeBinaryValue{Value: ""},
+			Body:        model.ArchivalMaybeBinaryString(""),
 			Code:        200,
 			HeadersList: []tracex.HTTPHeader{},
 			Headers:     map[string]tracex.MaybeBinaryValue{},

--- a/internal/experiment/riseupvpn/riseupvpn.go
+++ b/internal/experiment/riseupvpn/riseupvpn.go
@@ -304,7 +304,7 @@ func parseGateways(testKeys *TestKeys) []GatewayV3 {
 			// TODO(bassosimone,cyberta): is it reasonable that we discard
 			// the error when the JSON we fetched cannot be parsed?
 			// See https://github.com/ooni/probe/issues/1432
-			eipService, err := DecodeEIP3(requestEntry.Response.Body.Value)
+			eipService, err := DecodeEIP3(string(requestEntry.Response.Body))
 			if err == nil {
 				return eipService.Gateways
 			}

--- a/internal/experiment/riseupvpn/riseupvpn_test.go
+++ b/internal/experiment/riseupvpn/riseupvpn_test.go
@@ -773,13 +773,13 @@ func generateMockGetter(requestResponse map[string]string, responseStatus map[st
 				Failure: failure,
 				Request: tracex.HTTPRequest{
 					URL:             url,
-					Body:            tracex.MaybeBinaryValue{},
+					Body:            model.ArchivalMaybeBinaryString(""),
 					BodyIsTruncated: false,
 				},
 				Response: tracex.HTTPResponse{
-					Body: tracex.HTTPBody{
-						Value: responseBody,
-					},
+					Body: model.ArchivalMaybeBinaryString(
+						responseBody,
+					),
 					BodyIsTruncated: false,
 				}},
 			},

--- a/internal/experiment/urlgetter/getter.go
+++ b/internal/experiment/urlgetter/getter.go
@@ -69,7 +69,7 @@ func (g Getter) Get(ctx context.Context) (TestKeys, error) {
 	if len(tk.Requests) > 0 {
 		// OONI's convention is that the last request appears first
 		tk.HTTPResponseStatus = tk.Requests[0].Response.Code
-		tk.HTTPResponseBody = tk.Requests[0].Response.Body.Value
+		tk.HTTPResponseBody = string(tk.Requests[0].Response.Body)
 		tk.HTTPResponseLocations = tk.Requests[0].Response.Locations
 	}
 	tk.TCPConnect = append(

--- a/internal/experiment/webconnectivity/httpanalysis.go
+++ b/internal/experiment/webconnectivity/httpanalysis.go
@@ -56,7 +56,7 @@ func HTTPBodyLengthChecks(
 	if response.BodyIsTruncated {
 		return
 	}
-	measurement := int64(len(response.Body.Value))
+	measurement := int64(len(response.Body))
 	if measurement <= 0 {
 		return
 	}
@@ -201,7 +201,7 @@ func HTTPTitleMatch(tk urlgetter.TestKeys, ctrl ControlResponse) (out *bool) {
 		return
 	}
 	control := ctrl.HTTPRequest.Title
-	measurementBody := response.Body.Value
+	measurementBody := string(response.Body)
 	measurement := measurexlite.WebGetTitle(measurementBody)
 	if measurement == "" {
 		return

--- a/internal/experiment/webconnectivity/httpanalysis_test.go
+++ b/internal/experiment/webconnectivity/httpanalysis_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/experiment/urlgetter"
 	"github.com/ooni/probe-cli/v3/internal/experiment/webconnectivity"
 	"github.com/ooni/probe-cli/v3/internal/legacy/tracex"
+	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/randx"
 )
 
@@ -76,9 +77,9 @@ func TestHTTPBodyLengthChecks(t *testing.T) {
 			tk: urlgetter.TestKeys{
 				Requests: []tracex.RequestEntry{{
 					Response: tracex.HTTPResponse{
-						Body: tracex.MaybeBinaryValue{
-							Value: randx.Letters(768),
-						},
+						Body: model.ArchivalMaybeBinaryString(
+							randx.Letters(768),
+						),
 					},
 				}},
 			},
@@ -95,9 +96,9 @@ func TestHTTPBodyLengthChecks(t *testing.T) {
 			tk: urlgetter.TestKeys{
 				Requests: []tracex.RequestEntry{{
 					Response: tracex.HTTPResponse{
-						Body: tracex.MaybeBinaryValue{
-							Value: randx.Letters(768),
-						},
+						Body: model.ArchivalMaybeBinaryString(
+							randx.Letters(768),
+						),
 					},
 				}},
 			},
@@ -115,9 +116,9 @@ func TestHTTPBodyLengthChecks(t *testing.T) {
 			tk: urlgetter.TestKeys{
 				Requests: []tracex.RequestEntry{{
 					Response: tracex.HTTPResponse{
-						Body: tracex.MaybeBinaryValue{
-							Value: randx.Letters(1024),
-						},
+						Body: model.ArchivalMaybeBinaryString(
+							randx.Letters(1024),
+						),
 					},
 				}},
 			},
@@ -135,9 +136,9 @@ func TestHTTPBodyLengthChecks(t *testing.T) {
 			tk: urlgetter.TestKeys{
 				Requests: []tracex.RequestEntry{{
 					Response: tracex.HTTPResponse{
-						Body: tracex.MaybeBinaryValue{
-							Value: randx.Letters(8),
-						},
+						Body: model.ArchivalMaybeBinaryString(
+							randx.Letters(8),
+						),
 					},
 				}},
 			},
@@ -155,9 +156,9 @@ func TestHTTPBodyLengthChecks(t *testing.T) {
 			tk: urlgetter.TestKeys{
 				Requests: []tracex.RequestEntry{{
 					Response: tracex.HTTPResponse{
-						Body: tracex.MaybeBinaryValue{
-							Value: randx.Letters(16),
-						},
+						Body: model.ArchivalMaybeBinaryString(
+							randx.Letters(16),
+						),
 					},
 				}},
 			},
@@ -698,7 +699,7 @@ func TestTitleMatch(t *testing.T) {
 				Requests: []tracex.RequestEntry{{
 					Response: tracex.HTTPResponse{
 						Code: 200,
-						Body: tracex.MaybeBinaryValue{Value: "<HTML/>"},
+						Body: model.ArchivalMaybeBinaryString("<HTML/>"),
 					},
 				}},
 			},
@@ -711,7 +712,7 @@ func TestTitleMatch(t *testing.T) {
 				Requests: []tracex.RequestEntry{{
 					Response: tracex.HTTPResponse{
 						Code: 200,
-						Body: tracex.MaybeBinaryValue{Value: "<HTML/>"},
+						Body: model.ArchivalMaybeBinaryString("<HTML/>"),
 					},
 				}},
 			},
@@ -730,8 +731,8 @@ func TestTitleMatch(t *testing.T) {
 				Requests: []tracex.RequestEntry{{
 					Response: tracex.HTTPResponse{
 						Code: 200,
-						Body: tracex.MaybeBinaryValue{
-							Value: "<HTML><TITLE>La community di MSN</TITLE></HTML>"},
+						Body: model.ArchivalMaybeBinaryString(
+							"<HTML><TITLE>La community di MSN</TITLE></HTML>"),
 					},
 				}},
 			},
@@ -750,8 +751,8 @@ func TestTitleMatch(t *testing.T) {
 				Requests: []tracex.RequestEntry{{
 					Response: tracex.HTTPResponse{
 						Code: 200,
-						Body: tracex.MaybeBinaryValue{
-							Value: "<HTML><TITLE>La communità di MSN</TITLE></HTML>"},
+						Body: model.ArchivalMaybeBinaryString(
+							"<HTML><TITLE>La communità di MSN</TITLE></HTML>"),
 					},
 				}},
 			},
@@ -770,8 +771,8 @@ func TestTitleMatch(t *testing.T) {
 				Requests: []tracex.RequestEntry{{
 					Response: tracex.HTTPResponse{
 						Code: 200,
-						Body: tracex.MaybeBinaryValue{
-							Value: "<HTML><TITLE>" + randx.Letters(1024) + "</TITLE></HTML>"},
+						Body: model.ArchivalMaybeBinaryString(
+							"<HTML><TITLE>" + randx.Letters(1024) + "</TITLE></HTML>"),
 					},
 				}},
 			},
@@ -790,8 +791,8 @@ func TestTitleMatch(t *testing.T) {
 				Requests: []tracex.RequestEntry{{
 					Response: tracex.HTTPResponse{
 						Code: 200,
-						Body: tracex.MaybeBinaryValue{
-							Value: "<HTML><TiTLe>La commUNity di MSN</tITLE></HTML>"},
+						Body: model.ArchivalMaybeBinaryString(
+							"<HTML><TiTLe>La commUNity di MSN</tITLE></HTML>"),
 					},
 				}},
 			},
@@ -810,8 +811,8 @@ func TestTitleMatch(t *testing.T) {
 				Requests: []tracex.RequestEntry{{
 					Response: tracex.HTTPResponse{
 						Code: 200,
-						Body: tracex.MaybeBinaryValue{
-							Value: "<HTML><TiTLe>La commUNity di MSN</tITLE></HTML>"},
+						Body: model.ArchivalMaybeBinaryString(
+							"<HTML><TiTLe>La commUNity di MSN</tITLE></HTML>"),
 					},
 				}},
 			},

--- a/internal/experiment/webconnectivitylte/analysishttpdiff.go
+++ b/internal/experiment/webconnectivitylte/analysishttpdiff.go
@@ -91,7 +91,7 @@ func (tk *TestKeys) httpDiffBodyLengthChecks(
 	if response.BodyIsTruncated {
 		return // cannot trust body length in this case
 	}
-	measurement := int64(len(response.Body.Value))
+	measurement := int64(len(response.Body))
 	if measurement <= 0 {
 		return // no actual length
 	}
@@ -230,7 +230,7 @@ func (tk *TestKeys) httpDiffTitleMatch(
 		return
 	}
 	control := ctrl.Title
-	measurementBody := response.Body.Value
+	measurementBody := string(response.Body)
 	measurement := measurexlite.WebGetTitle(measurementBody)
 	if control == "" || measurement == "" {
 		return

--- a/internal/legacy/tracex/archival.go
+++ b/internal/legacy/tracex/archival.go
@@ -27,7 +27,6 @@ type (
 	DNSQueryEntry    = model.ArchivalDNSLookupResult
 	DNSAnswerEntry   = model.ArchivalDNSAnswer
 	TLSHandshake     = model.ArchivalTLSOrQUICHandshakeResult
-	HTTPBody         = model.ArchivalHTTPBody
 	HTTPHeader       = model.ArchivalHTTPHeader
 	RequestEntry     = model.ArchivalHTTPRequestResult
 	HTTPRequest      = model.ArchivalHTTPRequest
@@ -147,7 +146,7 @@ func newRequestList(begin time.Time, events []Event) (out []RequestEntry) {
 				ev.HTTPResponseHeaders, &entry.Response.HeadersList, &entry.Response.Headers)
 			entry.Response.Code = int64(ev.HTTPStatusCode)
 			entry.Response.Locations = ev.HTTPResponseHeaders.Values("Location")
-			entry.Response.Body.Value = string(ev.HTTPResponseBody)
+			entry.Response.Body = model.ArchivalMaybeBinaryString(ev.HTTPResponseBody)
 			entry.Response.BodyIsTruncated = ev.HTTPResponseBodyIsTruncated
 			entry.Failure = ev.Err.ToFailure()
 			out = append(out, entry)

--- a/internal/legacy/tracex/archival_test.go
+++ b/internal/legacy/tracex/archival_test.go
@@ -191,9 +191,7 @@ func TestNewRequestList(t *testing.T) {
 			T: 0.02,
 		}, {
 			Request: HTTPRequest{
-				Body: MaybeBinaryValue{
-					Value: "",
-				},
+				Body: model.ArchivalMaybeBinaryString(""),
 				HeadersList: []HTTPHeader{{
 					Key: "User-Agent",
 					Value: MaybeBinaryValue{
@@ -207,9 +205,7 @@ func TestNewRequestList(t *testing.T) {
 				URL:    "https://www.example.com/submit",
 			},
 			Response: HTTPResponse{
-				Body: MaybeBinaryValue{
-					Value: "{}",
-				},
+				Body: model.ArchivalMaybeBinaryString("{}"),
 				Code: 200,
 				HeadersList: []HTTPHeader{{
 					Key: "Server",

--- a/internal/measurexlite/http.go
+++ b/internal/measurexlite/http.go
@@ -52,7 +52,7 @@ func NewArchivalHTTPRequestResult(index int64, started time.Duration, network, a
 		ALPN:    alpn,
 		Failure: NewFailure(err),
 		Request: model.ArchivalHTTPRequest{
-			Body:            model.ArchivalMaybeBinaryData{},
+			Body:            model.ArchivalMaybeBinaryString(""),
 			BodyIsTruncated: false,
 			HeadersList:     newHTTPRequestHeaderList(req),
 			Headers:         newHTTPRequestHeaderMap(req),
@@ -62,7 +62,7 @@ func NewArchivalHTTPRequestResult(index int64, started time.Duration, network, a
 			URL:             httpRequestURL(req),
 		},
 		Response: model.ArchivalHTTPResponse{
-			Body:            httpResponseBody(body),
+			Body:            model.ArchivalMaybeBinaryString(body),
 			BodyIsTruncated: httpResponseBodyIsTruncated(body, maxRespBodySize),
 			Code:            httpResponseStatusCode(resp),
 			HeadersList:     newHTTPResponseHeaderList(resp),
@@ -108,14 +108,6 @@ func newHTTPRequestHeaderMap(req *http.Request) map[string]model.ArchivalMaybeBi
 func httpRequestURL(req *http.Request) (out string) {
 	if req != nil && req.URL != nil {
 		out = req.URL.String()
-	}
-	return
-}
-
-// httpResponseBody returns the response body, if possible, or an empty body.
-func httpResponseBody(body []byte) (out model.ArchivalMaybeBinaryData) {
-	if body != nil {
-		out.Value = string(body)
 	}
 	return
 }

--- a/internal/measurexlite/http_test.go
+++ b/internal/measurexlite/http_test.go
@@ -58,7 +58,7 @@ func TestNewArchivalHTTPRequestResult(t *testing.T) {
 			ALPN:    "",
 			Failure: nil,
 			Request: model.ArchivalHTTPRequest{
-				Body:            model.ArchivalMaybeBinaryData{},
+				Body:            model.ArchivalMaybeBinaryString(""),
 				BodyIsTruncated: false,
 				HeadersList:     []model.ArchivalHTTPHeader{},
 				Headers:         map[string]model.ArchivalMaybeBinaryData{},
@@ -68,7 +68,7 @@ func TestNewArchivalHTTPRequestResult(t *testing.T) {
 				URL:             "",
 			},
 			Response: model.ArchivalHTTPResponse{
-				Body:            model.ArchivalMaybeBinaryData{},
+				Body:            model.ArchivalMaybeBinaryString(""),
 				BodyIsTruncated: false,
 				Code:            0,
 				HeadersList:     []model.ArchivalHTTPHeader{},
@@ -117,7 +117,7 @@ func TestNewArchivalHTTPRequestResult(t *testing.T) {
 				return &s
 			}(),
 			Request: model.ArchivalHTTPRequest{
-				Body:            model.ArchivalMaybeBinaryData{},
+				Body:            model.ArchivalMaybeBinaryString(""),
 				BodyIsTruncated: false,
 				HeadersList: []model.ArchivalHTTPHeader{{
 					Key: "Accept",
@@ -140,7 +140,7 @@ func TestNewArchivalHTTPRequestResult(t *testing.T) {
 				URL:       "http://dns.google/",
 			},
 			Response: model.ArchivalHTTPResponse{
-				Body:            model.ArchivalMaybeBinaryData{},
+				Body:            model.ArchivalMaybeBinaryString(""),
 				BodyIsTruncated: false,
 				Code:            0,
 				HeadersList:     []model.ArchivalHTTPHeader{},
@@ -192,7 +192,7 @@ func TestNewArchivalHTTPRequestResult(t *testing.T) {
 			ALPN:    "h3",
 			Failure: nil,
 			Request: model.ArchivalHTTPRequest{
-				Body:            model.ArchivalMaybeBinaryData{},
+				Body:            model.ArchivalMaybeBinaryString(""),
 				BodyIsTruncated: false,
 				HeadersList: []model.ArchivalHTTPHeader{{
 					Key: "Accept",
@@ -215,9 +215,9 @@ func TestNewArchivalHTTPRequestResult(t *testing.T) {
 				URL:       "https://dns.google/",
 			},
 			Response: model.ArchivalHTTPResponse{
-				Body: model.ArchivalMaybeBinaryData{
-					Value: string(testingx.HTTPBlockpage451),
-				},
+				Body: model.ArchivalMaybeBinaryString(
+					testingx.HTTPBlockpage451,
+				),
 				BodyIsTruncated: false,
 				Code:            200,
 				HeadersList: []model.ArchivalHTTPHeader{{
@@ -290,7 +290,7 @@ func TestNewArchivalHTTPRequestResult(t *testing.T) {
 			ALPN:    "h3",
 			Failure: nil,
 			Request: model.ArchivalHTTPRequest{
-				Body:            model.ArchivalMaybeBinaryData{},
+				Body:            model.ArchivalMaybeBinaryString(""),
 				BodyIsTruncated: false,
 				HeadersList: []model.ArchivalHTTPHeader{{
 					Key: "Accept",
@@ -313,9 +313,7 @@ func TestNewArchivalHTTPRequestResult(t *testing.T) {
 				URL:       "https://dns.google/",
 			},
 			Response: model.ArchivalHTTPResponse{
-				Body: model.ArchivalMaybeBinaryData{
-					Value: "",
-				},
+				Body:            model.ArchivalMaybeBinaryString(""),
 				BodyIsTruncated: false,
 				Code:            302,
 				HeadersList: []model.ArchivalHTTPHeader{{

--- a/internal/model/archival.go
+++ b/internal/model/archival.go
@@ -323,7 +323,7 @@ type ArchivalHTTPRequestResult struct {
 // Headers are a map in Web Connectivity data format but
 // we have added support for a list since January 2020.
 type ArchivalHTTPRequest struct {
-	Body            ArchivalHTTPBody                   `json:"body"`
+	Body            ArchivalMaybeBinaryString          `json:"body"`
 	BodyIsTruncated bool                               `json:"body_is_truncated"`
 	HeadersList     []ArchivalHTTPHeader               `json:"headers_list"`
 	Headers         map[string]ArchivalMaybeBinaryData `json:"headers"`
@@ -338,7 +338,7 @@ type ArchivalHTTPRequest struct {
 // Headers are a map in Web Connectivity data format but
 // we have added support for a list since January 2020.
 type ArchivalHTTPResponse struct {
-	Body            ArchivalHTTPBody                   `json:"body"`
+	Body            ArchivalMaybeBinaryString          `json:"body"`
 	BodyIsTruncated bool                               `json:"body_is_truncated"`
 	Code            int64                              `json:"code"`
 	HeadersList     []ArchivalHTTPHeader               `json:"headers_list"`
@@ -348,13 +348,6 @@ type ArchivalHTTPResponse struct {
 	// analysing the measurements in telegram, whatsapp, etc.
 	Locations []string `json:"-"`
 }
-
-// ArchivalHTTPBody is an HTTP body. As an implementation note, this type must
-// be an alias for the MaybeBinaryValue type, otherwise the specific serialisation
-// mechanism implemented by MaybeBinaryValue is not working.
-//
-// QUIRK: it's quite fragile we must use an alias here--more robust solution?
-type ArchivalHTTPBody = ArchivalMaybeBinaryData
 
 // ArchivalHTTPHeader is a single HTTP header.
 type ArchivalHTTPHeader struct {

--- a/internal/model/archival_test.go
+++ b/internal/model/archival_test.go
@@ -294,6 +294,14 @@ func TestArchivalBinaryData(t *testing.T) {
 }
 
 func TestArchivalMaybeBinaryString(t *testing.T) {
+	t.Run("Supports assignment from a nil byte array", func(t *testing.T) {
+		var data []byte = nil // explicit
+		casted := model.ArchivalMaybeBinaryString(data)
+		if casted != "" {
+			t.Fatal("unexpected value")
+		}
+	})
+
 	// This test verifies that we correctly serialize a string to JSON by
 	// producing "" | {"format":"base64","data":"<base64>"}
 	t.Run("MarshalJSON", func(t *testing.T) {

--- a/internal/model/archival_test.go
+++ b/internal/model/archival_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
-	"github.com/ooni/probe-cli/v3/internal/testingx"
 )
 
 func TestArchivalExtSpec(t *testing.T) {
@@ -788,28 +787,6 @@ func TestHTTPHeader(t *testing.T) {
 	})
 }
 
-func TestHTTPBody(t *testing.T) {
-	// Implementation note: the content is always going to be the same
-	// even if we modify the implementation to become:
-	//
-	//     type ArchivalHTTPBody ArchivalMaybeBinaryData
-	//
-	// instead of the correct:
-	//
-	//     type ArchivalHTTPBody = ArchivalMaybeBinaryData
-	//
-	// However, cmp.Diff also takes into account the data type. Hence, if
-	// we make a mistake and apply the above change (which will in turn
-	// break correct JSON serialization), the this test will fail.
-	var body model.ArchivalHTTPBody
-	ff := &testingx.FakeFiller{}
-	ff.Fill(&body)
-	data := model.ArchivalMaybeBinaryData(body)
-	if diff := cmp.Diff(body, data); diff != "" {
-		t.Fatal(diff)
-	}
-}
-
 // This test ensures that ArchivalDNSLookupResult is WAI
 func TestArchivalDNSLookupResult(t *testing.T) {
 
@@ -1463,7 +1440,7 @@ func TestArchivalHTTPRequestResult(t *testing.T) {
 					ALPN:    "h2",
 					Failure: nil,
 					Request: model.ArchivalHTTPRequest{
-						Body:            model.ArchivalMaybeBinaryData{Value: ""},
+						Body:            model.ArchivalMaybeBinaryString(""),
 						BodyIsTruncated: false,
 						HeadersList: []model.ArchivalHTTPHeader{{
 							Key: "Accept",
@@ -1490,9 +1467,9 @@ func TestArchivalHTTPRequestResult(t *testing.T) {
 						URL:       "https://www.example.com/",
 					},
 					Response: model.ArchivalHTTPResponse{
-						Body: model.ArchivalMaybeBinaryData{
-							Value: "Bonsoir, Elliot!",
-						},
+						Body: model.ArchivalMaybeBinaryString(
+							"Bonsoir, Elliot!",
+						),
 						BodyIsTruncated: false,
 						Code:            200,
 						HeadersList: []model.ArchivalHTTPHeader{{
@@ -1529,7 +1506,7 @@ func TestArchivalHTTPRequestResult(t *testing.T) {
 						return &s
 					})(),
 					Request: model.ArchivalHTTPRequest{
-						Body:            model.ArchivalMaybeBinaryData{Value: ""},
+						Body:            model.ArchivalMaybeBinaryString(""),
 						BodyIsTruncated: false,
 						HeadersList: []model.ArchivalHTTPHeader{{
 							Key: "Accept",
@@ -1556,7 +1533,7 @@ func TestArchivalHTTPRequestResult(t *testing.T) {
 						URL:       "https://www.example.com/",
 					},
 					Response: model.ArchivalHTTPResponse{
-						Body:            model.ArchivalMaybeBinaryData{},
+						Body:            model.ArchivalMaybeBinaryString(""),
 						BodyIsTruncated: false,
 						Code:            0,
 						HeadersList:     []model.ArchivalHTTPHeader{},
@@ -1585,7 +1562,7 @@ func TestArchivalHTTPRequestResult(t *testing.T) {
 					ALPN:    "h2",
 					Failure: nil,
 					Request: model.ArchivalHTTPRequest{
-						Body:            model.ArchivalMaybeBinaryData{Value: ""},
+						Body:            model.ArchivalMaybeBinaryString(""),
 						BodyIsTruncated: false,
 						HeadersList: []model.ArchivalHTTPHeader{{
 							Key: "Accept",
@@ -1623,9 +1600,9 @@ func TestArchivalHTTPRequestResult(t *testing.T) {
 						URL:       "https://www.example.com/",
 					},
 					Response: model.ArchivalHTTPResponse{
-						Body: model.ArchivalMaybeBinaryData{
-							Value: string(archivalBinaryInput[:77]),
-						},
+						Body: model.ArchivalMaybeBinaryString(
+							archivalBinaryInput[:77],
+						),
 						BodyIsTruncated: false,
 						Code:            200,
 						HeadersList: []model.ArchivalHTTPHeader{{
@@ -1679,7 +1656,7 @@ func TestArchivalHTTPRequestResult(t *testing.T) {
 					ALPN:    "h2",
 					Failure: nil,
 					Request: model.ArchivalHTTPRequest{
-						Body:            model.ArchivalMaybeBinaryData{Value: ""},
+						Body:            model.ArchivalMaybeBinaryString(""),
 						BodyIsTruncated: false,
 						HeadersList: []model.ArchivalHTTPHeader{{
 							Key: "Accept",
@@ -1730,9 +1707,9 @@ func TestArchivalHTTPRequestResult(t *testing.T) {
 						URL:       "https://www.example.com/",
 					},
 					Response: model.ArchivalHTTPResponse{
-						Body: model.ArchivalMaybeBinaryData{
-							Value: "<HTML><BODY>Your address is 130.192.91.211 and 2606:2800:220:1:248:1893:25c8:1946 and you have endpoints [2606:2800:220:1:248:1893:25c8:1946]:5222 and 130.192.91.211:443. You're welcome.</BODY></HTML>",
-						},
+						Body: model.ArchivalMaybeBinaryString(
+							"<HTML><BODY>Your address is 130.192.91.211 and 2606:2800:220:1:248:1893:25c8:1946 and you have endpoints [2606:2800:220:1:248:1893:25c8:1946]:5222 and 130.192.91.211:443. You're welcome.</BODY></HTML>",
+						),
 						BodyIsTruncated: false,
 						Code:            200,
 						HeadersList: []model.ArchivalHTTPHeader{{
@@ -1843,7 +1820,7 @@ func TestArchivalHTTPRequestResult(t *testing.T) {
 				ALPN:    "h2",
 				Failure: nil,
 				Request: model.ArchivalHTTPRequest{
-					Body:            model.ArchivalMaybeBinaryData{Value: ""},
+					Body:            model.ArchivalMaybeBinaryString(""),
 					BodyIsTruncated: false,
 					HeadersList: []model.ArchivalHTTPHeader{{
 						Key: "Accept",
@@ -1870,9 +1847,9 @@ func TestArchivalHTTPRequestResult(t *testing.T) {
 					URL:       "https://www.example.com/",
 				},
 				Response: model.ArchivalHTTPResponse{
-					Body: model.ArchivalMaybeBinaryData{
-						Value: "Bonsoir, Elliot!",
-					},
+					Body: model.ArchivalMaybeBinaryString(
+						"Bonsoir, Elliot!",
+					),
 					BodyIsTruncated: false,
 					Code:            200,
 					HeadersList: []model.ArchivalHTTPHeader{{
@@ -1906,7 +1883,7 @@ func TestArchivalHTTPRequestResult(t *testing.T) {
 					return &s
 				})(),
 				Request: model.ArchivalHTTPRequest{
-					Body:            model.ArchivalMaybeBinaryData{Value: ""},
+					Body:            model.ArchivalMaybeBinaryString(""),
 					BodyIsTruncated: false,
 					HeadersList: []model.ArchivalHTTPHeader{{
 						Key: "Accept",
@@ -1933,7 +1910,7 @@ func TestArchivalHTTPRequestResult(t *testing.T) {
 					URL:       "https://www.example.com/",
 				},
 				Response: model.ArchivalHTTPResponse{
-					Body:            model.ArchivalMaybeBinaryData{},
+					Body:            model.ArchivalMaybeBinaryString(""),
 					BodyIsTruncated: false,
 					Code:            0,
 					HeadersList:     []model.ArchivalHTTPHeader{},


### PR DESCRIPTION
This diff modifies the model for HTTP requests and responses to use the ArchivalBinaryString type to represent bodies.

The tests I have introduced in previous commits are still passing, so we can have good confidence that this change is actually WAI.

Part of https://github.com/ooni/probe/issues/2531
