### PR TITLE
chore(ooniprobe): add riseupvpn to experimental test suite

### DIFF
--- a/cmd/ooniprobe/internal/nettests/groups.go
+++ b/cmd/ooniprobe/internal/nettests/groups.go
@@ -57,6 +57,7 @@ var All = map[string]Group{
 			DNSCheck{},
 			ECHCheck{},
 			STUNReachability{},
+			RiseupVPN{},
 			TorSf{},
 			VanillaTor{},
 		},


### PR DESCRIPTION
Concludes riseupvpn work for release 3.19.

Reference issue: https://github.com/ooni/probe/issues/2524.
