### PR TITLE
feat(webconnectivitylte): classic supports XNullNullFlags

### DIFF
--- a/internal/cmd/minipipeline/testdata/analysis.json
+++ b/internal/cmd/minipipeline/testdata/analysis.json
@@ -1,7 +1,15 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "130.192.16.171"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2,
+    3
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -20,12 +28,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/cmd/minipipeline/testdata/analysis_classic.json
+++ b/internal/cmd/minipipeline/testdata/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "130.192.16.171"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -17,12 +23,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/cmd/minipipeline/testdata/observations.json
+++ b/internal/cmd/minipipeline/testdata/observations.json
@@ -382,7 +382,10 @@
       "ControlHTTPResponseTitle": "Nexa Center for Internet \u0026 Society | Il centro Nexa è un centro di ricerca del Dipartimento di Automatica e Informatica del Politecnico di Torino"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "130.192.16.171"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/cmd/minipipeline/testdata/observations_classic.json
+++ b/internal/cmd/minipipeline/testdata/observations_classic.json
@@ -141,7 +141,10 @@
       "ControlHTTPResponseTitle": "Nexa Center for Internet \u0026 Society | Il centro Nexa è un centro di ricerca del Dipartimento di Automatica e Informatica del Politecnico di Torino"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "130.192.16.171"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/experiment/webconnectivitylte/analysisext.go
+++ b/internal/experiment/webconnectivitylte/analysisext.go
@@ -266,7 +266,7 @@ func analysisExtExpectedFailures(tk *TestKeys, analysis *minipipeline.WebAnalysi
 
 	// if the control did not resolve any address but the probe could, this is
 	// quite likely censorship injecting addrs for otherwise "down" or nonexisting
-	// domains, which lives on as a ghost hunting people
+	// domains, which lives on as a ghost haunting people
 	if !analysis.ControlExpectations.IsNone() {
 		expect := analysis.ControlExpectations.Unwrap()
 		if expect.DNSAddresses.Len() <= 0 && analysis.DNSLookupSuccess.Len() > 0 {

--- a/internal/experiment/webconnectivityqa/badssl.go
+++ b/internal/experiment/webconnectivityqa/badssl.go
@@ -94,6 +94,7 @@ func badSSLWithUnknownAuthorityWithInconsistentDNS() *TestCase {
 			XStatus:               9248, // StatusExperimentHTTP | StatusAnomalyTLSHandshake | StatusAnomalyDNS
 			XDNSFlags:             4,    // AnalysisDNSFlagUnexpectedAddrs
 			XBlockingFlags:        33,   // AnalysisBlockingFlagSuccess | AnalysisBlockingFlagDNSBlocking
+			XNullNullFlags:        4,    // AnalysisFlagNullNullExpectedTLSHandshakeFailure
 			Accessible:            false,
 			Blocking:              "dns",
 		},

--- a/internal/experiment/webconnectivityqa/testkeys.go
+++ b/internal/experiment/webconnectivityqa/testkeys.go
@@ -77,9 +77,6 @@ func compareTestKeys(expected, got *testKeys) error {
 		// ignore the fields that are specific to v0.4
 		options = append(options, cmpopts.IgnoreFields(testKeys{}, "XStatus"))
 
-		// TODO(bassosimone): ignore fields used by the v0.5 "orig" local analysis engine
-		options = append(options, cmpopts.IgnoreFields(testKeys{}, "XNullNullFlags"))
-
 	default:
 		return fmt.Errorf("unknown experiment version: %s", got.XExperimentVersion)
 	}

--- a/internal/minipipeline/classic.go
+++ b/internal/minipipeline/classic.go
@@ -53,7 +53,7 @@ func ClassicFilter(input *WebObservationsContainer) (output *WebObservationsCont
 	}
 
 	// ControlFinalResponseExpectations
-	output.ControlFinalResponseExpectations = input.ControlFinalResponseExpectations
+	output.ControlExpectations = input.ControlExpectations
 
 	return
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithExpiredCertificate/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithExpiredCertificate/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": "unknown_error"
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "104.154.89.105"
+    ],
+    "FinalResponseFailure": "unknown_error"
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -18,12 +25,16 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [
+    3
+  ],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithExpiredCertificate/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithExpiredCertificate/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": "unknown_error"
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "104.154.89.105"
+    ],
+    "FinalResponseFailure": "unknown_error"
   },
+  "DNSLookupSuccess": [
+    1
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1
@@ -16,12 +22,16 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [
+    3
+  ],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithExpiredCertificate/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithExpiredCertificate/observations.json
@@ -187,7 +187,10 @@
       "ControlHTTPResponseTitle": null
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": "unknown_error"
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "104.154.89.105"
+    ],
+    "FinalResponseFailure": "unknown_error"
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithExpiredCertificate/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithExpiredCertificate/observations_classic.json
@@ -96,7 +96,10 @@
       "ControlHTTPResponseTitle": null
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": "unknown_error"
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "104.154.89.105"
+    ],
+    "FinalResponseFailure": "unknown_error"
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithUnknownAuthorityWithConsistentDNS/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithUnknownAuthorityWithConsistentDNS/analysis.json
@@ -1,7 +1,15 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": "unknown_error"
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "104.154.89.105"
+    ],
+    "FinalResponseFailure": "unknown_error"
   },
+  "DNSLookupSuccess": [
+    1,
+    2,
+    3
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -20,12 +28,16 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [
+    4
+  ],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithUnknownAuthorityWithConsistentDNS/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithUnknownAuthorityWithConsistentDNS/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": "unknown_error"
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "104.154.89.105"
+    ],
+    "FinalResponseFailure": "unknown_error"
   },
+  "DNSLookupSuccess": [
+    1
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1
@@ -16,12 +22,16 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [
+    4
+  ],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithUnknownAuthorityWithConsistentDNS/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithUnknownAuthorityWithConsistentDNS/observations.json
@@ -277,7 +277,10 @@
       "ControlHTTPResponseTitle": null
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": "unknown_error"
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "104.154.89.105"
+    ],
+    "FinalResponseFailure": "unknown_error"
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithUnknownAuthorityWithConsistentDNS/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithUnknownAuthorityWithConsistentDNS/observations_classic.json
@@ -96,7 +96,10 @@
       "ControlHTTPResponseTitle": null
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": "unknown_error"
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "104.154.89.105"
+    ],
+    "FinalResponseFailure": "unknown_error"
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithUnknownAuthorityWithInconsistentDNS/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithUnknownAuthorityWithInconsistentDNS/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [
     1,
     2
@@ -18,12 +25,16 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [
+    3
+  ],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithUnknownAuthorityWithInconsistentDNS/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithUnknownAuthorityWithInconsistentDNS/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [
     2
   ],
@@ -16,12 +22,16 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [
+    3
+  ],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithUnknownAuthorityWithInconsistentDNS/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithUnknownAuthorityWithInconsistentDNS/observations.json
@@ -261,7 +261,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithUnknownAuthorityWithInconsistentDNS/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithUnknownAuthorityWithInconsistentDNS/observations_classic.json
@@ -106,7 +106,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithWrongServerName/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithWrongServerName/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": "unknown_error"
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "104.154.89.105"
+    ],
+    "FinalResponseFailure": "unknown_error"
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -18,12 +25,16 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [
+    3
+  ],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithWrongServerName/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithWrongServerName/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": "unknown_error"
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "104.154.89.105"
+    ],
+    "FinalResponseFailure": "unknown_error"
   },
+  "DNSLookupSuccess": [
+    1
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1
@@ -16,12 +22,16 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [
+    3
+  ],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithWrongServerName/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithWrongServerName/observations.json
@@ -187,7 +187,10 @@
       "ControlHTTPResponseTitle": null
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": "unknown_error"
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "104.154.89.105"
+    ],
+    "FinalResponseFailure": "unknown_error"
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithWrongServerName/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/badSSLWithWrongServerName/observations_classic.json
@@ -96,7 +96,10 @@
       "ControlHTTPResponseTitle": null
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": "unknown_error"
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "104.154.89.105"
+    ],
+    "FinalResponseFailure": "unknown_error"
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/controlFailureWithSuccessfulHTTPSWebsite/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/controlFailureWithSuccessfulHTTPSWebsite/analysis.json
@@ -1,5 +1,9 @@
 {
-  "ControlFinalResponseExpectations": null,
+  "ControlExpectations": null,
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1
@@ -12,12 +16,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/controlFailureWithSuccessfulHTTPSWebsite/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/controlFailureWithSuccessfulHTTPSWebsite/analysis_classic.json
@@ -1,5 +1,8 @@
 {
-  "ControlFinalResponseExpectations": null,
+  "ControlExpectations": null,
+  "DNSLookupSuccess": [
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1
@@ -12,12 +15,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/controlFailureWithSuccessfulHTTPSWebsite/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/controlFailureWithSuccessfulHTTPSWebsite/observations.json
@@ -184,5 +184,5 @@
       "ControlHTTPResponseTitle": null
     }
   },
-  "ControlFinalResponseExpectations": null
+  "ControlExpectations": null
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/controlFailureWithSuccessfulHTTPSWebsite/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/controlFailureWithSuccessfulHTTPSWebsite/observations_classic.json
@@ -97,5 +97,5 @@
       "ControlHTTPResponseTitle": null
     }
   },
-  "ControlFinalResponseExpectations": null
+  "ControlExpectations": null
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/controlFailureWithSuccessfulHTTPWebsite/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/controlFailureWithSuccessfulHTTPWebsite/analysis.json
@@ -1,5 +1,9 @@
 {
-  "ControlFinalResponseExpectations": null,
+  "ControlExpectations": null,
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1
@@ -12,12 +16,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/controlFailureWithSuccessfulHTTPWebsite/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/controlFailureWithSuccessfulHTTPWebsite/analysis_classic.json
@@ -1,5 +1,8 @@
 {
-  "ControlFinalResponseExpectations": null,
+  "ControlExpectations": null,
+  "DNSLookupSuccess": [
+    1
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [],
   "DNSLookupSuccessWithBogonAddresses": [],
@@ -10,12 +13,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/controlFailureWithSuccessfulHTTPWebsite/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/controlFailureWithSuccessfulHTTPWebsite/observations.json
@@ -228,5 +228,5 @@
       "ControlHTTPResponseTitle": null
     }
   },
-  "ControlFinalResponseExpectations": null
+  "ControlExpectations": null
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/controlFailureWithSuccessfulHTTPWebsite/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/controlFailureWithSuccessfulHTTPWebsite/observations_classic.json
@@ -97,5 +97,5 @@
       "ControlHTTPResponseTitle": null
     }
   },
-  "ControlFinalResponseExpectations": null
+  "ControlExpectations": null
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingAndroidDNSCacheNoData/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingAndroidDNSCacheNoData/analysis.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     2
@@ -18,12 +24,14 @@
   "DNSExperimentFailure": "android_dns_cache_no_data",
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingAndroidDNSCacheNoData/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingAndroidDNSCacheNoData/analysis_classic.json
@@ -1,7 +1,11 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [],
   "DNSLookupSuccessWithBogonAddresses": [],
@@ -14,12 +18,14 @@
   "DNSExperimentFailure": "android_dns_cache_no_data",
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingAndroidDNSCacheNoData/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingAndroidDNSCacheNoData/observations.json
@@ -210,7 +210,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingAndroidDNSCacheNoData/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingAndroidDNSCacheNoData/observations_classic.json
@@ -52,7 +52,10 @@
   ],
   "DNSLookupSuccesses": [],
   "KnownTCPEndpoints": {},
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingBOGON/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingBOGON/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [
     1
   ],
@@ -22,12 +29,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingBOGON/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingBOGON/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [
     1
   ],
@@ -18,12 +24,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingBOGON/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingBOGON/observations.json
@@ -263,7 +263,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingBOGON/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingBOGON/observations_classic.json
@@ -106,7 +106,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingNXDOMAIN/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingNXDOMAIN/analysis.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1
@@ -18,12 +24,14 @@
   "DNSExperimentFailure": "dns_nxdomain_error",
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingNXDOMAIN/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingNXDOMAIN/analysis_classic.json
@@ -1,7 +1,11 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [],
   "DNSLookupSuccessWithBogonAddresses": [],
@@ -14,12 +18,14 @@
   "DNSExperimentFailure": "dns_nxdomain_error",
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingNXDOMAIN/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingNXDOMAIN/observations.json
@@ -210,7 +210,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingNXDOMAIN/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsBlockingNXDOMAIN/observations_classic.json
@@ -52,7 +52,10 @@
   ],
   "DNSLookupSuccesses": [],
   "KnownTCPEndpoints": {},
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsHijackingToProxyWithHTTPSURL/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsHijackingToProxyWithHTTPSURL/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [
     1
   ],
@@ -19,12 +26,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsHijackingToProxyWithHTTPSURL/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsHijackingToProxyWithHTTPSURL/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     2
@@ -16,12 +22,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsHijackingToProxyWithHTTPSURL/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsHijackingToProxyWithHTTPSURL/observations.json
@@ -261,7 +261,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsHijackingToProxyWithHTTPSURL/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsHijackingToProxyWithHTTPSURL/observations_classic.json
@@ -111,7 +111,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsHijackingToProxyWithHTTPURL/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsHijackingToProxyWithHTTPURL/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [
     1
   ],
@@ -19,12 +26,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsHijackingToProxyWithHTTPURL/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsHijackingToProxyWithHTTPURL/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [
     2
   ],
@@ -16,12 +22,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsHijackingToProxyWithHTTPURL/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsHijackingToProxyWithHTTPURL/observations.json
@@ -360,7 +360,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/dnsHijackingToProxyWithHTTPURL/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/dnsHijackingToProxyWithHTTPURL/observations_classic.json
@@ -110,7 +110,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/httpBlockingConnectionReset/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/httpBlockingConnectionReset/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -18,12 +25,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/httpBlockingConnectionReset/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/httpBlockingConnectionReset/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     2
@@ -16,12 +22,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/httpBlockingConnectionReset/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/httpBlockingConnectionReset/observations.json
@@ -258,7 +258,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/httpBlockingConnectionReset/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/httpBlockingConnectionReset/observations_classic.json
@@ -106,7 +106,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/httpDiffWithConsistentDNS/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/httpDiffWithConsistentDNS/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -18,12 +25,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/httpDiffWithConsistentDNS/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/httpDiffWithConsistentDNS/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     2
@@ -16,12 +22,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/httpDiffWithConsistentDNS/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/httpDiffWithConsistentDNS/observations.json
@@ -258,7 +258,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/httpDiffWithConsistentDNS/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/httpDiffWithConsistentDNS/observations_classic.json
@@ -106,7 +106,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/httpDiffWithInconsistentDNS/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/httpDiffWithInconsistentDNS/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [
     1
   ],
@@ -19,12 +26,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/httpDiffWithInconsistentDNS/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/httpDiffWithInconsistentDNS/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [
     2
   ],
@@ -16,12 +22,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/httpDiffWithInconsistentDNS/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/httpDiffWithInconsistentDNS/observations.json
@@ -356,7 +356,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/httpDiffWithInconsistentDNS/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/httpDiffWithInconsistentDNS/observations_classic.json
@@ -106,7 +106,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionRefusedForHTTP/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionRefusedForHTTP/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -18,6 +25,7 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
@@ -31,6 +39,7 @@
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [
     7
   ],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionRefusedForHTTP/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionRefusedForHTTP/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     2
@@ -16,6 +22,7 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
@@ -26,6 +33,7 @@
     6
   ],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionRefusedForHTTP/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionRefusedForHTTP/observations.json
@@ -454,7 +454,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionRefusedForHTTP/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionRefusedForHTTP/observations_classic.json
@@ -208,7 +208,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionRefusedForHTTPS/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionRefusedForHTTPS/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -18,6 +25,7 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
@@ -28,6 +36,7 @@
     6
   ],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionRefusedForHTTPS/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionRefusedForHTTPS/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -17,6 +23,7 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
@@ -27,6 +34,7 @@
     6
   ],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionRefusedForHTTPS/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionRefusedForHTTPS/observations.json
@@ -405,7 +405,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionRefusedForHTTPS/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionRefusedForHTTPS/observations_classic.json
@@ -208,7 +208,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionResetForHTTP/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionResetForHTTP/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -18,12 +25,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionResetForHTTP/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionResetForHTTP/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -17,12 +23,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionResetForHTTP/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionResetForHTTP/observations.json
@@ -454,7 +454,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionResetForHTTP/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionResetForHTTP/observations_classic.json
@@ -208,7 +208,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionResetForHTTPS/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionResetForHTTPS/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -18,12 +25,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionResetForHTTPS/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionResetForHTTPS/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1
@@ -16,12 +22,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionResetForHTTPS/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionResetForHTTPS/observations.json
@@ -405,7 +405,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionResetForHTTPS/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenConnectionResetForHTTPS/observations_classic.json
@@ -208,7 +208,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenEOFForHTTP/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenEOFForHTTP/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -18,12 +25,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenEOFForHTTP/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenEOFForHTTP/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     2
@@ -16,12 +22,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenEOFForHTTP/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenEOFForHTTP/observations.json
@@ -454,7 +454,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenEOFForHTTP/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenEOFForHTTP/observations_classic.json
@@ -208,7 +208,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenEOFForHTTPS/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenEOFForHTTPS/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -18,12 +25,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenEOFForHTTPS/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenEOFForHTTPS/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     2
@@ -16,12 +22,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenEOFForHTTPS/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenEOFForHTTPS/observations.json
@@ -405,7 +405,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenEOFForHTTPS/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenEOFForHTTPS/observations_classic.json
@@ -208,7 +208,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenNXDOMAIN/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenNXDOMAIN/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -21,12 +28,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenNXDOMAIN/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenNXDOMAIN/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -19,12 +25,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenNXDOMAIN/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenNXDOMAIN/observations.json
@@ -352,7 +352,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenNXDOMAIN/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenNXDOMAIN/observations_classic.json
@@ -158,7 +158,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenTimeoutForHTTP/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenTimeoutForHTTP/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -18,12 +25,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenTimeoutForHTTP/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenTimeoutForHTTP/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1
@@ -16,12 +22,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenTimeoutForHTTP/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenTimeoutForHTTP/observations.json
@@ -454,7 +454,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenTimeoutForHTTP/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenTimeoutForHTTP/observations_classic.json
@@ -208,7 +208,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenTimeoutForHTTPS/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenTimeoutForHTTPS/analysis.json
@@ -1,7 +1,15 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2,
+    3
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -20,12 +28,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenTimeoutForHTTPS/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenTimeoutForHTTPS/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1
@@ -16,12 +22,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenTimeoutForHTTPS/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenTimeoutForHTTPS/observations.json
@@ -505,7 +505,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenTimeoutForHTTPS/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/redirectWithConsistentDNSAndThenTimeoutForHTTPS/observations_classic.json
@@ -208,7 +208,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "67.199.248.11"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/successWithHTTP/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/successWithHTTP/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -18,12 +25,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/successWithHTTP/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/successWithHTTP/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     2
@@ -16,12 +22,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/successWithHTTP/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/successWithHTTP/observations.json
@@ -263,7 +263,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/successWithHTTP/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/successWithHTTP/observations_classic.json
@@ -111,7 +111,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/successWithHTTPS/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/successWithHTTPS/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -18,12 +25,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/successWithHTTPS/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/successWithHTTPS/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -17,12 +23,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/successWithHTTPS/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/successWithHTTPS/observations.json
@@ -212,7 +212,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/successWithHTTPS/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/successWithHTTPS/observations_classic.json
@@ -111,7 +111,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/tcpBlockingConnectTimeout/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/tcpBlockingConnectTimeout/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -18,6 +25,7 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [
     3
   ],
@@ -28,6 +36,7 @@
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/tcpBlockingConnectTimeout/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/tcpBlockingConnectTimeout/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     2
@@ -16,6 +22,7 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [
     3
   ],
@@ -26,6 +33,7 @@
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/tcpBlockingConnectTimeout/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/tcpBlockingConnectTimeout/observations.json
@@ -207,7 +207,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/tcpBlockingConnectTimeout/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/tcpBlockingConnectTimeout/observations_classic.json
@@ -106,7 +106,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/tcpBlockingConnectionRefusedWithInconsistentDNS/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/tcpBlockingConnectionRefusedWithInconsistentDNS/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [
     1,
     2
@@ -18,6 +25,7 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [
     3
   ],
@@ -28,6 +36,7 @@
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/tcpBlockingConnectionRefusedWithInconsistentDNS/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/tcpBlockingConnectionRefusedWithInconsistentDNS/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [
     1
   ],
@@ -16,6 +22,7 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [
     3
   ],
@@ -26,6 +33,7 @@
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/tcpBlockingConnectionRefusedWithInconsistentDNS/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/tcpBlockingConnectionRefusedWithInconsistentDNS/observations.json
@@ -361,7 +361,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/tcpBlockingConnectionRefusedWithInconsistentDNS/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/tcpBlockingConnectionRefusedWithInconsistentDNS/observations_classic.json
@@ -106,7 +106,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/tlsBlockingConnectionResetWithConsistentDNS/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/tlsBlockingConnectionResetWithConsistentDNS/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -18,12 +25,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [
     3
   ],

--- a/internal/minipipeline/testdata/webconnectivity/generated/tlsBlockingConnectionResetWithConsistentDNS/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/tlsBlockingConnectionResetWithConsistentDNS/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     2
@@ -16,12 +22,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [
     3
   ],

--- a/internal/minipipeline/testdata/webconnectivity/generated/tlsBlockingConnectionResetWithConsistentDNS/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/tlsBlockingConnectionResetWithConsistentDNS/observations.json
@@ -207,7 +207,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/tlsBlockingConnectionResetWithConsistentDNS/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/tlsBlockingConnectionResetWithConsistentDNS/observations_classic.json
@@ -106,7 +106,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/tlsBlockingConnectionResetWithInconsistentDNS/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/tlsBlockingConnectionResetWithInconsistentDNS/analysis.json
@@ -1,7 +1,14 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [
     1,
     2
@@ -18,12 +25,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [
     3,
     4

--- a/internal/minipipeline/testdata/webconnectivity/generated/tlsBlockingConnectionResetWithInconsistentDNS/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/tlsBlockingConnectionResetWithInconsistentDNS/analysis_classic.json
@@ -1,7 +1,13 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [
     2
   ],
@@ -16,12 +22,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [
     3
   ],

--- a/internal/minipipeline/testdata/webconnectivity/generated/tlsBlockingConnectionResetWithInconsistentDNS/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/tlsBlockingConnectionResetWithInconsistentDNS/observations.json
@@ -256,7 +256,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/tlsBlockingConnectionResetWithInconsistentDNS/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/tlsBlockingConnectionResetWithInconsistentDNS/observations_classic.json
@@ -106,7 +106,10 @@
       "ControlHTTPResponseTitle": "Default Web Page"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "93.184.216.34"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/websiteDownNXDOMAIN/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/websiteDownNXDOMAIN/analysis.json
@@ -1,7 +1,9 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": "dns_lookup_error"
+  "ControlExpectations": {
+    "DNSAddresses": [],
+    "FinalResponseFailure": "dns_lookup_error"
   },
+  "DNSLookupSuccess": [],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [],
   "DNSLookupSuccessWithBogonAddresses": [],
@@ -15,12 +17,14 @@
     2
   ],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/websiteDownNXDOMAIN/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/websiteDownNXDOMAIN/analysis_classic.json
@@ -1,7 +1,9 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": "dns_lookup_error"
+  "ControlExpectations": {
+    "DNSAddresses": [],
+    "FinalResponseFailure": "dns_lookup_error"
   },
+  "DNSLookupSuccess": [],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [],
   "DNSLookupSuccessWithBogonAddresses": [],
@@ -14,12 +16,14 @@
     2
   ],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/generated/websiteDownNXDOMAIN/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/websiteDownNXDOMAIN/observations.json
@@ -129,7 +129,8 @@
   ],
   "DNSLookupSuccesses": [],
   "KnownTCPEndpoints": {},
-  "ControlFinalResponseExpectations": {
-    "Failure": "dns_lookup_error"
+  "ControlExpectations": {
+    "DNSAddresses": [],
+    "FinalResponseFailure": "dns_lookup_error"
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/generated/websiteDownNXDOMAIN/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/generated/websiteDownNXDOMAIN/observations_classic.json
@@ -45,7 +45,8 @@
   ],
   "DNSLookupSuccesses": [],
   "KnownTCPEndpoints": {},
-  "ControlFinalResponseExpectations": {
-    "Failure": "dns_lookup_error"
+  "ControlExpectations": {
+    "DNSAddresses": [],
+    "FinalResponseFailure": "dns_lookup_error"
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/manual/dnsgoogle80/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/manual/dnsgoogle80/analysis.json
@@ -1,7 +1,18 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": "generic_timeout_error"
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "2001:4860:4860::8844",
+      "2001:4860:4860::8888",
+      "8.8.4.4",
+      "8.8.8.8"
+    ],
+    "FinalResponseFailure": "generic_timeout_error"
   },
+  "DNSLookupSuccess": [
+    1,
+    2,
+    3
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -20,12 +31,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/manual/dnsgoogle80/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/manual/dnsgoogle80/analysis_classic.json
@@ -1,7 +1,16 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": "generic_timeout_error"
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "2001:4860:4860::8844",
+      "2001:4860:4860::8888",
+      "8.8.4.4",
+      "8.8.8.8"
+    ],
+    "FinalResponseFailure": "generic_timeout_error"
   },
+  "DNSLookupSuccess": [
+    1
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1
@@ -16,12 +25,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/manual/dnsgoogle80/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/manual/dnsgoogle80/observations.json
@@ -1028,7 +1028,13 @@
       "ControlHTTPResponseTitle": null
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": "generic_timeout_error"
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "2001:4860:4860::8844",
+      "2001:4860:4860::8888",
+      "8.8.4.4",
+      "8.8.8.8"
+    ],
+    "FinalResponseFailure": "generic_timeout_error"
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/manual/dnsgoogle80/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/manual/dnsgoogle80/observations_classic.json
@@ -420,7 +420,13 @@
       "ControlHTTPResponseTitle": null
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": "generic_timeout_error"
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "2001:4860:4860::8844",
+      "2001:4860:4860::8888",
+      "8.8.4.4",
+      "8.8.8.8"
+    ],
+    "FinalResponseFailure": "generic_timeout_error"
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/manual/noipv6/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/manual/noipv6/analysis.json
@@ -1,7 +1,23 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "142.251.32.78",
+      "142.251.33.174",
+      "142.251.41.46",
+      "142.251.41.78",
+      "172.217.165.14",
+      "2607:f8b0:400b:802::200e",
+      "2607:f8b0:400b:803::200e",
+      "2607:f8b0:400b:807::200e",
+      "2607:f8b0:400b:80c::200e"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2,
+    3
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -20,12 +36,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/manual/noipv6/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/manual/noipv6/analysis_classic.json
@@ -1,7 +1,21 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "142.251.32.78",
+      "142.251.33.174",
+      "142.251.41.46",
+      "142.251.41.78",
+      "172.217.165.14",
+      "2607:f8b0:400b:802::200e",
+      "2607:f8b0:400b:803::200e",
+      "2607:f8b0:400b:807::200e",
+      "2607:f8b0:400b:80c::200e"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    3
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -17,12 +31,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/manual/noipv6/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/manual/noipv6/observations.json
@@ -4588,7 +4588,18 @@
       "ControlHTTPResponseTitle": "YouTube"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "142.251.32.78",
+      "142.251.33.174",
+      "142.251.41.46",
+      "142.251.41.78",
+      "172.217.165.14",
+      "2607:f8b0:400b:802::200e",
+      "2607:f8b0:400b:803::200e",
+      "2607:f8b0:400b:807::200e",
+      "2607:f8b0:400b:80c::200e"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/manual/noipv6/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/manual/noipv6/observations_classic.json
@@ -1846,7 +1846,18 @@
       "ControlHTTPResponseTitle": "YouTube"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "142.251.32.78",
+      "142.251.33.174",
+      "142.251.41.46",
+      "142.251.41.78",
+      "172.217.165.14",
+      "2607:f8b0:400b:802::200e",
+      "2607:f8b0:400b:803::200e",
+      "2607:f8b0:400b:807::200e",
+      "2607:f8b0:400b:80c::200e"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/manual/youtube/analysis.json
+++ b/internal/minipipeline/testdata/webconnectivity/manual/youtube/analysis.json
@@ -1,7 +1,24 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "142.251.32.78",
+      "142.251.33.174",
+      "142.251.41.46",
+      "142.251.41.78",
+      "172.217.1.14",
+      "172.217.165.14",
+      "2607:f8b0:400b:802::200e",
+      "2607:f8b0:400b:803::200e",
+      "2607:f8b0:400b:807::200e",
+      "2607:f8b0:400b:80c::200e"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    1,
+    2,
+    3
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     1,
@@ -20,12 +37,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/manual/youtube/analysis_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/manual/youtube/analysis_classic.json
@@ -1,7 +1,22 @@
 {
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "142.251.32.78",
+      "142.251.33.174",
+      "142.251.41.46",
+      "142.251.41.78",
+      "172.217.1.14",
+      "172.217.165.14",
+      "2607:f8b0:400b:802::200e",
+      "2607:f8b0:400b:803::200e",
+      "2607:f8b0:400b:807::200e",
+      "2607:f8b0:400b:80c::200e"
+    ],
+    "FinalResponseFailure": ""
   },
+  "DNSLookupSuccess": [
+    2
+  ],
   "DNSLookupSuccessWithInvalidAddresses": [],
   "DNSLookupSuccessWithValidAddress": [
     2
@@ -16,12 +31,14 @@
   "DNSExperimentFailure": null,
   "DNSLookupExpectedFailure": [],
   "DNSLookupExpectedSuccess": [],
+  "TCPConnectExpectedFailure": [],
   "TCPConnectUnexpectedFailure": [],
   "TCPConnectUnexpectedFailureDuringWebFetch": [],
   "TCPConnectUnexpectedFailureDuringConnectivityCheck": [],
   "TCPConnectUnexplainedFailure": [],
   "TCPConnectUnexplainedFailureDuringWebFetch": [],
   "TCPConnectUnexplainedFailureDuringConnectivityCheck": [],
+  "TLSHandshakeExpectedFailure": [],
   "TLSHandshakeUnexpectedFailure": [],
   "TLSHandshakeUnexpectedFailureDuringWebFetch": [],
   "TLSHandshakeUnexpectedFailureDuringConnectivityCheck": [],

--- a/internal/minipipeline/testdata/webconnectivity/manual/youtube/observations.json
+++ b/internal/minipipeline/testdata/webconnectivity/manual/youtube/observations.json
@@ -4768,7 +4768,19 @@
       "ControlHTTPResponseTitle": "YouTube"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "142.251.32.78",
+      "142.251.33.174",
+      "142.251.41.46",
+      "142.251.41.78",
+      "172.217.1.14",
+      "172.217.165.14",
+      "2607:f8b0:400b:802::200e",
+      "2607:f8b0:400b:803::200e",
+      "2607:f8b0:400b:807::200e",
+      "2607:f8b0:400b:80c::200e"
+    ],
+    "FinalResponseFailure": ""
   }
 }

--- a/internal/minipipeline/testdata/webconnectivity/manual/youtube/observations_classic.json
+++ b/internal/minipipeline/testdata/webconnectivity/manual/youtube/observations_classic.json
@@ -1917,7 +1917,19 @@
       "ControlHTTPResponseTitle": "YouTube"
     }
   },
-  "ControlFinalResponseExpectations": {
-    "Failure": ""
+  "ControlExpectations": {
+    "DNSAddresses": [
+      "142.251.32.78",
+      "142.251.33.174",
+      "142.251.41.46",
+      "142.251.41.78",
+      "172.217.1.14",
+      "172.217.165.14",
+      "2607:f8b0:400b:802::200e",
+      "2607:f8b0:400b:803::200e",
+      "2607:f8b0:400b:807::200e",
+      "2607:f8b0:400b:80c::200e"
+    ],
+    "FinalResponseFailure": ""
   }
 }


### PR DESCRIPTION
This diff extends webconnectivitylte's classic analysis engine and minipipeline to generate `XNullNullFlags`.

With this change implemented, we have successfully replaced the "orig" engine with "classic".

This work is part of https://github.com/ooni/probe/issues/2640.

While this diff is large, most of the changes are in the generated files for the minipipeline test suite.