### PR TITLE
refactor(riseupvpn): rename structs, change progress, bump version

### DIFF
--- a/internal/experiment/riseupvpn/riseupvpn.go
+++ b/internal/experiment/riseupvpn/riseupvpn.go
@@ -16,25 +16,28 @@ import (
 
 const (
 	testName      = "riseupvpn"
-	testVersion   = "0.2.0"
+	testVersion   = "0.3.0"
 	eipServiceURL = "https://api.black.riseup.net:443/3/config/eip-service.json"
 	providerURL   = "https://riseup.net/provider.json"
 	geoServiceURL = "https://api.black.riseup.net:9001/json"
 	tcpConnect    = "tcpconnect://"
 )
 
-// EipService is the main JSON object of eip-service.json.
-type EipService struct {
+// EIPServiceV3 is the main JSON object returned by eip-service.json.
+type EIPServiceV3 struct {
 	Gateways []GatewayV3
+}
+
+// CapabilitiesV3 is a list of transports a gateway supports
+type CapabilitiesV3 struct {
+	Transport []TransportV3
 }
 
 // GatewayV3 describes a gateway.
 type GatewayV3 struct {
-	Capabilities struct {
-		Transport []TransportV3
-	}
-	Host      string
-	IPAddress string `json:"ip_address"`
+	Capabilities CapabilitiesV3
+	Host         string
+	IPAddress    string `json:"ip_address"`
 }
 
 // TransportV3 describes a transport.
@@ -203,7 +206,7 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 			FailOnHTTPError: true,
 		}},
 	}
-	for entry := range multi.CollectOverall(ctx, inputs, 0, 50, "riseupvpn", callbacks) {
+	for entry := range multi.CollectOverall(ctx, inputs, 0, 20, "riseupvpn", callbacks) {
 		tk := entry.TestKeys
 		testkeys.AddCACertFetchTestKeys(tk)
 		if tk.Failure != nil {
@@ -241,7 +244,7 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 			FailOnHTTPError: true,
 		}},
 	}
-	for entry := range multi.CollectOverall(ctx, inputs, 1, 50, "riseupvpn", callbacks) {
+	for entry := range multi.CollectOverall(ctx, inputs, 1, 20, "riseupvpn", callbacks) {
 		testkeys.UpdateProviderAPITestKeys(entry)
 	}
 
@@ -251,10 +254,11 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	openvpnEndpoints := generateMultiInputs(gateways, "openvpn")
 	obfs4Endpoints := generateMultiInputs(gateways, "obfs4")
 	overallCount := 1 + len(inputs) + len(openvpnEndpoints) + len(obfs4Endpoints)
+	startCount := 1 + len(inputs)
 
 	// measure openvpn in parallel
 	for entry := range multi.CollectOverall(
-		ctx, openvpnEndpoints, 1+len(inputs), overallCount, "riseupvpn", callbacks) {
+		ctx, openvpnEndpoints, startCount, overallCount, "riseupvpn", callbacks) {
 		testkeys.AddGatewayConnectTestKeys(entry, "openvpn")
 	}
 
@@ -262,8 +266,9 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	// TODO(bassosimone): when urlgetter is able to do obfs4 handshakes, here
 	// can possibly also test for the obfs4 handshake.
 	// See https://github.com/ooni/probe/issues/1463.
+	startCount += len(openvpnEndpoints)
 	for entry := range multi.CollectOverall(
-		ctx, obfs4Endpoints, 1+len(inputs)+len(openvpnEndpoints), overallCount, "riseupvpn", callbacks) {
+		ctx, obfs4Endpoints, startCount, overallCount, "riseupvpn", callbacks) {
 		testkeys.AddGatewayConnectTestKeys(entry, "obfs4")
 	}
 
@@ -303,7 +308,7 @@ func parseGateways(testKeys *TestKeys) []GatewayV3 {
 			// TODO(bassosimone,cyberta): is it reasonable that we discard
 			// the error when the JSON we fetched cannot be parsed?
 			// See https://github.com/ooni/probe/issues/1432
-			eipService, err := DecodeEIP3(string(requestEntry.Response.Body))
+			eipService, err := DecodeEIPService3(string(requestEntry.Response.Body))
 			if err == nil {
 				return eipService.Gateways
 			}
@@ -312,9 +317,9 @@ func parseGateways(testKeys *TestKeys) []GatewayV3 {
 	return nil
 }
 
-// DecodeEIP3 decodes eip-service.json version 3
-func DecodeEIP3(body string) (*EipService, error) {
-	var eip EipService
+// DecodeEIPService3 decodes eip-service.json version 3
+func DecodeEIPService3(body string) (*EIPServiceV3, error) {
+	var eip EIPServiceV3
 	err := json.Unmarshal([]byte(body), &eip)
 	if err != nil {
 		return nil, err

--- a/internal/experiment/riseupvpn/riseupvpn.go
+++ b/internal/experiment/riseupvpn/riseupvpn.go
@@ -308,7 +308,7 @@ func parseGateways(testKeys *TestKeys) []GatewayV3 {
 			// TODO(bassosimone,cyberta): is it reasonable that we discard
 			// the error when the JSON we fetched cannot be parsed?
 			// See https://github.com/ooni/probe/issues/1432
-			eipService, err := DecodeEIPService3(string(requestEntry.Response.Body))
+			eipService, err := DecodeEIPServiceV3(string(requestEntry.Response.Body))
 			if err == nil {
 				return eipService.Gateways
 			}
@@ -317,8 +317,8 @@ func parseGateways(testKeys *TestKeys) []GatewayV3 {
 	return nil
 }
 
-// DecodeEIPService3 decodes eip-service.json version 3
-func DecodeEIPService3(body string) (*EIPServiceV3, error) {
+// DecodeEIPServiceV3 decodes eip-service.json version 3
+func DecodeEIPServiceV3(body string) (*EIPServiceV3, error) {
 	var eip EIPServiceV3
 	err := json.Unmarshal([]byte(body), &eip)
 	if err != nil {

--- a/internal/experiment/riseupvpn/riseupvpn_test.go
+++ b/internal/experiment/riseupvpn/riseupvpn_test.go
@@ -549,7 +549,7 @@ func TestFailureTransport(t *testing.T) {
 }
 
 func TestMissingTransport(t *testing.T) {
-	eipService, err := riseupvpn.DecodeEIPService3(eipservice)
+	eipService, err := riseupvpn.DecodeEIPServiceV3(eipservice)
 	if err != nil {
 		t.Fatal("Preconditions for the test are not met.")
 	}

--- a/internal/experiment/riseupvpn/riseupvpn_test.go
+++ b/internal/experiment/riseupvpn/riseupvpn_test.go
@@ -203,7 +203,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "riseupvpn" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.2.0" {
+	if measurer.ExperimentVersion() != "0.3.0" {
 		t.Fatal("unexpected version")
 	}
 }
@@ -549,7 +549,7 @@ func TestFailureTransport(t *testing.T) {
 }
 
 func TestMissingTransport(t *testing.T) {
-	eipService, err := riseupvpn.DecodeEIP3(eipservice)
+	eipService, err := riseupvpn.DecodeEIPService3(eipservice)
 	if err != nil {
 		t.Fatal("Preconditions for the test are not met.")
 	}


### PR DESCRIPTION
This diff renames some structs, changes the code emitting the progress, and bumps the experiment version. In my previous commit, I said I did bump the version number but that was not actually the case.

This diff has been extracted from https://github.com/ooni/probe-cli/pull/1125.

This diff is part of https://github.com/ooni/probe/issues/1432

---------

Co-authored-by: cyBerta <cyberta@riseup.net>