### PR TITLE
fix(webconnectivitylte): always save "connect" network events

### DIFF
--- a/internal/experiment/webconnectivitylte/cleartextflow.go
+++ b/internal/experiment/webconnectivitylte/cleartextflow.go
@@ -119,14 +119,12 @@ func (t *CleartextFlow) Run(parentCtx context.Context, index int64) error {
 	tcpDialer := trace.NewDialerWithoutResolver(t.Logger)
 	tcpConn, err := tcpDialer.DialContext(tcpCtx, "tcp", t.Address)
 	t.TestKeys.AppendTCPConnectResults(trace.TCPConnects()...)
+	defer t.TestKeys.AppendNetworkEvents(trace.NetworkEvents()...) // here to include connect events
 	if err != nil {
 		ol.Stop(err)
 		return err
 	}
-	defer func() {
-		t.TestKeys.AppendNetworkEvents(trace.NetworkEvents()...)
-		tcpConn.Close()
-	}()
+	defer tcpConn.Close()
 
 	alpn := "" // no ALPN because we're not using TLS
 

--- a/internal/experiment/webconnectivitylte/secureflow.go
+++ b/internal/experiment/webconnectivitylte/secureflow.go
@@ -126,14 +126,12 @@ func (t *SecureFlow) Run(parentCtx context.Context, index int64) error {
 	tcpDialer := trace.NewDialerWithoutResolver(t.Logger)
 	tcpConn, err := tcpDialer.DialContext(tcpCtx, "tcp", t.Address)
 	t.TestKeys.AppendTCPConnectResults(trace.TCPConnects()...)
+	defer t.TestKeys.AppendNetworkEvents(trace.NetworkEvents()...) // here to include "connect" events
 	if err != nil {
 		ol.Stop(err)
 		return err
 	}
-	defer func() {
-		t.TestKeys.AppendNetworkEvents(trace.NetworkEvents()...)
-		tcpConn.Close()
-	}()
+	defer tcpConn.Close()
 
 	// perform TLS handshake
 	tlsSNI, err := t.sni()


### PR DESCRIPTION
We're not saving "connect" network events when TCP connect fails. This diff fixes the codebase so that we always save these events.

Fix extracted from https://github.com/ooni/probe-cli/pull/1392.

Reference issue https://github.com/ooni/probe/issues/2634.
