### PR TITLE
fix: rename beacons to bridges

### DIFF
--- a/internal/enginenetx/bridgespolicy_test.go
+++ b/internal/enginenetx/bridgespolicy_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestBeaconsPolicy(t *testing.T) {
-	t.Run("for domains for which we don't have beacons and DNS failure", func(t *testing.T) {
+	t.Run("for domains for which we don't have bridges and DNS failure", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		p := &beaconsPolicy{
+		p := &bridgesPolicy{
 			Fallback: &dnsPolicy{
 				Logger: model.DiscardLogger,
 				Resolver: &mocks.Resolver{
@@ -36,8 +36,8 @@ func TestBeaconsPolicy(t *testing.T) {
 		}
 	})
 
-	t.Run("for domains for which we don't have beacons and DNS success", func(t *testing.T) {
-		p := &beaconsPolicy{
+	t.Run("for domains for which we don't have bridges and DNS success", func(t *testing.T) {
+		p := &bridgesPolicy{
 			Fallback: &dnsPolicy{
 				Logger: model.DiscardLogger,
 				Resolver: &mocks.Resolver{
@@ -78,7 +78,7 @@ func TestBeaconsPolicy(t *testing.T) {
 
 	t.Run("for the api.ooni.io domain", func(t *testing.T) {
 		expected := errors.New("mocked error")
-		p := &beaconsPolicy{
+		p := &bridgesPolicy{
 			Fallback: &dnsPolicy{
 				Logger: model.DiscardLogger,
 				Resolver: &mocks.Resolver{
@@ -118,11 +118,11 @@ func TestBeaconsPolicy(t *testing.T) {
 	})
 
 	t.Run("for test helper domains", func(t *testing.T) {
-		for _, domain := range beaconsPolicyTestHelpersDomains {
+		for _, domain := range bridgesPolicyTestHelpersDomains {
 			t.Run(domain, func(t *testing.T) {
 				expectedAddrs := []string{"164.92.180.7"}
 
-				p := &beaconsPolicy{
+				p := &bridgesPolicy{
 					Fallback: &dnsPolicy{
 						Logger: model.DiscardLogger,
 						Resolver: &mocks.Resolver{

--- a/internal/enginenetx/network.go
+++ b/internal/enginenetx/network.go
@@ -159,7 +159,7 @@ func newHTTPSDialerPolicy(
 
 	// create a composed fallback TLS dialer policy
 	fallback := &statsPolicy{
-		Fallback: &beaconsPolicy{Fallback: &dnsPolicy{logger, resolver}},
+		Fallback: &bridgesPolicy{Fallback: &dnsPolicy{logger, resolver}},
 		Stats:    stats,
 	}
 

--- a/internal/enginenetx/statspolicy_test.go
+++ b/internal/enginenetx/statspolicy_test.go
@@ -19,7 +19,7 @@ func TestStatsPolicyWorkingAsIntended(t *testing.T) {
 	// prepare the content of the stats
 	twentyMinutesAgo := time.Now().Add(-20 * time.Minute)
 
-	const beaconAddress = netemx.AddressApiOONIIo
+	const bridgeAddress = netemx.AddressApiOONIIo
 
 	expectTacticsStats := []*statsTactic{{
 		CountStarted:               5,
@@ -34,7 +34,7 @@ func TestStatsPolicyWorkingAsIntended(t *testing.T) {
 		HistoTLSVerificationError:  map[string]int64{},
 		LastUpdated:                twentyMinutesAgo,
 		Tactic: &httpsDialerTactic{
-			Address:        beaconAddress,
+			Address:        bridgeAddress,
 			InitialDelay:   0,
 			Port:           "443",
 			SNI:            "www.repubblica.it",
@@ -53,7 +53,7 @@ func TestStatsPolicyWorkingAsIntended(t *testing.T) {
 		HistoTLSVerificationError:  map[string]int64{},
 		LastUpdated:                twentyMinutesAgo,
 		Tactic: &httpsDialerTactic{
-			Address:        beaconAddress,
+			Address:        bridgeAddress,
 			InitialDelay:   0,
 			Port:           "443",
 			SNI:            "www.kernel.org",
@@ -72,7 +72,7 @@ func TestStatsPolicyWorkingAsIntended(t *testing.T) {
 		HistoTLSVerificationError:  map[string]int64{},
 		LastUpdated:                twentyMinutesAgo,
 		Tactic: &httpsDialerTactic{
-			Address:        beaconAddress,
+			Address:        bridgeAddress,
 			InitialDelay:   0,
 			Port:           "443",
 			SNI:            "theconversation.com",
@@ -104,7 +104,7 @@ func TestStatsPolicyWorkingAsIntended(t *testing.T) {
 		HistoTLSVerificationError:  map[string]int64{},
 		LastUpdated:                time.Time{}, // the zero time should exclude this one
 		Tactic: &httpsDialerTactic{
-			Address:        beaconAddress,
+			Address:        bridgeAddress,
 			InitialDelay:   0,
 			Port:           "443",
 			SNI:            "ilpost.it",
@@ -151,7 +151,7 @@ func TestStatsPolicyWorkingAsIntended(t *testing.T) {
 					MockLookupHost: func(ctx context.Context, domain string) ([]string, error) {
 						switch domain {
 						case "api.ooni.io":
-							return []string{beaconAddress}, nil
+							return []string{bridgeAddress}, nil
 						default:
 							return nil, netxlite.ErrOODNSNoSuchHost
 						}
@@ -182,7 +182,7 @@ func TestStatsPolicyWorkingAsIntended(t *testing.T) {
 
 		// extend the expected list to include DNS results
 		expect = append(expect, &httpsDialerTactic{
-			Address:        beaconAddress,
+			Address:        bridgeAddress,
 			InitialDelay:   2 * time.Second,
 			Port:           "443",
 			SNI:            "api.ooni.io",
@@ -216,7 +216,7 @@ func TestStatsPolicyWorkingAsIntended(t *testing.T) {
 						switch domain {
 						case "api.ooni.io":
 							// Twice so we try to cause duplicate entries also with the DNS policy
-							return []string{beaconAddress, beaconAddress}, nil
+							return []string{bridgeAddress, bridgeAddress}, nil
 						default:
 							return nil, netxlite.ErrOODNSNoSuchHost
 						}
@@ -247,7 +247,7 @@ func TestStatsPolicyWorkingAsIntended(t *testing.T) {
 
 		// extend the expected list to include DNS results
 		expect = append(expect, &httpsDialerTactic{
-			Address:        beaconAddress,
+			Address:        bridgeAddress,
 			InitialDelay:   2 * time.Second,
 			Port:           "443",
 			SNI:            "api.ooni.io",

--- a/internal/enginenetx/userpolicy.go
+++ b/internal/enginenetx/userpolicy.go
@@ -2,7 +2,7 @@ package enginenetx
 
 //
 // user policy - the possibility of loading a user policy from a JSON
-// document named `httpsdialer.conf` in $OONI_HOME/engine that contains
+// document named `bridges.conf` in $OONI_HOME/engine that contains
 // a specific policy for TLS dialing for specific endpoints.
 //
 // This policy helps a lot with exploration and experimentation.
@@ -32,7 +32,7 @@ type userPolicy struct {
 }
 
 // userPolicyKey is the kvstore key used to retrieve the user policy.
-const userPolicyKey = "httpsdialer.conf"
+const userPolicyKey = "bridges.conf"
 
 // errUserPolicyWrongVersion means that the user policy document has the wrong version number.
 var errUserPolicyWrongVersion = errors.New("wrong user policy version")

--- a/internal/enginenetx/userpolicy_test.go
+++ b/internal/enginenetx/userpolicy_test.go
@@ -57,7 +57,7 @@ func TestUserPolicy(t *testing.T) {
 			name:           "with empty JSON",
 			key:            userPolicyKey,
 			input:          []byte(`{}`),
-			expectErr:      "httpsdialer.conf: wrong user policy version: expected=3 got=0",
+			expectErr:      "bridges.conf: wrong user policy version: expected=3 got=0",
 			expectedPolicy: nil,
 		}, {
 			name: "with real serialized policy",


### PR DESCRIPTION
They're quack like bridges, OONI bridges. Also, name the config file from the PoV of the user.

Part of https://github.com/ooni/probe/issues/2531.