### PR TITLE
feat(buildtool): introduce script/go.bash wrapper

### DIFF
--- a/.github/workflows/gofixpath.yml
+++ b/.github/workflows/gofixpath.yml
@@ -1,5 +1,7 @@
 # Ensures that ./internal/cmd/buildtool gofixpath {command} [arguments] downloads the correct
 # version of go and executes {command} with [arguments] with "go" being the right version.
+#
+# See https://github.com/ooni/probe/issues/2664.
 
 name: gofixpath
 on:

--- a/.github/workflows/gofixpath.yml
+++ b/.github/workflows/gofixpath.yml
@@ -29,4 +29,4 @@ jobs:
         with:
           go-version: "${{ matrix.goversion }}"
 
-      - run: go run ./internal/cmd/buildtool gofixpath -- go run ./internal/cmd/buildtool generic miniooni
+      - run: ./script/go.bash run ./internal/cmd/buildtool generic miniooni

--- a/internal/cmd/buildtool/gofixpath.go
+++ b/internal/cmd/buildtool/gofixpath.go
@@ -27,6 +27,8 @@ func gofixpathSubcommand() *cobra.Command {
 // gofixpathMain ensures the correct version of Go is in path, otherwise
 // installs such a version, configure the PATH correctly, and then executes
 // whatever argument passed to the command with the correct PATH.
+//
+// See https://github.com/ooni/probe/issues/2664.
 func gofixpathMain(deps buildtoolmodel.Dependencies, args ...string) {
 	// create empty environment
 	envp := &shellx.Envp{}

--- a/script/go.bash
+++ b/script/go.bash
@@ -2,4 +2,6 @@
 set -euxo pipefail
 # We invoke ./script/internal/go.bash through the gofixpath subcommand such that
 # the "go" binary in PATH is the correct version of go.
+#
+# See https://github.com/ooni/probe/issues/2664
 go run ./internal/cmd/buildtool gofixpath -- ./script/internal/go.bash "$@"

--- a/script/go.bash
+++ b/script/go.bash
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euxo pipefail
+go run ./internal/cmd/buildtool gofixpath -- ./script/internal/go.bash "$@"

--- a/script/go.bash
+++ b/script/go.bash
@@ -1,3 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
+# We invoke ./script/internal/go.bash through the gofixpath subcommand such that
+# the "go" binary in PATH is the correct version of go.
 go run ./internal/cmd/buildtool gofixpath -- ./script/internal/go.bash "$@"

--- a/script/internal/go.bash
+++ b/script/internal/go.bash
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euxo pipefail
+go "$@"

--- a/script/internal/go.bash
+++ b/script/internal/go.bash
@@ -2,4 +2,6 @@
 set -euxo pipefail
 # If this script is invoked by ./script/go.bash, then go is
 # the correct version of go expected by the buildtool.
+#
+# See https://github.com/ooni/probe/issues/2664
 go "$@"

--- a/script/internal/go.bash
+++ b/script/internal/go.bash
@@ -1,3 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
+# If this script is invoked by ./script/go.bash, then go is
+# the correct version of go expected by the buildtool.
 go "$@"


### PR DESCRIPTION
This wrapper invokes buildtool's gofixpath to ensure we end up executing the correct version of golang.

Part of https://github.com/ooni/probe/issues/2664.

