### PR TITLE
cleanup(webconnectivitytle): avoid code duplication

### DIFF
--- a/internal/experiment/webconnectivitylte/analysisclassic.go
+++ b/internal/experiment/webconnectivitylte/analysisclassic.go
@@ -112,14 +112,27 @@ var _ analysisClassicTestKeysProxy = &TestKeys{}
 
 // httpDiff implements analysisClassicTestKeysProxy.
 func (tk *TestKeys) httpDiff() bool {
-	hds := &analysisHTTPDiffStatus{
-		BodyProportion:  optional.Some(tk.BodyProportion),
-		BodyLengthMatch: tk.BodyLengthMatch,
-		HeadersMatch:    tk.HeadersMatch,
-		StatusCodeMatch: tk.StatusCodeMatch,
-		TitleMatch:      tk.TitleMatch,
-	}
-	return hds.httpDiff()
+	return analysisHTTPDiffAlgorithm(tk)
+}
+
+// bodyLengthMatch implements analysisHTTPDiffValuesProvider.
+func (tk *TestKeys) bodyLengthMatch() optional.Value[bool] {
+	return tk.BodyLengthMatch
+}
+
+// headersMatch implements analysisHTTPDiffValuesProvider.
+func (tk *TestKeys) headersMatch() optional.Value[bool] {
+	return tk.HeadersMatch
+}
+
+// statusCodeMatch implements analysisHTTPDiffValuesProvider.
+func (tk *TestKeys) statusCodeMatch() optional.Value[bool] {
+	return tk.StatusCodeMatch
+}
+
+// titleMatch implements analysisHTTPDiffValuesProvider.
+func (tk *TestKeys) titleMatch() optional.Value[bool] {
+	return tk.TitleMatch
 }
 
 // setBlockingFalse implements analysisClassicTestKeysProxy.

--- a/internal/experiment/webconnectivitylte/analysisext.go
+++ b/internal/experiment/webconnectivitylte/analysisext.go
@@ -142,7 +142,7 @@ func analysisExtHTTPFinalResponse(tk *TestKeys, analysis *minipipeline.WebAnalys
 	if success := analysis.HTTPFinalResponseSuccessTCPWithControl; !success.IsNone() {
 		txID := success.Unwrap()
 		hds := newAnalysisHTTPDiffStatus(analysis)
-		if hds.httpDiff() {
+		if analysisHTTPDiffAlgorithm(hds) {
 			tk.BlockingFlags |= AnalysisBlockingFlagHTTPDiff
 			fmt.Fprintf(info, "- the final response (transaction: %d) differs from the control response\n", txID)
 			return

--- a/internal/experiment/webconnectivitylte/testkeys.go
+++ b/internal/experiment/webconnectivitylte/testkeys.go
@@ -99,16 +99,16 @@ type TestKeys struct {
 	BodyProportion float64 `json:"body_proportion"`
 
 	// BodyLength match tells us whether the body length matches.
-	BodyLengthMatch *bool `json:"body_length_match"`
+	BodyLengthMatch optional.Value[bool] `json:"body_length_match"`
 
 	// HeadersMatch tells us whether the headers match.
-	HeadersMatch *bool `json:"headers_match"`
+	HeadersMatch optional.Value[bool] `json:"headers_match"`
 
 	// StatusCodeMatch tells us whether the status code matches.
-	StatusCodeMatch *bool `json:"status_code_match"`
+	StatusCodeMatch optional.Value[bool] `json:"status_code_match"`
 
 	// TitleMatch tells us whether the title matches.
-	TitleMatch *bool `json:"title_match"`
+	TitleMatch optional.Value[bool] `json:"title_match"`
 
 	// Blocking indicates the reason for blocking. This is notoriously a bad
 	// type because it can be one of the following values:
@@ -363,10 +363,10 @@ func NewTestKeys() *TestKeys {
 		BlockingFlags:         0,
 		NullNullFlags:         0,
 		BodyProportion:        0,
-		BodyLengthMatch:       nil,
-		HeadersMatch:          nil,
-		StatusCodeMatch:       nil,
-		TitleMatch:            nil,
+		BodyLengthMatch:       optional.None[bool](),
+		HeadersMatch:          optional.None[bool](),
+		StatusCodeMatch:       optional.None[bool](),
+		TitleMatch:            optional.None[bool](),
 		Blocking:              nil,
 		Accessible:            nil,
 		ControlRequest:        nil,


### PR DESCRIPTION
Use a single algorithm for determining whether there's HTTP diff. We can do this by migrating the HTTP diff flags to use `optional.Value` and then we can always use code written for the "ext" sub-engine to do that.

Part of https://github.com/ooni/probe/issues/2640