### PR TITLE
fix(nettests): failing to start a nettest is a warning

### DIFF
--- a/cmd/ooniprobe/internal/nettests/run.go
+++ b/cmd/ooniprobe/internal/nettests/run.go
@@ -78,7 +78,7 @@ func RunGroup(config RunGroupConfig) error {
 		return err
 	}
 	if err := sess.MaybeLookupBackends(); err != nil {
-		log.WithError(err).Warn("Failed to discover OONI backends")
+		log.WithError(err).Errorf("Failed to discover OONI backends")
 		return err
 	}
 
@@ -116,7 +116,9 @@ func RunGroup(config RunGroupConfig) error {
 		ctl.RunType = config.RunType
 		ctl.SetNettestIndex(i, len(group.Nettests))
 		if err = nt.Run(ctl); err != nil {
-			log.WithError(err).Errorf("Failed to run %s", group.Label)
+			// Note that here we would like to emit a warning--the proper choice
+			// given that we continue running. See https://github.com/ooni/probe/issues/2576.
+			log.WithError(err).Warnf("Failed to run %s", group.Label)
 		}
 	}
 


### PR DESCRIPTION
Emitting an error causes ooni/probe-desktop to try to generate a warning window that (1) is a bit unpleasant to visually see and (2) more importantly is not proper to show, given that we have default-disabled experiments right now.

See https://github.com/ooni/probe/issues/2576 for extra information.
