### PR TITLE
refactor(dslx): finish making funcs stateless

### DIFF
--- a/internal/dslx/http_test.go
+++ b/internal/dslx/http_test.go
@@ -252,7 +252,7 @@ func TestHTTPRequest(t *testing.T) {
 		})
 
 		t.Run("with invalid domain", func(t *testing.T) {
-			httpTransport := HTTPTransport{
+			httpTransport := HTTPConnection{
 				Address:   "1.2.3.4:567",
 				Domain:    "\t", // invalid domain
 				Network:   "tcp",

--- a/internal/dslx/http_test.go
+++ b/internal/dslx/http_test.go
@@ -406,19 +406,10 @@ func TestHTTPRequest(t *testing.T) {
 
 /*
 Test cases:
-- Get httpTransportTCPFunc
 - Get composed function: TCP with HTTP
 - Apply httpTransportTCPFunc
 */
 func TestHTTPTCP(t *testing.T) {
-	t.Run("Get httpTransportTCPFunc", func(t *testing.T) {
-		rt := NewMinimalRuntime(model.DiscardLogger, time.Now())
-		f := HTTPTransportTCP(rt)
-		if _, ok := f.(*httpTransportTCPFunc); !ok {
-			t.Fatal("unexpected type")
-		}
-	})
-
 	t.Run("Get composed function: TCP with HTTP", func(t *testing.T) {
 		rt := NewMinimalRuntime(model.DiscardLogger, time.Now())
 		f := HTTPRequestOverTCP(rt)
@@ -439,9 +430,9 @@ func TestHTTPTCP(t *testing.T) {
 			Network: "tcp",
 			Trace:   trace,
 		}
-		f := httpTransportTCPFunc{
-			rt: NewMinimalRuntime(model.DiscardLogger, time.Now()),
-		}
+		f := HTTPConnectionTCP(
+			NewMinimalRuntime(model.DiscardLogger, time.Now()),
+		)
 		res := f.Apply(context.Background(), tcpConn)
 		if res.Error != nil {
 			t.Fatalf("unexpected error: %s", res.Error)
@@ -460,19 +451,10 @@ func TestHTTPTCP(t *testing.T) {
 
 /*
 Test cases:
-- Get httpTransportQUICFunc
 - Get composed function: QUIC with HTTP
 - Apply httpTransportQUICFunc
 */
 func TestHTTPQUIC(t *testing.T) {
-	t.Run("Get httpTransportQUICFunc", func(t *testing.T) {
-		rt := NewMinimalRuntime(model.DiscardLogger, time.Now())
-		f := HTTPTransportQUIC(rt)
-		if _, ok := f.(*httpTransportQUICFunc); !ok {
-			t.Fatal("unexpected type")
-		}
-	})
-
 	t.Run("Get composed function: QUIC with HTTP", func(t *testing.T) {
 		rt := NewMinimalRuntime(model.DiscardLogger, time.Now())
 		f := HTTPRequestOverQUIC(rt)
@@ -493,9 +475,9 @@ func TestHTTPQUIC(t *testing.T) {
 			Network:  "udp",
 			Trace:    trace,
 		}
-		f := httpTransportQUICFunc{
-			rt: NewMinimalRuntime(model.DiscardLogger, time.Now()),
-		}
+		f := HTTPConnectionQUIC(
+			NewMinimalRuntime(model.DiscardLogger, time.Now()),
+		)
 		res := f.Apply(context.Background(), quicConn)
 		if res.Error != nil {
 			t.Fatalf("unexpected error: %s", res.Error)
@@ -514,19 +496,10 @@ func TestHTTPQUIC(t *testing.T) {
 
 /*
 Test cases:
-- Get httpTransportTLSFunc
 - Get composed function: TLS with HTTP
 - Apply httpTransportTLSFunc
 */
 func TestHTTPTLS(t *testing.T) {
-	t.Run("Get httpTransportTLSFunc", func(t *testing.T) {
-		rt := NewMinimalRuntime(model.DiscardLogger, time.Now())
-		f := HTTPTransportTLS(rt)
-		if _, ok := f.(*httpTransportTLSFunc); !ok {
-			t.Fatal("unexpected type")
-		}
-	})
-
 	t.Run("Get composed function: TLS with HTTP", func(t *testing.T) {
 		rt := NewMinimalRuntime(model.DiscardLogger, time.Now())
 		f := HTTPRequestOverTLS(rt)
@@ -547,9 +520,9 @@ func TestHTTPTLS(t *testing.T) {
 			Network: "tcp",
 			Trace:   trace,
 		}
-		f := httpTransportTLSFunc{
-			rt: NewMinimalRuntime(model.DiscardLogger, time.Now()),
-		}
+		f := HTTPConnectionTLS(
+			NewMinimalRuntime(model.DiscardLogger, time.Now()),
+		)
 		res := f.Apply(context.Background(), tlsConn)
 		if res.Error != nil {
 			t.Fatalf("unexpected error: %s", res.Error)

--- a/internal/dslx/http_test.go
+++ b/internal/dslx/http_test.go
@@ -239,9 +239,9 @@ func TestHTTPRequest(t *testing.T) {
 				Trace:     trace,
 				Transport: eofTransport,
 			}
-			httpRequest := &httpRequestFunc{
-				Rt: NewMinimalRuntime(model.DiscardLogger, time.Now()),
-			}
+			httpRequest := HTTPRequest(
+				NewMinimalRuntime(model.DiscardLogger, time.Now()),
+			)
 			res := httpRequest.Apply(context.Background(), &httpTransport)
 			if res.Error != io.EOF {
 				t.Fatal("not the error we expected")
@@ -279,9 +279,9 @@ func TestHTTPRequest(t *testing.T) {
 				Trace:     trace,
 				Transport: goodTransport,
 			}
-			httpRequest := &httpRequestFunc{
-				Rt: NewMinimalRuntime(model.DiscardLogger, time.Now()),
-			}
+			httpRequest := HTTPRequest(
+				NewMinimalRuntime(model.DiscardLogger, time.Now()),
+			)
 			res := httpRequest.Apply(context.Background(), &httpTransport)
 			if res.Error != nil {
 				t.Fatal("expected error")
@@ -331,9 +331,9 @@ func TestHTTPRequest(t *testing.T) {
 				Trace:     trace,
 				Transport: goodTransport,
 			}
-			httpRequest := &httpRequestFunc{
-				Rt: NewMinimalRuntime(model.DiscardLogger, time.Now()),
-			}
+			httpRequest := HTTPRequest(
+				NewMinimalRuntime(model.DiscardLogger, time.Now()),
+			)
 			res := httpRequest.Apply(context.Background(), &httpTransport)
 			if res.Error != nil {
 				t.Fatal("unexpected error")
@@ -352,9 +352,9 @@ func TestHTTPRequest(t *testing.T) {
 				Trace:     trace,
 				Transport: goodTransport,
 			}
-			httpRequest := &httpRequestFunc{
-				Rt: NewMinimalRuntime(model.DiscardLogger, time.Now()),
-			}
+			httpRequest := HTTPRequest(
+				NewMinimalRuntime(model.DiscardLogger, time.Now()),
+			)
 			res := httpRequest.Apply(context.Background(), &httpTransport)
 			if res.Error != nil {
 				t.Fatal("unexpected error")

--- a/internal/dslx/http_test.go
+++ b/internal/dslx/http_test.go
@@ -20,7 +20,7 @@ import (
 func TestHTTPNewRequest(t *testing.T) {
 	t.Run("without any option and with domain", func(t *testing.T) {
 		ctx := context.Background()
-		conn := &HTTPTransport{
+		conn := &HTTPConnection{
 			Address:               "130.192.91.211:443",
 			Domain:                "example.com",
 			Network:               "tcp",
@@ -60,7 +60,7 @@ func TestHTTPNewRequest(t *testing.T) {
 
 	t.Run("without any option, without domain but with standard port", func(t *testing.T) {
 		ctx := context.Background()
-		conn := &HTTPTransport{
+		conn := &HTTPConnection{
 			Address:               "130.192.91.211:443",
 			Domain:                "",
 			Network:               "tcp",
@@ -100,7 +100,7 @@ func TestHTTPNewRequest(t *testing.T) {
 
 	t.Run("without any option, without domain but with nonstandard port", func(t *testing.T) {
 		ctx := context.Background()
-		conn := &HTTPTransport{
+		conn := &HTTPConnection{
 			Address:               "130.192.91.211:443",
 			Domain:                "",
 			Network:               "tcp",
@@ -140,7 +140,7 @@ func TestHTTPNewRequest(t *testing.T) {
 
 	t.Run("with all options", func(t *testing.T) {
 		ctx := context.Background()
-		conn := &HTTPTransport{
+		conn := &HTTPConnection{
 			Address:               "130.192.91.211:443",
 			Domain:                "example.com",
 			Network:               "tcp",
@@ -232,7 +232,7 @@ func TestHTTPRequest(t *testing.T) {
 		trace := measurexlite.NewTrace(idGen.Add(1), zeroTime, "antani")
 
 		t.Run("with EOF", func(t *testing.T) {
-			httpTransport := HTTPTransport{
+			httpTransport := HTTPConnection{
 				Address:   "1.2.3.4:567",
 				Network:   "tcp",
 				Scheme:    "https",
@@ -272,7 +272,7 @@ func TestHTTPRequest(t *testing.T) {
 		})
 
 		t.Run("with port-less address", func(t *testing.T) {
-			httpTransport := HTTPTransport{
+			httpTransport := HTTPConnection{
 				Address:   "1.2.3.4",
 				Network:   "tcp",
 				Scheme:    "https",
@@ -324,7 +324,7 @@ func TestHTTPRequest(t *testing.T) {
 		}
 
 		t.Run("with success (https)", func(t *testing.T) {
-			httpTransport := HTTPTransport{
+			httpTransport := HTTPConnection{
 				Address:   "1.2.3.4:443",
 				Network:   "tcp",
 				Scheme:    "https",
@@ -345,7 +345,7 @@ func TestHTTPRequest(t *testing.T) {
 		})
 
 		t.Run("with success (http)", func(t *testing.T) {
-			httpTransport := HTTPTransport{
+			httpTransport := HTTPConnection{
 				Address:   "1.2.3.4:80",
 				Network:   "tcp",
 				Scheme:    "http",
@@ -366,7 +366,7 @@ func TestHTTPRequest(t *testing.T) {
 		})
 
 		t.Run("with header options", func(t *testing.T) {
-			httpTransport := HTTPTransport{
+			httpTransport := HTTPConnection{
 				Address:   "1.2.3.4:567",
 				Domain:    "domain.com",
 				Network:   "tcp",
@@ -422,7 +422,7 @@ func TestHTTPTCP(t *testing.T) {
 	t.Run("Get composed function: TCP with HTTP", func(t *testing.T) {
 		rt := NewMinimalRuntime(model.DiscardLogger, time.Now())
 		f := HTTPRequestOverTCP(rt)
-		if _, ok := f.(*compose2Func[*TCPConnection, *HTTPTransport, *HTTPResponse]); !ok {
+		if _, ok := f.(*compose2Func[*TCPConnection, *HTTPConnection, *HTTPResponse]); !ok {
 			t.Fatal("unexpected type")
 		}
 	})
@@ -476,7 +476,7 @@ func TestHTTPQUIC(t *testing.T) {
 	t.Run("Get composed function: QUIC with HTTP", func(t *testing.T) {
 		rt := NewMinimalRuntime(model.DiscardLogger, time.Now())
 		f := HTTPRequestOverQUIC(rt)
-		if _, ok := f.(*compose2Func[*QUICConnection, *HTTPTransport, *HTTPResponse]); !ok {
+		if _, ok := f.(*compose2Func[*QUICConnection, *HTTPConnection, *HTTPResponse]); !ok {
 			t.Fatal("unexpected type")
 		}
 	})
@@ -530,7 +530,7 @@ func TestHTTPTLS(t *testing.T) {
 	t.Run("Get composed function: TLS with HTTP", func(t *testing.T) {
 		rt := NewMinimalRuntime(model.DiscardLogger, time.Now())
 		f := HTTPRequestOverTLS(rt)
-		if _, ok := f.(*compose2Func[*TLSConnection, *HTTPTransport, *HTTPResponse]); !ok {
+		if _, ok := f.(*compose2Func[*TLSConnection, *HTTPConnection, *HTTPResponse]); !ok {
 			t.Fatal("unexpected type")
 		}
 	})

--- a/internal/dslx/httpcore.go
+++ b/internal/dslx/httpcore.go
@@ -19,12 +19,12 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/throttling"
 )
 
-// HTTPTransport is an HTTP transport bound to a TCP, TLS or QUIC connection
+// HTTPConnection is an HTTP connection bound to a TCP, TLS or QUIC connection
 // that would use such a connection only and for any input URL. You generally
 // use [HTTPTransportTCP], [HTTPTransportTLS] or [HTTPTransportQUIC] to
 // create a new instance; if you want to initialize manually, make sure you
 // init the fields marked as MANDATORY.
-type HTTPTransport struct {
+type HTTPConnection struct {
 	// Address is the MANDATORY address we're connected to.
 	Address string
 
@@ -101,8 +101,8 @@ func HTTPRequestOptionUserAgent(value string) HTTPRequestOption {
 }
 
 // HTTPRequest issues an HTTP request using a transport and returns a response.
-func HTTPRequest(rt Runtime, options ...HTTPRequestOption) Func[*HTTPTransport, *Maybe[*HTTPResponse]] {
-	return FuncAdapter[*HTTPTransport, *Maybe[*HTTPResponse]](func(ctx context.Context, input *HTTPTransport) *Maybe[*HTTPResponse] {
+func HTTPRequest(rt Runtime, options ...HTTPRequestOption) Func[*HTTPConnection, *Maybe[*HTTPResponse]] {
+	return FuncAdapter[*HTTPConnection, *Maybe[*HTTPResponse]](func(ctx context.Context, input *HTTPConnection) *Maybe[*HTTPResponse] {
 		// setup
 		const timeout = 10 * time.Second
 		ctx, cancel := context.WithTimeout(ctx, timeout)
@@ -159,7 +159,7 @@ func HTTPRequest(rt Runtime, options ...HTTPRequestOption) Func[*HTTPTransport, 
 
 // httpNewRequest is a convenience function for creating a new request.
 func httpNewRequest(
-	ctx context.Context, input *HTTPTransport, logger model.Logger, options ...HTTPRequestOption) (*http.Request, error) {
+	ctx context.Context, input *HTTPConnection, logger model.Logger, options ...HTTPRequestOption) (*http.Request, error) {
 	// create the default HTTP request
 	URL := &url.URL{
 		Scheme:      input.Scheme,
@@ -194,7 +194,7 @@ func httpNewRequest(
 }
 
 // httpNewURLHost computes the URL host to use.
-func httpNewURLHost(input *HTTPTransport, logger model.Logger) string {
+func httpNewURLHost(input *HTTPConnection, logger model.Logger) string {
 	if input.Domain != "" {
 		return input.Domain
 	}
@@ -216,7 +216,7 @@ func httpNewURLHost(input *HTTPTransport, logger model.Logger) string {
 // httpRoundTrip performs the actual HTTP round trip
 func httpRoundTrip(
 	ctx context.Context,
-	input *HTTPTransport,
+	input *HTTPConnection,
 	req *http.Request,
 ) (*http.Response, []byte, []*Observations, error) {
 	const maxbody = 1 << 19 // TODO(bassosimone): allow to configure this value?

--- a/internal/dslx/httpquic.go
+++ b/internal/dslx/httpquic.go
@@ -16,7 +16,7 @@ func HTTPRequestOverQUIC(rt Runtime, options ...HTTPRequestOption) Func[*QUICCon
 }
 
 // HTTPTransportQUIC converts a QUIC connection into an HTTP transport.
-func HTTPTransportQUIC(rt Runtime) Func[*QUICConnection, *Maybe[*HTTPTransport]] {
+func HTTPTransportQUIC(rt Runtime) Func[*QUICConnection, *Maybe[*HTTPConnection]] {
 	return &httpTransportQUICFunc{rt}
 }
 
@@ -27,7 +27,7 @@ type httpTransportQUICFunc struct {
 
 // Apply implements Func.
 func (f *httpTransportQUICFunc) Apply(
-	ctx context.Context, input *QUICConnection) *Maybe[*HTTPTransport] {
+	ctx context.Context, input *QUICConnection) *Maybe[*HTTPConnection] {
 	// create transport
 	httpTransport := netxlite.NewHTTP3Transport(
 		f.rt.Logger(),
@@ -35,7 +35,7 @@ func (f *httpTransportQUICFunc) Apply(
 		input.TLSConfig,
 	)
 
-	state := &HTTPTransport{
+	state := &HTTPConnection{
 		Address:               input.Address,
 		Domain:                input.Domain,
 		Network:               input.Network,
@@ -44,7 +44,7 @@ func (f *httpTransportQUICFunc) Apply(
 		Trace:                 input.Trace,
 		Transport:             httpTransport,
 	}
-	return &Maybe[*HTTPTransport]{
+	return &Maybe[*HTTPConnection]{
 		Error:        nil,
 		Observations: nil,
 		Operation:    "", // we cannot fail, so no need to store operation name

--- a/internal/dslx/httpquic.go
+++ b/internal/dslx/httpquic.go
@@ -12,42 +12,33 @@ import (
 
 // HTTPRequestOverQUIC returns a Func that issues HTTP requests over QUIC.
 func HTTPRequestOverQUIC(rt Runtime, options ...HTTPRequestOption) Func[*QUICConnection, *Maybe[*HTTPResponse]] {
-	return Compose2(HTTPTransportQUIC(rt), HTTPRequest(rt, options...))
+	return Compose2(HTTPConnectionQUIC(rt), HTTPRequest(rt, options...))
 }
 
-// HTTPTransportQUIC converts a QUIC connection into an HTTP transport.
-func HTTPTransportQUIC(rt Runtime) Func[*QUICConnection, *Maybe[*HTTPConnection]] {
-	return &httpTransportQUICFunc{rt}
-}
+// HTTPConnectionQUIC converts a QUIC connection into an HTTP connection.
+func HTTPConnectionQUIC(rt Runtime) Func[*QUICConnection, *Maybe[*HTTPConnection]] {
+	return FuncAdapter[*QUICConnection, *Maybe[*HTTPConnection]](func(ctx context.Context, input *QUICConnection) *Maybe[*HTTPConnection] {
+		// create transport
+		httpTransport := netxlite.NewHTTP3Transport(
+			rt.Logger(),
+			netxlite.NewSingleUseQUICDialer(input.QUICConn),
+			input.TLSConfig,
+		)
 
-// httpTransportQUICFunc is the function returned by HTTPTransportQUIC.
-type httpTransportQUICFunc struct {
-	rt Runtime
-}
-
-// Apply implements Func.
-func (f *httpTransportQUICFunc) Apply(
-	ctx context.Context, input *QUICConnection) *Maybe[*HTTPConnection] {
-	// create transport
-	httpTransport := netxlite.NewHTTP3Transport(
-		f.rt.Logger(),
-		netxlite.NewSingleUseQUICDialer(input.QUICConn),
-		input.TLSConfig,
-	)
-
-	state := &HTTPConnection{
-		Address:               input.Address,
-		Domain:                input.Domain,
-		Network:               input.Network,
-		Scheme:                "https",
-		TLSNegotiatedProtocol: input.TLSState.NegotiatedProtocol,
-		Trace:                 input.Trace,
-		Transport:             httpTransport,
-	}
-	return &Maybe[*HTTPConnection]{
-		Error:        nil,
-		Observations: nil,
-		Operation:    "", // we cannot fail, so no need to store operation name
-		State:        state,
-	}
+		state := &HTTPConnection{
+			Address:               input.Address,
+			Domain:                input.Domain,
+			Network:               input.Network,
+			Scheme:                "https",
+			TLSNegotiatedProtocol: input.TLSState.NegotiatedProtocol,
+			Trace:                 input.Trace,
+			Transport:             httpTransport,
+		}
+		return &Maybe[*HTTPConnection]{
+			Error:        nil,
+			Observations: nil,
+			Operation:    "", // we cannot fail, so no need to store operation name
+			State:        state,
+		}
+	})
 }

--- a/internal/dslx/httptcp.go
+++ b/internal/dslx/httptcp.go
@@ -16,7 +16,7 @@ func HTTPRequestOverTCP(rt Runtime, options ...HTTPRequestOption) Func[*TCPConne
 }
 
 // HTTPTransportTCP converts a TCP connection into an HTTP transport.
-func HTTPTransportTCP(rt Runtime) Func[*TCPConnection, *Maybe[*HTTPTransport]] {
+func HTTPTransportTCP(rt Runtime) Func[*TCPConnection, *Maybe[*HTTPConnection]] {
 	return &httpTransportTCPFunc{rt}
 }
 
@@ -27,7 +27,7 @@ type httpTransportTCPFunc struct {
 
 // Apply implements Func
 func (f *httpTransportTCPFunc) Apply(
-	ctx context.Context, input *TCPConnection) *Maybe[*HTTPTransport] {
+	ctx context.Context, input *TCPConnection) *Maybe[*HTTPConnection] {
 	// TODO(https://github.com/ooni/probe/issues/2534): here we're using the QUIRKY netxlite.NewHTTPTransport
 	// function, but we can probably avoid using it, given that this code is
 	// not using tracing and does not care about those quirks.
@@ -36,7 +36,7 @@ func (f *httpTransportTCPFunc) Apply(
 		netxlite.NewSingleUseDialer(input.Conn),
 		netxlite.NewNullTLSDialer(),
 	)
-	state := &HTTPTransport{
+	state := &HTTPConnection{
 		Address:               input.Address,
 		Domain:                input.Domain,
 		Network:               input.Network,
@@ -45,7 +45,7 @@ func (f *httpTransportTCPFunc) Apply(
 		Trace:                 input.Trace,
 		Transport:             httpTransport,
 	}
-	return &Maybe[*HTTPTransport]{
+	return &Maybe[*HTTPConnection]{
 		Error:        nil,
 		Observations: nil,
 		Operation:    "", // we cannot fail, so no need to store operation name

--- a/internal/dslx/httptcp.go
+++ b/internal/dslx/httptcp.go
@@ -12,43 +12,34 @@ import (
 
 // HTTPRequestOverTCP returns a Func that issues HTTP requests over TCP.
 func HTTPRequestOverTCP(rt Runtime, options ...HTTPRequestOption) Func[*TCPConnection, *Maybe[*HTTPResponse]] {
-	return Compose2(HTTPTransportTCP(rt), HTTPRequest(rt, options...))
+	return Compose2(HTTPConnectionTCP(rt), HTTPRequest(rt, options...))
 }
 
-// HTTPTransportTCP converts a TCP connection into an HTTP transport.
-func HTTPTransportTCP(rt Runtime) Func[*TCPConnection, *Maybe[*HTTPConnection]] {
-	return &httpTransportTCPFunc{rt}
-}
-
-// httpTransportTCPFunc is the function returned by HTTPTransportTCP
-type httpTransportTCPFunc struct {
-	rt Runtime
-}
-
-// Apply implements Func
-func (f *httpTransportTCPFunc) Apply(
-	ctx context.Context, input *TCPConnection) *Maybe[*HTTPConnection] {
-	// TODO(https://github.com/ooni/probe/issues/2534): here we're using the QUIRKY netxlite.NewHTTPTransport
-	// function, but we can probably avoid using it, given that this code is
-	// not using tracing and does not care about those quirks.
-	httpTransport := netxlite.NewHTTPTransport(
-		f.rt.Logger(),
-		netxlite.NewSingleUseDialer(input.Conn),
-		netxlite.NewNullTLSDialer(),
-	)
-	state := &HTTPConnection{
-		Address:               input.Address,
-		Domain:                input.Domain,
-		Network:               input.Network,
-		Scheme:                "http",
-		TLSNegotiatedProtocol: "",
-		Trace:                 input.Trace,
-		Transport:             httpTransport,
-	}
-	return &Maybe[*HTTPConnection]{
-		Error:        nil,
-		Observations: nil,
-		Operation:    "", // we cannot fail, so no need to store operation name
-		State:        state,
-	}
+// HTTPConnectionTCP converts a TCP connection into an HTTP connection.
+func HTTPConnectionTCP(rt Runtime) Func[*TCPConnection, *Maybe[*HTTPConnection]] {
+	return FuncAdapter[*TCPConnection, *Maybe[*HTTPConnection]](func(ctx context.Context, input *TCPConnection) *Maybe[*HTTPConnection] {
+		// TODO(https://github.com/ooni/probe/issues/2534): here we're using the QUIRKY netxlite.NewHTTPTransport
+		// function, but we can probably avoid using it, given that this code is
+		// not using tracing and does not care about those quirks.
+		httpTransport := netxlite.NewHTTPTransport(
+			rt.Logger(),
+			netxlite.NewSingleUseDialer(input.Conn),
+			netxlite.NewNullTLSDialer(),
+		)
+		state := &HTTPConnection{
+			Address:               input.Address,
+			Domain:                input.Domain,
+			Network:               input.Network,
+			Scheme:                "http",
+			TLSNegotiatedProtocol: "",
+			Trace:                 input.Trace,
+			Transport:             httpTransport,
+		}
+		return &Maybe[*HTTPConnection]{
+			Error:        nil,
+			Observations: nil,
+			Operation:    "", // we cannot fail, so no need to store operation name
+			State:        state,
+		}
+	})
 }

--- a/internal/dslx/httptls.go
+++ b/internal/dslx/httptls.go
@@ -12,43 +12,34 @@ import (
 
 // HTTPRequestOverTLS returns a Func that issues HTTP requests over TLS.
 func HTTPRequestOverTLS(rt Runtime, options ...HTTPRequestOption) Func[*TLSConnection, *Maybe[*HTTPResponse]] {
-	return Compose2(HTTPTransportTLS(rt), HTTPRequest(rt, options...))
+	return Compose2(HTTPConnectionTLS(rt), HTTPRequest(rt, options...))
 }
 
-// HTTPTransportTLS converts a TLS connection into an HTTP transport.
-func HTTPTransportTLS(rt Runtime) Func[*TLSConnection, *Maybe[*HTTPConnection]] {
-	return &httpTransportTLSFunc{rt}
-}
-
-// httpTransportTLSFunc is the function returned by HTTPTransportTLS.
-type httpTransportTLSFunc struct {
-	rt Runtime
-}
-
-// Apply implements Func.
-func (f *httpTransportTLSFunc) Apply(
-	ctx context.Context, input *TLSConnection) *Maybe[*HTTPConnection] {
-	// TODO(https://github.com/ooni/probe/issues/2534): here we're using the QUIRKY netxlite.NewHTTPTransport
-	// function, but we can probably avoid using it, given that this code is
-	// not using tracing and does not care about those quirks.
-	httpTransport := netxlite.NewHTTPTransport(
-		f.rt.Logger(),
-		netxlite.NewNullDialer(),
-		netxlite.NewSingleUseTLSDialer(input.Conn),
-	)
-	state := &HTTPConnection{
-		Address:               input.Address,
-		Domain:                input.Domain,
-		Network:               input.Network,
-		Scheme:                "https",
-		TLSNegotiatedProtocol: input.TLSState.NegotiatedProtocol,
-		Trace:                 input.Trace,
-		Transport:             httpTransport,
-	}
-	return &Maybe[*HTTPConnection]{
-		Error:        nil,
-		Observations: nil,
-		Operation:    "", // we cannot fail, so no need to store operation name
-		State:        state,
-	}
+// HTTPConnectionTLS converts a TLS connection into an HTTP connection.
+func HTTPConnectionTLS(rt Runtime) Func[*TLSConnection, *Maybe[*HTTPConnection]] {
+	return FuncAdapter[*TLSConnection, *Maybe[*HTTPConnection]](func(ctx context.Context, input *TLSConnection) *Maybe[*HTTPConnection] {
+		// TODO(https://github.com/ooni/probe/issues/2534): here we're using the QUIRKY netxlite.NewHTTPTransport
+		// function, but we can probably avoid using it, given that this code is
+		// not using tracing and does not care about those quirks.
+		httpTransport := netxlite.NewHTTPTransport(
+			rt.Logger(),
+			netxlite.NewNullDialer(),
+			netxlite.NewSingleUseTLSDialer(input.Conn),
+		)
+		state := &HTTPConnection{
+			Address:               input.Address,
+			Domain:                input.Domain,
+			Network:               input.Network,
+			Scheme:                "https",
+			TLSNegotiatedProtocol: input.TLSState.NegotiatedProtocol,
+			Trace:                 input.Trace,
+			Transport:             httpTransport,
+		}
+		return &Maybe[*HTTPConnection]{
+			Error:        nil,
+			Observations: nil,
+			Operation:    "", // we cannot fail, so no need to store operation name
+			State:        state,
+		}
+	})
 }

--- a/internal/dslx/httptls.go
+++ b/internal/dslx/httptls.go
@@ -16,7 +16,7 @@ func HTTPRequestOverTLS(rt Runtime, options ...HTTPRequestOption) Func[*TLSConne
 }
 
 // HTTPTransportTLS converts a TLS connection into an HTTP transport.
-func HTTPTransportTLS(rt Runtime) Func[*TLSConnection, *Maybe[*HTTPTransport]] {
+func HTTPTransportTLS(rt Runtime) Func[*TLSConnection, *Maybe[*HTTPConnection]] {
 	return &httpTransportTLSFunc{rt}
 }
 
@@ -27,7 +27,7 @@ type httpTransportTLSFunc struct {
 
 // Apply implements Func.
 func (f *httpTransportTLSFunc) Apply(
-	ctx context.Context, input *TLSConnection) *Maybe[*HTTPTransport] {
+	ctx context.Context, input *TLSConnection) *Maybe[*HTTPConnection] {
 	// TODO(https://github.com/ooni/probe/issues/2534): here we're using the QUIRKY netxlite.NewHTTPTransport
 	// function, but we can probably avoid using it, given that this code is
 	// not using tracing and does not care about those quirks.
@@ -36,7 +36,7 @@ func (f *httpTransportTLSFunc) Apply(
 		netxlite.NewNullDialer(),
 		netxlite.NewSingleUseTLSDialer(input.Conn),
 	)
-	state := &HTTPTransport{
+	state := &HTTPConnection{
 		Address:               input.Address,
 		Domain:                input.Domain,
 		Network:               input.Network,
@@ -45,7 +45,7 @@ func (f *httpTransportTLSFunc) Apply(
 		Trace:                 input.Trace,
 		Transport:             httpTransport,
 	}
-	return &Maybe[*HTTPTransport]{
+	return &Maybe[*HTTPConnection]{
 		Error:        nil,
 		Observations: nil,
 		Operation:    "", // we cannot fail, so no need to store operation name

--- a/internal/dslx/integration_test.go
+++ b/internal/dslx/integration_test.go
@@ -37,7 +37,7 @@ func TestMakeSureWeCollectSpeedSamples(t *testing.T) {
 	// create a measuring function
 	f0 := Compose3(
 		TCPConnect(rt),
-		HTTPTransportTCP(rt),
+		HTTPConnectionTCP(rt),
 		HTTPRequest(rt),
 	)
 


### PR DESCRIPTION
This diff completes the work described by and closes https://github.com/ooni/probe/issues/2612.

We make the HTTPRequest stateless (use `git diff -w` to avoid noise caused by whitespace changes).

We rename HTTPTransport to HTTPConnection since that is a better name.

We make HTTPConnection adapters stateless as well.