### PR TITLE
refactor: use ArchivalMaybeBinaryString for headers list

### DIFF
--- a/internal/experiment/hhfm/hhfm_test.go
+++ b/internal/experiment/hhfm/hhfm_test.go
@@ -743,12 +743,12 @@ func TestNewRequestEntryList(t *testing.T) {
 		},
 		wantOut: []tracex.RequestEntry{{
 			Request: tracex.HTTPRequest{
-				HeadersList: []tracex.HTTPHeader{{
-					Key:   "ContENt-tYPE",
-					Value: tracex.MaybeBinaryValue{Value: "text/plain"},
+				HeadersList: []model.ArchivalHTTPHeader{{
+					model.ArchivalMaybeBinaryString("ContENt-tYPE"),
+					model.ArchivalMaybeBinaryString("text/plain"),
 				}, {
-					Key:   "User-aGENT",
-					Value: tracex.MaybeBinaryValue{Value: "foo/1.0"},
+					model.ArchivalMaybeBinaryString("User-aGENT"),
+					model.ArchivalMaybeBinaryString("foo/1.0"),
 				}},
 				Headers: map[string]model.ArchivalMaybeBinaryString{
 					"ContENt-tYPE": "text/plain",
@@ -774,7 +774,7 @@ func TestNewRequestEntryList(t *testing.T) {
 			Request: tracex.HTTPRequest{
 				Method:      "GeT",
 				Headers:     make(map[string]model.ArchivalMaybeBinaryString),
-				HeadersList: []tracex.HTTPHeader{},
+				HeadersList: []model.ArchivalHTTPHeader{},
 				URL:         "http://10.0.0.1/",
 			},
 		}},
@@ -813,12 +813,12 @@ func TestNewHTTPResponse(t *testing.T) {
 		wantOut: tracex.HTTPResponse{
 			Body: model.ArchivalMaybeBinaryString("deadbeef"),
 			Code: 200,
-			HeadersList: []tracex.HTTPHeader{{
-				Key:   "Content-Type",
-				Value: tracex.MaybeBinaryValue{Value: "text/plain"},
+			HeadersList: []model.ArchivalHTTPHeader{{
+				model.ArchivalMaybeBinaryString("Content-Type"),
+				model.ArchivalMaybeBinaryString("text/plain"),
 			}, {
-				Key:   "User-Agent",
-				Value: tracex.MaybeBinaryValue{Value: "foo/1.0"},
+				model.ArchivalMaybeBinaryString("User-Agent"),
+				model.ArchivalMaybeBinaryString("foo/1.0"),
 			}},
 			Headers: map[string]model.ArchivalMaybeBinaryString{
 				"Content-Type": "text/plain",
@@ -833,7 +833,7 @@ func TestNewHTTPResponse(t *testing.T) {
 		wantOut: tracex.HTTPResponse{
 			Body:        model.ArchivalMaybeBinaryString(""),
 			Code:        200,
-			HeadersList: []tracex.HTTPHeader{},
+			HeadersList: []model.ArchivalHTTPHeader{},
 			Headers:     map[string]model.ArchivalMaybeBinaryString{},
 		},
 	}}

--- a/internal/legacy/tracex/archival.go
+++ b/internal/legacy/tracex/archival.go
@@ -25,7 +25,6 @@ type (
 	DNSQueryEntry    = model.ArchivalDNSLookupResult
 	DNSAnswerEntry   = model.ArchivalDNSAnswer
 	TLSHandshake     = model.ArchivalTLSOrQUICHandshakeResult
-	HTTPHeader       = model.ArchivalHTTPHeader
 	RequestEntry     = model.ArchivalHTTPRequestResult
 	HTTPRequest      = model.ArchivalHTTPRequest
 	HTTPResponse     = model.ArchivalHTTPResponse

--- a/internal/legacy/tracex/archival_test.go
+++ b/internal/legacy/tracex/archival_test.go
@@ -172,11 +172,9 @@ func TestNewRequestList(t *testing.T) {
 		want: []RequestEntry{{
 			Failure: NewFailure(io.EOF),
 			Request: HTTPRequest{
-				HeadersList: []HTTPHeader{{
-					Key: "User-Agent",
-					Value: MaybeBinaryValue{
-						Value: "miniooni/0.1.0-dev",
-					},
+				HeadersList: []model.ArchivalHTTPHeader{{
+					model.ArchivalMaybeBinaryString("User-Agent"),
+					model.ArchivalMaybeBinaryString("miniooni/0.1.0-dev"),
 				}},
 				Headers: map[string]model.ArchivalMaybeBinaryString{
 					"User-Agent": "miniooni/0.1.0-dev",
@@ -185,18 +183,16 @@ func TestNewRequestList(t *testing.T) {
 				URL:    "https://www.example.com/result",
 			},
 			Response: HTTPResponse{
-				HeadersList: []HTTPHeader{},
+				HeadersList: []model.ArchivalHTTPHeader{},
 				Headers:     make(map[string]model.ArchivalMaybeBinaryString),
 			},
 			T: 0.02,
 		}, {
 			Request: HTTPRequest{
 				Body: model.ArchivalMaybeBinaryString(""),
-				HeadersList: []HTTPHeader{{
-					Key: "User-Agent",
-					Value: MaybeBinaryValue{
-						Value: "miniooni/0.1.0-dev",
-					},
+				HeadersList: []model.ArchivalHTTPHeader{{
+					model.ArchivalMaybeBinaryString("User-Agent"),
+					model.ArchivalMaybeBinaryString("miniooni/0.1.0-dev"),
 				}},
 				Headers: map[string]model.ArchivalMaybeBinaryString{
 					"User-Agent": "miniooni/0.1.0-dev",
@@ -207,11 +203,9 @@ func TestNewRequestList(t *testing.T) {
 			Response: HTTPResponse{
 				Body: model.ArchivalMaybeBinaryString("{}"),
 				Code: 200,
-				HeadersList: []HTTPHeader{{
-					Key: "Server",
-					Value: MaybeBinaryValue{
-						Value: "miniooni/0.1.0-dev",
-					},
+				HeadersList: []model.ArchivalHTTPHeader{{
+					model.ArchivalMaybeBinaryString("Server"),
+					model.ArchivalMaybeBinaryString("miniooni/0.1.0-dev"),
 				}},
 				Headers: map[string]model.ArchivalMaybeBinaryString{
 					"Server": "miniooni/0.1.0-dev",
@@ -242,11 +236,9 @@ func TestNewRequestList(t *testing.T) {
 		},
 		want: []RequestEntry{{
 			Request: HTTPRequest{
-				HeadersList: []HTTPHeader{{
-					Key: "User-Agent",
-					Value: MaybeBinaryValue{
-						Value: "miniooni/0.1.0-dev",
-					},
+				HeadersList: []model.ArchivalHTTPHeader{{
+					model.ArchivalMaybeBinaryString("User-Agent"),
+					model.ArchivalMaybeBinaryString("miniooni/0.1.0-dev"),
 				}},
 				Headers: map[string]model.ArchivalMaybeBinaryString{
 					"User-Agent": "miniooni/0.1.0-dev",
@@ -256,21 +248,15 @@ func TestNewRequestList(t *testing.T) {
 			},
 			Response: HTTPResponse{
 				Code: 302,
-				HeadersList: []HTTPHeader{{
-					Key: "Location",
-					Value: MaybeBinaryValue{
-						Value: "https://x.example.com",
-					},
+				HeadersList: []model.ArchivalHTTPHeader{{
+					model.ArchivalMaybeBinaryString("Location"),
+					model.ArchivalMaybeBinaryString("https://x.example.com"),
 				}, {
-					Key: "Location",
-					Value: MaybeBinaryValue{
-						Value: "https://y.example.com",
-					},
+					model.ArchivalMaybeBinaryString("Location"),
+					model.ArchivalMaybeBinaryString("https://y.example.com"),
 				}, {
-					Key: "Server",
-					Value: MaybeBinaryValue{
-						Value: "miniooni/0.1.0-dev",
-					},
+					model.ArchivalMaybeBinaryString("Server"),
+					model.ArchivalMaybeBinaryString("miniooni/0.1.0-dev"),
 				}},
 				Headers: map[string]model.ArchivalMaybeBinaryString{
 					"Server":   "miniooni/0.1.0-dev",

--- a/internal/measurexlite/http_test.go
+++ b/internal/measurexlite/http_test.go
@@ -120,15 +120,11 @@ func TestNewArchivalHTTPRequestResult(t *testing.T) {
 				Body:            model.ArchivalMaybeBinaryString(""),
 				BodyIsTruncated: false,
 				HeadersList: []model.ArchivalHTTPHeader{{
-					Key: "Accept",
-					Value: model.ArchivalMaybeBinaryData{
-						Value: "*/*",
-					},
+					model.ArchivalMaybeBinaryString("Accept"),
+					model.ArchivalMaybeBinaryString("*/*"),
 				}, {
-					Key: "User-Agent",
-					Value: model.ArchivalMaybeBinaryData{
-						Value: "miniooni/0.1.0-dev",
-					},
+					model.ArchivalMaybeBinaryString("User-Agent"),
+					model.ArchivalMaybeBinaryString("miniooni/0.1.0-dev"),
 				}},
 				Headers: map[string]model.ArchivalMaybeBinaryString{
 					"Accept":     "*/*",
@@ -195,15 +191,11 @@ func TestNewArchivalHTTPRequestResult(t *testing.T) {
 				Body:            model.ArchivalMaybeBinaryString(""),
 				BodyIsTruncated: false,
 				HeadersList: []model.ArchivalHTTPHeader{{
-					Key: "Accept",
-					Value: model.ArchivalMaybeBinaryData{
-						Value: "*/*",
-					},
+					model.ArchivalMaybeBinaryString("Accept"),
+					model.ArchivalMaybeBinaryString("*/*"),
 				}, {
-					Key: "User-Agent",
-					Value: model.ArchivalMaybeBinaryData{
-						Value: "miniooni/0.1.0-dev",
-					},
+					model.ArchivalMaybeBinaryString("User-Agent"),
+					model.ArchivalMaybeBinaryString("miniooni/0.1.0-dev"),
 				}},
 				Headers: map[string]model.ArchivalMaybeBinaryString{
 					"Accept":     "*/*",
@@ -221,15 +213,11 @@ func TestNewArchivalHTTPRequestResult(t *testing.T) {
 				BodyIsTruncated: false,
 				Code:            200,
 				HeadersList: []model.ArchivalHTTPHeader{{
-					Key: "Content-Type",
-					Value: model.ArchivalMaybeBinaryData{
-						Value: "text/html; charset=iso-8859-1",
-					},
+					model.ArchivalMaybeBinaryString("Content-Type"),
+					model.ArchivalMaybeBinaryString("text/html; charset=iso-8859-1"),
 				}, {
-					Key: "Server",
-					Value: model.ArchivalMaybeBinaryData{
-						Value: "Apache",
-					},
+					model.ArchivalMaybeBinaryString("Server"),
+					model.ArchivalMaybeBinaryString("Apache"),
 				}},
 				Headers: map[string]model.ArchivalMaybeBinaryString{
 					"Content-Type": "text/html; charset=iso-8859-1",
@@ -293,15 +281,11 @@ func TestNewArchivalHTTPRequestResult(t *testing.T) {
 				Body:            model.ArchivalMaybeBinaryString(""),
 				BodyIsTruncated: false,
 				HeadersList: []model.ArchivalHTTPHeader{{
-					Key: "Accept",
-					Value: model.ArchivalMaybeBinaryData{
-						Value: "*/*",
-					},
+					model.ArchivalMaybeBinaryString("Accept"),
+					model.ArchivalMaybeBinaryString("*/*"),
 				}, {
-					Key: "User-Agent",
-					Value: model.ArchivalMaybeBinaryData{
-						Value: "miniooni/0.1.0-dev",
-					},
+					model.ArchivalMaybeBinaryString("User-Agent"),
+					model.ArchivalMaybeBinaryString("miniooni/0.1.0-dev"),
 				}},
 				Headers: map[string]model.ArchivalMaybeBinaryString{
 					"Accept":     "*/*",
@@ -317,20 +301,14 @@ func TestNewArchivalHTTPRequestResult(t *testing.T) {
 				BodyIsTruncated: false,
 				Code:            302,
 				HeadersList: []model.ArchivalHTTPHeader{{
-					Key: "Content-Type",
-					Value: model.ArchivalMaybeBinaryData{
-						Value: "text/html; charset=iso-8859-1",
-					},
+					model.ArchivalMaybeBinaryString("Content-Type"),
+					model.ArchivalMaybeBinaryString("text/html; charset=iso-8859-1"),
 				}, {
-					Key: "Location",
-					Value: model.ArchivalMaybeBinaryData{
-						Value: "/v2/index.html",
-					},
+					model.ArchivalMaybeBinaryString("Location"),
+					model.ArchivalMaybeBinaryString("/v2/index.html"),
 				}, {
-					Key: "Server",
-					Value: model.ArchivalMaybeBinaryData{
-						Value: "Apache",
-					},
+					model.ArchivalMaybeBinaryString("Server"),
+					model.ArchivalMaybeBinaryString("Apache"),
 				}},
 				Headers: map[string]model.ArchivalMaybeBinaryString{
 					"Content-Type": "text/html; charset=iso-8859-1",


### PR DESCRIPTION
This commit changes the list representation of HTTP headers to use the ArchivalMaybeBinaryString type.

Now that we have migrated most representations of HTTP headers to use this new type, we can finally implement scrubbing.

As a reminder, we still need to migrate the ./legacy/measurex implementation, however that one is a bit annoying because there are no tests at all for measurex 🤦🤦🤦🤦🤦🤦🤦.

That said, given that ./legacy/measurex is deprecated and it is only used by the tor experiment, I think leaving it untouched would probably be the right thing to do here.

Part of https://github.com/ooni/probe/issues/2531
