### PR TITLE
feat(webconnectivitylte): handle ghost DNS censorship

### DIFF
--- a/internal/experiment/webconnectivitylte/analysisext.go
+++ b/internal/experiment/webconnectivitylte/analysisext.go
@@ -262,11 +262,14 @@ func analysisExtExpectedFailures(tk *TestKeys, analysis *minipipeline.WebAnalysi
 	//
 	//	tk.NullNullFlags |= AnalysisFlagNullNullSuccessfulHTTPS
 	//
-	// is set by analysisExtHTTPFinalResponse
+	// is set by analysisExtHTTPFinalResponse when we detect that we do not
+	// have a control response but nonetheless observe successful HTTPS.
 
-	// if the control did not resolve any address but the probe could, this is
+	// If the control did not resolve any address but the probe could, this is
 	// quite likely censorship injecting addrs for otherwise "down" or nonexisting
-	// domains, which lives on as a ghost haunting people
+	// domains, which lives on as a ghost haunting people.
+	//
+	// See https://github.com/ooni/probe/issues/2308.
 	if !analysis.ControlExpectations.IsNone() {
 		expect := analysis.ControlExpectations.Unwrap()
 		if expect.DNSAddresses.Len() <= 0 && analysis.DNSLookupSuccess.Len() > 0 {

--- a/internal/experiment/webconnectivityqa/badssl.go
+++ b/internal/experiment/webconnectivityqa/badssl.go
@@ -10,7 +10,7 @@ import (
 func badSSLWithExpiredCertificate() *TestCase {
 	return &TestCase{
 		Name:  "badSSLWithExpiredCertificate",
-		Flags: 0,
+		Flags: TestCaseFlagNoV04,
 		Input: "https://expired.badssl.com/",
 		Configure: func(env *netemx.QAEnv) {
 			// nothing
@@ -21,8 +21,8 @@ func badSSLWithExpiredCertificate() *TestCase {
 			HTTPExperimentFailure: "ssl_invalid_certificate",
 			XStatus:               16, // StatusAnomalyControlFailure
 			XNullNullFlags:        4,  // analysisFlagNullNullTLSMisconfigured
-			Accessible:            nil,
-			Blocking:              nil,
+			Accessible:            false,
+			Blocking:              false,
 		},
 	}
 }
@@ -32,7 +32,7 @@ func badSSLWithExpiredCertificate() *TestCase {
 func badSSLWithWrongServerName() *TestCase {
 	return &TestCase{
 		Name:  "badSSLWithWrongServerName",
-		Flags: 0,
+		Flags: TestCaseFlagNoV04,
 		Input: "https://wrong.host.badssl.com/",
 		Configure: func(env *netemx.QAEnv) {
 			// nothing
@@ -43,8 +43,8 @@ func badSSLWithWrongServerName() *TestCase {
 			HTTPExperimentFailure: "ssl_invalid_hostname",
 			XStatus:               16, // StatusAnomalyControlFailure
 			XNullNullFlags:        4,  // analysisFlagNullNullTLSMisconfigured
-			Accessible:            nil,
-			Blocking:              nil,
+			Accessible:            false,
+			Blocking:              false,
 		},
 	}
 }
@@ -53,7 +53,7 @@ func badSSLWithWrongServerName() *TestCase {
 func badSSLWithUnknownAuthorityWithConsistentDNS() *TestCase {
 	return &TestCase{
 		Name:  "badSSLWithUnknownAuthorityWithConsistentDNS",
-		Flags: 0,
+		Flags: TestCaseFlagNoV04,
 		Input: "https://untrusted-root.badssl.com/",
 		Configure: func(env *netemx.QAEnv) {
 			// nothing
@@ -64,8 +64,8 @@ func badSSLWithUnknownAuthorityWithConsistentDNS() *TestCase {
 			HTTPExperimentFailure: "ssl_unknown_authority",
 			XStatus:               16, // StatusAnomalyControlFailure
 			XNullNullFlags:        4,  // analysisFlagNullNullTLSMisconfigured
-			Accessible:            nil,
-			Blocking:              nil,
+			Accessible:            false,
+			Blocking:              false,
 		},
 	}
 }

--- a/internal/experiment/webconnectivityqa/dnsblocking.go
+++ b/internal/experiment/webconnectivityqa/dnsblocking.go
@@ -9,7 +9,7 @@ import (
 func dnsBlockingAndroidDNSCacheNoData() *TestCase {
 	return &TestCase{
 		Name:  "dnsBlockingAndroidDNSCacheNoData",
-		Flags: 0,
+		Flags: TestCaseFlagNoV04,
 		Input: "https://www.example.com/",
 		Configure: func(env *netemx.QAEnv) {
 			// make sure the env knows we want to emulate our getaddrinfo wrapper behavior
@@ -21,13 +21,14 @@ func dnsBlockingAndroidDNSCacheNoData() *TestCase {
 		},
 		ExpectErr: false,
 		ExpectTestKeys: &testKeys{
-			DNSExperimentFailure: "android_dns_cache_no_data",
-			DNSConsistency:       "inconsistent",
-			XStatus:              2080, // StatusExperimentDNS | StatusAnomalyDNS
-			XDNSFlags:            2,    // AnalysisDNSFlagUnexpectedFailure
-			XBlockingFlags:       33,   // AnalysisBlockingFlagDNSBlocking | AnalysisBlockingFlagSuccess
-			Accessible:           false,
-			Blocking:             "dns",
+			DNSExperimentFailure:  "android_dns_cache_no_data",
+			HTTPExperimentFailure: "android_dns_cache_no_data",
+			DNSConsistency:        "inconsistent",
+			XStatus:               2080, // StatusExperimentDNS | StatusAnomalyDNS
+			XDNSFlags:             2,    // AnalysisDNSFlagUnexpectedFailure
+			XBlockingFlags:        33,   // AnalysisBlockingFlagDNSBlocking | AnalysisBlockingFlagSuccess
+			Accessible:            false,
+			Blocking:              "dns",
 		},
 	}
 }
@@ -44,7 +45,7 @@ func dnsBlockingNXDOMAIN() *TestCase {
 	*/
 	return &TestCase{
 		Name:  "dnsBlockingNXDOMAIN",
-		Flags: 0,
+		Flags: TestCaseFlagNoV04,
 		Input: "https://www.example.com/",
 		Configure: func(env *netemx.QAEnv) {
 			// remove the record so that the DNS query returns NXDOMAIN
@@ -52,13 +53,14 @@ func dnsBlockingNXDOMAIN() *TestCase {
 		},
 		ExpectErr: false,
 		ExpectTestKeys: &testKeys{
-			DNSExperimentFailure: "dns_nxdomain_error",
-			DNSConsistency:       "inconsistent",
-			XStatus:              2080, // StatusExperimentDNS | StatusAnomalyDNS
-			XDNSFlags:            2,    // AnalysisDNSFlagUnexpectedFailure
-			XBlockingFlags:       33,   // AnalysisBlockingFlagDNSBlocking | AnalysisBlockingFlagSuccess
-			Accessible:           false,
-			Blocking:             "dns",
+			DNSExperimentFailure:  "dns_nxdomain_error",
+			HTTPExperimentFailure: "dns_nxdomain_error",
+			DNSConsistency:        "inconsistent",
+			XStatus:               2080, // StatusExperimentDNS | StatusAnomalyDNS
+			XDNSFlags:             2,    // AnalysisDNSFlagUnexpectedFailure
+			XBlockingFlags:        33,   // AnalysisBlockingFlagDNSBlocking | AnalysisBlockingFlagSuccess
+			Accessible:            false,
+			Blocking:              "dns",
 		},
 	}
 }

--- a/internal/experiment/webconnectivityqa/ghost.go
+++ b/internal/experiment/webconnectivityqa/ghost.go
@@ -44,7 +44,7 @@ func ghostDNSBlockingWithHTTP() *TestCase {
 }
 
 // ghostDNSBlockingWithHTTPS is the case where the domain does not exist anymore but
-// there's still ghost censorship because of the system resolver configuration, which
+// there's still ghost censorship because of the censor DNS censoring configuration, which
 // says that we should censor the domain by returning a specific IP address.
 //
 // See https://github.com/ooni/probe/issues/2308.

--- a/internal/experiment/webconnectivityqa/ghost.go
+++ b/internal/experiment/webconnectivityqa/ghost.go
@@ -1,0 +1,81 @@
+package webconnectivityqa
+
+import (
+	"github.com/apex/log"
+	"github.com/ooni/netem"
+	"github.com/ooni/probe-cli/v3/internal/netemx"
+)
+
+// ghostDNSBlockingWithHTTP is the case where the domain does not exist anymore but
+// there's still ghost censorship because of the system resolver configuration, which
+// says that we should censor the domain by returning a specific IP address.
+//
+// See https://github.com/ooni/probe/issues/2308.
+func ghostDNSBlockingWithHTTP() *TestCase {
+	return &TestCase{
+		Name:  "ghostDNSBlockingWithHTTP",
+		Flags: TestCaseFlagNoV04,
+		Input: "http://itsat.info/",
+		Configure: func(env *netemx.QAEnv) {
+			// remove the record so that the DNS query returns NXDOMAIN
+			env.ISPResolverConfig().RemoveRecord("itsat.info")
+			env.OtherResolversConfig().RemoveRecord("itsat.info")
+
+			// however introduce a rule causing DNS to respond to the query
+			env.DPIEngine().AddRule(&netem.DPISpoofDNSResponse{
+				Addresses: []string{
+					netemx.AddressPublicBlockpage,
+				},
+				Logger: log.Log,
+				Domain: "itsat.info",
+			})
+		},
+		ExpectErr: false,
+		ExpectTestKeys: &testKeys{
+			DNSExperimentFailure: nil,
+			DNSConsistency:       "inconsistent",
+			XBlockingFlags:       16, // AnalysisBlockingFlagHTTPDiff
+			XNullNullFlags:       16, // AnalysisFlagNullNullUnexpectedDNSLookupSuccess
+			XStatus:              16, // StatusAnomalyControlFailure
+			Accessible:           false,
+			Blocking:             "dns",
+		},
+	}
+}
+
+// ghostDNSBlockingWithHTTPS is the case where the domain does not exist anymore but
+// there's still ghost censorship because of the system resolver configuration, which
+// says that we should censor the domain by returning a specific IP address.
+//
+// See https://github.com/ooni/probe/issues/2308.
+func ghostDNSBlockingWithHTTPS() *TestCase {
+	return &TestCase{
+		Name:  "ghostDNSBlockingWithHTTPS",
+		Flags: 0,
+		Input: "https://itsat.info/",
+		Configure: func(env *netemx.QAEnv) {
+			// remove the record so that the DNS query returns NXDOMAIN
+			env.ISPResolverConfig().RemoveRecord("itsat.info")
+			env.OtherResolversConfig().RemoveRecord("itsat.info")
+
+			// however introduce a rule causing DNS to respond to the query
+			env.DPIEngine().AddRule(&netem.DPISpoofDNSResponse{
+				Addresses: []string{
+					netemx.AddressPublicBlockpage,
+				},
+				Logger: log.Log,
+				Domain: "itsat.info",
+			})
+		},
+		ExpectErr: false,
+		ExpectTestKeys: &testKeys{
+			DNSExperimentFailure:  nil,
+			DNSConsistency:        "inconsistent",
+			HTTPExperimentFailure: "connection_refused",
+			XNullNullFlags:        16,   // AnalysisFlagNullNullUnexpectedDNSLookupSuccess
+			XStatus:               4256, // StatusExperimentConnect | StatusAnomalyDNS | StatusAnomalyConnect
+			Accessible:            false,
+			Blocking:              "dns",
+		},
+	}
+}

--- a/internal/experiment/webconnectivityqa/ghost.go
+++ b/internal/experiment/webconnectivityqa/ghost.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ghostDNSBlockingWithHTTP is the case where the domain does not exist anymore but
-// there's still ghost censorship because of the system resolver configuration, which
+// there's still ghost censorship because of the censor DNS censoring configuration, which
 // says that we should censor the domain by returning a specific IP address.
 //
 // See https://github.com/ooni/probe/issues/2308.

--- a/internal/experiment/webconnectivityqa/testcase.go
+++ b/internal/experiment/webconnectivityqa/testcase.go
@@ -52,6 +52,9 @@ func AllTestCases() []*TestCase {
 		dnsHijackingToProxyWithHTTPURL(),
 		dnsHijackingToProxyWithHTTPSURL(),
 
+		ghostDNSBlockingWithHTTP(),
+		ghostDNSBlockingWithHTTPS(),
+
 		httpBlockingConnectionReset(),
 
 		httpDiffWithConsistentDNS(),

--- a/internal/experiment/webconnectivityqa/websitedown.go
+++ b/internal/experiment/webconnectivityqa/websitedown.go
@@ -21,18 +21,19 @@ func websiteDownNXDOMAIN() *TestCase {
 	*/
 	return &TestCase{
 		Name:      "websiteDownNXDOMAIN",
-		Flags:     0,                         // see above
+		Flags:     TestCaseFlagNoV04,
 		Input:     "http://www.example.xyz/", // domain not defined in the simulation
 		Configure: nil,
 		ExpectErr: false,
 		ExpectTestKeys: &testKeys{
-			DNSExperimentFailure: "dns_nxdomain_error",
-			DNSConsistency:       "consistent",
-			XStatus:              2052, // StatusExperimentDNS | StatusSuccessNXDOMAIN
-			XBlockingFlags:       0,
-			XNullNullFlags:       1, // analysisFlagNullNullNoAddrs
-			Accessible:           true,
-			Blocking:             false,
+			DNSExperimentFailure:  "dns_nxdomain_error",
+			HTTPExperimentFailure: "dns_nxdomain_error",
+			DNSConsistency:        "consistent",
+			XStatus:               2052, // StatusExperimentDNS | StatusSuccessNXDOMAIN
+			XBlockingFlags:        0,
+			XNullNullFlags:        1, // analysisFlagNullNullNoAddrs
+			Accessible:            false,
+			Blocking:              false,
 		},
 	}
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2652
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: no need
- [x] if you changed code inside an experiment, make sure you bump its version number: already bumped for 3.21.x

## Description

This commit modifies webconnectivitylte to handle ghost DNS censorship.

We define ghost DNS censorship the case where the original domain does not exist anymore but the censor continues to return an IP address for the original domain nonetheless.

We used to have null-null handling for this case in the "orig" engine and a reference issue as https://github.com/ooni/probe/issues/2307.

With this commit, we modify the "classic" engine to correctly handle this case.

To this end, we need to:

1. mark DNS inconsistency when we have successful probe lookups and no IP address has been resolved by the test helper, which is indeed the case of ghost DNS censorship.

2. specific handling on the case in which the website seems down where we also ask ourselves the question of whether the culprit could be the DNS and otherwise set accessible = false and blocking = false.

Note that, with those two changes, we depart from strict v0.4-is-always-right orthodoxy.

So, while there, let's recognize that always setting HTTPExprimentFailure is probably for the greater good.

