### PR TITLE
cleanup(netxlite): remove first-order implicit-Netx wrappers

### DIFF
--- a/internal/cmd/apitool/main.go
+++ b/internal/cmd/apitool/main.go
@@ -28,7 +28,8 @@ import (
 func newclient() probeservices.Client {
 	// TODO(https://github.com/ooni/probe/issues/2534): NewHTTPTransportStdlib has QUIRKS but we
 	// don't actually care about those QUIRKS in this context
-	txp := netxlite.NewHTTPTransportStdlib(log.Log)
+	netx := &netxlite.Netx{}
+	txp := netx.NewHTTPTransportStdlib(log.Log)
 	ua := fmt.Sprintf("apitool/%s ooniprobe-engine/%s", version.Version, version.Version)
 	return probeservices.Client{
 		APIClientTemplate: httpx.APIClientTemplate{

--- a/internal/cmd/gardener/internal/dnsreport/dnsreport.go
+++ b/internal/cmd/gardener/internal/dnsreport/dnsreport.go
@@ -253,7 +253,8 @@ func (s *Subcommand) dnsLookupHost(domain string) ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	dnsResolver := netxlite.NewParallelDNSOverHTTPSResolver(log.Log, s.DNSOverHTTPSServerURL)
+	netx := &netxlite.Netx{}
+	dnsResolver := netx.NewParallelDNSOverHTTPSResolver(log.Log, s.DNSOverHTTPSServerURL)
 	defer dnsResolver.CloseIdleConnections()
 
 	// lookup for both A and AAAA entries

--- a/internal/cmd/oohelper/oohelper.go
+++ b/internal/cmd/oohelper/oohelper.go
@@ -28,7 +28,8 @@ func init() {
 	// Use a nonstandard resolver, which is enough to work around the
 	// puzzling https://github.com/ooni/probe/issues/1409 issue.
 	const resolverURL = "https://8.8.8.8/dns-query"
-	resolver = netxlite.NewParallelDNSOverHTTPSResolver(log.Log, resolverURL)
+	netx := &netxlite.Netx{}
+	resolver = netx.NewParallelDNSOverHTTPSResolver(log.Log, resolverURL)
 	// TODO(https://github.com/ooni/probe/issues/2534): the NewHTTPClientWithResolver func has QUIRKS but we don't care.
 	httpClient = netxlite.NewHTTPClientWithResolver(log.Log, resolver)
 }

--- a/internal/cmd/ooporthelper/main_test.go
+++ b/internal/cmd/ooporthelper/main_test.go
@@ -19,7 +19,8 @@ func TestMainWorkingAsIntended(t *testing.T) {
 		portsMap[port] = false
 	}
 	go main()
-	dialer := netxlite.NewDialerWithoutResolver(model.DiscardLogger)
+	netx := &netxlite.Netx{}
+	dialer := netx.NewDialerWithoutResolver(model.DiscardLogger)
 	for i := 0; i < len(TestPorts); i++ {
 		port := <-srvTestChan
 		addr := net.JoinHostPort("127.0.0.1", port)

--- a/internal/enginelocate/cloudflare_test.go
+++ b/internal/enginelocate/cloudflare_test.go
@@ -16,12 +16,13 @@ func TestIPLookupWorksUsingcloudlflare(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 
+	netx := &netxlite.Netx{}
 	ip, err := cloudflareIPLookup(
 		context.Background(),
 		http.DefaultClient,
 		log.Log,
 		model.HTTPHeaderUserAgent,
-		netxlite.NewStdlibResolver(model.DiscardLogger),
+		netx.NewStdlibResolver(model.DiscardLogger),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/enginelocate/geolocate.go
+++ b/internal/enginelocate/geolocate.go
@@ -82,8 +82,9 @@ func NewTask(config Config) *Task {
 	if config.UserAgent == "" {
 		config.UserAgent = fmt.Sprintf("ooniprobe-engine/%s", version.Version)
 	}
+	netx := &netxlite.Netx{}
 	if config.Resolver == nil {
-		config.Resolver = netxlite.NewStdlibResolver(config.Logger)
+		config.Resolver = netx.NewStdlibResolver(config.Logger)
 	}
 	return &Task{
 		countryLookupper:     mmdbLookupper{},

--- a/internal/enginelocate/iplookup_test.go
+++ b/internal/enginelocate/iplookup_test.go
@@ -17,9 +17,10 @@ func TestIPLookupGood(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 
+	netx := &netxlite.Netx{}
 	ip, err := (ipLookupClient{
 		Logger:    log.Log,
-		Resolver:  netxlite.NewStdlibResolver(model.DiscardLogger),
+		Resolver:  netx.NewStdlibResolver(model.DiscardLogger),
 		UserAgent: "ooniprobe-engine/0.1.0",
 	}).LookupProbeIP(context.Background())
 	if err != nil {
@@ -33,9 +34,10 @@ func TestIPLookupGood(t *testing.T) {
 func TestIPLookupAllFailed(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately cancel to cause Do() to fail
+	netx := &netxlite.Netx{}
 	ip, err := (ipLookupClient{
 		Logger:    log.Log,
-		Resolver:  netxlite.NewStdlibResolver(model.DiscardLogger),
+		Resolver:  netx.NewStdlibResolver(model.DiscardLogger),
 		UserAgent: "ooniprobe-engine/0.1.0",
 	}).LookupProbeIP(ctx)
 	if !errors.Is(err, context.Canceled) {
@@ -48,9 +50,10 @@ func TestIPLookupAllFailed(t *testing.T) {
 
 func TestIPLookupInvalidIP(t *testing.T) {
 	ctx := context.Background()
+	netx := &netxlite.Netx{}
 	ip, err := (ipLookupClient{
 		Logger:    log.Log,
-		Resolver:  netxlite.NewStdlibResolver(model.DiscardLogger),
+		Resolver:  netx.NewStdlibResolver(model.DiscardLogger),
 		UserAgent: "ooniprobe-engine/0.1.0",
 	}).doWithCustomFunc(ctx, invalidIPLookup)
 	if !errors.Is(err, ErrInvalidIPAddress) {

--- a/internal/enginelocate/resolverlookup.go
+++ b/internal/enginelocate/resolverlookup.go
@@ -14,7 +14,8 @@ type resolverLookupClient struct {
 
 func (rlc resolverLookupClient) LookupResolverIP(ctx context.Context) (string, error) {
 	// MUST be the system resolver! See https://github.com/ooni/probe/issues/2360
-	reso := netxlite.NewStdlibResolver(rlc.Logger)
+	netx := &netxlite.Netx{}
+	reso := netx.NewStdlibResolver(rlc.Logger)
 	var ips []string
 	ips, err := reso.LookupHost(ctx, "whoami.v4.powerdns.org")
 	if err != nil {

--- a/internal/enginelocate/stun.go
+++ b/internal/enginelocate/stun.go
@@ -33,7 +33,8 @@ func stunIPLookup(ctx context.Context, config stunConfig) (string, error) {
 	ip, err := func() (string, error) {
 		dialer := config.Dialer
 		if dialer == nil {
-			dialer = netxlite.NewDialerWithResolver(config.Logger, config.Resolver)
+			netx := &netxlite.Netx{}
+			dialer = netx.NewDialerWithResolver(config.Logger, config.Resolver)
 		}
 		conn, err := dialer.DialContext(ctx, "udp", config.Endpoint)
 		if err != nil {

--- a/internal/enginelocate/stun_test.go
+++ b/internal/enginelocate/stun_test.go
@@ -18,10 +18,11 @@ import (
 func TestSTUNIPLookupCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // stop immediately
+	netx := &netxlite.Netx{}
 	ip, err := stunIPLookup(ctx, stunConfig{
 		Endpoint: "stun.ekiga.net:3478",
 		Logger:   log.Log,
-		Resolver: netxlite.NewStdlibResolver(model.DiscardLogger),
+		Resolver: netx.NewStdlibResolver(model.DiscardLogger),
 	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("not the error we expected: %+v", err)
@@ -151,12 +152,13 @@ func TestIPLookupWorksUsingSTUNEkiga(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 
+	netx := &netxlite.Netx{}
 	ip, err := stunEkigaIPLookup(
 		context.Background(),
 		http.DefaultClient,
 		log.Log,
 		model.HTTPHeaderUserAgent,
-		netxlite.NewStdlibResolver(model.DiscardLogger),
+		netx.NewStdlibResolver(model.DiscardLogger),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -171,12 +173,13 @@ func TestIPLookupWorksUsingSTUNGoogle(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 
+	netx := &netxlite.Netx{}
 	ip, err := stunGoogleIPLookup(
 		context.Background(),
 		http.DefaultClient,
 		log.Log,
 		model.HTTPHeaderUserAgent,
-		netxlite.NewStdlibResolver(model.DiscardLogger),
+		netx.NewStdlibResolver(model.DiscardLogger),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/enginelocate/ubuntu_test.go
+++ b/internal/enginelocate/ubuntu_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestUbuntuParseError(t *testing.T) {
+	netx := &netxlite.Netx{}
 	ip, err := ubuntuIPLookup(
 		context.Background(),
 		&http.Client{Transport: FakeTransport{
@@ -24,7 +25,7 @@ func TestUbuntuParseError(t *testing.T) {
 		}},
 		log.Log,
 		model.HTTPHeaderUserAgent,
-		netxlite.NewStdlibResolver(model.DiscardLogger),
+		netx.NewStdlibResolver(model.DiscardLogger),
 	)
 	if err == nil || !strings.HasPrefix(err.Error(), "XML syntax error") {
 		t.Fatalf("not the error we expected: %+v", err)
@@ -39,12 +40,13 @@ func TestIPLookupWorksUsingUbuntu(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 
+	netx := &netxlite.Netx{}
 	ip, err := ubuntuIPLookup(
 		context.Background(),
 		http.DefaultClient,
 		log.Log,
 		model.HTTPHeaderUserAgent,
-		netxlite.NewStdlibResolver(model.DiscardLogger),
+		netx.NewStdlibResolver(model.DiscardLogger),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/enginenetx/httpsdialer_test.go
+++ b/internal/enginenetx/httpsdialer_test.go
@@ -493,7 +493,8 @@ func TestHTTPSDialerHostNetworkQA(t *testing.T) {
 
 		// The resolver we're creating here reproduces the test case described by
 		// https://github.com/ooni/probe-cli/pull/1295#issuecomment-1731243994
-		resolver := netxlite.MaybeWrapWithBogonResolver(true, netxlite.NewStdlibResolver(log.Log))
+		netx := &netxlite.Netx{}
+		resolver := netxlite.MaybeWrapWithBogonResolver(true, netx.NewStdlibResolver(log.Log))
 
 		httpsDialer := newHTTPSDialer(
 			log.Log,

--- a/internal/enginenetx/network.go
+++ b/internal/enginenetx/network.go
@@ -90,7 +90,8 @@ func NewNetwork(
 	// Create a dialer ONLY used for dialing unencrypted TCP connections. The common use
 	// case of this Network is to dial encrypted connections. For this reason, here it is
 	// reasonably fine to use the legacy sequential dialer implemented in netxlite.
-	dialer := netxlite.NewDialerWithResolver(logger, resolver)
+	netx := &netxlite.Netx{}
+	dialer := netx.NewDialerWithResolver(logger, resolver)
 
 	// Create manager for keeping track of statistics
 	const trimInterval = 30 * time.Second
@@ -135,12 +136,12 @@ func NewNetwork(
 	// Make sure we count the bytes sent and received as part of the session
 	txp = bytecounter.WrapHTTPTransport(txp, counter)
 
-	netx := &Network{
+	network := &Network{
 		reso:  resolver,
 		stats: stats,
 		txp:   txp,
 	}
-	return netx
+	return network
 }
 
 // newHTTPSDialerPolicy contains the logic to select the [HTTPSDialerPolicy] to use.

--- a/internal/enginenetx/network_internal_test.go
+++ b/internal/enginenetx/network_internal_test.go
@@ -187,7 +187,7 @@ func TestNetworkUnit(t *testing.T) {
 						tc.kvStore(),
 						log.Log,
 						nil, // proxy URL
-						netxlite.NewStdlibResolver(log.Log),
+						(&netxlite.Netx{}).NewStdlibResolver(log.Log),
 					)
 					defer netx.Close()
 

--- a/internal/enginenetx/network_test.go
+++ b/internal/enginenetx/network_test.go
@@ -25,12 +25,13 @@ func TestNetworkQA(t *testing.T) {
 		defer env.Close()
 
 		env.Do(func() {
+			netx := &netxlite.Netx{}
 			txp := enginenetx.NewNetwork(
 				bytecounter.New(),
 				&kvstore.Memory{},
 				log.Log,
 				nil,
-				netxlite.NewStdlibResolver(log.Log),
+				netx.NewStdlibResolver(log.Log),
 			)
 			client := txp.NewHTTPClient()
 			resp, err := client.Get("https://www.example.com/")
@@ -62,6 +63,7 @@ func TestNetworkQA(t *testing.T) {
 		defer proxy.Close()
 
 		env.Do(func() {
+			netx := &netxlite.Netx{}
 			txp := enginenetx.NewNetwork(
 				bytecounter.New(),
 				&kvstore.Memory{},
@@ -71,7 +73,7 @@ func TestNetworkQA(t *testing.T) {
 					Host:   net.JoinHostPort(env.ClientStack.IPAddress(), "9050"),
 					Path:   "/",
 				},
-				netxlite.NewStdlibResolver(log.Log),
+				netx.NewStdlibResolver(log.Log),
 			)
 			client := txp.NewHTTPClient()
 
@@ -131,6 +133,7 @@ func TestNetworkQA(t *testing.T) {
 		defer proxy.Close()
 
 		env.Do(func() {
+			netx := &netxlite.Netx{}
 			txp := enginenetx.NewNetwork(
 				bytecounter.New(),
 				&kvstore.Memory{},
@@ -140,7 +143,7 @@ func TestNetworkQA(t *testing.T) {
 					Host:   net.JoinHostPort(env.ClientStack.IPAddress(), "8080"),
 					Path:   "/",
 				},
-				netxlite.NewStdlibResolver(log.Log),
+				netx.NewStdlibResolver(log.Log),
 			)
 			client := txp.NewHTTPClient()
 
@@ -202,6 +205,7 @@ func TestNetworkQA(t *testing.T) {
 		defer proxy.Close()
 
 		env.Do(func() {
+			netx := &netxlite.Netx{}
 			txp := enginenetx.NewNetwork(
 				bytecounter.New(),
 				&kvstore.Memory{},
@@ -211,7 +215,7 @@ func TestNetworkQA(t *testing.T) {
 					Host:   net.JoinHostPort(env.ClientStack.IPAddress(), "4443"),
 					Path:   "/",
 				},
-				netxlite.NewStdlibResolver(log.Log),
+				netx.NewStdlibResolver(log.Log),
 			)
 			client := txp.NewHTTPClient()
 
@@ -257,12 +261,13 @@ func TestNetworkQA(t *testing.T) {
 	})
 
 	t.Run("NewHTTPClient returns a client with a cookie jar", func(t *testing.T) {
+		netx := &netxlite.Netx{}
 		txp := enginenetx.NewNetwork(
 			bytecounter.New(),
 			&kvstore.Memory{},
 			log.Log,
 			nil,
-			netxlite.NewStdlibResolver(log.Log),
+			netx.NewStdlibResolver(log.Log),
 		)
 		client := txp.NewHTTPClient()
 		if client.Jar == nil {

--- a/internal/enginenetx/statsmanager_test.go
+++ b/internal/enginenetx/statsmanager_test.go
@@ -228,7 +228,7 @@ func TestNetworkCollectsStats(t *testing.T) {
 
 			qa.Do(func() {
 				byteCounter := bytecounter.New()
-				resolver := netxlite.NewStdlibResolver(log.Log)
+				resolver := (&netxlite.Netx{}).NewStdlibResolver(log.Log)
 
 				netx := NewNetwork(byteCounter, kvStore, log.Log, nil, resolver)
 				defer netx.Close()

--- a/internal/engineresolver/factory.go
+++ b/internal/engineresolver/factory.go
@@ -78,6 +78,7 @@ func newChildResolverHTTPS(
 	proxyURL *url.URL,
 ) model.Resolver {
 	var txp model.HTTPTransport
+	netx := &netxlite.Netx{}
 	switch http3Enabled {
 	case false:
 		dialer := netxlite.NewDialerWithStdlibResolver(logger)
@@ -89,7 +90,7 @@ func newChildResolverHTTPS(
 			netxlite.HTTPTransportOptionProxyURL(proxyURL),        // nil here disables using the proxy
 		)
 	case true:
-		txp = netxlite.NewHTTP3TransportStdlib(logger)
+		txp = netx.NewHTTP3TransportStdlib(logger)
 	}
 	txp = bytecounter.MaybeWrapHTTPTransport(txp, counter)
 	dnstxp := netxlite.NewDNSOverHTTPSTransportWithHTTPTransport(txp, URL)

--- a/internal/engineresolver/factory.go
+++ b/internal/engineresolver/factory.go
@@ -57,8 +57,9 @@ func newChildResolver(
 	case "http", "https": // http is here for testing
 		reso = newChildResolverHTTPS(logger, URL, http3Enabled, counter, proxyURL)
 	case "system":
+		netx := &netxlite.Netx{}
 		reso = bytecounter.MaybeWrapSystemResolver(
-			netxlite.NewStdlibResolver(logger),
+			netx.NewStdlibResolver(logger),
 			counter, // handles correctly the case where counter is nil
 		)
 	default:

--- a/internal/engineresolver/factory.go
+++ b/internal/engineresolver/factory.go
@@ -83,7 +83,7 @@ func newChildResolverHTTPS(
 	switch http3Enabled {
 	case false:
 		dialer := netxlite.NewDialerWithStdlibResolver(logger)
-		thx := netxlite.NewTLSHandshakerStdlib(logger)
+		thx := netx.NewTLSHandshakerStdlib(logger)
 		tlsDialer := netxlite.NewTLSDialer(dialer, thx)
 		txp = netxlite.NewHTTPTransportWithOptions(
 			logger, dialer, tlsDialer,

--- a/internal/experiment/ndt7/dial.go
+++ b/internal/experiment/ndt7/dial.go
@@ -31,7 +31,7 @@ func newDialManager(ndt7URL string, logger model.Logger, userAgent string) dialM
 
 func (mgr dialManager) dialWithTestName(ctx context.Context, testName string) (*websocket.Conn, error) {
 	netx := &netxlite.Netx{}
-	reso := netxlite.NewStdlibResolver(mgr.logger)
+	reso := netx.NewStdlibResolver(mgr.logger)
 	dlr := netx.NewDialerWithResolver(mgr.logger, reso)
 	dlr = bytecounter.WrapWithContextAwareDialer(dlr)
 	// Implements shaping if the user builds using `-tags shaping`

--- a/internal/experiment/ndt7/dial.go
+++ b/internal/experiment/ndt7/dial.go
@@ -30,8 +30,9 @@ func newDialManager(ndt7URL string, logger model.Logger, userAgent string) dialM
 }
 
 func (mgr dialManager) dialWithTestName(ctx context.Context, testName string) (*websocket.Conn, error) {
+	netx := &netxlite.Netx{}
 	reso := netxlite.NewStdlibResolver(mgr.logger)
-	dlr := netxlite.NewDialerWithResolver(mgr.logger, reso)
+	dlr := netx.NewDialerWithResolver(mgr.logger, reso)
 	dlr = bytecounter.WrapWithContextAwareDialer(dlr)
 	// Implements shaping if the user builds using `-tags shaping`
 	// See https://github.com/ooni/probe/issues/2112

--- a/internal/experiment/simplequicping/simplequicping.go
+++ b/internal/experiment/simplequicping/simplequicping.go
@@ -172,7 +172,8 @@ func (m *Measurer) quicHandshake(ctx context.Context, index int64,
 	alpn := strings.Split(m.config.alpn(), " ")
 	trace := measurexlite.NewTrace(index, zeroTime)
 	ol := logx.NewOperationLogger(logger, "SimpleQUICPing #%d %s %s %v", index, address, sni, alpn)
-	listener := netxlite.NewUDPListener()
+	netx := &netxlite.Netx{}
+	listener := netx.NewUDPListener()
 	dialer := trace.NewQUICDialerWithoutResolver(listener, logger)
 	// See https://github.com/ooni/probe/issues/2413 to understand
 	// why we're using nil to force netxlite to use the cached

--- a/internal/experiment/webconnectivitylte/dnsresolvers.go
+++ b/internal/experiment/webconnectivitylte/dnsresolvers.go
@@ -249,7 +249,8 @@ func (t *DNSResolvers) lookupHostUDP(parentCtx context.Context, udpAddress strin
 	)
 
 	// runs the lookup
-	dialer := netxlite.NewDialerWithoutResolver(t.Logger)
+	netx := &netxlite.Netx{}
+	dialer := netx.NewDialerWithoutResolver(t.Logger)
 	reso := trace.NewParallelUDPResolver(t.Logger, dialer, udpAddress)
 	addrs, err := reso.LookupHost(lookupCtx, t.Domain)
 

--- a/internal/experiment/webconnectivitylte/dnswhoami.go
+++ b/internal/experiment/webconnectivitylte/dnswhoami.go
@@ -33,7 +33,8 @@ func (svc *DNSWhoamiService) SystemV4(ctx context.Context) ([]DNSWhoamiInfoEntry
 	if len(svc.systemv4) <= 0 {
 		ctx, cancel := context.WithTimeout(ctx, 4*time.Second)
 		defer cancel()
-		reso := netxlite.NewStdlibResolver(model.DiscardLogger)
+		netx := &netxlite.Netx{}
+		reso := netx.NewStdlibResolver(model.DiscardLogger)
 		addrs, err := reso.LookupHost(ctx, "whoami.v4.powerdns.org")
 		if err != nil || len(addrs) < 1 {
 			return nil, false

--- a/internal/experiment/webconnectivitylte/dnswhoami.go
+++ b/internal/experiment/webconnectivitylte/dnswhoami.go
@@ -53,8 +53,9 @@ func (svc *DNSWhoamiService) UDPv4(ctx context.Context, address string) ([]DNSWh
 	if len(svc.udpv4[address]) <= 0 {
 		ctx, cancel := context.WithTimeout(ctx, 4*time.Second)
 		defer cancel()
+		netx := &netxlite.Netx{}
 		dialer := netxlite.NewDialerWithStdlibResolver(model.DiscardLogger)
-		reso := netxlite.NewParallelUDPResolver(model.DiscardLogger, dialer, address)
+		reso := netx.NewParallelUDPResolver(model.DiscardLogger, dialer, address)
 		// TODO(bassosimone): this should actually only send an A query. Sending an AAAA
 		// query is _way_ unnecessary since we know that only A is going to work.
 		addrs, err := reso.LookupHost(ctx, "whoami.v4.powerdns.org")

--- a/internal/experiment/webconnectivityqa/control_test.go
+++ b/internal/experiment/webconnectivityqa/control_test.go
@@ -18,8 +18,9 @@ func TestControlFailureWithSuccessfulHTTPWebsite(t *testing.T) {
 	tc.Configure(env)
 
 	env.Do(func() {
+		netx := &netxlite.Netx{}
 		tcpDialer := netxlite.NewDialerWithStdlibResolver(log.Log)
-		tlsHandshaker := netxlite.NewTLSHandshakerStdlib(log.Log)
+		tlsHandshaker := netx.NewTLSHandshakerStdlib(log.Log)
 		tlsDialer := netxlite.NewTLSDialer(tcpDialer, tlsHandshaker)
 		for _, sni := range []string{"0.th.ooni.org", "1.th.ooni.org", "2.th.ooni.org", "3.th.ooni.org", "d33d1gs9kpq1c5.cloudfront.net"} {
 			conn, err := tlsDialer.DialTLSContext(context.Background(), "tcp", net.JoinHostPort(sni, "443"))
@@ -41,8 +42,9 @@ func TestControlFailureWithSuccessfulHTTPSWebsite(t *testing.T) {
 	tc.Configure(env)
 
 	env.Do(func() {
+		netx := &netxlite.Netx{}
 		tcpDialer := netxlite.NewDialerWithStdlibResolver(log.Log)
-		tlsHandshaker := netxlite.NewTLSHandshakerStdlib(log.Log)
+		tlsHandshaker := netx.NewTLSHandshakerStdlib(log.Log)
 		tlsDialer := netxlite.NewTLSDialer(tcpDialer, tlsHandshaker)
 		for _, sni := range []string{"0.th.ooni.org", "1.th.ooni.org", "2.th.ooni.org", "3.th.ooni.org", "d33d1gs9kpq1c5.cloudfront.net"} {
 			conn, err := tlsDialer.DialTLSContext(context.Background(), "tcp", net.JoinHostPort(sni, "443"))

--- a/internal/experiment/webconnectivityqa/dnsblocking_test.go
+++ b/internal/experiment/webconnectivityqa/dnsblocking_test.go
@@ -19,7 +19,8 @@ func TestDNSBlockingAndroidDNSCacheNoData(t *testing.T) {
 	tc.Configure(env)
 
 	env.Do(func() {
-		reso := netxlite.NewStdlibResolver(log.Log)
+		netx := &netxlite.Netx{}
+		reso := netx.NewStdlibResolver(log.Log)
 		addrs, err := reso.LookupHost(context.Background(), "www.example.com")
 		if !errors.Is(err, netxlite.ErrAndroidDNSCacheNoData) {
 			t.Fatal("unexpected error", err)
@@ -38,7 +39,8 @@ func TestDNSBlockingNXDOMAIN(t *testing.T) {
 	tc.Configure(env)
 
 	env.Do(func() {
-		reso := netxlite.NewStdlibResolver(log.Log)
+		netx := &netxlite.Netx{}
+		reso := netx.NewStdlibResolver(log.Log)
 		addrs, err := reso.LookupHost(context.Background(), "www.example.com")
 		if err == nil || err.Error() != netxlite.FailureDNSNXDOMAINError {
 			t.Fatal("unexpected error", err)
@@ -57,7 +59,8 @@ func TestDNSBlockingBOGON(t *testing.T) {
 	tc.Configure(env)
 
 	env.Do(func() {
-		reso := netxlite.NewStdlibResolver(log.Log)
+		netx := &netxlite.Netx{}
+		reso := netx.NewStdlibResolver(log.Log)
 		addrs, err := reso.LookupHost(context.Background(), "www.example.com")
 		if err != nil {
 			t.Fatal(err)

--- a/internal/experiment/webconnectivityqa/dnshijacking_test.go
+++ b/internal/experiment/webconnectivityqa/dnshijacking_test.go
@@ -38,7 +38,8 @@ func TestDNSHijackingTestCases(t *testing.T) {
 				})
 
 				t.Run("with UDP resolver", func(t *testing.T) {
-					d := netxlite.NewDialerWithoutResolver(log.Log)
+					netx := &netxlite.Netx{}
+					d := netx.NewDialerWithoutResolver(log.Log)
 					reso := netxlite.NewParallelUDPResolver(log.Log, d, "8.8.8.8:53")
 					addrs, err := reso.LookupHost(context.Background(), "www.example.com")
 					if err != nil {

--- a/internal/experiment/webconnectivityqa/dnshijacking_test.go
+++ b/internal/experiment/webconnectivityqa/dnshijacking_test.go
@@ -27,7 +27,8 @@ func TestDNSHijackingTestCases(t *testing.T) {
 				expect := []string{netemx.ISPProxyAddress}
 
 				t.Run("with stdlib resolver", func(t *testing.T) {
-					reso := netxlite.NewStdlibResolver(log.Log)
+					netx := &netxlite.Netx{}
+					reso := netx.NewStdlibResolver(log.Log)
 					addrs, err := reso.LookupHost(context.Background(), "www.example.com")
 					if err != nil {
 						t.Fatal(err)

--- a/internal/experiment/webconnectivityqa/dnshijacking_test.go
+++ b/internal/experiment/webconnectivityqa/dnshijacking_test.go
@@ -41,7 +41,7 @@ func TestDNSHijackingTestCases(t *testing.T) {
 				t.Run("with UDP resolver", func(t *testing.T) {
 					netx := &netxlite.Netx{}
 					d := netx.NewDialerWithoutResolver(log.Log)
-					reso := netxlite.NewParallelUDPResolver(log.Log, d, "8.8.8.8:53")
+					reso := netx.NewParallelUDPResolver(log.Log, d, "8.8.8.8:53")
 					addrs, err := reso.LookupHost(context.Background(), "www.example.com")
 					if err != nil {
 						t.Fatal(err)

--- a/internal/experiment/webconnectivityqa/httpblocking_test.go
+++ b/internal/experiment/webconnectivityqa/httpblocking_test.go
@@ -18,8 +18,9 @@ func TestHTTPBlockingConnectionReset(t *testing.T) {
 	tc.Configure(env)
 
 	env.Do(func() {
+		netx := &netxlite.Netx{}
 		dialer := netxlite.NewDialerWithStdlibResolver(log.Log)
-		tlsDialer := netxlite.NewTLSDialer(dialer, netxlite.NewTLSHandshakerStdlib(log.Log))
+		tlsDialer := netxlite.NewTLSDialer(dialer, netx.NewTLSHandshakerStdlib(log.Log))
 		txp := netxlite.NewHTTPTransportWithOptions(log.Log, dialer, tlsDialer)
 		client := &http.Client{Transport: txp}
 		resp, err := client.Get("http://www.example.com/")

--- a/internal/experiment/webconnectivityqa/httpdiff_test.go
+++ b/internal/experiment/webconnectivityqa/httpdiff_test.go
@@ -91,7 +91,8 @@ func TestHTTPDiffWithInconsistentDNS(t *testing.T) {
 					})
 
 					t.Run("with UDP resolver", func(t *testing.T) {
-						d := netxlite.NewDialerWithoutResolver(log.Log)
+						netx := &netxlite.Netx{}
+						d := netx.NewDialerWithoutResolver(log.Log)
 						reso := netxlite.NewParallelUDPResolver(log.Log, d, "8.8.8.8:53")
 						addrs, err := reso.LookupHost(context.Background(), "www.example.com")
 						if err != nil {

--- a/internal/experiment/webconnectivityqa/httpdiff_test.go
+++ b/internal/experiment/webconnectivityqa/httpdiff_test.go
@@ -80,7 +80,8 @@ func TestHTTPDiffWithInconsistentDNS(t *testing.T) {
 					expect := []string{netemx.ISPProxyAddress}
 
 					t.Run("with stdlib resolver", func(t *testing.T) {
-						reso := netxlite.NewStdlibResolver(log.Log)
+						netx := &netxlite.Netx{}
+						reso := netx.NewStdlibResolver(log.Log)
 						addrs, err := reso.LookupHost(context.Background(), "www.example.com")
 						if err != nil {
 							t.Fatal(err)

--- a/internal/experiment/webconnectivityqa/httpdiff_test.go
+++ b/internal/experiment/webconnectivityqa/httpdiff_test.go
@@ -94,7 +94,7 @@ func TestHTTPDiffWithInconsistentDNS(t *testing.T) {
 					t.Run("with UDP resolver", func(t *testing.T) {
 						netx := &netxlite.Netx{}
 						d := netx.NewDialerWithoutResolver(log.Log)
-						reso := netxlite.NewParallelUDPResolver(log.Log, d, "8.8.8.8:53")
+						reso := netx.NewParallelUDPResolver(log.Log, d, "8.8.8.8:53")
 						addrs, err := reso.LookupHost(context.Background(), "www.example.com")
 						if err != nil {
 							t.Fatal(err)

--- a/internal/experiment/webconnectivityqa/redirect_test.go
+++ b/internal/experiment/webconnectivityqa/redirect_test.go
@@ -98,7 +98,8 @@ func TestRedirectWithConsistentDNSAndThenNXDOMAIN(t *testing.T) {
 
 			env.Do(func() {
 				t.Run("with stdlib resolver", func(t *testing.T) {
-					reso := netxlite.NewStdlibResolver(log.Log)
+					netx := &netxlite.Netx{}
+					reso := netx.NewStdlibResolver(log.Log)
 					addrs, err := reso.LookupHost(context.Background(), "www.example.com")
 					if err == nil || err.Error() != netxlite.FailureDNSNXDOMAINError {
 						t.Fatal("unexpected error", err)

--- a/internal/experiment/webconnectivityqa/redirect_test.go
+++ b/internal/experiment/webconnectivityqa/redirect_test.go
@@ -112,7 +112,7 @@ func TestRedirectWithConsistentDNSAndThenNXDOMAIN(t *testing.T) {
 				t.Run("with UDP resolver", func(t *testing.T) {
 					netx := &netxlite.Netx{}
 					d := netx.NewDialerWithoutResolver(log.Log)
-					reso := netxlite.NewParallelUDPResolver(log.Log, d, "8.8.8.8:53")
+					reso := netx.NewParallelUDPResolver(log.Log, d, "8.8.8.8:53")
 					addrs, err := reso.LookupHost(context.Background(), "www.example.com")
 					if err == nil || err.Error() != netxlite.FailureDNSNXDOMAINError {
 						t.Fatal("unexpected error", err)

--- a/internal/experiment/webconnectivityqa/redirect_test.go
+++ b/internal/experiment/webconnectivityqa/redirect_test.go
@@ -32,7 +32,8 @@ func TestRedirectWithConsistentDNSAndThenConnectionRefused(t *testing.T) {
 
 				for _, port := range ports {
 					t.Run(fmt.Sprintf("for port %s", port), func(t *testing.T) {
-						dialer := netxlite.NewDialerWithoutResolver(log.Log)
+						netx := &netxlite.Netx{}
+						dialer := netx.NewDialerWithoutResolver(log.Log)
 						endpoint := net.JoinHostPort(netemx.AddressWwwExampleCom, port)
 						conn, err := dialer.DialContext(context.Background(), "tcp", endpoint)
 						if err == nil || err.Error() != netxlite.FailureConnectionRefused {
@@ -108,7 +109,8 @@ func TestRedirectWithConsistentDNSAndThenNXDOMAIN(t *testing.T) {
 				})
 
 				t.Run("with UDP resolver", func(t *testing.T) {
-					d := netxlite.NewDialerWithoutResolver(log.Log)
+					netx := &netxlite.Netx{}
+					d := netx.NewDialerWithoutResolver(log.Log)
 					reso := netxlite.NewParallelUDPResolver(log.Log, d, "8.8.8.8:53")
 					addrs, err := reso.LookupHost(context.Background(), "www.example.com")
 					if err == nil || err.Error() != netxlite.FailureDNSNXDOMAINError {

--- a/internal/experiment/webconnectivityqa/tcpblocking_test.go
+++ b/internal/experiment/webconnectivityqa/tcpblocking_test.go
@@ -40,7 +40,7 @@ func TestTCPBlockingConnectionRefusedWithInconsistentDNS(t *testing.T) {
 
 	env.Do(func() {
 		netx := &netxlite.Netx{}
-		dialer := netx.NewDialerWithResolver(log.Log, netxlite.NewStdlibResolver(log.Log))
+		dialer := netx.NewDialerWithResolver(log.Log, netx.NewStdlibResolver(log.Log))
 		conn, err := dialer.DialContext(context.Background(), "tcp", "www.example.org:443")
 		if err == nil || err.Error() != netxlite.FailureConnectionRefused {
 			t.Fatal("unexpected error", err)

--- a/internal/experiment/webconnectivityqa/tcpblocking_test.go
+++ b/internal/experiment/webconnectivityqa/tcpblocking_test.go
@@ -38,7 +38,8 @@ func TestTCPBlockingConnectionRefusedWithInconsistentDNS(t *testing.T) {
 	tc.Configure(env)
 
 	env.Do(func() {
-		dialer := netxlite.NewDialerWithResolver(log.Log, netxlite.NewStdlibResolver(log.Log))
+		netx := &netxlite.Netx{}
+		dialer := netx.NewDialerWithResolver(log.Log, netxlite.NewStdlibResolver(log.Log))
 		conn, err := dialer.DialContext(context.Background(), "tcp", "www.example.org:443")
 		if err == nil || err.Error() != netxlite.FailureConnectionRefused {
 			t.Fatal("unexpected error", err)

--- a/internal/experiment/webconnectivityqa/tcpblocking_test.go
+++ b/internal/experiment/webconnectivityqa/tcpblocking_test.go
@@ -18,7 +18,8 @@ func TestTCPBlockingConnectTimeout(t *testing.T) {
 	tc.Configure(env)
 
 	env.Do(func() {
-		dialer := netxlite.NewDialerWithoutResolver(log.Log)
+		netx := &netxlite.Netx{}
+		dialer := netx.NewDialerWithoutResolver(log.Log)
 		endpoint := net.JoinHostPort(netemx.AddressWwwExampleCom, "443")
 		conn, err := dialer.DialContext(context.Background(), "tcp", endpoint)
 		if err == nil || err.Error() != netxlite.FailureGenericTimeoutError {

--- a/internal/experiment/webconnectivityqa/tlsblocking_test.go
+++ b/internal/experiment/webconnectivityqa/tlsblocking_test.go
@@ -86,7 +86,7 @@ func TestBlockingTLSConnectionResetWithInconsistentDNS(t *testing.T) {
 			t.Run("with UDP resolver", func(t *testing.T) {
 				netx := &netxlite.Netx{}
 				d := netx.NewDialerWithoutResolver(log.Log)
-				reso := netxlite.NewParallelUDPResolver(log.Log, d, "8.8.8.8:53")
+				reso := netx.NewParallelUDPResolver(log.Log, d, "8.8.8.8:53")
 				addrs, err := reso.LookupHost(context.Background(), "www.example.com")
 				if err != nil {
 					t.Fatal(err)

--- a/internal/experiment/webconnectivityqa/tlsblocking_test.go
+++ b/internal/experiment/webconnectivityqa/tlsblocking_test.go
@@ -72,7 +72,8 @@ func TestBlockingTLSConnectionResetWithInconsistentDNS(t *testing.T) {
 			expect := []string{netemx.ISPProxyAddress}
 
 			t.Run("with stdlib resolver", func(t *testing.T) {
-				reso := netxlite.NewStdlibResolver(log.Log)
+				netx := &netxlite.Netx{}
+				reso := netx.NewStdlibResolver(log.Log)
 				addrs, err := reso.LookupHost(context.Background(), "www.example.com")
 				if err != nil {
 					t.Fatal(err)

--- a/internal/experiment/webconnectivityqa/tlsblocking_test.go
+++ b/internal/experiment/webconnectivityqa/tlsblocking_test.go
@@ -83,7 +83,8 @@ func TestBlockingTLSConnectionResetWithInconsistentDNS(t *testing.T) {
 			})
 
 			t.Run("with UDP resolver", func(t *testing.T) {
-				d := netxlite.NewDialerWithoutResolver(log.Log)
+				netx := &netxlite.Netx{}
+				d := netx.NewDialerWithoutResolver(log.Log)
 				reso := netxlite.NewParallelUDPResolver(log.Log, d, "8.8.8.8:53")
 				addrs, err := reso.LookupHost(context.Background(), "www.example.com")
 				if err != nil {

--- a/internal/legacy/measurex/dialer.go
+++ b/internal/legacy/measurex/dialer.go
@@ -33,7 +33,8 @@ func WrapDialer(begin time.Time, db WritableDB, dialer model.Dialer) model.Diale
 // NewDialerWithSystemResolver creates a
 func (mx *Measurer) NewDialerWithSystemResolver(db WritableDB, logger model.Logger) model.Dialer {
 	r := mx.NewResolverSystem(db, logger)
-	return mx.WrapDialer(db, netxlite.NewDialerWithResolver(logger, r))
+	netx := &netxlite.Netx{}
+	return mx.WrapDialer(db, netx.NewDialerWithResolver(logger, r))
 }
 
 // NewDialerWithoutResolver is a convenience factory for creating

--- a/internal/legacy/measurex/dialer.go
+++ b/internal/legacy/measurex/dialer.go
@@ -41,7 +41,8 @@ func (mx *Measurer) NewDialerWithSystemResolver(db WritableDB, logger model.Logg
 // a dialer that saves measurements into the DB and that is not attached
 // to any resolver (hence only works when passed IP addresses).
 func (mx *Measurer) NewDialerWithoutResolver(db WritableDB, logger model.Logger) model.Dialer {
-	return mx.WrapDialer(db, netxlite.NewDialerWithoutResolver(logger))
+	netx := &netxlite.Netx{}
+	return mx.WrapDialer(db, netx.NewDialerWithoutResolver(logger))
 }
 
 type dialerDB struct {

--- a/internal/legacy/measurex/measurer.go
+++ b/internal/legacy/measurex/measurer.go
@@ -97,6 +97,7 @@ type Measurer struct {
 // NewMeasurerWithDefaultSettings creates a new Measurer
 // instance using the most default settings.
 func NewMeasurerWithDefaultSettings() *Measurer {
+	netx := &netxlite.Netx{}
 	return &Measurer{
 		Begin:                   time.Now(),
 		DNSLookupTimeout:        0,
@@ -115,7 +116,7 @@ func NewMeasurerWithDefaultSettings() *Measurer {
 		}},
 		TCPconnectTimeout:   0,
 		TLSHandshakeTimeout: 0,
-		TLSHandshaker:       netxlite.NewTLSHandshakerStdlib(log.Log),
+		TLSHandshaker:       netx.NewTLSHandshakerStdlib(log.Log),
 	}
 }
 

--- a/internal/legacy/measurex/quic.go
+++ b/internal/legacy/measurex/quic.go
@@ -109,12 +109,12 @@ func (qh *quicDialerDB) DialContext(ctx context.Context, address string,
 	tlsConfig *tls.Config, quicConfig *quic.Config) (quic.EarlyConnection, error) {
 	started := time.Since(qh.begin).Seconds()
 	var state tls.ConnectionState
+	netx := &netxlite.Netx{}
 	listener := &udpListenerDB{
-		UDPListener: netxlite.NewUDPListener(),
+		UDPListener: netx.NewUDPListener(),
 		begin:       qh.begin,
 		db:          qh.db,
 	}
-	netx := &netxlite.Netx{}
 	dialer := netx.NewQUICDialerWithoutResolver(listener, qh.logger)
 	defer dialer.CloseIdleConnections()
 	sess, err := dialer.DialContext(ctx, address, tlsConfig, quicConfig)

--- a/internal/legacy/measurex/quic.go
+++ b/internal/legacy/measurex/quic.go
@@ -114,7 +114,8 @@ func (qh *quicDialerDB) DialContext(ctx context.Context, address string,
 		begin:       qh.begin,
 		db:          qh.db,
 	}
-	dialer := netxlite.NewQUICDialerWithoutResolver(listener, qh.logger)
+	netx := &netxlite.Netx{}
+	dialer := netx.NewQUICDialerWithoutResolver(listener, qh.logger)
 	defer dialer.CloseIdleConnections()
 	sess, err := dialer.DialContext(ctx, address, tlsConfig, quicConfig)
 	if err == nil {

--- a/internal/legacy/measurex/resolver.go
+++ b/internal/legacy/measurex/resolver.go
@@ -29,7 +29,8 @@ func WrapResolver(begin time.Time, db WritableDB, r model.Resolver) model.Resolv
 // NewResolverSystem creates a system resolver and then wraps
 // it using the WrapResolver function.
 func (mx *Measurer) NewResolverSystem(db WritableDB, logger model.Logger) model.Resolver {
-	return mx.WrapResolver(db, netxlite.NewStdlibResolver(logger))
+	netx := &netxlite.Netx{}
+	return mx.WrapResolver(db, netx.NewStdlibResolver(logger))
 }
 
 // NewResolverUDP is a convenience factory for creating a Resolver

--- a/internal/legacy/measurex/resolver_test.go
+++ b/internal/legacy/measurex/resolver_test.go
@@ -12,7 +12,8 @@ func TestResolverModifiesStdlibResolverName(t *testing.T) {
 	// See https://github.com/ooni/spec/pull/257 for more information.
 
 	t.Run("for LookupHost", func(t *testing.T) {
-		child := netxlite.NewStdlibResolver(model.DiscardLogger)
+		netx := &netxlite.Netx{}
+		child := netx.NewStdlibResolver(model.DiscardLogger)
 		mx := NewMeasurerWithDefaultSettings()
 		dbout := &MeasurementDB{}
 		txp := mx.WrapResolver(dbout, child)
@@ -34,7 +35,8 @@ func TestResolverModifiesStdlibResolverName(t *testing.T) {
 	})
 
 	t.Run("for LookupHTTPS", func(t *testing.T) {
-		child := netxlite.NewStdlibResolver(model.DiscardLogger)
+		netx := &netxlite.Netx{}
+		child := netx.NewStdlibResolver(model.DiscardLogger)
 		mx := NewMeasurerWithDefaultSettings()
 		dbout := &MeasurementDB{}
 		txp := mx.WrapResolver(dbout, child)

--- a/internal/legacy/measurex/tls.go
+++ b/internal/legacy/measurex/tls.go
@@ -26,7 +26,8 @@ func (mx *Measurer) WrapTLSHandshaker(db WritableDB, thx model.TLSHandshaker) mo
 // NewTLSHandshakerStdlib creates a new TLS handshaker that
 // saves results into the DB and uses the stdlib for TLS.
 func (mx *Measurer) NewTLSHandshakerStdlib(db WritableDB, logger model.Logger) model.TLSHandshaker {
-	return mx.WrapTLSHandshaker(db, netxlite.NewTLSHandshakerStdlib(logger))
+	netx := &netxlite.Netx{}
+	return mx.WrapTLSHandshaker(db, netx.NewTLSHandshakerStdlib(logger))
 }
 
 type tlsHandshakerDB struct {

--- a/internal/legacy/measurex/tracing.go
+++ b/internal/legacy/measurex/tracing.go
@@ -57,7 +57,7 @@ func NewTracingHTTPTransportWithDefaultSettings(
 	return NewTracingHTTPTransport(logger, begin, db,
 		netx.NewStdlibResolver(logger),
 		netx.NewDialerWithoutResolver(logger),
-		netxlite.NewTLSHandshakerStdlib(logger),
+		netx.NewTLSHandshakerStdlib(logger),
 		DefaultHTTPMaxBodySnapshotSize)
 }
 

--- a/internal/legacy/measurex/tracing.go
+++ b/internal/legacy/measurex/tracing.go
@@ -53,9 +53,10 @@ func NewTracingHTTPTransport(logger model.Logger, begin time.Time, db WritableDB
 // eventually become the measurement
 func NewTracingHTTPTransportWithDefaultSettings(
 	begin time.Time, logger model.Logger, db WritableDB) *HTTPTransportDB {
+	netx := &netxlite.Netx{}
 	return NewTracingHTTPTransport(logger, begin, db,
 		netxlite.NewStdlibResolver(logger),
-		netxlite.NewDialerWithoutResolver(logger),
+		netx.NewDialerWithoutResolver(logger),
 		netxlite.NewTLSHandshakerStdlib(logger),
 		DefaultHTTPMaxBodySnapshotSize)
 }

--- a/internal/legacy/measurex/tracing.go
+++ b/internal/legacy/measurex/tracing.go
@@ -55,7 +55,7 @@ func NewTracingHTTPTransportWithDefaultSettings(
 	begin time.Time, logger model.Logger, db WritableDB) *HTTPTransportDB {
 	netx := &netxlite.Netx{}
 	return NewTracingHTTPTransport(logger, begin, db,
-		netxlite.NewStdlibResolver(logger),
+		netx.NewStdlibResolver(logger),
 		netx.NewDialerWithoutResolver(logger),
 		netxlite.NewTLSHandshakerStdlib(logger),
 		DefaultHTTPMaxBodySnapshotSize)

--- a/internal/legacy/netx/dialer.go
+++ b/internal/legacy/netx/dialer.go
@@ -17,7 +17,8 @@ func NewDialer(config Config) model.Dialer {
 		config.FullResolver = NewResolver(config)
 	}
 	logger := model.ValidLoggerOrDefault(config.Logger)
-	d := netxlite.NewDialerWithResolver(
+	netx := &netxlite.Netx{}
+	d := netx.NewDialerWithResolver(
 		logger, config.FullResolver, config.Saver.NewConnectObserver(),
 		config.ReadWriteSaver.NewReadWriteObserver(),
 	)

--- a/internal/legacy/netx/quic.go
+++ b/internal/legacy/netx/quic.go
@@ -16,7 +16,8 @@ func NewQUICDialer(config Config) model.QUICDialer {
 	}
 	// TODO(https://github.com/ooni/probe/issues/2121#issuecomment-1147424810): we
 	// should count the bytes consumed by this QUIC dialer
+	netx := &netxlite.Netx{}
 	ql := config.ReadWriteSaver.WrapUDPListener(netxlite.NewUDPListener())
 	logger := model.ValidLoggerOrDefault(config.Logger)
-	return netxlite.NewQUICDialerWithResolver(ql, logger, config.FullResolver, config.Saver)
+	return netx.NewQUICDialerWithResolver(ql, logger, config.FullResolver, config.Saver)
 }

--- a/internal/legacy/netx/quic.go
+++ b/internal/legacy/netx/quic.go
@@ -17,7 +17,7 @@ func NewQUICDialer(config Config) model.QUICDialer {
 	// TODO(https://github.com/ooni/probe/issues/2121#issuecomment-1147424810): we
 	// should count the bytes consumed by this QUIC dialer
 	netx := &netxlite.Netx{}
-	ql := config.ReadWriteSaver.WrapUDPListener(netxlite.NewUDPListener())
+	ql := config.ReadWriteSaver.WrapUDPListener(netx.NewUDPListener())
 	logger := model.ValidLoggerOrDefault(config.Logger)
 	return netx.NewQUICDialerWithResolver(ql, logger, config.FullResolver, config.Saver)
 }

--- a/internal/legacy/netx/tls.go
+++ b/internal/legacy/netx/tls.go
@@ -14,8 +14,9 @@ func NewTLSDialer(config Config) model.TLSDialer {
 	if config.Dialer == nil {
 		config.Dialer = NewDialer(config)
 	}
+	netx := &netxlite.Netx{}
 	logger := model.ValidLoggerOrDefault(config.Logger)
-	thx := netxlite.NewTLSHandshakerStdlib(logger)
+	thx := netx.NewTLSHandshakerStdlib(logger)
 	thx = config.Saver.WrapTLSHandshaker(thx) // WAI even when config.Saver is nil
 	tlsConfig := netxlite.ClonedTLSConfigOrNewEmptyConfig(config.TLSConfig)
 	return netxlite.NewTLSDialerWithConfig(config.Dialer, thx, tlsConfig)

--- a/internal/legacy/tracex/http_test.go
+++ b/internal/legacy/tracex/http_test.go
@@ -81,8 +81,9 @@ func TestHTTPTransportSaver(t *testing.T) {
 
 		measureHTTP := func(t *testing.T, URL *url.URL) (*http.Response, *Saver, error) {
 			saver := &Saver{}
+			netx := &netxlite.Netx{}
 			txp := &HTTPTransportSaver{
-				HTTPTransport: netxlite.NewHTTPTransportStdlib(model.DiscardLogger),
+				HTTPTransport: netx.NewHTTPTransportStdlib(model.DiscardLogger),
 				Saver:         saver,
 			}
 			req, err := http.NewRequest("GET", URL.String(), nil)

--- a/internal/legacy/tracex/resolver_test.go
+++ b/internal/legacy/tracex/resolver_test.go
@@ -116,7 +116,8 @@ func TestResolverSaver(t *testing.T) {
 
 		t.Run("with stdlib resolver there's correct .Network remapping", func(t *testing.T) {
 			saver := &Saver{}
-			reso := saver.WrapResolver(netxlite.NewStdlibResolver(model.DiscardLogger))
+			netx := &netxlite.Netx{}
+			reso := saver.WrapResolver(netx.NewStdlibResolver(model.DiscardLogger))
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel() // immediately fail the operation
 			_, _ = reso.LookupHost(ctx, "www.google.com")
@@ -149,7 +150,8 @@ func TestResolverSaver(t *testing.T) {
 		})
 
 		t.Run("when using the stdlib resolver", func(t *testing.T) {
-			child := netxlite.NewStdlibResolver(model.DiscardLogger)
+			netx := &netxlite.Netx{}
+			child := netx.NewStdlibResolver(model.DiscardLogger)
 			switch network := child.Network(); network {
 			case netxlite.StdlibResolverGetaddrinfo,
 				netxlite.StdlibResolverGolangNetResolver:

--- a/internal/measurexlite/dialer.go
+++ b/internal/measurexlite/dialer.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
-// NewDialerWithoutResolver is equivalent to netxlite.NewDialerWithoutResolver
+// NewDialerWithoutResolver is equivalent to [netxlite.Netx.NewDialerWithoutResolver]
 // except that it returns a model.Dialer that uses this trace.
 //
 // Caveat: the dialer wrappers are there to implement the [model.MeasuringNetwork]

--- a/internal/measurexlite/doc.go
+++ b/internal/measurexlite/doc.go
@@ -16,7 +16,7 @@
 //
 // The [*Trace] features methods that mirror existing [netxlite] methods but implement support for
 // collecting network events using the [*Trace]. For example, [*Trace.NewStdlibResolver] is like
-// [netxlite.NewStdlibResolver] but the DNS lookups performed with the resolved returned by
+// [netxlite.Netx.NewStdlibResolver] but the DNS lookups performed with the resolved returned by
 // [*Trace.NewStdlibResolver] generate events that you can collect using the [*Trace].
 //
 // As mentioned above, internally, the [*Trace] uses buffered channels on which the underlying

--- a/internal/measurexlite/quic.go
+++ b/internal/measurexlite/quic.go
@@ -14,7 +14,7 @@ import (
 	"github.com/quic-go/quic-go"
 )
 
-// NewQUICDialerWithoutResolver is equivalent to netxlite.NewQUICDialerWithoutResolver
+// NewQUICDialerWithoutResolver is equivalent to netxlite.Netx.NewQUICDialerWithoutResolver
 // except that it returns a model.QUICDialer that uses this trace.
 //
 // Caveat: the dialer wrappers are there to implement the [model.MeasuringNetwork]

--- a/internal/measurexlite/quic_test.go
+++ b/internal/measurexlite/quic_test.go
@@ -284,7 +284,8 @@ func TestOnQUICHandshakeDoneExtractsTheConnectionState(t *testing.T) {
 	trace := NewTrace(0, time.Now())
 
 	// create a QUIC dialer
-	udpListener := netxlite.NewUDPListener()
+	netx := &netxlite.Netx{}
+	udpListener := netx.NewUDPListener()
 	quicDialer := trace.NewQUICDialerWithoutResolver(udpListener, model.DiscardLogger)
 
 	// dial with the endpoint we use for testing

--- a/internal/measurexlite/tls.go
+++ b/internal/measurexlite/tls.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
-// NewTLSHandshakerStdlib is equivalent to netxlite.NewTLSHandshakerStdlib
+// NewTLSHandshakerStdlib is equivalent to netxlite.Netx.NewTLSHandshakerStdlib
 // except that it returns a model.TLSHandshaker that uses this trace.
 func (tx *Trace) NewTLSHandshakerStdlib(dl model.DebugLogger) model.TLSHandshaker {
 	return &tlsHandshakerTrace{

--- a/internal/measurexlite/tls_test.go
+++ b/internal/measurexlite/tls_test.go
@@ -236,7 +236,8 @@ func TestNewTLSHandshakerStdlib(t *testing.T) {
 		ca := netem.MustNewCA()
 		cert := ca.MustNewTLSCertificate("dns.google")
 		server := testingx.MustNewTLSServer(testingx.TLSHandlerHandshakeAndWriteText(cert, testingx.HTTPBlockpage451))
-		dialer := netxlite.NewDialerWithoutResolver(model.DiscardLogger)
+		netx := &netxlite.Netx{}
+		dialer := netx.NewDialerWithoutResolver(model.DiscardLogger)
 		ctx := context.Background()
 		conn, err := dialer.DialContext(ctx, "tcp", server.Endpoint())
 		if err != nil {

--- a/internal/measurexlite/trace_test.go
+++ b/internal/measurexlite/trace_test.go
@@ -190,7 +190,8 @@ func TestTrace(t *testing.T) {
 
 	t.Run("NewParallelUDPResolver works as intended", func(t *testing.T) {
 		tx := NewTrace(0, time.Now())
-		dialer := netxlite.NewDialerWithoutResolver(model.DiscardLogger)
+		netx := &netxlite.Netx{}
+		dialer := netx.NewDialerWithoutResolver(model.DiscardLogger)
 		resolver := tx.NewParallelUDPResolver(model.DiscardLogger, dialer, "1.1.1.1:53")
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()

--- a/internal/measurexlite/utls.go
+++ b/internal/measurexlite/utls.go
@@ -9,7 +9,7 @@ import (
 	utls "gitlab.com/yawning/utls.git"
 )
 
-// NewTLSHandshakerUTLS is equivalent to netxlite.NewTLSHandshakerUTLS
+// NewTLSHandshakerUTLS is equivalent to netxlite.Netx.NewTLSHandshakerUTLS
 // except that it returns a model.TLSHandshaker that uses this trace.
 func (tx *Trace) NewTLSHandshakerUTLS(dl model.DebugLogger, id *utls.ClientHelloID) model.TLSHandshaker {
 	return &tlsHandshakerTrace{

--- a/internal/netemx/android_test.go
+++ b/internal/netemx/android_test.go
@@ -18,7 +18,8 @@ func TestEmulateAndroidGetaddrinfo(t *testing.T) {
 	defer env.EmulateAndroidGetaddrinfo(false)
 
 	env.Do(func() {
-		reso := netxlite.NewStdlibResolver(log.Log)
+		netx := &netxlite.Netx{}
+		reso := netx.NewStdlibResolver(log.Log)
 		addrs, err := reso.LookupHost(context.Background(), "www.nonexistent.xyz")
 		if !errors.Is(err, netxlite.ErrAndroidDNSCacheNoData) {
 			t.Fatal("unexpected error")

--- a/internal/netemx/badssl_test.go
+++ b/internal/netemx/badssl_test.go
@@ -46,7 +46,7 @@ func TestBadSSL(t *testing.T) {
 				netx := &netxlite.Netx{}
 				tlsDialer := netxlite.NewTLSDialerWithConfig(
 					netx.NewDialerWithoutResolver(log.Log),
-					netxlite.NewTLSHandshakerStdlib(log.Log),
+					netx.NewTLSHandshakerStdlib(log.Log),
 					tlsConfig,
 				)
 

--- a/internal/netemx/badssl_test.go
+++ b/internal/netemx/badssl_test.go
@@ -43,8 +43,9 @@ func TestBadSSL(t *testing.T) {
 			t.Run(fmt.Sprintf("for %s expect %s", tc.serverName, tc.expectErr), func(t *testing.T) {
 				tlsConfig := &tls.Config{ServerName: tc.serverName}
 
+				netx := &netxlite.Netx{}
 				tlsDialer := netxlite.NewTLSDialerWithConfig(
-					netxlite.NewDialerWithoutResolver(log.Log),
+					netx.NewDialerWithoutResolver(log.Log),
 					netxlite.NewTLSHandshakerStdlib(log.Log),
 					tlsConfig,
 				)

--- a/internal/netemx/dnsoverudp_test.go
+++ b/internal/netemx/dnsoverudp_test.go
@@ -19,8 +19,9 @@ func TestDNSOverUDPServerFactory(t *testing.T) {
 	env.AddRecordToAllResolvers("www.example.com", "", AddressWwwExampleCom)
 
 	env.Do(func() {
+		netx := &netxlite.Netx{}
 		reso := netxlite.NewParallelUDPResolver(
-			log.Log, netxlite.NewDialerWithoutResolver(log.Log),
+			log.Log, netx.NewDialerWithoutResolver(log.Log),
 			net.JoinHostPort(AddressDNSGoogle8844, "53"))
 		addrs, err := reso.LookupHost(context.Background(), "www.example.com")
 		if err != nil {

--- a/internal/netemx/dnsoverudp_test.go
+++ b/internal/netemx/dnsoverudp_test.go
@@ -20,7 +20,7 @@ func TestDNSOverUDPServerFactory(t *testing.T) {
 
 	env.Do(func() {
 		netx := &netxlite.Netx{}
-		reso := netxlite.NewParallelUDPResolver(
+		reso := netx.NewParallelUDPResolver(
 			log.Log, netx.NewDialerWithoutResolver(log.Log),
 			net.JoinHostPort(AddressDNSGoogle8844, "53"))
 		addrs, err := reso.LookupHost(context.Background(), "www.example.com")

--- a/internal/netemx/example_test.go
+++ b/internal/netemx/example_test.go
@@ -556,7 +556,8 @@ func Example_exampleURLShortener() {
 	env.Do(func() {
 		// TODO(https://github.com/ooni/probe/issues/2534): NewHTTPTransportStdlib has QUIRKS but we
 		// don't actually care about those QUIRKS in this context
-		client := netxlite.NewHTTPTransportStdlib(log.Log)
+		netx := &netxlite.Netx{}
+		client := netx.NewHTTPTransportStdlib(log.Log)
 
 		req, err := http.NewRequest("GET", "https://bit.ly/21645", nil)
 		if err != nil {

--- a/internal/netemx/example_test.go
+++ b/internal/netemx/example_test.go
@@ -178,11 +178,14 @@ func Example_customNetStackHandler() {
 
 	// run netxlite code inside the netemx environment
 	env.Do(func() {
+		// use the default netxlite.Netx.
+		netx := &netxlite.Netx{}
+
 		// create a system resolver instance
 		reso := netxlite.NewStdlibResolver(log.Log)
 
 		// create a dialer
-		dialer := netxlite.NewDialerWithResolver(log.Log, reso)
+		dialer := netx.NewDialerWithResolver(log.Log, reso)
 
 		// attempt to establish a TCP connection
 		conn, err := dialer.DialContext(context.Background(), "tcp", "e1.whatsapp.net:5222")
@@ -224,9 +227,11 @@ func Example_dohWithInternetScenario() {
 
 	env.Do(func() {
 		for _, domain := range []string{"mozilla.cloudflare-dns.com", "dns.google", "dns.quad9.net"} {
+			netx := &netxlite.Netx{}
+
 			// DNS-over-UDP
 			{
-				dialer := netxlite.NewDialerWithResolver(log.Log, netxlite.NewStdlibResolver(log.Log))
+				dialer := netx.NewDialerWithResolver(log.Log, netxlite.NewStdlibResolver(log.Log))
 				reso := netxlite.NewParallelUDPResolver(log.Log, dialer, net.JoinHostPort(domain, "53"))
 				defer reso.CloseIdleConnections()
 

--- a/internal/netemx/example_test.go
+++ b/internal/netemx/example_test.go
@@ -248,8 +248,9 @@ func Example_dohWithInternetScenario() {
 
 			// DNS-over-HTTPS
 			{
+				netx := &netxlite.Netx{}
 				URL := &url.URL{Scheme: "https", Host: domain, Path: "/dns-query"}
-				reso := netxlite.NewParallelDNSOverHTTPSResolver(log.Log, URL.String())
+				reso := netx.NewParallelDNSOverHTTPSResolver(log.Log, URL.String())
 				defer reso.CloseIdleConnections()
 
 				addrs, err := reso.LookupHost(context.Background(), "www.example.com")

--- a/internal/netemx/example_test.go
+++ b/internal/netemx/example_test.go
@@ -131,6 +131,8 @@ func Example_resolverConfig() {
 
 	// run netxlite code inside the netemx environment
 	env.Do(func() {
+		netx := &netxlite.Netx{}
+
 		// use a system resolver instance
 		{
 			reso := netxlite.NewStdlibResolver(log.Log)
@@ -139,14 +141,14 @@ func Example_resolverConfig() {
 
 		// use 8.8.4.4
 		{
-			dialer := netxlite.NewDialerWithoutResolver(log.Log)
+			dialer := netx.NewDialerWithoutResolver(log.Log)
 			reso := netxlite.NewParallelUDPResolver(log.Log, dialer, "8.8.4.4:53")
 			googleResults = runtimex.Try1(reso.LookupHost(context.Background(), "example.com"))
 		}
 
 		// use 9.9.9.9
 		{
-			dialer := netxlite.NewDialerWithoutResolver(log.Log)
+			dialer := netx.NewDialerWithoutResolver(log.Log)
 			reso := netxlite.NewParallelUDPResolver(log.Log, dialer, "9.9.9.9:53")
 			quad9Results = runtimex.Try1(reso.LookupHost(context.Background(), "example.com"))
 		}
@@ -284,7 +286,8 @@ func Example_dnsOverUDPWithInternetScenario() {
 		}
 
 		for _, endpoint := range resolvers {
-			dialer := netxlite.NewDialerWithoutResolver(log.Log)
+			netx := &netxlite.Netx{}
+			dialer := netx.NewDialerWithoutResolver(log.Log)
 			reso := netxlite.NewParallelUDPResolver(log.Log, dialer, endpoint)
 			defer reso.CloseIdleConnections()
 

--- a/internal/netemx/example_test.go
+++ b/internal/netemx/example_test.go
@@ -80,7 +80,8 @@ func Example_dpiRule() {
 	// run netxlite code inside the netemx environment
 	env.Do(func() {
 		// create a system resolver instance
-		reso := netxlite.NewStdlibResolver(model.DiscardLogger)
+		netx := &netxlite.Netx{}
+		reso := netx.NewStdlibResolver(model.DiscardLogger)
 
 		// create the HTTP client
 		// TODO(https://github.com/ooni/probe/issues/2534): the NewHTTPClientWithResolver func has QUIRKS but we don't care.
@@ -135,7 +136,7 @@ func Example_resolverConfig() {
 
 		// use a system resolver instance
 		{
-			reso := netxlite.NewStdlibResolver(log.Log)
+			reso := netx.NewStdlibResolver(log.Log)
 			ispResults = runtimex.Try1(reso.LookupHost(context.Background(), "example.com"))
 		}
 
@@ -184,7 +185,7 @@ func Example_customNetStackHandler() {
 		netx := &netxlite.Netx{}
 
 		// create a system resolver instance
-		reso := netxlite.NewStdlibResolver(log.Log)
+		reso := netx.NewStdlibResolver(log.Log)
 
 		// create a dialer
 		dialer := netx.NewDialerWithResolver(log.Log, reso)
@@ -233,7 +234,7 @@ func Example_dohWithInternetScenario() {
 
 			// DNS-over-UDP
 			{
-				dialer := netx.NewDialerWithResolver(log.Log, netxlite.NewStdlibResolver(log.Log))
+				dialer := netx.NewDialerWithResolver(log.Log, netx.NewStdlibResolver(log.Log))
 				reso := netxlite.NewParallelUDPResolver(log.Log, dialer, net.JoinHostPort(domain, "53"))
 				defer reso.CloseIdleConnections()
 
@@ -315,7 +316,8 @@ func Example_getaddrinfoWithInternetScenario() {
 	defer env.Close()
 
 	env.Do(func() {
-		reso := netxlite.NewStdlibResolver(log.Log)
+		netx := &netxlite.Netx{}
+		reso := netx.NewStdlibResolver(log.Log)
 		defer reso.CloseIdleConnections()
 
 		addrs, err := reso.LookupHost(context.Background(), "www.example.com")

--- a/internal/netemx/example_test.go
+++ b/internal/netemx/example_test.go
@@ -143,14 +143,14 @@ func Example_resolverConfig() {
 		// use 8.8.4.4
 		{
 			dialer := netx.NewDialerWithoutResolver(log.Log)
-			reso := netxlite.NewParallelUDPResolver(log.Log, dialer, "8.8.4.4:53")
+			reso := netx.NewParallelUDPResolver(log.Log, dialer, "8.8.4.4:53")
 			googleResults = runtimex.Try1(reso.LookupHost(context.Background(), "example.com"))
 		}
 
 		// use 9.9.9.9
 		{
 			dialer := netx.NewDialerWithoutResolver(log.Log)
-			reso := netxlite.NewParallelUDPResolver(log.Log, dialer, "9.9.9.9:53")
+			reso := netx.NewParallelUDPResolver(log.Log, dialer, "9.9.9.9:53")
 			quad9Results = runtimex.Try1(reso.LookupHost(context.Background(), "example.com"))
 		}
 	})
@@ -235,7 +235,7 @@ func Example_dohWithInternetScenario() {
 			// DNS-over-UDP
 			{
 				dialer := netx.NewDialerWithResolver(log.Log, netx.NewStdlibResolver(log.Log))
-				reso := netxlite.NewParallelUDPResolver(log.Log, dialer, net.JoinHostPort(domain, "53"))
+				reso := netx.NewParallelUDPResolver(log.Log, dialer, net.JoinHostPort(domain, "53"))
 				defer reso.CloseIdleConnections()
 
 				addrs, err := reso.LookupHost(context.Background(), "www.example.com")
@@ -290,7 +290,7 @@ func Example_dnsOverUDPWithInternetScenario() {
 		for _, endpoint := range resolvers {
 			netx := &netxlite.Netx{}
 			dialer := netx.NewDialerWithoutResolver(log.Log)
-			reso := netxlite.NewParallelUDPResolver(log.Log, dialer, endpoint)
+			reso := netx.NewParallelUDPResolver(log.Log, dialer, endpoint)
 			defer reso.CloseIdleConnections()
 
 			addrs, err := reso.LookupHost(context.Background(), "www.example.com")

--- a/internal/netemx/http3_test.go
+++ b/internal/netemx/http3_test.go
@@ -27,7 +27,8 @@ func TestHTTP3ServerFactory(t *testing.T) {
 		env.AddRecordToAllResolvers("www.example.com", "", AddressWwwExampleCom)
 
 		env.Do(func() {
-			client := netxlite.NewHTTP3ClientWithResolver(log.Log, netxlite.NewStdlibResolver(log.Log))
+			netx := &netxlite.Netx{}
+			client := netxlite.NewHTTP3ClientWithResolver(log.Log, netx.NewStdlibResolver(log.Log))
 			req := runtimex.Try1(http.NewRequest("GET", "https://www.example.com/", nil))
 			resp, err := client.Do(req)
 			if err != nil {

--- a/internal/netemx/qaenv_test.go
+++ b/internal/netemx/qaenv_test.go
@@ -39,7 +39,8 @@ func TestQAEnv(t *testing.T) {
 		env.Do(func() {
 			// create stdlib resolver, which will use the underlying client stack
 			// GetaddrinfoLookupANY method for the DNS lookup
-			reso := netxlite.NewStdlibResolver(model.DiscardLogger)
+			netx := &netxlite.Netx{}
+			reso := netx.NewStdlibResolver(model.DiscardLogger)
 
 			// lookup the hostname
 			ctx := context.Background()

--- a/internal/netemx/qaenv_test.go
+++ b/internal/netemx/qaenv_test.go
@@ -165,7 +165,8 @@ func TestQAEnv(t *testing.T) {
 
 		env.Do(func() {
 			// create an HTTP3 client
-			txp := netxlite.NewHTTP3TransportStdlib(model.DiscardLogger)
+			netx := &netxlite.Netx{}
+			txp := netx.NewHTTP3TransportStdlib(model.DiscardLogger)
 			client := &http.Client{Transport: txp}
 
 			// create the request; see above remarks for the HTTPS case

--- a/internal/netxlite/dialer.go
+++ b/internal/netxlite/dialer.go
@@ -19,7 +19,7 @@ import (
 // with the default [Netx] where the resolver argument is the previously created resolver.
 func NewDialerWithStdlibResolver(dl model.DebugLogger) model.Dialer {
 	netx := &Netx{}
-	reso := NewStdlibResolver(dl)
+	reso := netx.NewStdlibResolver(dl)
 	return netx.NewDialerWithResolver(dl, reso)
 }
 

--- a/internal/netxlite/dialer.go
+++ b/internal/netxlite/dialer.go
@@ -150,13 +150,6 @@ func (netx *Netx) NewDialerWithoutResolver(dl model.DebugLogger, w ...model.Dial
 	return netx.NewDialerWithResolver(dl, &NullResolver{}, w...)
 }
 
-// NewDialerWithoutResolver is equivalent to creating an empty [*Netx]
-// and calling its NewDialerWithoutResolver method.
-func NewDialerWithoutResolver(dl model.DebugLogger, w ...model.DialerWrapper) model.Dialer {
-	netx := &Netx{Underlying: nil}
-	return netx.NewDialerWithoutResolver(dl, w...)
-}
-
 // dialerSystem is a model.Dialer that uses the stdlib's net.Dialer
 // to construct the new SimpleDialer used for dialing. This dialer has
 // a fixed timeout for each connect operation equal to 15 seconds.

--- a/internal/netxlite/dialer.go
+++ b/internal/netxlite/dialer.go
@@ -15,11 +15,12 @@ import (
 )
 
 // NewDialerWithStdlibResolver is equivalent to creating a system resolver
-// using NewStdlibResolver and then a dialer using NewDialerWithResolver where
-// the resolver argument is the previously created resolver.
+// using NewStdlibResolver and then a dialer using [Netx.NewDialerWithResolver]
+// with the default [Netx] where the resolver argument is the previously created resolver.
 func NewDialerWithStdlibResolver(dl model.DebugLogger) model.Dialer {
+	netx := &Netx{}
 	reso := NewStdlibResolver(dl)
-	return NewDialerWithResolver(dl, reso)
+	return netx.NewDialerWithResolver(dl, reso)
 }
 
 // NewDialerWithResolver creates a [Dialer] with error wrapping.
@@ -36,17 +37,10 @@ func (netx *Netx) NewDialerWithResolver(dl model.DebugLogger, r model.Resolver, 
 	return WrapDialer(dl, r, &dialerSystem{provider: netx.MaybeCustomUnderlyingNetwork()}, w...)
 }
 
-// NewDialerWithResolver is equivalent to creating an empty [*Netx]
-// and calling its NewDialerWithResolver method.
-func NewDialerWithResolver(dl model.DebugLogger, r model.Resolver, w ...model.DialerWrapper) model.Dialer {
-	netx := &Netx{Underlying: nil}
-	return netx.NewDialerWithResolver(dl, r, w...)
-}
-
 // WrapDialer wraps an existing Dialer to add extra functionality
 // such as separting DNS lookup and connecting, error wrapping, logging, etc.
 //
-// When possible use NewDialerWithResolver or NewDialerWithoutResolver
+// When possible use [Netx.NewDialerWithResolver] or NewDialerWithoutResolver
 // instead of using this rather low-level function.
 //
 // # Arguments

--- a/internal/netxlite/dialer_test.go
+++ b/internal/netxlite/dialer_test.go
@@ -61,7 +61,8 @@ func TestNewDialer(t *testing.T) {
 			nil, // explicitly test for this documented case
 			&dialerWrapperSecond{},
 		}
-		d := NewDialerWithoutResolver(log.Log, modifiers...)
+		netx := &Netx{}
+		d := netx.NewDialerWithoutResolver(log.Log, modifiers...)
 		logger := d.(*dialerLogger)
 		if logger.DebugLogger != log.Log {
 			t.Fatal("invalid logger")

--- a/internal/netxlite/dnsoverhttps_test.go
+++ b/internal/netxlite/dnsoverhttps_test.go
@@ -32,7 +32,8 @@ func TestNewDNSOverHTTPSTransportWithHTTPTransport(t *testing.T) {
 	const URL = "https://1.1.1.1/dns-query"
 	// TODO(https://github.com/ooni/probe/issues/2534): NewHTTPTransportStdlib has QUIRKS but we
 	// don't actually care about those QUIRKS in this context
-	httpTxp := NewHTTPTransportStdlib(model.DiscardLogger)
+	netx := &Netx{}
+	httpTxp := netx.NewHTTPTransportStdlib(model.DiscardLogger)
 	txp := NewDNSOverHTTPSTransportWithHTTPTransport(httpTxp, URL)
 	ew := txp.(*dnsTransportErrWrapper)
 	https := ew.DNSTransport.(*DNSOverHTTPSTransport)

--- a/internal/netxlite/dnsoverudp_test.go
+++ b/internal/netxlite/dnsoverudp_test.go
@@ -261,7 +261,8 @@ func TestDNSOverUDPTransport(t *testing.T) {
 			dnsRtx := testingx.NewDNSRoundTripperWithDNSConfig(dnsConfig)
 			listener := testingx.MustNewDNSOverUDPListener(udpAddr, &testingx.DNSOverUDPListenerStdlib{}, dnsRtx)
 			defer listener.Close()
-			dialer := NewDialerWithoutResolver(model.DiscardLogger)
+			netx := &Netx{}
+			dialer := netx.NewDialerWithoutResolver(model.DiscardLogger)
 			txp := NewUnwrappedDNSOverUDPTransport(dialer, listener.LocalAddr().String())
 			encoder := &DNSEncoderMiekg{}
 			query := encoder.Encode("dns.google.", dns.TypeA, false)
@@ -294,7 +295,8 @@ func TestDNSOverUDPTransport(t *testing.T) {
 			listener := testingx.MustNewDNSSimulateGWFListener(
 				udpAddr, &testingx.DNSOverUDPListenerStdlib{}, dnsConfigBogus,
 				dnsConfigGood, testingx.DNSNumBogusResponses(1))
-			dialer := NewDialerWithoutResolver(model.DiscardLogger)
+			netx := &Netx{}
+			dialer := netx.NewDialerWithoutResolver(model.DiscardLogger)
 			expectedAddress := listener.LocalAddr().String()
 			txp := NewUnwrappedDNSOverUDPTransport(dialer, expectedAddress)
 			txp.lateResponses = make(chan any, 1) // with buffer to avoid deadlocks
@@ -329,7 +331,8 @@ func TestDNSOverUDPTransport(t *testing.T) {
 				udpAddr, &testingx.DNSOverUDPListenerStdlib{}, dnsConfigBogus,
 				dnsConfigGood, testingx.DNSNumBogusResponses(1))
 			defer listener.Close()
-			dialer := NewDialerWithoutResolver(model.DiscardLogger)
+			netx := &Netx{}
+			dialer := netx.NewDialerWithoutResolver(model.DiscardLogger)
 			expectedAddress := listener.LocalAddr().String()
 			txp := NewUnwrappedDNSOverUDPTransport(dialer, expectedAddress)
 			encoder := &DNSEncoderMiekg{}
@@ -420,7 +423,8 @@ func TestDNSOverUDPTransport(t *testing.T) {
 				udpAddr, &testingx.DNSOverUDPListenerStdlib{}, dnsConfigBogus,
 				netem.NewDNSConfig(), testingx.DNSNumBogusResponses(1))
 			defer listener.Close()
-			dialer := NewDialerWithoutResolver(model.DiscardLogger)
+			netx := &Netx{}
+			dialer := netx.NewDialerWithoutResolver(model.DiscardLogger)
 			expectedAddress := listener.LocalAddr().String()
 			txp := NewUnwrappedDNSOverUDPTransport(dialer, expectedAddress)
 			encoder := &DNSEncoderMiekg{}
@@ -506,7 +510,8 @@ func TestDNSOverUDPTransport(t *testing.T) {
 
 	t.Run("other functions okay", func(t *testing.T) {
 		const address = "9.9.9.9:53"
-		txp := NewUnwrappedDNSOverUDPTransport(NewDialerWithoutResolver(log.Log), address)
+		netx := &Netx{}
+		txp := NewUnwrappedDNSOverUDPTransport(netx.NewDialerWithoutResolver(log.Log), address)
 		if txp.RequiresPadding() != false {
 			t.Fatal("invalid RequiresPadding")
 		}

--- a/internal/netxlite/http3.go
+++ b/internal/netxlite/http3.go
@@ -71,13 +71,6 @@ func (netx *Netx) NewHTTP3TransportStdlib(logger model.DebugLogger) model.HTTPTr
 	return NewHTTP3Transport(logger, qd, nil)
 }
 
-// NewHTTP3TransportStdlib is equivalent to creating an empty [*Netx]
-// and calling its NewHTTP3TransportStdlib method.
-func NewHTTP3TransportStdlib(logger model.DebugLogger) model.HTTPTransport {
-	netx := &Netx{Underlying: nil}
-	return netx.NewHTTP3TransportStdlib(logger)
-}
-
 // NewHTTPTransportWithResolver creates a new HTTPTransport using http3
 // that uses the given logger and the given resolver.
 func NewHTTP3TransportWithResolver(logger model.DebugLogger, reso model.Resolver) model.HTTPTransport {

--- a/internal/netxlite/http3.go
+++ b/internal/netxlite/http3.go
@@ -74,7 +74,8 @@ func (netx *Netx) NewHTTP3TransportStdlib(logger model.DebugLogger) model.HTTPTr
 // NewHTTPTransportWithResolver creates a new HTTPTransport using http3
 // that uses the given logger and the given resolver.
 func NewHTTP3TransportWithResolver(logger model.DebugLogger, reso model.Resolver) model.HTTPTransport {
-	qd := NewQUICDialerWithResolver(NewUDPListener(), logger, reso)
+	netx := &Netx{}
+	qd := netx.NewQUICDialerWithResolver(NewUDPListener(), logger, reso)
 	return NewHTTP3Transport(logger, qd, nil)
 }
 

--- a/internal/netxlite/http3.go
+++ b/internal/netxlite/http3.go
@@ -75,7 +75,7 @@ func (netx *Netx) NewHTTP3TransportStdlib(logger model.DebugLogger) model.HTTPTr
 // that uses the given logger and the given resolver.
 func NewHTTP3TransportWithResolver(logger model.DebugLogger, reso model.Resolver) model.HTTPTransport {
 	netx := &Netx{}
-	qd := netx.NewQUICDialerWithResolver(NewUDPListener(), logger, reso)
+	qd := netx.NewQUICDialerWithResolver(netx.NewUDPListener(), logger, reso)
 	return NewHTTP3Transport(logger, qd, nil)
 }
 

--- a/internal/netxlite/http3_test.go
+++ b/internal/netxlite/http3_test.go
@@ -125,7 +125,8 @@ func TestNewHTTP3Transport(t *testing.T) {
 
 func TestNewHTTP3TransportStdlib(t *testing.T) {
 	t.Run("creates the correct type chain", func(t *testing.T) {
-		txp := NewHTTP3TransportStdlib(model.DiscardLogger)
+		netx := &Netx{}
+		txp := netx.NewHTTP3TransportStdlib(model.DiscardLogger)
 		verifyTypeChainForHTTP3(t, txp, model.DiscardLogger, nil, nil, nil)
 	})
 }

--- a/internal/netxlite/httpquirks.go
+++ b/internal/netxlite/httpquirks.go
@@ -109,21 +109,13 @@ func (netx *Netx) NewHTTPTransportStdlib(logger model.DebugLogger) model.HTTPTra
 	return NewHTTPTransport(logger, dialer, tlsDialer)
 }
 
-// NewHTTPTransportStdlib is equivalent to creating an empty [*Netx]
-// and calling its NewHTTPTransportStdlib method.
-//
-// This function behavior is QUIRKY as documented in [NewHTTPTransport].
-func NewHTTPTransportStdlib(logger model.DebugLogger) model.HTTPTransport {
-	netx := &Netx{Underlying: nil}
-	return netx.NewHTTPTransportStdlib(logger)
-}
-
 // NewHTTPClientStdlib creates a new HTTPClient that uses the
 // standard library for TLS and DNS resolutions.
 //
 // This function behavior is QUIRKY as documented in [NewHTTPTransport].
 func NewHTTPClientStdlib(logger model.DebugLogger) model.HTTPClient {
-	txp := NewHTTPTransportStdlib(logger)
+	netx := &Netx{}
+	txp := netx.NewHTTPTransportStdlib(logger)
 	return NewHTTPClient(txp)
 }
 

--- a/internal/netxlite/httpquirks.go
+++ b/internal/netxlite/httpquirks.go
@@ -20,7 +20,8 @@ import (
 //
 // This function behavior is QUIRKY as documented in [NewHTTPTransport].
 func NewHTTPTransportWithResolver(logger model.DebugLogger, reso model.Resolver) model.HTTPTransport {
-	dialer := NewDialerWithResolver(logger, reso)
+	netx := &Netx{}
+	dialer := netx.NewDialerWithResolver(logger, reso)
 	thx := NewTLSHandshakerStdlib(logger)
 	tlsDialer := NewTLSDialer(dialer, thx)
 	return NewHTTPTransport(logger, dialer, tlsDialer)

--- a/internal/netxlite/httpquirks.go
+++ b/internal/netxlite/httpquirks.go
@@ -22,7 +22,7 @@ import (
 func NewHTTPTransportWithResolver(logger model.DebugLogger, reso model.Resolver) model.HTTPTransport {
 	netx := &Netx{}
 	dialer := netx.NewDialerWithResolver(logger, reso)
-	thx := NewTLSHandshakerStdlib(logger)
+	thx := netx.NewTLSHandshakerStdlib(logger)
 	tlsDialer := NewTLSDialer(dialer, thx)
 	return NewHTTPTransport(logger, dialer, tlsDialer)
 }

--- a/internal/netxlite/httpquirks_test.go
+++ b/internal/netxlite/httpquirks_test.go
@@ -38,6 +38,7 @@ func TestNewHTTPTransport(t *testing.T) {
 	t.Run("works as intended with failing dialer", func(t *testing.T) {
 		called := &atomic.Int64{}
 		expected := errors.New("mocked error")
+		netx := &Netx{}
 		d := &dialerResolverWithTracing{
 			Dialer: &mocks.Dialer{
 				MockDialContext: func(ctx context.Context,
@@ -48,7 +49,7 @@ func TestNewHTTPTransport(t *testing.T) {
 					called.Add(1)
 				},
 			},
-			Resolver: NewStdlibResolver(log.Log),
+			Resolver: netx.NewStdlibResolver(log.Log),
 		}
 		td := NewTLSDialer(d, NewTLSHandshakerStdlib(log.Log))
 		txp := NewHTTPTransport(log.Log, d, td)

--- a/internal/netxlite/httpquirks_test.go
+++ b/internal/netxlite/httpquirks_test.go
@@ -51,7 +51,7 @@ func TestNewHTTPTransport(t *testing.T) {
 			},
 			Resolver: netx.NewStdlibResolver(log.Log),
 		}
-		td := NewTLSDialer(d, NewTLSHandshakerStdlib(log.Log))
+		td := NewTLSDialer(d, netx.NewTLSHandshakerStdlib(log.Log))
 		txp := NewHTTPTransport(log.Log, d, td)
 		client := &http.Client{Transport: txp}
 		resp, err := client.Get("https://8.8.4.4/robots.txt")

--- a/internal/netxlite/httpquirks_test.go
+++ b/internal/netxlite/httpquirks_test.go
@@ -104,7 +104,8 @@ func TestNewHTTPTransport(t *testing.T) {
 }
 
 func TestNewHTTPTransportStdlib(t *testing.T) {
-	txp := NewHTTPTransportStdlib(log.Log)
+	netx := &Netx{}
+	txp := netx.NewHTTPTransportStdlib(log.Log)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately!
 	req, err := http.NewRequestWithContext(ctx, "GET", "http://x.org", nil)

--- a/internal/netxlite/integration_test.go
+++ b/internal/netxlite/integration_test.go
@@ -531,7 +531,8 @@ func TestHTTPTransport(t *testing.T) {
 	}
 
 	t.Run("works as intended", func(t *testing.T) {
-		d := netxlite.NewDialerWithResolver(log.Log, netxlite.NewStdlibResolver(log.Log))
+		netx := &netxlite.Netx{}
+		d := netx.NewDialerWithResolver(log.Log, netxlite.NewStdlibResolver(log.Log))
 		td := netxlite.NewTLSDialer(d, netxlite.NewTLSHandshakerStdlib(log.Log))
 		txp := netxlite.NewHTTPTransport(log.Log, d, td)
 		client := &http.Client{Transport: txp}

--- a/internal/netxlite/integration_test.go
+++ b/internal/netxlite/integration_test.go
@@ -591,7 +591,8 @@ func TestHTTP3Transport(t *testing.T) {
 	}
 
 	t.Run("works as intended", func(t *testing.T) {
-		d := netxlite.NewQUICDialerWithResolver(
+		netx := &netxlite.Netx{}
+		d := netx.NewQUICDialerWithResolver(
 			netxlite.NewUDPListener(),
 			log.Log,
 			netxlite.NewStdlibResolver(log.Log),

--- a/internal/netxlite/integration_test.go
+++ b/internal/netxlite/integration_test.go
@@ -108,7 +108,8 @@ func TestMeasureWithUDPResolver(t *testing.T) {
 	//
 
 	t.Run("on success", func(t *testing.T) {
-		dlr := netxlite.NewDialerWithoutResolver(log.Log)
+		netx := &netxlite.Netx{}
+		dlr := netx.NewDialerWithoutResolver(log.Log)
 		r := netxlite.NewParallelUDPResolver(log.Log, dlr, "8.8.4.4:53")
 		defer r.CloseIdleConnections()
 		ctx := context.Background()
@@ -129,7 +130,8 @@ func TestMeasureWithUDPResolver(t *testing.T) {
 		dnsRtx := testingx.NewDNSRoundTripperNXDOMAIN()
 		listener := testingx.MustNewDNSOverUDPListener(udpAddr, &testingx.DNSOverUDPListenerStdlib{}, dnsRtx)
 		defer listener.Close()
-		dlr := netxlite.NewDialerWithoutResolver(log.Log)
+		netx := &netxlite.Netx{}
+		dlr := netx.NewDialerWithoutResolver(log.Log)
 		r := netxlite.NewParallelUDPResolver(log.Log, dlr, listener.LocalAddr().String())
 		defer r.CloseIdleConnections()
 		ctx := context.Background()
@@ -150,7 +152,8 @@ func TestMeasureWithUDPResolver(t *testing.T) {
 		dnsRtx := testingx.NewDNSRoundTripperRefused()
 		listener := testingx.MustNewDNSOverUDPListener(udpAddr, &testingx.DNSOverUDPListenerStdlib{}, dnsRtx)
 		defer listener.Close()
-		dlr := netxlite.NewDialerWithoutResolver(log.Log)
+		netx := &netxlite.Netx{}
+		dlr := netx.NewDialerWithoutResolver(log.Log)
 		r := netxlite.NewParallelUDPResolver(log.Log, dlr, listener.LocalAddr().String())
 		defer r.CloseIdleConnections()
 		ctx := context.Background()
@@ -171,7 +174,8 @@ func TestMeasureWithUDPResolver(t *testing.T) {
 		dnsRtx := testingx.NewDNSRoundTripperSimulateTimeout(time.Millisecond, errors.New("mocked error"))
 		listener := testingx.MustNewDNSOverUDPListener(udpAddr, &testingx.DNSOverUDPListenerStdlib{}, dnsRtx)
 		defer listener.Close()
-		dlr := netxlite.NewDialerWithoutResolver(log.Log)
+		netx := &netxlite.Netx{}
+		dlr := netx.NewDialerWithoutResolver(log.Log)
 		r := netxlite.NewParallelUDPResolver(log.Log, dlr, listener.LocalAddr().String())
 		defer r.CloseIdleConnections()
 		ctx := context.Background()
@@ -201,7 +205,8 @@ func TestMeasureWithDialer(t *testing.T) {
 	//
 
 	t.Run("on success", func(t *testing.T) {
-		d := netxlite.NewDialerWithoutResolver(log.Log)
+		netx := &netxlite.Netx{}
+		d := netx.NewDialerWithoutResolver(log.Log)
 		defer d.CloseIdleConnections()
 		ctx := context.Background()
 		conn, err := d.DialContext(ctx, "tcp", "8.8.4.4:443")
@@ -215,7 +220,8 @@ func TestMeasureWithDialer(t *testing.T) {
 	})
 
 	t.Run("on connection refused", func(t *testing.T) {
-		d := netxlite.NewDialerWithoutResolver(log.Log)
+		netx := &netxlite.Netx{}
+		d := netx.NewDialerWithoutResolver(log.Log)
 		defer d.CloseIdleConnections()
 		ctx := context.Background()
 		// Here we assume that no-one is listening on 127.0.0.1:1
@@ -242,7 +248,8 @@ func TestMeasureWithDialer(t *testing.T) {
 		// the kernel races with the timeout we've configured. For this
 		// reason, I have set a smaller context timeout (see below).
 		//
-		d := netxlite.NewDialerWithoutResolver(log.Log)
+		netx := &netxlite.Netx{}
+		d := netx.NewDialerWithoutResolver(log.Log)
 		defer d.CloseIdleConnections()
 		const timeout = 5 * time.Second
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -276,7 +283,8 @@ func TestMeasureWithTLSHandshaker(t *testing.T) {
 	//
 
 	dial := func(ctx context.Context, address string) (net.Conn, error) {
-		d := netxlite.NewDialerWithoutResolver(log.Log)
+		netx := &netxlite.Netx{}
+		d := netx.NewDialerWithoutResolver(log.Log)
 		return d.DialContext(ctx, "tcp", address)
 	}
 

--- a/internal/netxlite/integration_test.go
+++ b/internal/netxlite/integration_test.go
@@ -487,8 +487,9 @@ func TestMeasureWithQUICDialer(t *testing.T) {
 	//
 
 	t.Run("on success", func(t *testing.T) {
+		netx := &netxlite.Netx{}
 		ql := netxlite.NewUDPListener()
-		d := netxlite.NewQUICDialerWithoutResolver(ql, log.Log)
+		d := netx.NewQUICDialerWithoutResolver(ql, log.Log)
 		defer d.CloseIdleConnections()
 		ctx := context.Background()
 		// See https://github.com/ooni/probe/issues/2413 to understand
@@ -510,8 +511,9 @@ func TestMeasureWithQUICDialer(t *testing.T) {
 	})
 
 	t.Run("on timeout", func(t *testing.T) {
+		netx := &netxlite.Netx{}
 		ql := netxlite.NewUDPListener()
-		d := netxlite.NewQUICDialerWithoutResolver(ql, log.Log)
+		d := netx.NewQUICDialerWithoutResolver(ql, log.Log)
 		defer d.CloseIdleConnections()
 		ctx := context.Background()
 		// See https://github.com/ooni/probe/issues/2413 to understand

--- a/internal/netxlite/integration_test.go
+++ b/internal/netxlite/integration_test.go
@@ -113,7 +113,7 @@ func TestMeasureWithUDPResolver(t *testing.T) {
 	t.Run("on success", func(t *testing.T) {
 		netx := &netxlite.Netx{}
 		dlr := netx.NewDialerWithoutResolver(log.Log)
-		r := netxlite.NewParallelUDPResolver(log.Log, dlr, "8.8.4.4:53")
+		r := netx.NewParallelUDPResolver(log.Log, dlr, "8.8.4.4:53")
 		defer r.CloseIdleConnections()
 		ctx := context.Background()
 		addrs, err := r.LookupHost(ctx, "dns.google.com")
@@ -135,7 +135,7 @@ func TestMeasureWithUDPResolver(t *testing.T) {
 		defer listener.Close()
 		netx := &netxlite.Netx{}
 		dlr := netx.NewDialerWithoutResolver(log.Log)
-		r := netxlite.NewParallelUDPResolver(log.Log, dlr, listener.LocalAddr().String())
+		r := netx.NewParallelUDPResolver(log.Log, dlr, listener.LocalAddr().String())
 		defer r.CloseIdleConnections()
 		ctx := context.Background()
 		addrs, err := r.LookupHost(ctx, "ooni.org")
@@ -157,7 +157,7 @@ func TestMeasureWithUDPResolver(t *testing.T) {
 		defer listener.Close()
 		netx := &netxlite.Netx{}
 		dlr := netx.NewDialerWithoutResolver(log.Log)
-		r := netxlite.NewParallelUDPResolver(log.Log, dlr, listener.LocalAddr().String())
+		r := netx.NewParallelUDPResolver(log.Log, dlr, listener.LocalAddr().String())
 		defer r.CloseIdleConnections()
 		ctx := context.Background()
 		addrs, err := r.LookupHost(ctx, "ooni.org")
@@ -179,7 +179,7 @@ func TestMeasureWithUDPResolver(t *testing.T) {
 		defer listener.Close()
 		netx := &netxlite.Netx{}
 		dlr := netx.NewDialerWithoutResolver(log.Log)
-		r := netxlite.NewParallelUDPResolver(log.Log, dlr, listener.LocalAddr().String())
+		r := netx.NewParallelUDPResolver(log.Log, dlr, listener.LocalAddr().String())
 		defer r.CloseIdleConnections()
 		ctx := context.Background()
 		addrs, err := r.LookupHost(ctx, "ooni.org")

--- a/internal/netxlite/integration_test.go
+++ b/internal/netxlite/integration_test.go
@@ -444,7 +444,8 @@ func TestMeasureWithTLSHandshaker(t *testing.T) {
 
 	t.Run("for utls handshaker", func(t *testing.T) {
 		t.Run("on success", func(t *testing.T) {
-			th := netxlite.NewTLSHandshakerUTLS(log.Log, &utls.HelloFirefox_55)
+			netx := &netxlite.Netx{}
+			th := netx.NewTLSHandshakerUTLS(log.Log, &utls.HelloFirefox_55)
 			err := successFlow(th)
 			if err != nil {
 				t.Fatal(err)
@@ -452,7 +453,8 @@ func TestMeasureWithTLSHandshaker(t *testing.T) {
 		})
 
 		t.Run("on connection reset", func(t *testing.T) {
-			th := netxlite.NewTLSHandshakerUTLS(log.Log, &utls.HelloFirefox_55)
+			netx := &netxlite.Netx{}
+			th := netx.NewTLSHandshakerUTLS(log.Log, &utls.HelloFirefox_55)
 			err := connectionResetFlow(th)
 			if err != nil {
 				t.Fatal(err)
@@ -460,7 +462,8 @@ func TestMeasureWithTLSHandshaker(t *testing.T) {
 		})
 
 		t.Run("on timeout", func(t *testing.T) {
-			th := netxlite.NewTLSHandshakerUTLS(log.Log, &utls.HelloFirefox_55)
+			netx := &netxlite.Netx{}
+			th := netx.NewTLSHandshakerUTLS(log.Log, &utls.HelloFirefox_55)
 			err := timeoutFlow(th)
 			if err != nil {
 				t.Fatal(err)
@@ -468,7 +471,8 @@ func TestMeasureWithTLSHandshaker(t *testing.T) {
 		})
 
 		t.Run("on TLS unrecognized name alert", func(t *testing.T) {
-			th := netxlite.NewTLSHandshakerUTLS(log.Log, &utls.HelloFirefox_55)
+			netx := &netxlite.Netx{}
+			th := netx.NewTLSHandshakerUTLS(log.Log, &utls.HelloFirefox_55)
 			err := tlsUnrecognizedNameFlow(th)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/netxlite/integration_test.go
+++ b/internal/netxlite/integration_test.go
@@ -566,7 +566,8 @@ func TestHTTPTransport(t *testing.T) {
 		defer srvr.Close()
 		// TODO(https://github.com/ooni/probe/issues/2534): NewHTTPTransportStdlib has QUIRKS but we
 		// don't actually care about those QUIRKS in this context
-		txp := netxlite.NewHTTPTransportStdlib(model.DiscardLogger)
+		netx := &netxlite.Netx{}
+		txp := netx.NewHTTPTransportStdlib(model.DiscardLogger)
 		req, err := http.NewRequest("GET", srvr.URL, nil)
 		if err != nil {
 			t.Fatal(err)

--- a/internal/netxlite/integration_test.go
+++ b/internal/netxlite/integration_test.go
@@ -43,7 +43,8 @@ func TestMeasureWithSystemResolver(t *testing.T) {
 	//
 
 	t.Run("on success", func(t *testing.T) {
-		r := netxlite.NewStdlibResolver(log.Log)
+		netx := &netxlite.Netx{}
+		r := netx.NewStdlibResolver(log.Log)
 		defer r.CloseIdleConnections()
 		ctx := context.Background()
 		addrs, err := r.LookupHost(ctx, "dns.google.com")
@@ -56,7 +57,8 @@ func TestMeasureWithSystemResolver(t *testing.T) {
 	})
 
 	t.Run("for nxdomain", func(t *testing.T) {
-		r := netxlite.NewStdlibResolver(log.Log)
+		netx := &netxlite.Netx{}
+		r := netx.NewStdlibResolver(log.Log)
 		defer r.CloseIdleConnections()
 		ctx := context.Background()
 		addrs, err := r.LookupHost(ctx, "www.ooni.nonexistent")
@@ -69,7 +71,8 @@ func TestMeasureWithSystemResolver(t *testing.T) {
 	})
 
 	t.Run("for timeout", func(t *testing.T) {
-		r := netxlite.NewStdlibResolver(log.Log)
+		netx := &netxlite.Netx{}
+		r := netx.NewStdlibResolver(log.Log)
 		defer r.CloseIdleConnections()
 		const timeout = time.Nanosecond
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -542,7 +545,7 @@ func TestHTTPTransport(t *testing.T) {
 
 	t.Run("works as intended", func(t *testing.T) {
 		netx := &netxlite.Netx{}
-		d := netx.NewDialerWithResolver(log.Log, netxlite.NewStdlibResolver(log.Log))
+		d := netx.NewDialerWithResolver(log.Log, netx.NewStdlibResolver(log.Log))
 		td := netxlite.NewTLSDialer(d, netxlite.NewTLSHandshakerStdlib(log.Log))
 		txp := netxlite.NewHTTPTransport(log.Log, d, td)
 		client := &http.Client{Transport: txp}
@@ -597,7 +600,7 @@ func TestHTTP3Transport(t *testing.T) {
 		d := netx.NewQUICDialerWithResolver(
 			netxlite.NewUDPListener(),
 			log.Log,
-			netxlite.NewStdlibResolver(log.Log),
+			netx.NewStdlibResolver(log.Log),
 		)
 		txp := netxlite.NewHTTP3Transport(log.Log, d, &tls.Config{})
 		client := &http.Client{Transport: txp}

--- a/internal/netxlite/integration_test.go
+++ b/internal/netxlite/integration_test.go
@@ -406,7 +406,8 @@ func TestMeasureWithTLSHandshaker(t *testing.T) {
 
 	t.Run("for stdlib handshaker", func(t *testing.T) {
 		t.Run("on success", func(t *testing.T) {
-			th := netxlite.NewTLSHandshakerStdlib(log.Log)
+			netx := &netxlite.Netx{}
+			th := netx.NewTLSHandshakerStdlib(log.Log)
 			err := successFlow(th)
 			if err != nil {
 				t.Fatal(err)
@@ -414,7 +415,8 @@ func TestMeasureWithTLSHandshaker(t *testing.T) {
 		})
 
 		t.Run("on connection reset", func(t *testing.T) {
-			th := netxlite.NewTLSHandshakerStdlib(log.Log)
+			netx := &netxlite.Netx{}
+			th := netx.NewTLSHandshakerStdlib(log.Log)
 			err := connectionResetFlow(th)
 			if err != nil {
 				t.Fatal(err)
@@ -422,7 +424,8 @@ func TestMeasureWithTLSHandshaker(t *testing.T) {
 		})
 
 		t.Run("on timeout", func(t *testing.T) {
-			th := netxlite.NewTLSHandshakerStdlib(log.Log)
+			netx := &netxlite.Netx{}
+			th := netx.NewTLSHandshakerStdlib(log.Log)
 			err := timeoutFlow(th)
 			if err != nil {
 				t.Fatal(err)
@@ -430,7 +433,8 @@ func TestMeasureWithTLSHandshaker(t *testing.T) {
 		})
 
 		t.Run("on TLS unrecognized name alert", func(t *testing.T) {
-			th := netxlite.NewTLSHandshakerStdlib(log.Log)
+			netx := &netxlite.Netx{}
+			th := netx.NewTLSHandshakerStdlib(log.Log)
 			err := tlsUnrecognizedNameFlow(th)
 			if err != nil {
 				t.Fatal(err)
@@ -546,7 +550,7 @@ func TestHTTPTransport(t *testing.T) {
 	t.Run("works as intended", func(t *testing.T) {
 		netx := &netxlite.Netx{}
 		d := netx.NewDialerWithResolver(log.Log, netx.NewStdlibResolver(log.Log))
-		td := netxlite.NewTLSDialer(d, netxlite.NewTLSHandshakerStdlib(log.Log))
+		td := netxlite.NewTLSDialer(d, netx.NewTLSHandshakerStdlib(log.Log))
 		txp := netxlite.NewHTTPTransport(log.Log, d, td)
 		client := &http.Client{Transport: txp}
 		resp, err := client.Get("https://www.google.com/robots.txt")

--- a/internal/netxlite/integration_test.go
+++ b/internal/netxlite/integration_test.go
@@ -495,7 +495,7 @@ func TestMeasureWithQUICDialer(t *testing.T) {
 
 	t.Run("on success", func(t *testing.T) {
 		netx := &netxlite.Netx{}
-		ql := netxlite.NewUDPListener()
+		ql := netx.NewUDPListener()
 		d := netx.NewQUICDialerWithoutResolver(ql, log.Log)
 		defer d.CloseIdleConnections()
 		ctx := context.Background()
@@ -519,7 +519,7 @@ func TestMeasureWithQUICDialer(t *testing.T) {
 
 	t.Run("on timeout", func(t *testing.T) {
 		netx := &netxlite.Netx{}
-		ql := netxlite.NewUDPListener()
+		ql := netx.NewUDPListener()
 		d := netx.NewQUICDialerWithoutResolver(ql, log.Log)
 		defer d.CloseIdleConnections()
 		ctx := context.Background()
@@ -602,7 +602,7 @@ func TestHTTP3Transport(t *testing.T) {
 	t.Run("works as intended", func(t *testing.T) {
 		netx := &netxlite.Netx{}
 		d := netx.NewQUICDialerWithResolver(
-			netxlite.NewUDPListener(),
+			netx.NewUDPListener(),
 			log.Log,
 			netx.NewStdlibResolver(log.Log),
 		)

--- a/internal/netxlite/quic.go
+++ b/internal/netxlite/quic.go
@@ -68,14 +68,6 @@ func (netx *Netx) NewQUICDialerWithoutResolver(listener model.UDPListener,
 	return netx.NewQUICDialerWithResolver(listener, logger, &NullResolver{}, wrappers...)
 }
 
-// NewQUICDialerWithoutResolver is equivalent to creating an empty [*Netx]
-// and calling its NewQUICDialerWithoutResolver method.
-func NewQUICDialerWithoutResolver(listener model.UDPListener,
-	logger model.DebugLogger, wrappers ...model.QUICDialerWrapper) model.QUICDialer {
-	netx := &Netx{Underlying: nil}
-	return netx.NewQUICDialerWithoutResolver(listener, logger, wrappers...)
-}
-
 // quicDialerQUICGo dials using the quic-go/quic-go library.
 type quicDialerQUICGo struct {
 	// UDPListener is the underlying UDPListener to use.

--- a/internal/netxlite/quic.go
+++ b/internal/netxlite/quic.go
@@ -34,14 +34,6 @@ func (netx *Netx) NewQUICDialerWithResolver(listener model.UDPListener, logger m
 	return wrapQUICDialer(logger, resolver, baseDialer, wrappers...)
 }
 
-// NewQUICDialerWithResolver is equivalent to creating an empty [*Netx]
-// and calling its NewQUICDialerWithResolver method.
-func NewQUICDialerWithResolver(listener model.UDPListener, logger model.DebugLogger,
-	resolver model.Resolver, wrappers ...model.QUICDialerWrapper) (outDialer model.QUICDialer) {
-	netx := &Netx{Underlying: nil}
-	return netx.NewQUICDialerWithResolver(listener, logger, resolver, wrappers...)
-}
-
 // wrapQUICDialer is similar to NewQUICDialerWithResolver except that it takes as
 // input an already constructed [model.QUICDialer] instead of creating one.
 func wrapQUICDialer(logger model.DebugLogger, resolver model.Resolver,

--- a/internal/netxlite/quic.go
+++ b/internal/netxlite/quic.go
@@ -18,7 +18,7 @@ import (
 
 // NewQUICDialerWithResolver creates a QUICDialer with error wrapping.
 //
-// Unlike the dialer returned by NewDialerWithResolver, this dialer MAY attempt
+// Unlike the dialer returned by [Netx.NewDialerWithResolver], this dialer MAY attempt
 // happy eyeballs, perform parallel dial attempts, and return an error
 // that aggregates all the errors that occurred.
 //

--- a/internal/netxlite/quic_test.go
+++ b/internal/netxlite/quic_test.go
@@ -48,7 +48,8 @@ func TestNewQUICDialer(t *testing.T) {
 		nil, // explicitly test for this documented case
 		&quicDialerWrapperSecond{},
 	}
-	dlr := NewQUICDialerWithoutResolver(ql, log.Log, extensions...)
+	netx := &Netx{}
+	dlr := netx.NewQUICDialerWithoutResolver(ql, log.Log, extensions...)
 	logger := dlr.(*quicDialerLogger)
 	if logger.Logger != log.Log {
 		t.Fatal("invalid logger")

--- a/internal/netxlite/quic_test.go
+++ b/internal/netxlite/quic_test.go
@@ -550,8 +550,9 @@ func TestQUICDialerResolver(t *testing.T) {
 	t.Run("DialContext", func(t *testing.T) {
 		t.Run("with missing port", func(t *testing.T) {
 			tlsConfig := &tls.Config{}
+			netx := &Netx{}
 			dialer := &quicDialerResolver{
-				Resolver: NewStdlibResolver(log.Log),
+				Resolver: netx.NewStdlibResolver(log.Log),
 				Dialer:   &quicDialerQUICGo{}}
 			qconn, err := dialer.DialContext(
 				context.Background(), "www.google.com",
@@ -586,9 +587,10 @@ func TestQUICDialerResolver(t *testing.T) {
 		t.Run("with invalid, non-numeric port)", func(t *testing.T) {
 			// This test allows us to check for the case where every attempt
 			// to establish a connection leads to a failure
+			netx := &Netx{}
 			tlsConf := &tls.Config{}
 			dialer := &quicDialerResolver{
-				Resolver: NewStdlibResolver(log.Log),
+				Resolver: netx.NewStdlibResolver(log.Log),
 				Dialer: &quicDialerQUICGo{
 					UDPListener: &udpListenerStdlib{},
 				}}
@@ -610,8 +612,9 @@ func TestQUICDialerResolver(t *testing.T) {
 			expected := errors.New("mocked error")
 			var gotTLSConfig *tls.Config
 			tlsConfig := &tls.Config{}
+			netx := &Netx{}
 			dialer := &quicDialerResolver{
-				Resolver: NewStdlibResolver(log.Log),
+				Resolver: netx.NewStdlibResolver(log.Log),
 				Dialer: &mocks.QUICDialer{
 					MockDialContext: func(ctx context.Context, address string,
 						tlsConfig *tls.Config, quicConfig *quic.Config) (quic.EarlyConnection, error) {
@@ -638,8 +641,9 @@ func TestQUICDialerResolver(t *testing.T) {
 
 		t.Run("on success", func(t *testing.T) {
 			expectedQConn := &mocks.QUICEarlyConnection{}
+			netx := &Netx{}
 			dialer := &quicDialerResolver{
-				Resolver: NewStdlibResolver(log.Log),
+				Resolver: netx.NewStdlibResolver(log.Log),
 				Dialer: &mocks.QUICDialer{
 					MockDialContext: func(ctx context.Context, address string,
 						tlsConfig *tls.Config, quicConfig *quic.Config) (quic.EarlyConnection, error) {

--- a/internal/netxlite/quic_test.go
+++ b/internal/netxlite/quic_test.go
@@ -42,13 +42,13 @@ func (*quicDialerWrapperSecond) WrapQUICDialer(qd model.QUICDialer) model.QUICDi
 }
 
 func TestNewQUICDialer(t *testing.T) {
-	ql := NewUDPListener()
+	netx := &Netx{}
+	ql := netx.NewUDPListener()
 	extensions := []model.QUICDialerWrapper{
 		&quicDialerWrapperFirst{},
 		nil, // explicitly test for this documented case
 		&quicDialerWrapperSecond{},
 	}
-	netx := &Netx{}
 	dlr := netx.NewQUICDialerWithoutResolver(ql, log.Log, extensions...)
 	logger := dlr.(*quicDialerLogger)
 	if logger.Logger != log.Log {

--- a/internal/netxlite/resolvercore.go
+++ b/internal/netxlite/resolvercore.go
@@ -44,6 +44,8 @@ func (netx *Netx) newUnwrappedStdlibResolver() model.Resolver {
 // NewUnwrappedStdlibResolver returns a new, unwrapped resolver using the standard
 // library (i.e., getaddrinfo if possible and &net.Resolver{} otherwise). As the name
 // implies, this function returns an unwrapped resolver.
+//
+// Deprecated: do not use this function inside new networking code.
 func NewUnwrappedStdlibResolver() model.Resolver {
 	netx := &Netx{Underlying: nil}
 	return netx.newUnwrappedStdlibResolver()

--- a/internal/netxlite/resolvercore.go
+++ b/internal/netxlite/resolvercore.go
@@ -54,7 +54,7 @@ func NewUnwrappedStdlibResolver() model.Resolver {
 // NewSerialUDPResolver creates a new Resolver using DNS-over-UDP
 // that performs serial A/AAAA lookups during LookupHost.
 //
-// Deprecated: use NewParallelResolverUDP.
+// Deprecated: use NewParallelUDPResolver.
 //
 // Arguments:
 //
@@ -74,13 +74,6 @@ func (netx *Netx) NewParallelUDPResolver(logger model.DebugLogger, dialer model.
 	return WrapResolver(logger, NewUnwrappedParallelResolver(
 		wrapDNSTransport(NewUnwrappedDNSOverUDPTransport(dialer, address)),
 	))
-}
-
-// NewParallelUDPResolver is equivalent to creating an empty [*Netx]
-// and calling its NewParallelUDPResolver method.
-func NewParallelUDPResolver(logger model.DebugLogger, dialer model.Dialer, address string) model.Resolver {
-	netx := &Netx{Underlying: nil}
-	return netx.NewParallelUDPResolver(logger, dialer, address)
 }
 
 // WrapResolver creates a new resolver that wraps an

--- a/internal/netxlite/resolvercore.go
+++ b/internal/netxlite/resolvercore.go
@@ -28,13 +28,6 @@ func (netx *Netx) NewStdlibResolver(logger model.DebugLogger) model.Resolver {
 	return WrapResolver(logger, netx.newUnwrappedStdlibResolver())
 }
 
-// NewStdlibResolver is equivalent to creating an empty [*Netx]
-// and calling its NewStdlibResolver method.
-func NewStdlibResolver(logger model.DebugLogger) model.Resolver {
-	netx := &Netx{Underlying: nil}
-	return netx.NewStdlibResolver(logger)
-}
-
 // NewParallelDNSOverHTTPSResolver implements [model.MeasuringNetwork].
 func (netx *Netx) NewParallelDNSOverHTTPSResolver(logger model.DebugLogger, URL string) model.Resolver {
 	client := &http.Client{Transport: netx.NewHTTPTransportStdlib(logger)}

--- a/internal/netxlite/resolvercore.go
+++ b/internal/netxlite/resolvercore.go
@@ -35,13 +35,6 @@ func (netx *Netx) NewParallelDNSOverHTTPSResolver(logger model.DebugLogger, URL 
 	return WrapResolver(logger, NewUnwrappedParallelResolver(txp))
 }
 
-// NewParallelDNSOverHTTPSResolver is equivalent to creating an empty [*Netx]
-// and calling its NewParallelDNSOverHTTPSResolver method.
-func NewParallelDNSOverHTTPSResolver(logger model.DebugLogger, URL string) model.Resolver {
-	netx := &Netx{Underlying: nil}
-	return netx.NewParallelDNSOverHTTPSResolver(logger, URL)
-}
-
 func (netx *Netx) newUnwrappedStdlibResolver() model.Resolver {
 	return &resolverSystem{
 		t: wrapDNSTransport(netx.newDNSOverGetaddrinfoTransport()),

--- a/internal/netxlite/resolvercore_test.go
+++ b/internal/netxlite/resolvercore_test.go
@@ -31,7 +31,8 @@ func typeCheckForSystemResolver(t *testing.T, resolver model.Resolver, logger mo
 }
 
 func TestNewResolverSystem(t *testing.T) {
-	resolver := NewStdlibResolver(model.DiscardLogger)
+	netx := &Netx{}
+	resolver := netx.NewStdlibResolver(model.DiscardLogger)
 	typeCheckForSystemResolver(t, resolver, model.DiscardLogger)
 }
 

--- a/internal/netxlite/resolvercore_test.go
+++ b/internal/netxlite/resolvercore_test.go
@@ -75,7 +75,8 @@ func TestNewParallelUDPResolver(t *testing.T) {
 }
 
 func TestNewParallelDNSOverHTTPSResolver(t *testing.T) {
-	resolver := NewParallelDNSOverHTTPSResolver(log.Log, "https://1.1.1.1/dns-query")
+	netx := &Netx{}
+	resolver := netx.NewParallelDNSOverHTTPSResolver(log.Log, "https://1.1.1.1/dns-query")
 	idnaReso := resolver.(*resolverIDNA)
 	logger := idnaReso.Resolver.(*resolverLogger)
 	if logger.Logger != log.Log {

--- a/internal/netxlite/resolvercore_test.go
+++ b/internal/netxlite/resolvercore_test.go
@@ -58,7 +58,7 @@ func TestNewSerialUDPResolver(t *testing.T) {
 func TestNewParallelUDPResolver(t *testing.T) {
 	netx := &Netx{}
 	d := netx.NewDialerWithoutResolver(log.Log)
-	resolver := NewParallelUDPResolver(log.Log, d, "1.1.1.1:53")
+	resolver := netx.NewParallelUDPResolver(log.Log, d, "1.1.1.1:53")
 	idnaReso := resolver.(*resolverIDNA)
 	logger := idnaReso.Resolver.(*resolverLogger)
 	if logger.Logger != log.Log {

--- a/internal/netxlite/resolvercore_test.go
+++ b/internal/netxlite/resolvercore_test.go
@@ -36,7 +36,8 @@ func TestNewResolverSystem(t *testing.T) {
 }
 
 func TestNewSerialUDPResolver(t *testing.T) {
-	d := NewDialerWithoutResolver(log.Log)
+	netx := &Netx{}
+	d := netx.NewDialerWithoutResolver(log.Log)
 	resolver := NewSerialUDPResolver(log.Log, d, "1.1.1.1:53")
 	idnaReso := resolver.(*resolverIDNA)
 	logger := idnaReso.Resolver.(*resolverLogger)
@@ -54,7 +55,8 @@ func TestNewSerialUDPResolver(t *testing.T) {
 }
 
 func TestNewParallelUDPResolver(t *testing.T) {
-	d := NewDialerWithoutResolver(log.Log)
+	netx := &Netx{}
+	d := netx.NewDialerWithoutResolver(log.Log)
 	resolver := NewParallelUDPResolver(log.Log, d, "1.1.1.1:53")
 	idnaReso := resolver.(*resolverIDNA)
 	logger := idnaReso.Resolver.(*resolverLogger)

--- a/internal/netxlite/tls.go
+++ b/internal/netxlite/tls.go
@@ -162,13 +162,6 @@ func (netx *Netx) NewTLSHandshakerStdlib(logger model.DebugLogger) model.TLSHand
 	)
 }
 
-// NewTLSHandshakerStdlib is equivalent to creating an empty [*Netx]
-// and calling its NewTLSHandshakerStdlib method.
-func NewTLSHandshakerStdlib(logger model.DebugLogger) model.TLSHandshaker {
-	netx := &Netx{Underlying: nil}
-	return netx.NewTLSHandshakerStdlib(logger)
-}
-
 // newTLSHandshakerLogger creates a new tlsHandshakerLogger instance.
 func newTLSHandshakerLogger(th model.TLSHandshaker, logger model.DebugLogger) model.TLSHandshaker {
 	return &tlsHandshakerLogger{

--- a/internal/netxlite/tls_test.go
+++ b/internal/netxlite/tls_test.go
@@ -123,7 +123,8 @@ func TestConfigureTLSVersion(t *testing.T) {
 }
 
 func TestNewTLSHandshakerStdlib(t *testing.T) {
-	th := NewTLSHandshakerStdlib(log.Log)
+	netx := &Netx{}
+	th := netx.NewTLSHandshakerStdlib(log.Log)
 	logger := th.(*tlsHandshakerLogger)
 	if logger.DebugLogger != log.Log {
 		t.Fatal("invalid logger")
@@ -403,7 +404,8 @@ func TestTLSHandshakerConfigurable(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			thx := NewTLSHandshakerStdlib(model.DiscardLogger)
+			netx := &Netx{}
+			thx := netx.NewTLSHandshakerStdlib(model.DiscardLogger)
 			tlsConfig := &tls.Config{
 				InsecureSkipVerify: true,
 				ServerName:         expectedSNI,
@@ -514,7 +516,8 @@ func TestTLSHandshakerConfigurable(t *testing.T) {
 					}
 				},
 			}
-			thx := NewTLSHandshakerStdlib(model.DiscardLogger)
+			netx := &Netx{}
+			thx := netx.NewTLSHandshakerStdlib(model.DiscardLogger)
 			tlsConfig := &tls.Config{
 				InsecureSkipVerify: true,
 				ServerName:         expectedSNI,

--- a/internal/netxlite/udp.go
+++ b/internal/netxlite/udp.go
@@ -12,13 +12,6 @@ func (netx *Netx) NewUDPListener() model.UDPListener {
 	return &udpListenerErrWrapper{&udpListenerStdlib{provider: netx.MaybeCustomUnderlyingNetwork()}}
 }
 
-// NewUDPListener is equivalent to creating an empty [*Netx]
-// and calling its NewUDPListener method.
-func NewUDPListener() model.UDPListener {
-	netx := &Netx{Underlying: nil}
-	return netx.NewUDPListener()
-}
-
 // udpListenerStdlib is a UDPListener using the standard library.
 type udpListenerStdlib struct {
 	// provider is the OPTIONAL nil-safe [model.UnderlyingNetwork] provider.

--- a/internal/netxlite/udp_test.go
+++ b/internal/netxlite/udp_test.go
@@ -3,7 +3,8 @@ package netxlite
 import "testing"
 
 func TestNewUDPListener(t *testing.T) {
-	ql := NewUDPListener()
+	netx := &Netx{}
+	ql := netx.NewUDPListener()
 	qew := ql.(*udpListenerErrWrapper)
 	_ = qew.UDPListener.(*udpListenerStdlib)
 }

--- a/internal/netxlite/utls.go
+++ b/internal/netxlite/utls.go
@@ -24,13 +24,6 @@ func (netx *Netx) NewTLSHandshakerUTLS(logger model.DebugLogger, id *utls.Client
 	}, logger)
 }
 
-// NewTLSHandshakerUTLS is equivalent to creating an empty [*Netx]
-// and calling its NewTLSHandshakerUTLS method.
-func NewTLSHandshakerUTLS(logger model.DebugLogger, id *utls.ClientHelloID) model.TLSHandshaker {
-	netx := &Netx{Underlying: nil}
-	return netx.NewTLSHandshakerUTLS(logger, id)
-}
-
 // UTLSConn implements TLSConn and uses a utls UConn as its underlying connection
 type UTLSConn struct {
 	// We include the real UConn

--- a/internal/netxlite/utls_test.go
+++ b/internal/netxlite/utls_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 func TestNewTLSHandshakerUTLS(t *testing.T) {
-	th := NewTLSHandshakerUTLS(log.Log, &utls.HelloChrome_83)
+	netx := &Netx{}
+	th := netx.NewTLSHandshakerUTLS(log.Log, &utls.HelloChrome_83)
 	logger := th.(*tlsHandshakerLogger)
 	if logger.DebugLogger != log.Log {
 		t.Fatal("invalid logger")

--- a/internal/oohelperd/handler.go
+++ b/internal/oohelperd/handler.go
@@ -105,7 +105,7 @@ func NewHandler() *Handler {
 		},
 		NewResolver: newResolver,
 		NewTLSHandshaker: func(logger model.Logger) model.TLSHandshaker {
-			return netxlite.NewTLSHandshakerStdlib(logger)
+			return netx.NewTLSHandshakerStdlib(logger)
 		},
 	}
 }

--- a/internal/oohelperd/handler.go
+++ b/internal/oohelperd/handler.go
@@ -70,6 +70,7 @@ var _ http.Handler = &Handler{}
 
 // NewHandler constructs the [handler].
 func NewHandler() *Handler {
+	netx := &netxlite.Netx{}
 	return &Handler{
 		BaseLogger:        log.Log,
 		CountRequests:     &atomic.Int64{},
@@ -94,7 +95,7 @@ func NewHandler() *Handler {
 		},
 
 		NewDialer: func(logger model.Logger) model.Dialer {
-			return netxlite.NewDialerWithoutResolver(logger)
+			return netx.NewDialerWithoutResolver(logger)
 		},
 		NewQUICDialer: func(logger model.Logger) model.QUICDialer {
 			return netxlite.NewQUICDialerWithoutResolver(

--- a/internal/oohelperd/handler.go
+++ b/internal/oohelperd/handler.go
@@ -99,7 +99,7 @@ func NewHandler() *Handler {
 		},
 		NewQUICDialer: func(logger model.Logger) model.QUICDialer {
 			return netx.NewQUICDialerWithoutResolver(
-				netxlite.NewUDPListener(),
+				netx.NewUDPListener(),
 				logger,
 			)
 		},

--- a/internal/oohelperd/handler.go
+++ b/internal/oohelperd/handler.go
@@ -206,7 +206,8 @@ func newResolver(logger model.Logger) model.Resolver {
 	// Implementation note: pin to a specific resolver so we don't depend upon the
 	// default resolver configured by the box. Also, use an encrypted transport thus
 	// we're less vulnerable to any policy implemented by the box's provider.
-	resolver := netxlite.NewParallelDNSOverHTTPSResolver(logger, "https://dns.google/dns-query")
+	netx := &netxlite.Netx{}
+	resolver := netx.NewParallelDNSOverHTTPSResolver(logger, "https://dns.google/dns-query")
 	return resolver
 }
 

--- a/internal/oohelperd/handler.go
+++ b/internal/oohelperd/handler.go
@@ -98,7 +98,7 @@ func NewHandler() *Handler {
 			return netx.NewDialerWithoutResolver(logger)
 		},
 		NewQUICDialer: func(logger model.Logger) model.QUICDialer {
-			return netxlite.NewQUICDialerWithoutResolver(
+			return netx.NewQUICDialerWithoutResolver(
 				netxlite.NewUDPListener(),
 				logger,
 			)

--- a/internal/testingproxy/hosthttp.go
+++ b/internal/testingproxy/hosthttp.go
@@ -56,7 +56,7 @@ func (tc *hostNetworkTestCaseWithHTTP) Run(t *testing.T) {
 		ExpectAddress: "127.0.0.1",
 		Dialer:        netx.NewDialerWithResolver(log.Log, netx.NewStdlibResolver(log.Log)),
 	}
-	tlsDialer := netxlite.NewTLSDialer(dialer, netxlite.NewTLSHandshakerStdlib(log.Log))
+	tlsDialer := netxlite.NewTLSDialer(dialer, netx.NewTLSHandshakerStdlib(log.Log))
 	txp := netxlite.NewHTTPTransportWithOptions(log.Log, dialer, tlsDialer,
 		netxlite.HTTPTransportOptionProxyURL(runtimex.Try1(url.Parse(proxyServer.URL))))
 	client := &http.Client{Transport: txp}

--- a/internal/testingproxy/hosthttps.go
+++ b/internal/testingproxy/hosthttps.go
@@ -71,7 +71,7 @@ func (tc *hostNetworkTestCaseWithHTTPWithTLS) Run(t *testing.T) {
 		Dialer:        netx.NewDialerWithResolver(log.Log, netx.NewStdlibResolver(log.Log)),
 	}
 	tlsDialer := netxlite.NewTLSDialerWithConfig(
-		dialer, netxlite.NewTLSHandshakerStdlib(log.Log),
+		dialer, netx.NewTLSHandshakerStdlib(log.Log),
 		tlsConfig,
 	)
 	txp := netxlite.NewHTTPTransportWithOptions(log.Log, dialer, tlsDialer,

--- a/internal/testingproxy/sockshost.go
+++ b/internal/testingproxy/sockshost.go
@@ -56,7 +56,7 @@ func (tc *hostNetworkTestCaseWithSOCKS) Run(t *testing.T) {
 		ExpectAddress: "127.0.0.1",
 		Dialer:        netx.NewDialerWithResolver(log.Log, netx.NewStdlibResolver(log.Log)),
 	}
-	tlsDialer := netxlite.NewTLSDialer(dialer, netxlite.NewTLSHandshakerStdlib(log.Log))
+	tlsDialer := netxlite.NewTLSDialer(dialer, netx.NewTLSHandshakerStdlib(log.Log))
 	txp := netxlite.NewHTTPTransportWithOptions(log.Log, dialer, tlsDialer,
 		netxlite.HTTPTransportOptionProxyURL(proxyServer.URL()))
 	client := &http.Client{Transport: txp}

--- a/internal/testingx/httptestx_test.go
+++ b/internal/testingx/httptestx_test.go
@@ -161,7 +161,8 @@ func TestHTTPTestxWithStdlib(t *testing.T) {
 
 			// create the HTTP client (we need to do more work than normally because
 			// we MUST correctly set the TLS dialer configuration)
-			tcpDialer := netxlite.NewDialerWithResolver(log.Log, netxlite.NewStdlibResolver(log.Log))
+			netx := &netxlite.Netx{}
+			tcpDialer := netx.NewDialerWithResolver(log.Log, netxlite.NewStdlibResolver(log.Log))
 			tlsHandshaker := netxlite.NewTLSHandshakerStdlib(log.Log)
 			tlsDialer := netxlite.NewTLSDialerWithConfig(
 				tcpDialer, tlsHandshaker, &tls.Config{RootCAs: srvr.X509CertPool})
@@ -440,7 +441,8 @@ func TestHTTPTestxWithNetem(t *testing.T) {
 
 				// create the HTTP client (we need to do more work than normally because
 				// we MUST correctly set the TLS dialer configuration)
-				tcpDialer := netxlite.NewDialerWithResolver(log.Log, netxlite.NewStdlibResolver(log.Log))
+				netx := &netxlite.Netx{}
+				tcpDialer := netx.NewDialerWithResolver(log.Log, netxlite.NewStdlibResolver(log.Log))
 				tlsHandshaker := netxlite.NewTLSHandshakerStdlib(log.Log)
 				tlsDialer := netxlite.NewTLSDialerWithConfig(
 					tcpDialer, tlsHandshaker, &tls.Config{RootCAs: srvr.X509CertPool})

--- a/internal/testingx/httptestx_test.go
+++ b/internal/testingx/httptestx_test.go
@@ -163,7 +163,7 @@ func TestHTTPTestxWithStdlib(t *testing.T) {
 			// we MUST correctly set the TLS dialer configuration)
 			netx := &netxlite.Netx{}
 			tcpDialer := netx.NewDialerWithResolver(log.Log, netx.NewStdlibResolver(log.Log))
-			tlsHandshaker := netxlite.NewTLSHandshakerStdlib(log.Log)
+			tlsHandshaker := netx.NewTLSHandshakerStdlib(log.Log)
 			tlsDialer := netxlite.NewTLSDialerWithConfig(
 				tcpDialer, tlsHandshaker, &tls.Config{RootCAs: srvr.X509CertPool})
 			// TODO(https://github.com/ooni/probe/issues/2534): here we're using the QUIRKY netxlite.NewHTTPTransport
@@ -443,7 +443,7 @@ func TestHTTPTestxWithNetem(t *testing.T) {
 				// we MUST correctly set the TLS dialer configuration)
 				netx := &netxlite.Netx{}
 				tcpDialer := netx.NewDialerWithResolver(log.Log, netx.NewStdlibResolver(log.Log))
-				tlsHandshaker := netxlite.NewTLSHandshakerStdlib(log.Log)
+				tlsHandshaker := netx.NewTLSHandshakerStdlib(log.Log)
 				tlsDialer := netxlite.NewTLSDialerWithConfig(
 					tcpDialer, tlsHandshaker, &tls.Config{RootCAs: srvr.X509CertPool})
 				// TODO(https://github.com/ooni/probe/issues/2534): here we're using the QUIRKY netxlite.NewHTTPTransport

--- a/internal/testingx/httptestx_test.go
+++ b/internal/testingx/httptestx_test.go
@@ -162,7 +162,7 @@ func TestHTTPTestxWithStdlib(t *testing.T) {
 			// create the HTTP client (we need to do more work than normally because
 			// we MUST correctly set the TLS dialer configuration)
 			netx := &netxlite.Netx{}
-			tcpDialer := netx.NewDialerWithResolver(log.Log, netxlite.NewStdlibResolver(log.Log))
+			tcpDialer := netx.NewDialerWithResolver(log.Log, netx.NewStdlibResolver(log.Log))
 			tlsHandshaker := netxlite.NewTLSHandshakerStdlib(log.Log)
 			tlsDialer := netxlite.NewTLSDialerWithConfig(
 				tcpDialer, tlsHandshaker, &tls.Config{RootCAs: srvr.X509CertPool})
@@ -442,7 +442,7 @@ func TestHTTPTestxWithNetem(t *testing.T) {
 				// create the HTTP client (we need to do more work than normally because
 				// we MUST correctly set the TLS dialer configuration)
 				netx := &netxlite.Netx{}
-				tcpDialer := netx.NewDialerWithResolver(log.Log, netxlite.NewStdlibResolver(log.Log))
+				tcpDialer := netx.NewDialerWithResolver(log.Log, netx.NewStdlibResolver(log.Log))
 				tlsHandshaker := netxlite.NewTLSHandshakerStdlib(log.Log)
 				tlsDialer := netxlite.NewTLSDialerWithConfig(
 					tcpDialer, tlsHandshaker, &tls.Config{RootCAs: srvr.X509CertPool})

--- a/internal/testingx/tlsx_test.go
+++ b/internal/testingx/tlsx_test.go
@@ -100,7 +100,7 @@ func TestTLSHandlerWithStdlib(t *testing.T) {
 			// create a TLS dialer
 			netx := &netxlite.Netx{}
 			tcpDialer := netx.NewDialerWithoutResolver(log.Log)
-			tlsHandshaker := netxlite.NewTLSHandshakerStdlib(log.Log)
+			tlsHandshaker := netx.NewTLSHandshakerStdlib(log.Log)
 			tlsDialer := netxlite.NewTLSDialerWithConfig(tcpDialer, tlsHandshaker, tlsConfig)
 
 			// create a context with a timeout
@@ -245,7 +245,7 @@ func TestTLSHandlerWithNetem(t *testing.T) {
 				// create a TLS dialer
 				netx := &netxlite.Netx{}
 				tcpDialer := netx.NewDialerWithoutResolver(log.Log)
-				tlsHandshaker := netxlite.NewTLSHandshakerStdlib(log.Log)
+				tlsHandshaker := netx.NewTLSHandshakerStdlib(log.Log)
 				tlsDialer := netxlite.NewTLSDialerWithConfig(tcpDialer, tlsHandshaker, tlsConfig)
 
 				// create a context with a timeout

--- a/internal/testingx/tlsx_test.go
+++ b/internal/testingx/tlsx_test.go
@@ -98,7 +98,8 @@ func TestTLSHandlerWithStdlib(t *testing.T) {
 			}
 
 			// create a TLS dialer
-			tcpDialer := netxlite.NewDialerWithoutResolver(log.Log)
+			netx := &netxlite.Netx{}
+			tcpDialer := netx.NewDialerWithoutResolver(log.Log)
 			tlsHandshaker := netxlite.NewTLSHandshakerStdlib(log.Log)
 			tlsDialer := netxlite.NewTLSDialerWithConfig(tcpDialer, tlsHandshaker, tlsConfig)
 
@@ -242,7 +243,8 @@ func TestTLSHandlerWithNetem(t *testing.T) {
 				}
 
 				// create a TLS dialer
-				tcpDialer := netxlite.NewDialerWithoutResolver(log.Log)
+				netx := &netxlite.Netx{}
+				tcpDialer := netx.NewDialerWithoutResolver(log.Log)
 				tlsHandshaker := netxlite.NewTLSHandshakerStdlib(log.Log)
 				tlsDialer := netxlite.NewTLSDialerWithConfig(tcpDialer, tlsHandshaker, tlsConfig)
 

--- a/internal/tutorial/netxlite/chapter01/README.md
+++ b/internal/tutorial/netxlite/chapter01/README.md
@@ -95,7 +95,8 @@ where we want to perform each operation independently.
 
 ```Go
 func dialTCP(ctx context.Context, address string) (net.Conn, error) {
-	d := netxlite.NewDialerWithoutResolver(log.Log)
+	netx := &netxlite.Netx{}
+	d := netx.NewDialerWithoutResolver(log.Log)
 	return d.DialContext(ctx, "tcp", address)
 }
 

--- a/internal/tutorial/netxlite/chapter01/main.go
+++ b/internal/tutorial/netxlite/chapter01/main.go
@@ -96,7 +96,8 @@ func main() {
 //
 // ```Go
 func dialTCP(ctx context.Context, address string) (net.Conn, error) {
-	d := netxlite.NewDialerWithoutResolver(log.Log)
+	netx := &netxlite.Netx{}
+	d := netx.NewDialerWithoutResolver(log.Log)
 	return d.DialContext(ctx, "tcp", address)
 }
 

--- a/internal/tutorial/netxlite/chapter02/README.md
+++ b/internal/tutorial/netxlite/chapter02/README.md
@@ -128,7 +128,8 @@ chapter why this guarantee helps when writing more complex code.)
 ```Go
 
 func handshakeTLS(ctx context.Context, tcpConn net.Conn, config *tls.Config) (model.TLSConn, error) {
-	th := netxlite.NewTLSHandshakerStdlib(log.Log)
+	netx := &netxlite.Netx{}
+	th := netx.NewTLSHandshakerStdlib(log.Log)
 	return th.Handshake(ctx, tcpConn, config)
 }
 

--- a/internal/tutorial/netxlite/chapter02/README.md
+++ b/internal/tutorial/netxlite/chapter02/README.md
@@ -102,7 +102,8 @@ The `dialTCP` function is exactly as in the previous chapter.
 ```Go
 
 func dialTCP(ctx context.Context, address string) (net.Conn, error) {
-	d := netxlite.NewDialerWithoutResolver(log.Log)
+	netx := &netxlite.Netx{}
+	d := netx.NewDialerWithoutResolver(log.Log)
 	return d.DialContext(ctx, "tcp", address)
 }
 

--- a/internal/tutorial/netxlite/chapter02/main.go
+++ b/internal/tutorial/netxlite/chapter02/main.go
@@ -103,7 +103,8 @@ func main() {
 // ```Go
 
 func dialTCP(ctx context.Context, address string) (net.Conn, error) {
-	d := netxlite.NewDialerWithoutResolver(log.Log)
+	netx := &netxlite.Netx{}
+	d := netx.NewDialerWithoutResolver(log.Log)
 	return d.DialContext(ctx, "tcp", address)
 }
 

--- a/internal/tutorial/netxlite/chapter02/main.go
+++ b/internal/tutorial/netxlite/chapter02/main.go
@@ -129,7 +129,8 @@ func dialTCP(ctx context.Context, address string) (net.Conn, error) {
 // ```Go
 
 func handshakeTLS(ctx context.Context, tcpConn net.Conn, config *tls.Config) (model.TLSConn, error) {
-	th := netxlite.NewTLSHandshakerStdlib(log.Log)
+	netx := &netxlite.Netx{}
+	th := netx.NewTLSHandshakerStdlib(log.Log)
 	return th.Handshake(ctx, tcpConn, config)
 }
 

--- a/internal/tutorial/netxlite/chapter03/README.md
+++ b/internal/tutorial/netxlite/chapter03/README.md
@@ -83,7 +83,8 @@ the `tls.Config` (such as the ALPN) may be ignored
 if they conflict with what the parroted browser would do.
 
 ```Go
-	th := netxlite.NewTLSHandshakerUTLS(log.Log, &utls.HelloFirefox_55)
+	netx := &netxlite.Netx{}
+	th := netx.NewTLSHandshakerUTLS(log.Log, &utls.HelloFirefox_55)
 ```
 
 The rest of the program is exactly like the one in the

--- a/internal/tutorial/netxlite/chapter03/README.md
+++ b/internal/tutorial/netxlite/chapter03/README.md
@@ -63,7 +63,8 @@ func main() {
 }
 
 func dialTCP(ctx context.Context, address string) (net.Conn, error) {
-	d := netxlite.NewDialerWithoutResolver(log.Log)
+	netx := &netxlite.Netx{}
+	d := netx.NewDialerWithoutResolver(log.Log)
 	return d.DialContext(ctx, "tcp", address)
 }
 

--- a/internal/tutorial/netxlite/chapter03/main.go
+++ b/internal/tutorial/netxlite/chapter03/main.go
@@ -84,7 +84,8 @@ func handshakeTLS(ctx context.Context, tcpConn net.Conn, config *tls.Config) (mo
 	// if they conflict with what the parroted browser would do.
 	//
 	// ```Go
-	th := netxlite.NewTLSHandshakerUTLS(log.Log, &utls.HelloFirefox_55)
+	netx := &netxlite.Netx{}
+	th := netx.NewTLSHandshakerUTLS(log.Log, &utls.HelloFirefox_55)
 	// ```
 	//
 	// The rest of the program is exactly like the one in the

--- a/internal/tutorial/netxlite/chapter03/main.go
+++ b/internal/tutorial/netxlite/chapter03/main.go
@@ -64,7 +64,8 @@ func main() {
 }
 
 func dialTCP(ctx context.Context, address string) (net.Conn, error) {
-	d := netxlite.NewDialerWithoutResolver(log.Log)
+	netx := &netxlite.Netx{}
+	d := netx.NewDialerWithoutResolver(log.Log)
 	return d.DialContext(ctx, "tcp", address)
 }
 

--- a/internal/tutorial/netxlite/chapter04/README.md
+++ b/internal/tutorial/netxlite/chapter04/README.md
@@ -91,8 +91,9 @@ in the next two chapters.)
 ```Go
 func dialQUIC(ctx context.Context, address string,
 	config *tls.Config) (quic.EarlyConnection, tls.ConnectionState, error) {
+	netx := &netxlite.Netx{}
 	ql := netxlite.NewUDPListener()
-	d := netxlite.NewQUICDialerWithoutResolver(ql, log.Log)
+	d := netx.NewQUICDialerWithoutResolver(ql, log.Log)
 	qconn, err := d.DialContext(ctx, address, config, &quic.Config{})
 	if err != nil {
 		return nil, tls.ConnectionState{}, err

--- a/internal/tutorial/netxlite/chapter04/README.md
+++ b/internal/tutorial/netxlite/chapter04/README.md
@@ -92,7 +92,7 @@ in the next two chapters.)
 func dialQUIC(ctx context.Context, address string,
 	config *tls.Config) (quic.EarlyConnection, tls.ConnectionState, error) {
 	netx := &netxlite.Netx{}
-	ql := netxlite.NewUDPListener()
+	ql := netx.NewUDPListener()
 	d := netx.NewQUICDialerWithoutResolver(ql, log.Log)
 	qconn, err := d.DialContext(ctx, address, config, &quic.Config{})
 	if err != nil {

--- a/internal/tutorial/netxlite/chapter04/main.go
+++ b/internal/tutorial/netxlite/chapter04/main.go
@@ -93,7 +93,7 @@ func main() {
 func dialQUIC(ctx context.Context, address string,
 	config *tls.Config) (quic.EarlyConnection, tls.ConnectionState, error) {
 	netx := &netxlite.Netx{}
-	ql := netxlite.NewUDPListener()
+	ql := netx.NewUDPListener()
 	d := netx.NewQUICDialerWithoutResolver(ql, log.Log)
 	qconn, err := d.DialContext(ctx, address, config, &quic.Config{})
 	if err != nil {

--- a/internal/tutorial/netxlite/chapter04/main.go
+++ b/internal/tutorial/netxlite/chapter04/main.go
@@ -92,8 +92,9 @@ func main() {
 // ```Go
 func dialQUIC(ctx context.Context, address string,
 	config *tls.Config) (quic.EarlyConnection, tls.ConnectionState, error) {
+	netx := &netxlite.Netx{}
 	ql := netxlite.NewUDPListener()
-	d := netxlite.NewQUICDialerWithoutResolver(ql, log.Log)
+	d := netx.NewQUICDialerWithoutResolver(ql, log.Log)
 	qconn, err := d.DialContext(ctx, address, config, &quic.Config{})
 	if err != nil {
 		return nil, tls.ConnectionState{}, err

--- a/internal/tutorial/netxlite/chapter05/README.md
+++ b/internal/tutorial/netxlite/chapter05/README.md
@@ -54,7 +54,8 @@ The returned resolver implements an interface that is very
 close to the API of the `net.Resolver` struct.
 
 ```Go
-	reso := netxlite.NewStdlibResolver(log.Log)
+	netx := &netxlite.Netx{}
+	reso := netx.NewStdlibResolver(log.Log)
 ```
 
 We call `LookupHost` to map the hostname to IP addrs. The returned

--- a/internal/tutorial/netxlite/chapter05/main.go
+++ b/internal/tutorial/netxlite/chapter05/main.go
@@ -55,7 +55,8 @@ func main() {
 	// close to the API of the `net.Resolver` struct.
 	//
 	// ```Go
-	reso := netxlite.NewStdlibResolver(log.Log)
+	netx := &netxlite.Netx{}
+	reso := netx.NewStdlibResolver(log.Log)
 	// ```
 	//
 	// We call `LookupHost` to map the hostname to IP addrs. The returned

--- a/internal/tutorial/netxlite/chapter06/README.md
+++ b/internal/tutorial/netxlite/chapter06/README.md
@@ -45,7 +45,8 @@ Here's where we start to diverge. We create a dialer without a resolver,
 which is going to be used by the UDP resolver.
 
 ```Go
-	dialer := netxlite.NewDialerWithoutResolver(log.Log)
+	netx := &netxlite.Netx{}
+	dialer := netx.NewDialerWithoutResolver(log.Log)
 ```
 
 Then, we create an UDP resolver. The arguments are the same as for

--- a/internal/tutorial/netxlite/chapter06/README.md
+++ b/internal/tutorial/netxlite/chapter06/README.md
@@ -54,7 +54,7 @@ creating a system resolver, except that we also need to specify the
 UDP endpoint address at which the server is listening.
 
 ```Go
-	reso := netxlite.NewParallelUDPResolver(log.Log, dialer, *serverAddr)
+	reso := netx.NewParallelUDPResolver(log.Log, dialer, *serverAddr)
 ```
 
 The API we invoke is the same as in the previous chapter, though,

--- a/internal/tutorial/netxlite/chapter06/main.go
+++ b/internal/tutorial/netxlite/chapter06/main.go
@@ -46,7 +46,8 @@ func main() {
 	// which is going to be used by the UDP resolver.
 	//
 	// ```Go
-	dialer := netxlite.NewDialerWithoutResolver(log.Log)
+	netx := &netxlite.Netx{}
+	dialer := netx.NewDialerWithoutResolver(log.Log)
 	// ```
 	//
 	// Then, we create an UDP resolver. The arguments are the same as for

--- a/internal/tutorial/netxlite/chapter06/main.go
+++ b/internal/tutorial/netxlite/chapter06/main.go
@@ -55,7 +55,7 @@ func main() {
 	// UDP endpoint address at which the server is listening.
 	//
 	// ```Go
-	reso := netxlite.NewParallelUDPResolver(log.Log, dialer, *serverAddr)
+	reso := netx.NewParallelUDPResolver(log.Log, dialer, *serverAddr)
 	// ```
 	//
 	// The API we invoke is the same as in the previous chapter, though,

--- a/internal/tutorial/netxlite/chapter07/README.md
+++ b/internal/tutorial/netxlite/chapter07/README.md
@@ -116,7 +116,8 @@ exactly like what we've seen in chapter03.
 ```Go
 
 func dialTCP(ctx context.Context, address string) (net.Conn, error) {
-	d := netxlite.NewDialerWithoutResolver(log.Log)
+	netx := &netxlite.Netx{}
+	d := netx.NewDialerWithoutResolver(log.Log)
 	return d.DialContext(ctx, "tcp", address)
 }
 

--- a/internal/tutorial/netxlite/chapter07/README.md
+++ b/internal/tutorial/netxlite/chapter07/README.md
@@ -122,7 +122,8 @@ func dialTCP(ctx context.Context, address string) (net.Conn, error) {
 }
 
 func handshakeTLS(ctx context.Context, tcpConn net.Conn, config *tls.Config) (model.TLSConn, error) {
-	th := netxlite.NewTLSHandshakerUTLS(log.Log, &utls.HelloFirefox_55)
+	netx := &netxlite.Netx{}
+	th := netx.NewTLSHandshakerUTLS(log.Log, &utls.HelloFirefox_55)
 	return th.Handshake(ctx, tcpConn, config)
 }
 

--- a/internal/tutorial/netxlite/chapter07/main.go
+++ b/internal/tutorial/netxlite/chapter07/main.go
@@ -123,7 +123,8 @@ func dialTCP(ctx context.Context, address string) (net.Conn, error) {
 }
 
 func handshakeTLS(ctx context.Context, tcpConn net.Conn, config *tls.Config) (model.TLSConn, error) {
-	th := netxlite.NewTLSHandshakerUTLS(log.Log, &utls.HelloFirefox_55)
+	netx := &netxlite.Netx{}
+	th := netx.NewTLSHandshakerUTLS(log.Log, &utls.HelloFirefox_55)
 	return th.Handshake(ctx, tcpConn, config)
 }
 

--- a/internal/tutorial/netxlite/chapter07/main.go
+++ b/internal/tutorial/netxlite/chapter07/main.go
@@ -117,7 +117,8 @@ func main() {
 // ```Go
 
 func dialTCP(ctx context.Context, address string) (net.Conn, error) {
-	d := netxlite.NewDialerWithoutResolver(log.Log)
+	netx := &netxlite.Netx{}
+	d := netx.NewDialerWithoutResolver(log.Log)
 	return d.DialContext(ctx, "tcp", address)
 }
 

--- a/internal/tutorial/netxlite/chapter08/README.md
+++ b/internal/tutorial/netxlite/chapter08/README.md
@@ -105,7 +105,7 @@ exactly like what we've seen in chapter04.
 func dialQUIC(ctx context.Context, address string,
 	config *tls.Config) (quic.EarlyConnection, tls.ConnectionState, error) {
 	netx := &netxlite.Netx{}
-	ql := netxlite.NewUDPListener()
+	ql := netx.NewUDPListener()
 	d := netx.NewQUICDialerWithoutResolver(ql, log.Log)
 	qconn, err := d.DialContext(ctx, address, config, &quic.Config{})
 	if err != nil {

--- a/internal/tutorial/netxlite/chapter08/README.md
+++ b/internal/tutorial/netxlite/chapter08/README.md
@@ -104,8 +104,9 @@ exactly like what we've seen in chapter04.
 
 func dialQUIC(ctx context.Context, address string,
 	config *tls.Config) (quic.EarlyConnection, tls.ConnectionState, error) {
+	netx := &netxlite.Netx{}
 	ql := netxlite.NewUDPListener()
-	d := netxlite.NewQUICDialerWithoutResolver(ql, log.Log)
+	d := netx.NewQUICDialerWithoutResolver(ql, log.Log)
 	qconn, err := d.DialContext(ctx, address, config, &quic.Config{})
 	if err != nil {
 		return nil, tls.ConnectionState{}, err

--- a/internal/tutorial/netxlite/chapter08/main.go
+++ b/internal/tutorial/netxlite/chapter08/main.go
@@ -106,7 +106,7 @@ func main() {
 func dialQUIC(ctx context.Context, address string,
 	config *tls.Config) (quic.EarlyConnection, tls.ConnectionState, error) {
 	netx := &netxlite.Netx{}
-	ql := netxlite.NewUDPListener()
+	ql := netx.NewUDPListener()
 	d := netx.NewQUICDialerWithoutResolver(ql, log.Log)
 	qconn, err := d.DialContext(ctx, address, config, &quic.Config{})
 	if err != nil {

--- a/internal/tutorial/netxlite/chapter08/main.go
+++ b/internal/tutorial/netxlite/chapter08/main.go
@@ -105,8 +105,9 @@ func main() {
 
 func dialQUIC(ctx context.Context, address string,
 	config *tls.Config) (quic.EarlyConnection, tls.ConnectionState, error) {
+	netx := &netxlite.Netx{}
 	ql := netxlite.NewUDPListener()
-	d := netxlite.NewQUICDialerWithoutResolver(ql, log.Log)
+	d := netx.NewQUICDialerWithoutResolver(ql, log.Log)
 	qconn, err := d.DialContext(ctx, address, config, &quic.Config{})
 	if err != nil {
 		return nil, tls.ConnectionState{}, err

--- a/internal/x/dslvm/trace.go
+++ b/internal/x/dslvm/trace.go
@@ -22,7 +22,7 @@ type Trace interface {
 	// Index returns the unique index used by this trace.
 	Index() int64
 
-	// NewDialerWithoutResolver is equivalent to netxlite.NewDialerWithoutResolver
+	// NewDialerWithoutResolver is equivalent to netxlite.Netx.NewDialerWithoutResolver
 	// except that it returns a model.Dialer that uses this trace.
 	//
 	// Caveat: the dialer wrappers are there to implement the

--- a/internal/x/dslvm/trace.go
+++ b/internal/x/dslvm/trace.go
@@ -33,7 +33,7 @@ type Trace interface {
 	NewParallelUDPResolver(logger model.DebugLogger, dialer model.Dialer, address string) model.Resolver
 
 	// NewQUICDialerWithoutResolver is equivalent to
-	// netxlite.NewQUICDialerWithoutResolver except that it returns a
+	// netxlite.Netx.NewQUICDialerWithoutResolver except that it returns a
 	// model.QUICDialer that uses this trace.
 	//
 	// Caveat: the dialer wrappers are there to implement the

--- a/internal/x/dslvm/trace.go
+++ b/internal/x/dslvm/trace.go
@@ -41,7 +41,7 @@ type Trace interface {
 	NewQUICDialerWithoutResolver(listener model.UDPListener,
 		dl model.DebugLogger, wrappers ...model.QUICDialerWrapper) model.QUICDialer
 
-	// NewTLSHandshakerStdlib is equivalent to netxlite.NewTLSHandshakerStdlib
+	// NewTLSHandshakerStdlib is equivalent to netxlite.Netx.NewTLSHandshakerStdlib
 	// except that it returns a model.TLSHandshaker that uses this trace.
 	NewTLSHandshakerStdlib(dl model.DebugLogger) model.TLSHandshaker
 

--- a/internal/x/dslx/quic_test.go
+++ b/internal/x/dslx/quic_test.go
@@ -82,12 +82,13 @@ func TestQUICHandshake(t *testing.T) {
 
 		for name, tt := range tests {
 			t.Run(name, func(t *testing.T) {
+				netx := &netxlite.Netx{}
 				rt := NewRuntimeMeasurexLite(model.DiscardLogger, time.Now(), RuntimeMeasurexLiteOptionMeasuringNetwork(&mocks.MeasuringNetwork{
 					MockNewQUICDialerWithoutResolver: func(listener model.UDPListener, logger model.DebugLogger, w ...model.QUICDialerWrapper) model.QUICDialer {
 						return tt.dialer
 					},
 					MockNewUDPListener: func() model.UDPListener {
-						return netxlite.NewUDPListener()
+						return netx.NewUDPListener()
 					},
 				}))
 				quicHandshake := QUICHandshake(rt, TLSHandshakeOptionServerName(tt.sni))

--- a/internal/x/dslx/trace.go
+++ b/internal/x/dslx/trace.go
@@ -22,7 +22,7 @@ type Trace interface {
 	// Index returns the unique index used by this trace.
 	Index() int64
 
-	// NewDialerWithoutResolver is equivalent to netxlite.NewDialerWithoutResolver
+	// NewDialerWithoutResolver is equivalent to netxlite.Netx.NewDialerWithoutResolver
 	// except that it returns a model.Dialer that uses this trace.
 	//
 	// Caveat: the dialer wrappers are there to implement the

--- a/internal/x/dslx/trace.go
+++ b/internal/x/dslx/trace.go
@@ -33,7 +33,7 @@ type Trace interface {
 	NewParallelUDPResolver(logger model.DebugLogger, dialer model.Dialer, address string) model.Resolver
 
 	// NewQUICDialerWithoutResolver is equivalent to
-	// netxlite.NewQUICDialerWithoutResolver except that it returns a
+	// netxlite.Netx.NewQUICDialerWithoutResolver except that it returns a
 	// model.QUICDialer that uses this trace.
 	//
 	// Caveat: the dialer wrappers are there to implement the

--- a/internal/x/dslx/trace.go
+++ b/internal/x/dslx/trace.go
@@ -41,7 +41,7 @@ type Trace interface {
 	NewQUICDialerWithoutResolver(listener model.UDPListener,
 		dl model.DebugLogger, wrappers ...model.QUICDialerWrapper) model.QUICDialer
 
-	// NewTLSHandshakerStdlib is equivalent to netxlite.NewTLSHandshakerStdlib
+	// NewTLSHandshakerStdlib is equivalent to netxlite.Netx.NewTLSHandshakerStdlib
 	// except that it returns a model.TLSHandshaker that uses this trace.
 	NewTLSHandshakerStdlib(dl model.DebugLogger) model.TLSHandshaker
 


### PR DESCRIPTION
This diff removes the first-order implicit-Netx wrappers. We define first-order implicit-Netx wrappers the top-level functions that have the same name of netxlite.Netx methods, allocate an empty Netx, and call the corresponding method.

The reason why we're doing this now is that it has been relatively hard to implement https://github.com/ooni/probe-cli/pull/1464 because of the ambiguity between those first-order wrappers and the methods. Getting this wrong means that QA tests would behave in a funny way.

The overall goal here is to refactor `oohelperd` to only depend on `netxlite.Netx` such that we can remove the code duplication between how we instantiate `oohelperd.Handler` in `oohelperd` and how we instantiate it inside `netemx`.

In turn, by doing this, we would ensure we have the same `oohelperd` behavior for QA and production.

In turn, with this guarantee, we can write QA tests that ensure we're correctly dealing with 127.0.0.1.

The reference issue is https://github.com/ooni/probe/issues/1517.