### PR TITLE
fix(libtor): prevent concurrent instances

### DIFF
--- a/.github/workflows/libtorlinux.yml
+++ b/.github/workflows/libtorlinux.yml
@@ -3,7 +3,6 @@ name: libtorlinux
 on:
   push:
     branches:
-      - "issue/2623"
       - "master"
       - "release/**"
       - "fullbuild"

--- a/.github/workflows/libtorlinux.yml
+++ b/.github/workflows/libtorlinux.yml
@@ -3,6 +3,7 @@ name: libtorlinux
 on:
   push:
     branches:
+      - "issue/2623"
       - "master"
       - "release/**"
       - "fullbuild"

--- a/internal/libtor/enabled.go
+++ b/internal/libtor/enabled.go
@@ -84,6 +84,7 @@ import (
 	"os"
 	"runtime"
 	"sync"
+	"sync/atomic"
 
 	"github.com/cretz/bine/process"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
@@ -163,6 +164,10 @@ func (p *torProcess) Wait() (err error) {
 	return
 }
 
+// ErrConcurrentCalls indicates there have been concurrent libtor calls, which
+// would lead to memory corruption inside of libtor.a.
+var ErrConcurrentCalls = errors.New("libtor: another thread is already running tor")
+
 // ErrTooManyArguments indicates that p.args contains too many arguments
 var ErrTooManyArguments = errors.New("libtor: too many arguments")
 
@@ -171,6 +176,9 @@ var ErrCannotCreateControlSocket = errors.New("libtor: cannot create a control s
 
 // ErrNonzeroExitCode indicates that tor returned a nonzero exit code
 var ErrNonzeroExitCode = errors.New("libtor: command completed with nonzero exit code")
+
+// concurrentCalls prevents concurrent libtor.a calls.
+var concurrentCalls = &atomic.Int64{}
 
 // runtor runs tor until completion and ensures that tor exits when
 // the given ctx is cancelled or its deadline expires.
@@ -190,6 +198,13 @@ func (p *torProcess) runtor(ctx context.Context, cc net.Conn, args ...string) {
 		close(p.closedWhenNotStarted)
 		return
 	}
+
+	// make sure we're not going to have actual concurrent calls.
+	if !concurrentCalls.CompareAndSwap(0, 1) {
+		p.startErr <- ErrConcurrentCalls // nonblocking channel
+		return
+	}
+	defer concurrentCalls.Store(0)
 
 	// Note: when writing this code I was wondering whether I needed to
 	// use unsafe.Pointer to track pointers that matter to C code. Reading

--- a/internal/libtor/enabled.go
+++ b/internal/libtor/enabled.go
@@ -85,6 +85,7 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/cretz/bine/process"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
@@ -299,7 +300,10 @@ func (p *torProcess) runtor(ctx context.Context, cc net.Conn, args ...string) {
 	if !p.simulateNonzeroExitCode {
 		code = C.tor_run_main(config)
 	} else {
+		// when simulating nonzero exit code we also want to sleep for a bit
+		// of time, to make sure we're able to see overalapped runs.
 		code = 1
+		time.Sleep(time.Second)
 	}
 	if code != 0 {
 		p.waitErr <- fmt.Errorf("%w: %d", ErrNonzeroExitCode, code) // nonblocking channel

--- a/internal/libtor/enabled.go
+++ b/internal/libtor/enabled.go
@@ -301,7 +301,7 @@ func (p *torProcess) runtor(ctx context.Context, cc net.Conn, args ...string) {
 		code = C.tor_run_main(config)
 	} else {
 		// when simulating nonzero exit code we also want to sleep for a bit
-		// of time, to make sure we're able to see overalapped runs.
+		// of time, to make sure we're able to see overlapped runs.
 		code = 1
 		time.Sleep(time.Second)
 	}

--- a/internal/libtor/enabled_test.go
+++ b/internal/libtor/enabled_test.go
@@ -327,7 +327,10 @@ func TestConcurrentCalls(t *testing.T) {
 		}
 		t.Fatal("unexpected error", err)
 	}
-	if countGood != 1 || countConcurrentErr != 4 {
-		t.Fatal("expected countGood = 1 and countConcurrentErr = 4, got", countGood, countConcurrentErr)
+	if countGood != 1 {
+		t.Fatal("expected countGood == 1, got", countGood)
+	}
+	if countConcurrentErr != 4 {
+		t.Fatal("expected countConcurrentErr = 4, got", countConcurrentErr)
 	}
 }

--- a/internal/libtor/enabled_test.go
+++ b/internal/libtor/enabled_test.go
@@ -257,7 +257,7 @@ func TestControlConnectionExplicitlyClosed(t *testing.T) {
 // This test ensures that we cannot make concurrent calls to the library.
 func TestConcurrentCalls(t *testing.T) {
 	// we need to simulate non zero exit code here such that we're not
-	// actually hitting into the real tor library; by doing this we would
+	// actually hitting into the real tor library; by doing this we
 	// make the test faster and reduce the risk of triggering the
 	// https://github.com/ooni/probe/issues/2406 bug caused by the
 	// fact we're invoking tor multiple times.

--- a/internal/libtor/enabled_test.go
+++ b/internal/libtor/enabled_test.go
@@ -294,7 +294,7 @@ func TestConcurrentCalls(t *testing.T) {
 			return
 		}
 
-		// the process that does not fail should complain about a nonzero
+		// the process that starts should complain about a nonzero
 		// exit code because it's configured in this way
 		if err := process.Wait(); !errors.Is(err, ErrNonzeroExitCode) {
 			t.Fatal("unexpected err", err)

--- a/internal/libtor/enabled_test.go
+++ b/internal/libtor/enabled_test.go
@@ -331,6 +331,6 @@ func TestConcurrentCalls(t *testing.T) {
 		t.Fatal("expected countGood == 1, got", countGood)
 	}
 	if countConcurrentErr != 4 {
-		t.Fatal("expected countConcurrentErr = 4, got", countConcurrentErr)
+		t.Fatal("expected countConcurrentErr == 4, got", countConcurrentErr)
 	}
 }

--- a/internal/libtor/enabled_test.go
+++ b/internal/libtor/enabled_test.go
@@ -257,7 +257,10 @@ func TestControlConnectionExplicitlyClosed(t *testing.T) {
 // This test ensures that we cannot make concurrent calls to the library.
 func TestConcurrentCalls(t *testing.T) {
 	// we need to simulate non zero exit code here such that we're not
-	// actually hitting into the real tor library
+	// actually hitting into the real tor library; by doing this we would
+	// make the test faster and reduce the risk of triggering the
+	// https://github.com/ooni/probe/issues/2406 bug caused by the
+	// fact we're invoking tor multiple times.
 
 	run := func(startch chan<- error) {
 		ctx := context.Background()

--- a/internal/libtor/enabled_test.go
+++ b/internal/libtor/enabled_test.go
@@ -304,7 +304,7 @@ func TestConcurrentCalls(t *testing.T) {
 	// attempt to create N=5 parallel instances
 	//
 	// what we would expect to see is that just one instance
-	// is able to start and fails and the others fail instead
+	// is able to start while the other four instances fail instead
 	// during their startup phase because of concurrency
 	const concurrentRuns = 5
 	start := make(chan error, concurrentRuns)

--- a/internal/libtor/enabled_test.go
+++ b/internal/libtor/enabled_test.go
@@ -312,8 +312,8 @@ func TestConcurrentCalls(t *testing.T) {
 		go run(start)
 	}
 	var (
-		countGood       int
-		countConcurrent int
+		countGood          int
+		countConcurrentErr int
 	)
 	for idx := 0; idx < concurrentRuns; idx++ {
 		err := <-start
@@ -322,12 +322,12 @@ func TestConcurrentCalls(t *testing.T) {
 			continue
 		}
 		if errors.Is(err, ErrConcurrentCalls) {
-			countConcurrent++
+			countConcurrentErr++
 			continue
 		}
 		t.Fatal("unexpected error", err)
 	}
-	if countGood != 1 || countConcurrent != 4 {
-		t.Fatal("expected countGood = 1 and countConcurrent = 4, got", countGood, countConcurrent)
+	if countGood != 1 || countConcurrentErr != 4 {
+		t.Fatal("expected countGood = 1 and countConcurrentErr = 4, got", countGood, countConcurrentErr)
 	}
 }


### PR DESCRIPTION
This PR is about preventing concurrent `./internal/libtor` instances. The `./internal/libtor` package links with `libtor.a` and runs `tor_run_main`. The expectation of such a function is that a single thread can execute within the same process. If we attempt to invoke `tor_run_main` while another instance is running, this is most likely going to cause memory corruption because the two instances try to operate on the same static data structures.

To address this issue, we use atomic compare and swap and atomic set to make sure there is just a single thread inside the "critical section" consisting of calling `tor_run_main`. All the other threads would fail with an error.

To test this branch on Linux, you need to run:

```sh
go run ./internal/cmd/buildtool linux cdeps zlib openssl libevent tor
```

to compile tor and its dependencies for GNU/Linux. (You would need `build-essential`, `autoconf`, `automake`, and `libtool` being installed on a Debian system.)

Then, run tests using:

```sh
go test -tags ooni_libtor -v ./internal/libtor/...
```

These tests should pass on a GNU/Linux system.

In addition to making sure we cannot have concurrent instances, this PR also modifies some tests that were not using `SocksPort auto`. As a result, those tests would fail in a system where `tor` is running as a daemon.

Closes https://github.com/ooni/probe/issues/2623