### PR TITLE
fix(DNSWhoamiService): implement cache expiration

### DIFF
--- a/internal/webconnectivityalgo/dnswhoami.go
+++ b/internal/webconnectivityalgo/dnswhoami.go
@@ -23,7 +23,7 @@ type DNSWhoamiInfoEntry struct {
 	Address string `json:"address"`
 }
 
-// dnsWhoamiInfoTimedEntry wraps a [DNSWhoamiInfoEntry].
+// dnsWhoamiInfoTimedEntry keeps an address and the time we create the entry together.
 type dnsWhoamiInfoTimedEntry struct {
 	Addr string
 	T    time.Time

--- a/internal/webconnectivityalgo/dnswhoami.go
+++ b/internal/webconnectivityalgo/dnswhoami.go
@@ -23,7 +23,7 @@ type DNSWhoamiInfoEntry struct {
 	Address string `json:"address"`
 }
 
-// dnsWhoamiInfoTimedEntry keeps an address and the time we create the entry together.
+// dnsWhoamiInfoTimedEntry keeps an address and the time we created the entry together.
 type dnsWhoamiInfoTimedEntry struct {
 	Addr string
 	T    time.Time

--- a/internal/webconnectivityalgo/dnswhoami.go
+++ b/internal/webconnectivityalgo/dnswhoami.go
@@ -73,21 +73,6 @@ func NewDNSWhoamiService(logger model.Logger) *DNSWhoamiService {
 	}
 }
 
-func (svc *DNSWhoamiService) cloneEntries() map[string]*dnsWhoamiInfoEntryWrapper {
-	defer svc.mu.Unlock()
-	svc.mu.Lock()
-	output := make(map[string]*dnsWhoamiInfoEntryWrapper)
-	for key, value := range svc.entries {
-		output[key] = &dnsWhoamiInfoEntryWrapper{
-			T: value.T,
-			V: &DNSWhoamiInfoEntry{
-				Address: value.V.Address,
-			},
-		}
-	}
-	return output
-}
-
 type dnsWhoamiResolverSpec struct {
 	name    string
 	factory func(logger model.Logger, netx *netxlite.Netx) model.Resolver
@@ -179,4 +164,19 @@ func (svc *DNSWhoamiService) lockAndUpdate(now time.Time, serverAddr, whoamiAddr
 			Address: whoamiAddr,
 		},
 	}
+}
+
+func (svc *DNSWhoamiService) cloneEntries() map[string]*dnsWhoamiInfoEntryWrapper {
+	defer svc.mu.Unlock()
+	svc.mu.Lock()
+	output := make(map[string]*dnsWhoamiInfoEntryWrapper)
+	for key, value := range svc.entries {
+		output[key] = &dnsWhoamiInfoEntryWrapper{
+			T: value.T,
+			V: &DNSWhoamiInfoEntry{
+				Address: value.V.Address,
+			},
+		}
+	}
+	return output
 }

--- a/internal/webconnectivityalgo/dnswhoami.go
+++ b/internal/webconnectivityalgo/dnswhoami.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ooni/probe-cli/v3/internal/logmodel"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/optional"
@@ -136,7 +135,7 @@ func (svc *DNSWhoamiService) SystemV4(ctx context.Context) ([]DNSWhoamiInfoEntry
 func (svc *DNSWhoamiService) UDPv4(ctx context.Context, address string) ([]DNSWhoamiInfoEntry, bool) {
 	spec := &dnsWhoamiResolverSpec{
 		name: address,
-		factory: func(logger logmodel.Logger, netx *netxlite.Netx) model.Resolver {
+		factory: func(logger model.Logger, netx *netxlite.Netx) model.Resolver {
 			dialer := svc.netx.NewDialerWithResolver(svc.logger, svc.netx.NewStdlibResolver(svc.logger))
 			return svc.netx.NewParallelUDPResolver(svc.logger, dialer, address)
 		},

--- a/internal/webconnectivityalgo/dnswhoami.go
+++ b/internal/webconnectivityalgo/dnswhoami.go
@@ -12,14 +12,22 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/logmodel"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
+	"github.com/ooni/probe-cli/v3/internal/optional"
 )
 
 // DNSWhoamiInfoEntry contains an entry for DNSWhoamiInfo.
 type DNSWhoamiInfoEntry struct {
-	// Address is the IP address
+	// Address is the IP address used by the resolver.
 	Address string `json:"address"`
+}
+
+// dnsWhoamiInfoEntryWrapper wraps a [DNSWhoamiInfoEntry].
+type dnsWhoamiInfoEntryWrapper struct {
+	T time.Time
+	V *DNSWhoamiInfoEntry
 }
 
 // TODO(bassosimone): this code needs refining before we can merge it inside
@@ -30,27 +38,25 @@ type DNSWhoamiInfoEntry struct {
 // TODO(bassosimone): consider factoring this code and keeping state
 // on disk rather than on memory.
 
-// TODO(bassosimone): we should periodically invalidate the whoami lookup results.
-
 // DNSWhoamiService is a service that performs DNS whoami lookups.
 //
 // The zero value of this struct is invalid. Please, construct using
 // the [NewDNSWhoamiService] factory function.
 type DNSWhoamiService struct {
-	// logger is the logger
+	// entries contains the entries.
+	entries map[string]*dnsWhoamiInfoEntryWrapper
+
+	// logger is the logger.
 	logger model.Logger
 
-	// mu provides mutual exclusion
+	// mu provides mutual exclusion.
 	mu *sync.Mutex
 
-	// netx is the underlying network we're using
+	// netx is the underlying network we're using.
 	netx *netxlite.Netx
 
-	// systemv4 contains systemv4 results
-	systemv4 []DNSWhoamiInfoEntry
-
-	// udpv4 contains udpv4 results
-	udpv4 map[string][]DNSWhoamiInfoEntry
+	// timeNow allows to get the current time.
+	timeNow func() time.Time
 
 	// whoamiDomain is the whoamiDomain to query for.
 	whoamiDomain string
@@ -59,53 +65,119 @@ type DNSWhoamiService struct {
 // NewDNSWhoamiService constructs a new [*DNSWhoamiService].
 func NewDNSWhoamiService(logger model.Logger) *DNSWhoamiService {
 	return &DNSWhoamiService{
+		entries:      map[string]*dnsWhoamiInfoEntryWrapper{},
 		logger:       logger,
 		mu:           &sync.Mutex{},
 		netx:         &netxlite.Netx{Underlying: nil},
-		systemv4:     []DNSWhoamiInfoEntry{},
-		udpv4:        map[string][]DNSWhoamiInfoEntry{},
+		timeNow:      time.Now,
 		whoamiDomain: "whoami.v4.powerdns.org",
 	}
 }
 
+func (svc *DNSWhoamiService) cloneEntries() map[string]*dnsWhoamiInfoEntryWrapper {
+	defer svc.mu.Unlock()
+	svc.mu.Lock()
+	output := make(map[string]*dnsWhoamiInfoEntryWrapper)
+	for key, value := range svc.entries {
+		output[key] = &dnsWhoamiInfoEntryWrapper{
+			T: value.T,
+			V: &DNSWhoamiInfoEntry{
+				Address: value.V.Address,
+			},
+		}
+	}
+	return output
+}
+
+type dnsWhoamiResolverSpec struct {
+	name    string
+	factory func(logger model.Logger, netx *netxlite.Netx) model.Resolver
+}
+
+func (svc *DNSWhoamiService) lookup(ctx context.Context, spec *dnsWhoamiResolverSpec) []DNSWhoamiInfoEntry {
+	// get the current time
+	now := svc.timeNow()
+
+	// possibly use cache
+	mentry := svc.lockAndGet(now, spec.name)
+	if !mentry.IsNone() {
+		return []DNSWhoamiInfoEntry{mentry.Unwrap()}
+	}
+
+	// perform lookup
+	ctx, cancel := context.WithTimeout(ctx, 4*time.Second)
+	defer cancel()
+	reso := spec.factory(svc.logger, svc.netx)
+	addrs, err := reso.LookupHost(ctx, svc.whoamiDomain)
+	if err != nil || len(addrs) < 1 {
+		return nil
+	}
+
+	// update cache
+	svc.lockAndUpdate(now, spec.name, addrs[0])
+
+	// return to the caller
+	return []DNSWhoamiInfoEntry{{Address: addrs[0]}}
+}
+
 // SystemV4 returns the results of querying using the system resolver and IPv4.
 func (svc *DNSWhoamiService) SystemV4(ctx context.Context) ([]DNSWhoamiInfoEntry, bool) {
-	svc.mu.Lock()
-	defer svc.mu.Unlock()
-	if len(svc.systemv4) <= 0 {
-		ctx, cancel := context.WithTimeout(ctx, 4*time.Second)
-		defer cancel()
-		reso := svc.netx.NewStdlibResolver(svc.logger)
-		addrs, err := reso.LookupHost(ctx, svc.whoamiDomain)
-		if err != nil || len(addrs) < 1 {
-			return nil, false
-		}
-		svc.systemv4 = []DNSWhoamiInfoEntry{{
-			Address: addrs[0],
-		}}
+	spec := &dnsWhoamiResolverSpec{
+		name: "system:///",
+		factory: func(logger model.Logger, netx *netxlite.Netx) model.Resolver {
+			return svc.netx.NewStdlibResolver(svc.logger)
+		},
 	}
-	return svc.systemv4, len(svc.systemv4) > 0
+	v := svc.lookup(ctx, spec)
+	return v, len(v) > 0
 }
 
 // UDPv4 returns the results of querying a given UDP resolver and IPv4.
 func (svc *DNSWhoamiService) UDPv4(ctx context.Context, address string) ([]DNSWhoamiInfoEntry, bool) {
-	svc.mu.Lock()
-	defer svc.mu.Unlock()
-	if len(svc.udpv4[address]) <= 0 {
-		ctx, cancel := context.WithTimeout(ctx, 4*time.Second)
-		defer cancel()
-		dialer := svc.netx.NewDialerWithResolver(svc.logger, svc.netx.NewStdlibResolver(svc.logger))
-		reso := svc.netx.NewParallelUDPResolver(svc.logger, dialer, address)
-		// TODO(bassosimone): this should actually only send an A query. Sending an AAAA
-		// query is _way_ unnecessary since we know that only A is going to work.
-		addrs, err := reso.LookupHost(ctx, svc.whoamiDomain)
-		if err != nil || len(addrs) < 1 {
-			return nil, false
-		}
-		svc.udpv4[address] = []DNSWhoamiInfoEntry{{
-			Address: addrs[0],
-		}}
+	spec := &dnsWhoamiResolverSpec{
+		name: address,
+		factory: func(logger logmodel.Logger, netx *netxlite.Netx) model.Resolver {
+			dialer := svc.netx.NewDialerWithResolver(svc.logger, svc.netx.NewStdlibResolver(svc.logger))
+			return svc.netx.NewParallelUDPResolver(svc.logger, dialer, address)
+		},
 	}
-	value := svc.udpv4[address]
-	return value, len(value) > 0
+	v := svc.lookup(ctx, spec)
+	return v, len(v) > 0
+}
+
+func (svc *DNSWhoamiService) lockAndGet(now time.Time, serverAddr string) optional.Value[DNSWhoamiInfoEntry] {
+	// ensure there's mutual exclusion
+	defer svc.mu.Unlock()
+	svc.mu.Lock()
+
+	// see if there's an entry
+	entry, found := svc.entries[serverAddr]
+	if !found {
+		return optional.None[DNSWhoamiInfoEntry]()
+	}
+
+	// make sure the entry has not expired
+	const validity = 45 * time.Second
+	if now.Sub(entry.T) > validity {
+		return optional.None[DNSWhoamiInfoEntry]()
+	}
+
+	// return a copy of the value
+	return optional.Some(DNSWhoamiInfoEntry{
+		Address: entry.V.Address,
+	})
+}
+
+func (svc *DNSWhoamiService) lockAndUpdate(now time.Time, serverAddr, whoamiAddr string) {
+	// ensure there's mutual exclusion
+	defer svc.mu.Unlock()
+	svc.mu.Lock()
+
+	// insert into the table
+	svc.entries[serverAddr] = &dnsWhoamiInfoEntryWrapper{
+		T: now,
+		V: &DNSWhoamiInfoEntry{
+			Address: whoamiAddr,
+		},
+	}
 }

--- a/internal/webconnectivityalgo/dnswhoami_test.go
+++ b/internal/webconnectivityalgo/dnswhoami_test.go
@@ -27,7 +27,7 @@ func TestDNSWhoamiService(t *testing.T) {
 		domain string
 
 		// internals contains the expected internals cache
-		internals map[string]*dnsWhoamiInfoEntryWrapper
+		internals map[string]*dnsWhoamiInfoTimedEntry
 
 		// callResults contains the expectations
 		callResults []callResults
@@ -47,18 +47,14 @@ func TestDNSWhoamiService(t *testing.T) {
 			}},
 			Good: true,
 		}},
-		internals: map[string]*dnsWhoamiInfoEntryWrapper{
+		internals: map[string]*dnsWhoamiInfoTimedEntry{
 			"system:///": {
-				T: time.Date(2024, 2, 8, 9, 8, 7, 6, time.UTC).Add(time.Second),
-				V: &DNSWhoamiInfoEntry{
-					Address: netemx.DefaultClientAddress,
-				},
+				Addr: netemx.DefaultClientAddress,
+				T:    time.Date(2024, 2, 8, 9, 8, 7, 6, time.UTC).Add(time.Second),
 			},
 			"8.8.8.8:53": {
-				T: time.Date(2024, 2, 8, 9, 8, 7, 6, time.UTC).Add(2 * time.Second),
-				V: &DNSWhoamiInfoEntry{
-					Address: netemx.DefaultClientAddress,
-				},
+				Addr: netemx.DefaultClientAddress,
+				T:    time.Date(2024, 2, 8, 9, 8, 7, 6, time.UTC).Add(2 * time.Second),
 			},
 		},
 	}, {
@@ -71,7 +67,7 @@ func TestDNSWhoamiService(t *testing.T) {
 			Entries: nil,
 			Good:    false,
 		}},
-		internals: map[string]*dnsWhoamiInfoEntryWrapper{},
+		internals: map[string]*dnsWhoamiInfoTimedEntry{},
 	}}
 
 	for _, tc := range cases {
@@ -155,8 +151,6 @@ func TestDNSWhoamiService(t *testing.T) {
 		svc.netx = &netxlite.Netx{Underlying: &netxlite.NetemUnderlyingNetworkAdapter{UNet: env.ClientStack}}
 		svc.timeNow = ttp.timeNow
 
-		t.Log("~~~ first run ~~~~", ttp)
-
 		// run for the first time
 		_, _ = svc.SystemV4(context.Background())
 		_, _ = svc.UDPv4(context.Background(), "8.8.8.8:53")
@@ -164,18 +158,14 @@ func TestDNSWhoamiService(t *testing.T) {
 		// establish expectations for first run
 		//
 		// we expect the cache to be related to the first run
-		expectFirstInternals := map[string]*dnsWhoamiInfoEntryWrapper{
+		expectFirstInternals := map[string]*dnsWhoamiInfoTimedEntry{
 			"system:///": {
-				T: time.Date(2024, 2, 8, 9, 8, 7, 6, time.UTC).Add(time.Second),
-				V: &DNSWhoamiInfoEntry{
-					Address: netemx.DefaultClientAddress,
-				},
+				Addr: netemx.DefaultClientAddress,
+				T:    time.Date(2024, 2, 8, 9, 8, 7, 6, time.UTC).Add(time.Second),
 			},
 			"8.8.8.8:53": {
-				T: time.Date(2024, 2, 8, 9, 8, 7, 6, time.UTC).Add(2 * time.Second),
-				V: &DNSWhoamiInfoEntry{
-					Address: netemx.DefaultClientAddress,
-				},
+				Addr: netemx.DefaultClientAddress,
+				T:    time.Date(2024, 2, 8, 9, 8, 7, 6, time.UTC).Add(2 * time.Second),
 			},
 		}
 
@@ -184,8 +174,6 @@ func TestDNSWhoamiService(t *testing.T) {
 			t.Fatal(diff)
 		}
 
-		t.Log("~~~ second run ~~~~", ttp)
-
 		// run for the second time
 		_, _ = svc.SystemV4(context.Background())
 		_, _ = svc.UDPv4(context.Background(), "8.8.8.8:53")
@@ -193,18 +181,14 @@ func TestDNSWhoamiService(t *testing.T) {
 		// establish expectations for second run
 		//
 		// we expect the cache to be related to the first run
-		expectSecondInternals := map[string]*dnsWhoamiInfoEntryWrapper{
+		expectSecondInternals := map[string]*dnsWhoamiInfoTimedEntry{
 			"system:///": {
-				T: time.Date(2024, 2, 8, 9, 8, 7, 6, time.UTC).Add(time.Second),
-				V: &DNSWhoamiInfoEntry{
-					Address: netemx.DefaultClientAddress,
-				},
+				Addr: netemx.DefaultClientAddress,
+				T:    time.Date(2024, 2, 8, 9, 8, 7, 6, time.UTC).Add(time.Second),
 			},
 			"8.8.8.8:53": {
-				T: time.Date(2024, 2, 8, 9, 8, 7, 6, time.UTC).Add(2 * time.Second),
-				V: &DNSWhoamiInfoEntry{
-					Address: netemx.DefaultClientAddress,
-				},
+				Addr: netemx.DefaultClientAddress,
+				T:    time.Date(2024, 2, 8, 9, 8, 7, 6, time.UTC).Add(2 * time.Second),
 			},
 		}
 
@@ -213,8 +197,6 @@ func TestDNSWhoamiService(t *testing.T) {
 			t.Fatal(diff)
 		}
 
-		t.Log("~~~ third run ~~~~", ttp)
-
 		// run for the third time
 		_, _ = svc.SystemV4(context.Background())
 		_, _ = svc.UDPv4(context.Background(), "8.8.8.8:53")
@@ -222,18 +204,14 @@ func TestDNSWhoamiService(t *testing.T) {
 		// establish expectations for third run
 		//
 		// we expect the cache to be related to the third run
-		expectThirdInternals := map[string]*dnsWhoamiInfoEntryWrapper{
+		expectThirdInternals := map[string]*dnsWhoamiInfoTimedEntry{
 			"system:///": {
-				T: time.Date(2024, 2, 8, 9, 8, 7, 6, time.UTC).Add(60 * time.Second),
-				V: &DNSWhoamiInfoEntry{
-					Address: netemx.DefaultClientAddress,
-				},
+				Addr: netemx.DefaultClientAddress,
+				T:    time.Date(2024, 2, 8, 9, 8, 7, 6, time.UTC).Add(60 * time.Second),
 			},
 			"8.8.8.8:53": {
-				T: time.Date(2024, 2, 8, 9, 8, 7, 6, time.UTC).Add(62 * time.Second),
-				V: &DNSWhoamiInfoEntry{
-					Address: netemx.DefaultClientAddress,
-				},
+				Addr: netemx.DefaultClientAddress,
+				T:    time.Date(2024, 2, 8, 9, 8, 7, 6, time.UTC).Add(62 * time.Second),
 			},
 		}
 

--- a/internal/webconnectivityalgo/dnswhoami_test.go
+++ b/internal/webconnectivityalgo/dnswhoami_test.go
@@ -157,7 +157,7 @@ func TestDNSWhoamiService(t *testing.T) {
 
 		// establish expectations for first run
 		//
-		// we expect the cache to be related to the first run
+		// we expect the internals to be related to the first run
 		expectFirstInternals := map[string]*dnsWhoamiInfoTimedEntry{
 			"system:///": {
 				Addr: netemx.DefaultClientAddress,
@@ -180,7 +180,8 @@ func TestDNSWhoamiService(t *testing.T) {
 
 		// establish expectations for second run
 		//
-		// we expect the cache to be related to the first run
+		// we expect the internals to be related to the first run because not
+		// enough time has elapsed since we create the cache entries
 		expectSecondInternals := map[string]*dnsWhoamiInfoTimedEntry{
 			"system:///": {
 				Addr: netemx.DefaultClientAddress,
@@ -203,7 +204,8 @@ func TestDNSWhoamiService(t *testing.T) {
 
 		// establish expectations for third run
 		//
-		// we expect the cache to be related to the third run
+		// we expect the cache to be related to the third run because now the
+		// entries are stale and so we perform another lookup
 		expectThirdInternals := map[string]*dnsWhoamiInfoTimedEntry{
 			"system:///": {
 				Addr: netemx.DefaultClientAddress,


### PR DESCRIPTION
Because the singleton is always active, we need to expire the cache otherwise we don't catch changes in the client network.

Part of https://github.com/ooni/probe/issues/2669

Closes https://github.com/ooni/probe/issues/2671
