### PR TITLE
chore: use latest zlib version published (1.3.1)

### DIFF
--- a/internal/cmd/buildtool/android_test.go
+++ b/internal/cmd/buildtool/android_test.go
@@ -440,12 +440,12 @@ func TestAndroidBuildCdepsZlib(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.tar.gz",
+				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.1.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "zlib-1.3.tar.gz",
+				"tar", "-xf", "zlib-1.3.1.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -493,12 +493,12 @@ func TestAndroidBuildCdepsZlib(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.tar.gz",
+				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.1.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "zlib-1.3.tar.gz",
+				"tar", "-xf", "zlib-1.3.1.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -546,12 +546,12 @@ func TestAndroidBuildCdepsZlib(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.tar.gz",
+				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.1.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "zlib-1.3.tar.gz",
+				"tar", "-xf", "zlib-1.3.1.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -599,12 +599,12 @@ func TestAndroidBuildCdepsZlib(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.tar.gz",
+				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.1.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "zlib-1.3.tar.gz",
+				"tar", "-xf", "zlib-1.3.1.tar.gz",
 			},
 		}, {
 			Env: []string{},

--- a/internal/cmd/buildtool/cdepszlib.go
+++ b/internal/cmd/buildtool/cdepszlib.go
@@ -25,13 +25,13 @@ func cdepsZlibBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependencies) 
 	defer restore()
 
 	// See https://github.com/Homebrew/homebrew-core/blob/master/Formula/z/zlib.rb
-	cdepsMustFetch("https://zlib.net/zlib-1.3.tar.gz")
+	cdepsMustFetch("https://zlib.net/zlib-1.3.1.tar.gz")
 	deps.VerifySHA256( // must be mockable
-		"ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e",
-		"zlib-1.3.tar.gz",
+		"9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23",
+		"zlib-1.3.1.tar.gz",
 	)
-	must.Run(log.Log, "tar", "-xf", "zlib-1.3.tar.gz")
-	_ = deps.MustChdir("zlib-1.3") // must be mockable
+	must.Run(log.Log, "tar", "-xf", "zlib-1.3.1.tar.gz")
+	_ = deps.MustChdir("zlib-1.3.1") // must be mockable
 
 	mydir := filepath.Join(topdir, "CDEPS", "zlib")
 	for _, patch := range cdepsMustListPatches(mydir) {

--- a/internal/cmd/buildtool/ios_test.go
+++ b/internal/cmd/buildtool/ios_test.go
@@ -140,12 +140,12 @@ func TestIOSBuildCdepsZlib(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.tar.gz",
+				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.1.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "zlib-1.3.tar.gz",
+				"tar", "-xf", "zlib-1.3.1.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -194,12 +194,12 @@ func TestIOSBuildCdepsZlib(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.tar.gz",
+				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.1.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "zlib-1.3.tar.gz",
+				"tar", "-xf", "zlib-1.3.1.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -248,12 +248,12 @@ func TestIOSBuildCdepsZlib(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.tar.gz",
+				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.1.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "zlib-1.3.tar.gz",
+				"tar", "-xf", "zlib-1.3.1.tar.gz",
 			},
 		}, {
 			Env: []string{},

--- a/internal/cmd/buildtool/linuxcdeps_test.go
+++ b/internal/cmd/buildtool/linuxcdeps_test.go
@@ -40,12 +40,12 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.tar.gz",
+				"curl", "-fsSLO", "https://zlib.net/zlib-1.3.1.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "zlib-1.3.tar.gz",
+				"tar", "-xf", "zlib-1.3.1.tar.gz",
 			},
 		}, {
 			Env: []string{},


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [ ] reference issue for this pull request: https://github.com/ooni/probe/issues/2660
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [ ] if you changed code inside an experiment, make sure you bump its version number: N/A


## Description

Bump to the latest zlib published version. Fixes `cmd/buildtool` tests at https://github.com/ooni/probe-cli/actions/runs/7644312040/job/20828352810

Closes https://github.com/ooni/probe/issues/2660
