### PR TITLE
fix(engineresolver): support HTTP/HTTPS proxies

### DIFF
--- a/internal/engineresolver/factory.go
+++ b/internal/engineresolver/factory.go
@@ -85,8 +85,8 @@ func newChildResolverHTTPS(
 		tlsDialer := netxlite.NewTLSDialer(dialer, thx)
 		txp = netxlite.NewHTTPTransportWithOptions(
 			logger, dialer, tlsDialer,
-			netxlite.HTTPTransportOptionDisableCompression(false),
-			netxlite.HTTPTransportOptionProxyURL(proxyURL),
+			netxlite.HTTPTransportOptionDisableCompression(false), // defaults to true but compression is fine here
+			netxlite.HTTPTransportOptionProxyURL(proxyURL), // nil here disables using the proxy
 		)
 	case true:
 		txp = netxlite.NewHTTP3TransportStdlib(logger)

--- a/internal/engineresolver/factory.go
+++ b/internal/engineresolver/factory.go
@@ -80,16 +80,14 @@ func newChildResolverHTTPS(
 	var txp model.HTTPTransport
 	switch http3Enabled {
 	case false:
-		dialer := netxlite.MaybeWrapWithProxyDialer(
-			netxlite.NewDialerWithStdlibResolver(logger),
-			proxyURL, // handles correctly the case where proxyURL is nil
-		)
+		dialer := netxlite.NewDialerWithStdlibResolver(logger)
 		thx := netxlite.NewTLSHandshakerStdlib(logger)
 		tlsDialer := netxlite.NewTLSDialer(dialer, thx)
-		// TODO(https://github.com/ooni/probe/issues/2534): here we're using the QUIRKY netxlite.NewHTTPTransport
-		// function, but we can probably avoid using it, given that this code is
-		// not using tracing and does not care about those quirks.
-		txp = netxlite.NewHTTPTransport(logger, dialer, tlsDialer)
+		txp = netxlite.NewHTTPTransportWithOptions(
+			logger, dialer, tlsDialer,
+			netxlite.HTTPTransportOptionDisableCompression(false),
+			netxlite.HTTPTransportOptionProxyURL(proxyURL),
+		)
 	case true:
 		txp = netxlite.NewHTTP3TransportStdlib(logger)
 	}

--- a/internal/engineresolver/factory.go
+++ b/internal/engineresolver/factory.go
@@ -86,7 +86,7 @@ func newChildResolverHTTPS(
 		txp = netxlite.NewHTTPTransportWithOptions(
 			logger, dialer, tlsDialer,
 			netxlite.HTTPTransportOptionDisableCompression(false), // defaults to true but compression is fine here
-			netxlite.HTTPTransportOptionProxyURL(proxyURL), // nil here disables using the proxy
+			netxlite.HTTPTransportOptionProxyURL(proxyURL),        // nil here disables using the proxy
 		)
 	case true:
 		txp = netxlite.NewHTTP3TransportStdlib(logger)


### PR DESCRIPTION
By using netxlite.NewHTTPTransportWithOptions in `./internal/engineresolver/factory.go`:

1. we remove an unnecessary usage of the quirky HTTP transport used for measuring by ./legacy/netx et al (removing such unnecessary usages is https://github.com/ooni/probe/issues/2534);

2. we enable using HTTP/HTTPS proxies in miniooni and ooniprobe.

Closes https://github.com/ooni/probe/issues/1955.
