### PR TITLE
fix(pkg/gobash/version.go): validate zip files content

### DIFF
--- a/.github/workflows/go1.22.yml
+++ b/.github/workflows/go1.22.yml
@@ -1,0 +1,24 @@
+# Runs the whole test suite using go1.22
+name: alltests-go1.22
+on:
+  pull_request:
+  push:
+    branches:
+      - "release/**"
+      - "fullbuild"
+      - "alltestsbuild"
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: magnetikonline/action-golang-cache@v4
+        with:
+          go-version: ~1.22
+          cache-key-suffix: "-alltests-go1.22"
+
+      # We cannot run buildtool tests using an unexpected version of Go because the
+      # tests check whether we're using the expected version of Go 😂😂😂😂.
+      - run: go test -race -tags shaping $(go list ./...|grep -v 'internal/cmd/buildtool')

--- a/.github/workflows/gobash.yml
+++ b/.github/workflows/gobash.yml
@@ -28,6 +28,7 @@ jobs:
           - "1.19" # debian 12 "bookworm"
           - "1.20"
           - "1.21"
+          - "1.22"
         system: [ubuntu-latest, macos-latest]
     runs-on: "${{ matrix.system }}"
     steps:

--- a/pkg/gobash/version.go
+++ b/pkg/gobash/version.go
@@ -260,7 +260,7 @@ func unpackZip(targetDir, archiveFile string) error {
 		// The validRelPath function rejects empty paths, paths containing backslash, paths
 		// starting with / and paths containing ../. Additionally, according to
 		// src/archive/zip/reader.go, the zip specification only allows files containing
-		// forward slashes and considers files containing backslashes to be inscure.
+		// forward slashes and considers files containing backslashes to be insecure.
 		//
 		// Therefore, by using validRelPath here, we should be able to fix the security alert.
 		if !validRelPath(f.Name) {


### PR DESCRIPTION
See https://github.com/ooni/probe-cli/security/code-scanning/12

While there, make sure we run tests using go1.22, which has been released in February while I was on leave.
