### PR TITLE
refactor(riseupvpn): handle failing API and simplify test keys

### DIFF
--- a/internal/experiment/riseupvpn/riseupvpn.go
+++ b/internal/experiment/riseupvpn/riseupvpn.go
@@ -172,11 +172,13 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 		if tk.Failure != nil {
 			testkeys.CACertStatus = false
 			testkeys.APIFailures = append(testkeys.APIFailures, *tk.Failure)
+			// Note well: returning nil here causes the measurement to be submitted.
 			return nil
 		}
 		if ok := certPool.AppendCertsFromPEM([]byte(tk.HTTPResponseBody)); !ok {
 			testkeys.CACertStatus = false
 			testkeys.APIFailures = append(testkeys.APIFailures, "invalid_ca")
+			// Note well: returning nil here causes the measurement to be submitted.
 			return nil
 		}
 	}
@@ -205,6 +207,7 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 		testkeys.UpdateProviderAPITestKeys(entry)
 		tk := entry.TestKeys
 		if tk.Failure != nil {
+			// Note well: returning nil here causes the measurement to be submitted.
 			return nil
 		}
 	}
@@ -231,6 +234,8 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 		ctx, obfs4Endpoints, startCount, overallCount, "riseupvpn", callbacks) {
 		testkeys.AddGatewayConnectTestKeys(entry, "obfs4")
 	}
+
+	// Note well: returning nil here causes the measurement to be submitted.
 	return nil
 }
 

--- a/internal/experiment/riseupvpn/riseupvpn.go
+++ b/internal/experiment/riseupvpn/riseupvpn.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/experiment/urlgetter"
-	"github.com/ooni/probe-cli/v3/internal/legacy/tracex"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
@@ -63,21 +62,15 @@ type Config struct {
 // TestKeys contains riseupvpn test keys.
 type TestKeys struct {
 	urlgetter.TestKeys
-	APIFailure      *string             `json:"api_failure"`
-	APIStatus       string              `json:"api_status"`
-	CACertStatus    bool                `json:"ca_cert_status"`
-	FailingGateways []GatewayConnection `json:"failing_gateways"`
-	TransportStatus map[string]string   `json:"transport_status"`
+	APIFailures  []string `json:"api_failures"`
+	CACertStatus bool     `json:"ca_cert_status"`
 }
 
 // NewTestKeys creates new riseupvpn TestKeys.
 func NewTestKeys() *TestKeys {
 	return &TestKeys{
-		APIFailure:      nil,
-		APIStatus:       "ok",
-		CACertStatus:    true,
-		FailingGateways: nil,
-		TransportStatus: nil,
+		APIFailures:  []string{},
+		CACertStatus: true,
 	}
 }
 
@@ -88,12 +81,8 @@ func (tk *TestKeys) UpdateProviderAPITestKeys(v urlgetter.MultiOutput) {
 	tk.Requests = append(tk.Requests, v.TestKeys.Requests...)
 	tk.TCPConnect = append(tk.TCPConnect, v.TestKeys.TCPConnect...)
 	tk.TLSHandshakes = append(tk.TLSHandshakes, v.TestKeys.TLSHandshakes...)
-	if tk.APIStatus != "ok" {
-		return // we already flipped the state
-	}
 	if v.TestKeys.Failure != nil {
-		tk.APIStatus = "blocked"
-		tk.APIFailure = v.TestKeys.Failure
+		tk.APIFailures = append(tk.APIFailures, *v.TestKeys.Failure)
 		return
 	}
 }
@@ -104,42 +93,6 @@ func (tk *TestKeys) UpdateProviderAPITestKeys(v urlgetter.MultiOutput) {
 func (tk *TestKeys) AddGatewayConnectTestKeys(v urlgetter.MultiOutput, transportType string) {
 	tk.NetworkEvents = append(tk.NetworkEvents, v.TestKeys.NetworkEvents...)
 	tk.TCPConnect = append(tk.TCPConnect, v.TestKeys.TCPConnect...)
-	for _, tcpConnect := range v.TestKeys.TCPConnect {
-		if !tcpConnect.Status.Success {
-			gatewayConnection := newGatewayConnection(tcpConnect, transportType)
-			tk.FailingGateways = append(tk.FailingGateways, *gatewayConnection)
-		}
-	}
-}
-
-func (tk *TestKeys) updateTransportStatus(openvpnGatewayCount, obfs4GatewayCount int) {
-	failingOpenvpnGateways, failingObfs4Gateways := 0, 0
-	for _, gw := range tk.FailingGateways {
-		if gw.TransportType == "openvpn" {
-			failingOpenvpnGateways++
-		} else if gw.TransportType == "obfs4" {
-			failingObfs4Gateways++
-		}
-	}
-	if failingOpenvpnGateways < openvpnGatewayCount {
-		tk.TransportStatus["openvpn"] = "ok"
-	} else {
-		tk.TransportStatus["openvpn"] = "blocked"
-	}
-	if failingObfs4Gateways < obfs4GatewayCount {
-		tk.TransportStatus["obfs4"] = "ok"
-	} else {
-		tk.TransportStatus["obfs4"] = "blocked"
-	}
-}
-
-func newGatewayConnection(
-	tcpConnect tracex.TCPConnectEntry, transportType string) *GatewayConnection {
-	return &GatewayConnection{
-		IP:            tcpConnect.IP,
-		Port:          tcpConnect.Port,
-		TransportType: transportType,
-	}
 }
 
 // AddCACertFetchTestKeys adds generic urlgetter.Get() testKeys to riseupvpn specific test keys
@@ -149,11 +102,6 @@ func (tk *TestKeys) AddCACertFetchTestKeys(testKeys urlgetter.TestKeys) {
 	tk.Requests = append(tk.Requests, testKeys.Requests...)
 	tk.TCPConnect = append(tk.TCPConnect, testKeys.TCPConnect...)
 	tk.TLSHandshakes = append(tk.TLSHandshakes, testKeys.TLSHandshakes...)
-	if testKeys.Failure != nil {
-		tk.APIStatus = "blocked"
-		tk.APIFailure = tk.Failure
-		tk.CACertStatus = false
-	}
 }
 
 // Measurer performs the measurement.
@@ -206,22 +154,24 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 			FailOnHTTPError: true,
 		}},
 	}
-	for entry := range multi.CollectOverall(ctx, inputs, 0, 20, "riseupvpn", callbacks) {
+
+	nullCallbacks := model.NewPrinterCallbacks(model.DiscardLogger)
+	noTLSVerify := true
+	for entry := range multi.CollectOverall(ctx, inputs, 0, 20, "riseupvpn", nullCallbacks) {
 		tk := entry.TestKeys
 		testkeys.AddCACertFetchTestKeys(tk)
 		if tk.Failure != nil {
-			// TODO(bassosimone,cyberta): should we update the testkeys
-			// in this case (e.g., APIFailure?)
-			// See https://github.com/ooni/probe/issues/1432.
-			return nil
+			testkeys.CACertStatus = false
+			testkeys.APIFailures = append(testkeys.APIFailures, *tk.Failure)
+			continue
 		}
 		if ok := certPool.AppendCertsFromPEM([]byte(tk.HTTPResponseBody)); !ok {
 			testkeys.CACertStatus = false
-			testkeys.APIStatus = "blocked"
-			errorValue := "invalid_ca"
-			testkeys.APIFailure = &errorValue
-			return nil
+			testkeys.APIFailures = append(testkeys.APIFailures, "invalid_ca")
+			continue
 		}
+		// We have a CA so we can verify certificates
+		noTLSVerify = false
 	}
 
 	// Now test the service endpoints using the above-fetched CA
@@ -232,24 +182,26 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 			CertPool:        certPool,
 			Method:          "GET",
 			FailOnHTTPError: true,
+			NoTLSVerify:     noTLSVerify,
 		}},
 		{Target: eipServiceURL, Config: urlgetter.Config{
 			CertPool:        certPool,
 			Method:          "GET",
 			FailOnHTTPError: true,
+			NoTLSVerify:     noTLSVerify,
 		}},
 		{Target: geoServiceURL, Config: urlgetter.Config{
 			CertPool:        certPool,
 			Method:          "GET",
 			FailOnHTTPError: true,
+			NoTLSVerify:     noTLSVerify,
 		}},
 	}
-	for entry := range multi.CollectOverall(ctx, inputs, 1, 20, "riseupvpn", callbacks) {
+	for entry := range multi.CollectOverall(ctx, inputs, 1, 20, "riseupvpn", nullCallbacks) {
 		testkeys.UpdateProviderAPITestKeys(entry)
 	}
 
 	// test gateways now
-	testkeys.TransportStatus = map[string]string{}
 	gateways := parseGateways(testkeys)
 	openvpnEndpoints := generateMultiInputs(gateways, "openvpn")
 	obfs4Endpoints := generateMultiInputs(gateways, "obfs4")
@@ -272,8 +224,6 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 		testkeys.AddGatewayConnectTestKeys(entry, "obfs4")
 	}
 
-	// set transport status based on gateway test results
-	testkeys.updateTransportStatus(len(openvpnEndpoints), len(obfs4Endpoints))
 	return nil
 }
 

--- a/internal/experiment/riseupvpn/riseupvpn_test.go
+++ b/internal/experiment/riseupvpn/riseupvpn_test.go
@@ -212,7 +212,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 
 func TestGood(t *testing.T) {
 	// the gateaway openvpnurl2 is filtered out, since it doesn't support additionally obfs4
-	measurement, err := runDefaultMockTest(t, generateDefaultMockGetter(map[string]bool{
+	measurement := runDefaultMockTest(t, generateDefaultMockGetter(map[string]bool{
 		cacerturl:     true,
 		eipserviceurl: true,
 		providerurl:   true,
@@ -222,9 +222,6 @@ func TestGood(t *testing.T) {
 		obfs4url1:     true,
 		obfs4url2:     false,
 	}))
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	tk := measurement.TestKeys.(*riseupvpn.TestKeys)
 	if tk.Agent != "" {
@@ -343,13 +340,17 @@ func TestInvalidCaCert(t *testing.T) {
 		Session:     sess,
 	}
 	err := measurer.Run(ctx, args)
-	if !errors.Is(err, riseupvpn.ErrBootstrap) {
-		t.Fatal("unexpected error", err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tk := measurement.TestKeys.(*riseupvpn.TestKeys)
+	if tk.CACertStatus == true {
+		t.Fatal("unexpected CaCertStatus")
 	}
 }
 
 func TestFailureCaCertFetch(t *testing.T) {
-	_, err := runDefaultMockTest(t, generateDefaultMockGetter(map[string]bool{
+	measurement := runDefaultMockTest(t, generateDefaultMockGetter(map[string]bool{
 		cacerturl:     false,
 		eipserviceurl: true,
 		providerurl:   true,
@@ -358,13 +359,27 @@ func TestFailureCaCertFetch(t *testing.T) {
 		openvpnurl2:   true,
 		obfs4url1:     true,
 	}))
-	if !errors.Is(err, riseupvpn.ErrBootstrap) {
-		t.Fatal("unexpected error", err)
+
+	tk := measurement.TestKeys.(*riseupvpn.TestKeys)
+	if tk.CACertStatus != false {
+		t.Fatal("invalid CACertStatus ")
+	}
+
+	if len(tk.APIFailures) != 1 || tk.APIFailures[0] != io.EOF.Error() {
+		t.Fatal("APIFailures should not be empty", tk.APIFailures)
+	}
+	if len(tk.Requests) != 1 {
+		t.Fatal("Expected a single request in this case")
+	}
+	for _, tcpConnect := range tk.TCPConnect {
+		if tcpConnect.IP == openvpnurl1 || tcpConnect.IP == openvpnurl2 || tcpConnect.IP == obfs4url1 || tcpConnect.IP == obfs4url2 {
+			t.Fatal("No gateaway tests should be run if API fails")
+		}
 	}
 }
 
 func TestFailureEipServiceBlocked(t *testing.T) {
-	_, err := runDefaultMockTest(t, generateDefaultMockGetter(map[string]bool{
+	measurement := runDefaultMockTest(t, generateDefaultMockGetter(map[string]bool{
 		cacerturl:     true,
 		eipserviceurl: false,
 		providerurl:   true,
@@ -373,13 +388,26 @@ func TestFailureEipServiceBlocked(t *testing.T) {
 		openvpnurl2:   true,
 		obfs4url1:     true,
 	}))
-	if !errors.Is(err, riseupvpn.ErrBootstrap) {
-		t.Fatal("unexpected error", err)
+	tk := measurement.TestKeys.(*riseupvpn.TestKeys)
+	if tk.CACertStatus != true {
+		t.Fatal("invalid CACertStatus")
+	}
+
+	for _, entry := range tk.Requests {
+		if entry.Request.URL == "https://api.black.riseup.net:443/3/config/eip-service.json" {
+			if entry.Failure == nil {
+				t.Fatal("Failure for " + entry.Request.URL + " should not be null")
+			}
+		}
+	}
+
+	if len(tk.APIFailures) <= 0 {
+		t.Fatal("APIFailures should not be empty")
 	}
 }
 
 func TestFailureProviderUrlBlocked(t *testing.T) {
-	_, err := runDefaultMockTest(t, generateDefaultMockGetter(map[string]bool{
+	measurement := runDefaultMockTest(t, generateDefaultMockGetter(map[string]bool{
 		cacerturl:     true,
 		eipserviceurl: true,
 		providerurl:   false,
@@ -388,13 +416,27 @@ func TestFailureProviderUrlBlocked(t *testing.T) {
 		openvpnurl2:   true,
 		obfs4url1:     true,
 	}))
-	if !errors.Is(err, riseupvpn.ErrBootstrap) {
-		t.Fatal("unexpected error", err)
+	tk := measurement.TestKeys.(*riseupvpn.TestKeys)
+
+	for _, entry := range tk.Requests {
+		if entry.Request.URL == "https://riseup.net/provider.json" {
+			if entry.Failure == nil {
+				t.Fatal("Failure for " + entry.Request.URL + " should not be null")
+			}
+		}
+	}
+
+	if tk.CACertStatus != true {
+		t.Fatal("invalid CACertStatus ")
+	}
+
+	if len(tk.APIFailures) <= 0 {
+		t.Fatal("APIFailures should not be empty")
 	}
 }
 
 func TestFailureGeoIpServiceBlocked(t *testing.T) {
-	_, err := runDefaultMockTest(t, generateDefaultMockGetter(map[string]bool{
+	measurement := runDefaultMockTest(t, generateDefaultMockGetter(map[string]bool{
 		cacerturl:     true,
 		eipserviceurl: true,
 		providerurl:   true,
@@ -403,13 +445,26 @@ func TestFailureGeoIpServiceBlocked(t *testing.T) {
 		openvpnurl2:   true,
 		obfs4url1:     true,
 	}))
-	if !errors.Is(err, riseupvpn.ErrBootstrap) {
-		t.Fatal("unexpected error", err)
+	tk := measurement.TestKeys.(*riseupvpn.TestKeys)
+	if tk.CACertStatus != true {
+		t.Fatal("invalid CACertStatus ")
+	}
+
+	for _, entry := range tk.Requests {
+		if entry.Request.URL == "https://api.black.riseup.net:9001/json" {
+			if entry.Failure == nil {
+				t.Fatal("Failure for " + entry.Request.URL + " should not be null")
+			}
+		}
+	}
+
+	if len(tk.APIFailures) <= 0 {
+		t.Fatal("APIFailures should not be empty")
 	}
 }
 
 func TestFailureGateway1TransportNOK(t *testing.T) {
-	measurement, err := runDefaultMockTest(t, generateDefaultMockGetter(map[string]bool{
+	measurement := runDefaultMockTest(t, generateDefaultMockGetter(map[string]bool{
 		cacerturl:     true,
 		eipserviceurl: true,
 		providerurl:   true,
@@ -419,10 +474,6 @@ func TestFailureGateway1TransportNOK(t *testing.T) {
 		obfs4url1:     true,
 		obfs4url2:     false,
 	}))
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	tk := measurement.TestKeys.(*riseupvpn.TestKeys)
 	if tk.CACertStatus != true {
 		t.Fatal("invalid CACertStatus ")
@@ -528,7 +579,7 @@ func generateDefaultMockGetter(responseStatuses map[string]bool) urlgetter.Multi
 	return generateMockGetter(RequestResponse, responseStatuses)
 }
 
-func runDefaultMockTest(t *testing.T, multiGetter urlgetter.MultiGetter) (*model.Measurement, error) {
+func runDefaultMockTest(t *testing.T, multiGetter urlgetter.MultiGetter) *model.Measurement {
 	measurer := riseupvpn.Measurer{
 		Config: riseupvpn.Config{},
 		Getter: multiGetter,
@@ -541,5 +592,9 @@ func runDefaultMockTest(t *testing.T, multiGetter urlgetter.MultiGetter) (*model
 		Session:     &mocks.Session{MockLogger: func() model.Logger { return log.Log }},
 	}
 	err := measurer.Run(context.Background(), args)
-	return measurement, err
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	return measurement
 }


### PR DESCRIPTION
This diff incorporates part of what has been implemented by @cyBerta in https://github.com/ooni/probe-cli/pull/1125 in response to my review as well as additional changes based on my own feelings about what is correct to do here.

Compared to the original diff, these are the changes that I implemented:

1. I have omitted the work to fetch from riseup geo service and figure out the correct gateways to test. The main reason for not including this body of work has been to reduce the size of the diff and the amount of code to deal with.

2. I modified the logic related to failures in fetching the CA and communicating with riseup services. The test fails immediately if we cannot fetch the proper CA or we cannot contact riseup services. I did not feel comfortable disabling the CA to access riseup services and connecting to the TCP endpoints discovered w/o CA verification.

3. In the test keys, I renamed `api_failure` to `api_failures` because I do not think it's optimal to keep the same name while the type has changed from `*string` to `[]string`.

The spirit of the changes is not directly compatible with what we discussed with @cyBerta. The main difference is in my decision to fail early in case we miss the preconditions. As I wrote in https://github.com/ooni/probe-cli/pull/1125#pullrequestreview-1526320800, I think we should be using richer input (and start with its simplest form) to provision to probes the data they need to perform this experiment. By provisioning the data ourselves, we remove the coupling between getting the CA, accessing riseup services to get information on what gateways we should measure, and measure the gateways, which makes the experiment several orders of magnitude more robust.

Unfortunately, I do not have time, in this cycle, to perform all this richer input work. We'll try again for 3.20.

This work is part of https://github.com/ooni/probe/issues/1432.

While there, I forced null callbacks when performing the CA fetch and contacting riseup services, otherwise we end up printing a non-monotonic progress status. Admittedly, also omitting to provide progress about these two operations is bad, but I think we won't be able to provide monotonic progress until we know what we should fetch in advance.

---------

Co-authored-by: cyBerta <cyberta@riseup.net>

