### PR TITLE
fix(tlsmiddlebox): if RemoteAddr is IPv6 set IPV6_UNICAST_HOPS

### DIFF
--- a/internal/experiment/tlsmiddlebox/measurer.go
+++ b/internal/experiment/tlsmiddlebox/measurer.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	testName    = "tlsmiddlebox"
-	testVersion = "0.1.1"
+	testVersion = "0.1.2"
 )
 
 // Measurer performs the measurement.

--- a/internal/experiment/tlsmiddlebox/measurer_test.go
+++ b/internal/experiment/tlsmiddlebox/measurer_test.go
@@ -18,7 +18,7 @@ func TestMeasurerExperimentNameVersion(t *testing.T) {
 	if measurer.ExperimentName() != "tlsmiddlebox" {
 		t.Fatal("unexpected ExperimentName")
 	}
-	if measurer.ExperimentVersion() != "0.1.1" {
+	if measurer.ExperimentVersion() != "0.1.2" {
 		t.Fatal("unexpected ExperimentVersion")
 	}
 }

--- a/internal/experiment/tlsmiddlebox/syscall_windows.go
+++ b/internal/experiment/tlsmiddlebox/syscall_windows.go
@@ -9,6 +9,7 @@ package tlsmiddlebox
 import (
 	"net"
 	"syscall"
+	"strings"
 )
 
 // SetTTL sets the IP TTL field for the underlying net.TCPConn
@@ -23,7 +24,12 @@ func (c *dialerTTLWrapperConn) SetTTL(ttl int) error {
 		return err
 	}
 	rawErr := rawConn.Control(func(fd uintptr) {
-		err = syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, syscall.IP_TTL, ttl)
+		isIPv6 := strings.Contains(tcpConn.RemoteAddr().String(), "[")
+		if isIPv6 {
+			err = syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, syscall.IPV6_UNICAST_HOPS, ttl)
+		} else {
+			err = syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, syscall.IP_TTL, ttl)
+		}
 	})
 	// The syscall err is given a higher priority and returned early if non-nil
 	if err != nil {


### PR DESCRIPTION
## Checklist

- [X] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [X] reference issue for this pull request: ooni/probe#2689
- [X] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

To set Hop Limit (IPv6) , we should set `IPV6_UNICAST_HOPS` option instead of `IP_TTL`.
