### PR TITLE
chore(oonimkall): re-enable TestTaskRunnerRun

### DIFF
--- a/pkg/oonimkall/taskrunner_test.go
+++ b/pkg/oonimkall/taskrunner_test.go
@@ -30,7 +30,6 @@ func TestMeasurementSubmissionFailure(t *testing.T) {
 }
 
 func TestTaskRunnerRun(t *testing.T) {
-	t.Skip("https://github.com/ooni/probe/issues/2541")
 	if testing.Short() {
 		t.Skip("skip test in short mode")
 	}
@@ -350,8 +349,7 @@ func TestTaskRunnerRun(t *testing.T) {
 		assertReducedEventsLike(t, expect, reduced)
 	})
 
-	t.Run(
-		"with InputOrStaticDefault policy and experiment with no static input",
+	t.Run("with InputOrStaticDefault policy and experiment with no static input",
 		func(t *testing.T) {
 			runner, emitter := newRunnerForTesting()
 			runner.settings.Name = "Antani" // no input for this experiment


### PR DESCRIPTION
I have ran the test several times locally with `go test -race -count 1` and it was working as intended. Either the CI run issue was just temporary or it's something fundamental of the CI that I can't reproduce.

For this reason, I am going to re-enable the test and see what happens.

Closes https://github.com/ooni/probe/issues/2541
