### PR TITLE
refactor(oohelperd,netmx): reduce construction diff to zero

### DIFF
--- a/internal/cmd/oohelperd/main.go
+++ b/internal/cmd/oohelperd/main.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/oohelperd"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 	"github.com/ooni/probe-cli/v3/internal/version"
@@ -92,7 +93,7 @@ func main() {
 	mux := http.NewServeMux()
 
 	// add the main oohelperd handler to the mux
-	mux.Handle("/", oohelperd.NewHandler())
+	mux.Handle("/", oohelperd.NewHandler(log.Log, &netxlite.Netx{}))
 
 	// create a listening server for serving ooniprobe requests
 	srv := &http.Server{Addr: *apiEndpoint, Handler: mux}

--- a/internal/oohelperd/handler_test.go
+++ b/internal/oohelperd/handler_test.go
@@ -10,8 +10,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/apex/log"
 	"github.com/ooni/probe-cli/v3/internal/mocks"
 	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/version"
 )
 
@@ -186,7 +188,7 @@ func TestHandlerWorkingAsIntended(t *testing.T) {
 	for _, expect := range expectations {
 		t.Run(expect.name, func(t *testing.T) {
 			// create handler and possibly override .Measure
-			handler := NewHandler()
+			handler := NewHandler(log.Log, &netxlite.Netx{})
 			if expect.measureFn != nil {
 				handler.Measure = expect.measureFn
 			}


### PR DESCRIPTION
This diff modifies how we construct oohelperd.Handler inside the oohelperd package and inside the netemx package such that we're now constructing using equivalent code. We know that construction is equivalent for HTTP clients because previosuly we made sure it was the case in https://github.com/ooni/probe-cli/pull/1464.

So, the next step would be removing the custom construction code inside of netemx and always use oohelperd.NewHandler.

In turn, by doing this, we would ensure we have the same `oohelperd` behavior for QA and production.

In turn, with this guarantee, we can write QA tests that ensure we're correctly dealing with 127.0.0.1.

The reference issue is https://github.com/ooni/probe/issues/1517.

