### PR TITLE
chore(webconnectivityqa): reproduce ooni/probe#2628 issue

### DIFF
--- a/internal/experiment/webconnectivityqa/redirect.go
+++ b/internal/experiment/webconnectivityqa/redirect.go
@@ -350,7 +350,7 @@ func redirectWithConsistentDNSAndThenTimeoutForHTTPS() *TestCase {
 func redirectWithBrokenLocationForHTTP() *TestCase {
 	return &TestCase{
 		Name:     "redirectWithBrokenLocationForHTTP",
-		Flags:    0,
+		Flags:    TestCaseFlagNoLTE,
 		Input:    "http://httpbin.com/broken-redirect-http",
 		LongTest: true,
 		Configure: func(env *netemx.QAEnv) {
@@ -360,12 +360,12 @@ func redirectWithBrokenLocationForHTTP() *TestCase {
 		ExpectTestKeys: &testKeys{
 			DNSExperimentFailure:  nil,
 			DNSConsistency:        "consistent",
-			HTTPExperimentFailure: "generic_timeout_error",
-			XStatus:               8704, // StatusExperimentHTTP | StatusAnomalyUnknown
+			HTTPExperimentFailure: "unknown_failure: http: no Host in request URL",
+			XStatus:               8192, // StatusExperimentHTTP
 			XDNSFlags:             0,
-			XBlockingFlags:        4, // AnalysisBlockingFlagTLSBlocking
-			Accessible:            false,
-			Blocking:              "http-failure",
+			XBlockingFlags:        1, // AnalysisBlockingFlagDNSBlocking
+			Accessible:            nil,
+			Blocking:              nil,
 		},
 	}
 }
@@ -377,7 +377,7 @@ func redirectWithBrokenLocationForHTTP() *TestCase {
 func redirectWithBrokenLocationForHTTPS() *TestCase {
 	return &TestCase{
 		Name:     "redirectWithBrokenLocationForHTTPS",
-		Flags:    0,
+		Flags:    TestCaseFlagNoLTE,
 		Input:    "https://httpbin.com/broken-redirect-https",
 		LongTest: true,
 		Configure: func(env *netemx.QAEnv) {
@@ -387,12 +387,12 @@ func redirectWithBrokenLocationForHTTPS() *TestCase {
 		ExpectTestKeys: &testKeys{
 			DNSExperimentFailure:  nil,
 			DNSConsistency:        "consistent",
-			HTTPExperimentFailure: "generic_timeout_error",
-			XStatus:               8704, // StatusExperimentHTTP | StatusAnomalyUnknown
+			HTTPExperimentFailure: "unknown_failure: http: no Host in request URL",
+			XStatus:               8192, // StatusExperimentHTTP
 			XDNSFlags:             0,
-			XBlockingFlags:        4, // AnalysisBlockingFlagTLSBlocking
-			Accessible:            false,
-			Blocking:              "http-failure",
+			XBlockingFlags:        1, // AnalysisBlockingFlagDNSBlocking
+			Accessible:            nil,
+			Blocking:              nil,
 		},
 	}
 }

--- a/internal/experiment/webconnectivityqa/redirect.go
+++ b/internal/experiment/webconnectivityqa/redirect.go
@@ -342,3 +342,57 @@ func redirectWithConsistentDNSAndThenTimeoutForHTTPS() *TestCase {
 		},
 	}
 }
+
+// redirectWithBrokenLocationForHTTP is a scenario where the redirect
+// returns a broken URL only containing `http://`.
+//
+// See https://github.com/ooni/probe/issues/2628 for more info.
+func redirectWithBrokenLocationForHTTP() *TestCase {
+	return &TestCase{
+		Name:     "redirectWithBrokenLocationForHTTP",
+		Flags:    0,
+		Input:    "http://httpbin.com/broken-redirect-http",
+		LongTest: true,
+		Configure: func(env *netemx.QAEnv) {
+			// nothing
+		},
+		ExpectErr: false,
+		ExpectTestKeys: &testKeys{
+			DNSExperimentFailure:  nil,
+			DNSConsistency:        "consistent",
+			HTTPExperimentFailure: "generic_timeout_error",
+			XStatus:               8704, // StatusExperimentHTTP | StatusAnomalyUnknown
+			XDNSFlags:             0,
+			XBlockingFlags:        4, // AnalysisBlockingFlagTLSBlocking
+			Accessible:            false,
+			Blocking:              "http-failure",
+		},
+	}
+}
+
+// redirectWithBrokenLocationForHTTPS is a scenario where the redirect
+// returns a broken URL only containing `https://`.
+//
+// See https://github.com/ooni/probe/issues/2628 for more info.
+func redirectWithBrokenLocationForHTTPS() *TestCase {
+	return &TestCase{
+		Name:     "redirectWithBrokenLocationForHTTPS",
+		Flags:    0,
+		Input:    "https://httpbin.com/broken-redirect-https",
+		LongTest: true,
+		Configure: func(env *netemx.QAEnv) {
+			// nothing
+		},
+		ExpectErr: false,
+		ExpectTestKeys: &testKeys{
+			DNSExperimentFailure:  nil,
+			DNSConsistency:        "consistent",
+			HTTPExperimentFailure: "generic_timeout_error",
+			XStatus:               8704, // StatusExperimentHTTP | StatusAnomalyUnknown
+			XDNSFlags:             0,
+			XBlockingFlags:        4, // AnalysisBlockingFlagTLSBlocking
+			Accessible:            false,
+			Blocking:              "http-failure",
+		},
+	}
+}

--- a/internal/experiment/webconnectivityqa/testcase.go
+++ b/internal/experiment/webconnectivityqa/testcase.go
@@ -71,6 +71,8 @@ func AllTestCases() []*TestCase {
 		localhostWithHTTP(),
 		localhostWithHTTPS(),
 
+		redirectWithBrokenLocationForHTTP(),
+		redirectWithBrokenLocationForHTTPS(),
 		redirectWithConsistentDNSAndThenConnectionRefusedForHTTP(),
 		redirectWithConsistentDNSAndThenConnectionRefusedForHTTPS(),
 		redirectWithConsistentDNSAndThenConnectionResetForHTTP(),

--- a/internal/netemx/address.go
+++ b/internal/netemx/address.go
@@ -71,5 +71,8 @@ const AddressYandexCom3 = "77.88.55.77"
 // AddressYandexCom4 is the fourth address associated with yandex.com.
 const AddressYandexCom4 = "77.88.55.80"
 
-// CloudflareCacheAddress1 is the first address associated with cloudflare caches.
-const CloudflareCacheAddress1 = "104.16.132.229"
+// AddressCloudflareCache1 is the first address associated with cloudflare caches.
+const AddressCloudflareCache1 = "104.16.132.229"
+
+// AddressHTTPBinCom1 is the first address associated with httpbin.com.
+const AddressHTTPBinCom1 = "172.67.144.64"

--- a/internal/netemx/address.go
+++ b/internal/netemx/address.go
@@ -74,5 +74,6 @@ const AddressYandexCom4 = "77.88.55.80"
 // AddressCloudflareCache1 is the first address associated with cloudflare caches.
 const AddressCloudflareCache1 = "104.16.132.229"
 
-// AddressHTTPBinCom1 is the first address associated with httpbin.com.
+// AddressHTTPBinCom1 is the first address associated an httpbin.com-like
+// service which our QA environment exports as httpbin.com.
 const AddressHTTPBinCom1 = "172.67.144.64"

--- a/internal/netemx/httpbin.go
+++ b/internal/netemx/httpbin.go
@@ -1,0 +1,56 @@
+package netemx
+
+import (
+	"log"
+	"net"
+	"net/http"
+
+	"github.com/ooni/netem"
+)
+
+// HTTPBinHandlerFactory implements httpbin.com.
+func HTTPBinHandlerFactory() HTTPHandlerFactory {
+	return HTTPHandlerFactoryFunc(func(env NetStackServerFactoryEnv, stack *netem.UNetStack) http.Handler {
+		return HTTPBinHandler()
+	})
+}
+
+// HTTPBinHandler returns the [http.Handler] for httpbin.
+func HTTPBinHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// missing address => 500
+		address, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			log.Printf("CLOUDFLARE_CACHE: missing address in request => 500")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if r.URL.Path == "/broken-redirect-http" {
+			log.Printf("ELLIOT: %+v", r.URL)
+			// See https://github.com/ooni/probe/issues/2628
+			if address == DefaultClientAddress {
+				w.Header().Set("Location", "http://")
+			} else {
+				w.Header().Set("Location", "http://www.example.com/")
+			}
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+
+		if r.URL.Path == "/broken-redirect-https" {
+			log.Printf("ELLIOT: %+v", r.URL)
+			// See https://github.com/ooni/probe/issues/2628
+			if address == DefaultClientAddress {
+				w.Header().Set("Location", "https://")
+			} else {
+				w.Header().Set("Location", "https://www.example.com/")
+			}
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	})
+}

--- a/internal/netemx/httpbin_test.go
+++ b/internal/netemx/httpbin_test.go
@@ -1,0 +1,64 @@
+package netemx
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestHTTPBinHandler(t *testing.T) {
+	t.Run("/broken-redirect with http", func(t *testing.T) {
+		req := &http.Request{
+			URL:   &url.URL{Scheme: "http://", Path: "/broken-redirect"},
+			Body:  http.NoBody,
+			Close: false,
+			Host:  "httpbin.com",
+		}
+		rr := httptest.NewRecorder()
+		handler := HTTPBinHandler()
+		handler.ServeHTTP(rr, req)
+		result := rr.Result()
+		if result.StatusCode != http.StatusFound {
+			t.Fatal("unexpected status code", result.StatusCode)
+		}
+		if loc := result.Header.Get("Location"); loc != "http://" {
+			t.Fatal("unexpected location", loc)
+		}
+	})
+
+	t.Run("/broken-redirect with https", func(t *testing.T) {
+		req := &http.Request{
+			URL:   &url.URL{Scheme: "https://", Path: "/broken-redirect"},
+			Body:  http.NoBody,
+			Close: false,
+			Host:  "httpbin.com",
+		}
+		rr := httptest.NewRecorder()
+		handler := HTTPBinHandler()
+		handler.ServeHTTP(rr, req)
+		result := rr.Result()
+		if result.StatusCode != http.StatusFound {
+			t.Fatal("unexpected status code", result.StatusCode)
+		}
+		if loc := result.Header.Get("Location"); loc != "https://" {
+			t.Fatal("unexpected location", loc)
+		}
+	})
+
+	t.Run("/", func(t *testing.T) {
+		req := &http.Request{
+			URL:   &url.URL{Scheme: "https://", Path: "/"},
+			Body:  http.NoBody,
+			Close: false,
+			Host:  "httpbin.com",
+		}
+		rr := httptest.NewRecorder()
+		handler := HTTPBinHandler()
+		handler.ServeHTTP(rr, req)
+		result := rr.Result()
+		if result.StatusCode != http.StatusNotFound {
+			t.Fatal("unexpected status code", result.StatusCode)
+		}
+	})
+}

--- a/internal/netemx/httpbin_test.go
+++ b/internal/netemx/httpbin_test.go
@@ -1,6 +1,7 @@
 package netemx
 
 import (
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -8,12 +9,29 @@ import (
 )
 
 func TestHTTPBinHandler(t *testing.T) {
-	t.Run("/broken-redirect with http", func(t *testing.T) {
+	t.Run("missing client address", func(t *testing.T) {
 		req := &http.Request{
-			URL:   &url.URL{Scheme: "http://", Path: "/broken-redirect"},
+			URL:   &url.URL{Scheme: "http://", Path: "/"},
 			Body:  http.NoBody,
 			Close: false,
 			Host:  "httpbin.com",
+		}
+		rr := httptest.NewRecorder()
+		handler := HTTPBinHandler()
+		handler.ServeHTTP(rr, req)
+		result := rr.Result()
+		if result.StatusCode != http.StatusInternalServerError {
+			t.Fatal("unexpected status code", result.StatusCode)
+		}
+	})
+
+	t.Run("/broken-redirect-http with client address", func(t *testing.T) {
+		req := &http.Request{
+			URL:        &url.URL{Scheme: "http://", Path: "/broken-redirect-http"},
+			Body:       http.NoBody,
+			Close:      false,
+			Host:       "httpbin.com",
+			RemoteAddr: net.JoinHostPort(DefaultClientAddress, "54321"),
 		}
 		rr := httptest.NewRecorder()
 		handler := HTTPBinHandler()
@@ -27,12 +45,33 @@ func TestHTTPBinHandler(t *testing.T) {
 		}
 	})
 
-	t.Run("/broken-redirect with https", func(t *testing.T) {
+	t.Run("/broken-redirect-http with another address", func(t *testing.T) {
 		req := &http.Request{
-			URL:   &url.URL{Scheme: "https://", Path: "/broken-redirect"},
-			Body:  http.NoBody,
-			Close: false,
-			Host:  "httpbin.com",
+			URL:        &url.URL{Scheme: "http://", Path: "/broken-redirect-http"},
+			Body:       http.NoBody,
+			Close:      false,
+			Host:       "httpbin.com",
+			RemoteAddr: net.JoinHostPort("8.8.8.8", "54321"),
+		}
+		rr := httptest.NewRecorder()
+		handler := HTTPBinHandler()
+		handler.ServeHTTP(rr, req)
+		result := rr.Result()
+		if result.StatusCode != http.StatusFound {
+			t.Fatal("unexpected status code", result.StatusCode)
+		}
+		if loc := result.Header.Get("Location"); loc != "http://www.example.com/" {
+			t.Fatal("unexpected location", loc)
+		}
+	})
+
+	t.Run("/broken-redirect-https with client address", func(t *testing.T) {
+		req := &http.Request{
+			URL:        &url.URL{Scheme: "http://", Path: "/broken-redirect-https"},
+			Body:       http.NoBody,
+			Close:      false,
+			Host:       "httpbin.com",
+			RemoteAddr: net.JoinHostPort(DefaultClientAddress, "54321"),
 		}
 		rr := httptest.NewRecorder()
 		handler := HTTPBinHandler()
@@ -46,12 +85,32 @@ func TestHTTPBinHandler(t *testing.T) {
 		}
 	})
 
-	t.Run("/", func(t *testing.T) {
+	t.Run("/broken-redirect-https with another address", func(t *testing.T) {
 		req := &http.Request{
-			URL:   &url.URL{Scheme: "https://", Path: "/"},
-			Body:  http.NoBody,
-			Close: false,
-			Host:  "httpbin.com",
+			URL:        &url.URL{Scheme: "http://", Path: "/broken-redirect-https"},
+			Body:       http.NoBody,
+			Close:      false,
+			Host:       "httpbin.com",
+			RemoteAddr: net.JoinHostPort("8.8.8.8", "54321"),
+		}
+		rr := httptest.NewRecorder()
+		handler := HTTPBinHandler()
+		handler.ServeHTTP(rr, req)
+		result := rr.Result()
+		if result.StatusCode != http.StatusFound {
+			t.Fatal("unexpected status code", result.StatusCode)
+		}
+		if loc := result.Header.Get("Location"); loc != "https://www.example.com/" {
+			t.Fatal("unexpected location", loc)
+		}
+	})
+	t.Run("/nonexistent URL", func(t *testing.T) {
+		req := &http.Request{
+			URL:        &url.URL{Scheme: "https://", Path: "/nonexistent"},
+			Body:       http.NoBody,
+			Close:      false,
+			Host:       "httpbin.com",
+			RemoteAddr: net.JoinHostPort("8.8.8.8", "54321"),
 		}
 		rr := httptest.NewRecorder()
 		handler := HTTPBinHandler()

--- a/internal/netemx/httpbin_test.go
+++ b/internal/netemx/httpbin_test.go
@@ -104,6 +104,7 @@ func TestHTTPBinHandler(t *testing.T) {
 			t.Fatal("unexpected location", loc)
 		}
 	})
+
 	t.Run("/nonexistent URL", func(t *testing.T) {
 		req := &http.Request{
 			URL:        &url.URL{Scheme: "https://", Path: "/nonexistent"},

--- a/internal/netemx/scenario.go
+++ b/internal/netemx/scenario.go
@@ -209,7 +209,7 @@ var InternetScenario = []*ScenarioDomainAddresses{{
 	WebServerFactory: YandexHandlerFactory(),
 }, {
 	Addresses: []string{
-		CloudflareCacheAddress1,
+		AddressCloudflareCache1,
 	},
 	Domains: []string{
 		"www.cloudflare-cache.com",
@@ -218,6 +218,17 @@ var InternetScenario = []*ScenarioDomainAddresses{{
 	ServerNameMain:   "www.cloudflare-cache.com",
 	ServerNameExtras: []string{},
 	WebServerFactory: CloudflareCAPTCHAHandlerFactory(),
+}, {
+	Addresses: []string{
+		AddressHTTPBinCom1,
+	},
+	Domains: []string{
+		"httpbin.com",
+	},
+	Role:             ScenarioRoleWebServer,
+	ServerNameMain:   "httpbin.com",
+	ServerNameExtras: []string{},
+	WebServerFactory: HTTPBinHandlerFactory(),
 }}
 
 // MustNewScenario constructs a complete testing scenario using the domains and IP

--- a/internal/netemx/yandex.go
+++ b/internal/netemx/yandex.go
@@ -14,7 +14,7 @@ func YandexHandlerFactory() HTTPHandlerFactory {
 	})
 }
 
-// YandexHandler returns the [http.Handler] for yandex.
+// YandexHandler returns the [http.Handler] for yandex.com.
 func YandexHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Alt-Svc", `h3=":443"`)


### PR DESCRIPTION
This PR improves webconnectivityqa to reproduce the https://github.com/ooni/probe/issues/2628 issue.

We model the v0.4 behavior as the correct behavior. We need to extend webconnectivitylte to correctly handle this case.