### PR TITLE
Update signal test endpoints fixes probe/2627

### DIFF
--- a/internal/experiment/signal/signal.go
+++ b/internal/experiment/signal/signal.go
@@ -192,11 +192,14 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 			FailOnHTTPError: false,
 			CertPool:        certPool,
 		}},
-		{Target: "https://contentproxy.signal.org/", Config: urlgetter.Config{
-			Method:          "GET",
-			FailOnHTTPError: false,
-			CertPool:        certPool,
-		}},
+		/*
+			TODO: understand why this endpoint does not speak TLS
+			{Target: "https://contentproxy.signal.org/", Config: urlgetter.Config{
+				Method:          "GET",
+				FailOnHTTPError: false,
+				CertPool:        certPool,
+			}},
+		*/
 		{Target: "https://sfu.voip.signal.org/", Config: urlgetter.Config{
 			Method:          "GET",
 			FailOnHTTPError: false,

--- a/internal/experiment/signal/signal.go
+++ b/internal/experiment/signal/signal.go
@@ -117,7 +117,6 @@ func (tk *TestKeys) Update(v urlgetter.MultiOutput) {
 		tk.SignalBackendFailure = v.TestKeys.Failure
 		return
 	}
-	return
 }
 
 // Measurer performs the measurement

--- a/internal/experiment/signal/signal.go
+++ b/internal/experiment/signal/signal.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	testName    = "signal"
-	testVersion = "0.2.3"
+	testVersion = "0.2.4"
 
 	signalCA = `-----BEGIN CERTIFICATE-----
 MIID7zCCAtegAwIBAgIJAIm6LatK5PNiMA0GCSqGSIb3DQEBBQUAMIGNMQswCQYD

--- a/internal/experiment/signal/signal.go
+++ b/internal/experiment/signal/signal.go
@@ -164,14 +164,10 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	}
 
 	inputs := []urlgetter.MultiInput{
+
 		// Here we need to provide the method explicitly. See
 		// https://github.com/ooni/probe-engine/issues/827.
-		{Target: "https://textsecure-service.whispersystems.org/", Config: urlgetter.Config{
-			Method:          "GET",
-			FailOnHTTPError: false,
-			CertPool:        certPool,
-		}},
-		{Target: "https://storage.signal.org/", Config: urlgetter.Config{
+		{Target: "https://api.backup.signal.org/", Config: urlgetter.Config{
 			Method:          "GET",
 			FailOnHTTPError: false,
 			CertPool:        certPool,
@@ -186,7 +182,47 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 			FailOnHTTPError: false,
 			CertPool:        certPool,
 		}},
+		{Target: "https://cdsi.signal.org/", Config: urlgetter.Config{
+			Method:          "GET",
+			FailOnHTTPError: false,
+			CertPool:        certPool,
+		}},
+		{Target: "https://chat.signal.org/", Config: urlgetter.Config{
+			Method:          "GET",
+			FailOnHTTPError: false,
+			CertPool:        certPool,
+		}},
+		{Target: "https://contentproxy.signal.org/", Config: urlgetter.Config{
+			Method:          "GET",
+			FailOnHTTPError: false,
+			CertPool:        certPool,
+		}},
 		{Target: "https://sfu.voip.signal.org/", Config: urlgetter.Config{
+			Method:          "GET",
+			FailOnHTTPError: false,
+			CertPool:        certPool,
+		}},
+		{Target: "https://storage.signal.org/", Config: urlgetter.Config{
+			Method:          "GET",
+			FailOnHTTPError: false,
+			CertPool:        certPool,
+		}},
+		{Target: "https://svr2.signal.org/", Config: urlgetter.Config{
+			Method:          "GET",
+			FailOnHTTPError: false,
+			CertPool:        certPool,
+		}},
+		{Target: "https://ud-chat.signal.org/", Config: urlgetter.Config{
+			Method:          "GET",
+			FailOnHTTPError: false,
+			CertPool:        certPool,
+		}},
+		{Target: "https://updates.signal.org/", Config: urlgetter.Config{
+			Method:          "GET",
+			FailOnHTTPError: false,
+			CertPool:        certPool,
+		}},
+		{Target: "https://updates2.signal.org/", Config: urlgetter.Config{
 			Method:          "GET",
 			FailOnHTTPError: false,
 			CertPool:        certPool,

--- a/internal/experiment/signal/signal_test.go
+++ b/internal/experiment/signal/signal_test.go
@@ -17,7 +17,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "signal" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.2.3" {
+	if measurer.ExperimentVersion() != "0.2.4" {
 		t.Fatal("unexpected version")
 	}
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2627
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: https://github.com/ooni/spec/pull/281
- [x] if you changed code inside an experiment, make sure you bump its version number

## Description

Signal has made changes to their endpoints. In this PR we drop a legacy endpoint and add more of the endpoints communicated to us by the signal devs.