### PR TITLE
fix(oonimkall): make sure SoftwareName is set

### DIFF
--- a/internal/ooapi/checkin.go
+++ b/internal/ooapi/checkin.go
@@ -25,7 +25,7 @@ func NewDescriptorCheckIn(
 		AcceptEncodingGzip: true, // we want a small response
 		Authorization:      "",
 		ContentType:        httpapi.ApplicationJSON,
-		LogBody:            false, // we don't want to log psiphon config
+		LogBody:            true,
 		MaxBodySize:        0,
 		Method:             http.MethodPost,
 		Request: &httpapi.RequestDescriptor[*model.OOAPICheckInConfig]{

--- a/internal/ooapi/checkin_test.go
+++ b/internal/ooapi/checkin_test.go
@@ -40,7 +40,7 @@ func TestNewDescriptorCheckIn(t *testing.T) {
 				t.Fatalf("unexpected desc.%s", name)
 			}
 		case "LogBody":
-			if !field.IsZero() {
+			if field.IsZero() {
 				t.Fatalf("unexpected desc.%s", name)
 			}
 		case "MaxBodySize":

--- a/pkg/oonimkall/session.go
+++ b/pkg/oonimkall/session.go
@@ -467,6 +467,7 @@ func (sess *Session) CheckIn(ctx *Context, config *CheckInConfig) (*CheckInInfo,
 		ProbeASN:        info.ASNString(),
 		ProbeCC:         info.CountryCode,
 		RunType:         model.RunType(config.RunType),
+		SoftwareName:    config.SoftwareName,
 		SoftwareVersion: config.SoftwareVersion,
 		WebConnectivity: config.WebConnectivity.toModel(),
 	}


### PR DESCRIPTION
While there, make sure we log the check-in request and response with `-v`, because otherwise 🤌🤌🤌🤌. (On this note, we did not want to log psiphon and tor configs, but we're not using check-in for them anymore, so this switch from not logging to logging seems indeed to be reasonably okay to do. We need /api/v1/register and /api/v1/login before serving config. Additionally, it seems having experiment-specific APIs is actually more flexible anyway.)

Part of https://github.com/ooni/probe/issues/2644.

