### PR TITLE
oohelperd: move prometheus metrics behind HTTP basic auth + docker image build + codepipeline buildspec

### DIFF
--- a/Dockerfile.oonith
+++ b/Dockerfile.oonith
@@ -21,10 +21,7 @@ COPY --from=builder /build/CLI/oohelperd-* /app
 RUN mv oohelperd-* oohelperd
 
 # oohelperd service
-EXPOSE 8080
-
-# prometheus metrics
-EXPOSE 9091
+EXPOSE 80
 
 # Run
-CMD ["/app/oohelperd",  "-api-endpoint", "0.0.0.0:8080", "--prometheus-endpoint", "0.0.0.0:9091"]
+CMD ["/app/oohelperd",  "-api-endpoint", "0.0.0.0:80"]

--- a/Dockerfile.oonith
+++ b/Dockerfile.oonith
@@ -1,0 +1,30 @@
+# This dockerfile is used to build the oohelperd binary
+# To make use of it, see the Makefile located inside of oonith/Makefile.
+#
+# Note: The Dockerfile needs to reside in the root of the repo, so that we can
+# copy files into the docker build context.
+FROM golang:1.20.12-bullseye as builder
+ARG BRANCH_NAME=master
+
+WORKDIR /build
+
+COPY . .
+
+RUN go run ./internal/cmd/buildtool oohelperd build
+
+## Image running on the host
+FROM golang:1.20.12-bullseye as runner
+
+WORKDIR /app
+
+COPY --from=builder /build/CLI/oohelperd-* /app
+RUN mv oohelperd-* oohelperd
+
+# oohelperd service
+EXPOSE 8080
+
+# prometheus metrics
+EXPOSE 9091
+
+# Run
+CMD ["/app/oohelperd",  "-api-endpoint", "0.0.0.0:8080", "--prometheus-endpoint", "0.0.0.0:9091"]

--- a/oonith/Makefile
+++ b/oonith/Makefile
@@ -1,0 +1,59 @@
+SERVICE_NAME ?= oohelperd
+
+ECS_CONTAINER_NAME ?= oonith-service-$(SERVICE_NAME)
+IMAGE_NAME ?= ooni/oonith-$(SERVICE_NAME)
+DATE := $(shell python3 -c "import datetime;print(datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%d'))")
+GIT_FULL_SHA ?= $(shell git rev-parse HEAD)
+SHORT_SHA := $(shell echo ${GIT_FULL_SHA} | cut -c1-8)
+PKG_VERSION := "3.20.1"
+
+BUILD_LABEL := $(DATE)-$(SHORT_SHA)
+VERSION_LABEL = v$(PKG_VERSION)
+ENV_LABEL ?= latest
+
+print-labels:
+	echo "ECS_CONTAINER_NAME=${ECS_CONTAINER_NAME}"
+	echo "PKG_VERSION=${PKG_VERSION}"
+	echo "BUILD_LABEL=${BUILD_LABEL}"
+	echo "VERSION_LABEL=${VERSION_LABEL}"
+	echo "ENV_LABEL=${ENV_LABEL}"
+
+docker-build:
+	# We need to use tar -czh to resolve the common dir symlink
+	cd .. && docker build -f Dockerfile.oonith \
+		--build-arg BRANCH_NAME=${VERSION_LABEL} \
+		-t ${IMAGE_NAME}:${BUILD_LABEL} \
+		-t ${IMAGE_NAME}:${VERSION_LABEL} \
+		-t ${IMAGE_NAME}:${ENV_LABEL} \
+		.
+
+	echo "built image: ${IMAGE_NAME}:${BUILD_LABEL} (${IMAGE_NAME}:${VERSION_LABEL} ${IMAGE_NAME}:${ENV_LABEL})"
+
+docker-push:
+	# We need to use tar -czh to resolve the common dir symlink
+	docker push ${IMAGE_NAME}:${BUILD_LABEL}
+	docker push ${IMAGE_NAME}:${VERSION_LABEL}
+	docker push ${IMAGE_NAME}:${ENV_LABEL}
+
+docker-smoketest:
+	echo "no smoketest implemented"
+
+imagedefinitions.json:
+	echo '[{"name":"${ECS_CONTAINER_NAME}","imageUri":"${IMAGE_NAME}:${BUILD_LABEL}"}]' > imagedefinitions.json
+
+test:
+	hatch run test
+
+test-cov:
+	hatch run test-cov
+
+build:
+	echo "no build implemented"
+
+clean:
+	rm -f imagedefinitions.json
+
+run:
+	echo "no run implemented"
+
+.PHONY: init test build clean docker print-labels

--- a/oonith/Makefile
+++ b/oonith/Makefile
@@ -54,6 +54,6 @@ clean:
 	rm -f imagedefinitions.json
 
 run:
-	echo "no run implemented"
+	cd .. && go run -tags netgo ./internal/cmd/oohelperd
 
 .PHONY: init test build clean docker print-labels

--- a/oonith/buildspec.yml
+++ b/oonith/buildspec.yml
@@ -1,0 +1,29 @@
+version: 0.2
+env:
+  variables:
+    OONI_CODE_PATH: oonith
+    DOCKERHUB_SECRET_ID: oonidevops/dockerhub/access_token
+
+phases:
+  install:
+    runtime-versions:
+      python: 3.11
+
+  pre_build:
+    commands:
+      - echo "Logging in to dockerhub"
+      - DOCKER_SECRET=$(aws secretsmanager get-secret-value --secret-id $DOCKERHUB_SECRET_ID --query SecretString --output text)
+      - echo $DOCKER_SECRET | docker login --username ooni --password-stdin
+
+  build:
+    commands:
+      - export GIT_FULL_SHA=${CODEBUILD_RESOLVED_SOURCE_VERSION}
+      - cd $OONI_CODE_PATH
+      - make docker-build
+      - make docker-smoketest
+      - make docker-push
+      - make imagedefinitions.json
+      - cat imagedefinitions.json | tee ${CODEBUILD_SRC_DIR}/imagedefinitions.json
+
+artifacts:
+  files: imagedefinitions.json


### PR DESCRIPTION
We implement the following changes:
* Move prometheus metric behind HTTP basic auth
* Read the prometheus password from the `PROMETHEUS_METRICS_PASSWORD` environment variable like we do for ooniapi-services
* Add Dockerfile to build oohelpderd
* Add codepipeline buildspec for oonihelpderd