### PR TITLE
fix(registry): disable vanilla_tor by default

### DIFF
--- a/internal/registry/factory_test.go
+++ b/internal/registry/factory_test.go
@@ -492,8 +492,10 @@ func TestNewFactory(t *testing.T) {
 			inputPolicy:      model.InputStrictlyRequired,
 		},
 		"vanilla_tor": {
-			enabledByDefault: true,
-			inputPolicy:      model.InputNone,
+			// The experiment crashes on Android and possibly also iOS. We want to
+			// control whether and when to run it using check-in.
+			//enabledByDefault: false,
+			inputPolicy: model.InputNone,
 		},
 		"web_connectivity": {
 			enabledByDefault: true,

--- a/internal/registry/vanillator.go
+++ b/internal/registry/vanillator.go
@@ -16,8 +16,11 @@ func init() {
 				*config.(*vanillator.Config),
 			)
 		},
-		config:           &vanillator.Config{},
-		enabledByDefault: true,
+		config: &vanillator.Config{},
+		// We discussed this topic with @aanorbel. On Android this experiment crashes
+		// frequently because of https://github.com/ooni/probe/issues/2406. So, it seems
+		// more cautious to disable it by default and let the check-in API decide.
+		enabledByDefault: false,
 		inputPolicy:      model.InputNone,
 	}
 }


### PR DESCRIPTION
The reference issue is https://github.com/ooni/probe/issues/2553.

When I implemented the disabled-by-default functionality, I missed that we should also disable-by-default vanilla_tor.

The reason for doing that is that the experiment crashes on Android and possibly iOS due to https://github.com/ooni/probe/issues/2406.
