### PR TITLE
cleanup: use (*Session).NewSubmitter()

### DIFF
--- a/internal/cmd/oonireport/oonireport.go
+++ b/internal/cmd/oonireport/oonireport.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/engine"
 	"github.com/ooni/probe-cli/v3/internal/fsx"
 	"github.com/ooni/probe-cli/v3/internal/model"
-	"github.com/ooni/probe-cli/v3/internal/probeservices"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 	"github.com/ooni/probe-cli/v3/internal/version"
 	"github.com/pborman/getopt/v2"
@@ -43,8 +42,7 @@ const (
 )
 
 var (
-	path    string
-	control bool
+	path string
 )
 
 func fatalIfFalse(cond bool, msg string) {
@@ -89,11 +87,8 @@ func newSession(ctx context.Context) *engine.Session {
 }
 
 // new Submitter creates a probe services client and submitter
-func newSubmitter(sess *engine.Session, ctx context.Context) *probeservices.Submitter {
-	psc, err := sess.NewProbeServicesClient(ctx)
-	runtimex.PanicOnError(err, "error occurred while creating client")
-	submitter := probeservices.NewSubmitter(psc, sess.Logger())
-	return submitter
+func newSubmitter(sess *engine.Session, ctx context.Context) model.Submitter {
+	return runtimex.Try1(sess.NewSubmitter(ctx))
 }
 
 // toMeasurement loads an input string as model.Measurement
@@ -106,7 +101,7 @@ func toMeasurement(s string) *model.Measurement {
 
 // submitAll submits the measurements in input. Returns the count of submitted measurements, both
 // on success and on error, and the error that occurred (nil on success).
-func submitAll(ctx context.Context, lines []string, subm *probeservices.Submitter) (int, error) {
+func submitAll(ctx context.Context, lines []string, subm model.Submitter) (int, error) {
 	submitted := 0
 	for _, line := range lines {
 		mm := toMeasurement(line)

--- a/internal/engine/experiment.go
+++ b/internal/engine/experiment.go
@@ -250,7 +250,7 @@ func (e *experiment) OpenReportContext(ctx context.Context) error {
 			e.byteCounter,
 		),
 	}
-	client, err := e.session.NewProbeServicesClient(ctx)
+	client, err := e.session.newProbeServicesClient(ctx)
 	if err != nil {
 		e.session.logger.Debugf("%+v", err)
 		return err

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -318,7 +318,7 @@ func (s *Session) newProbeServicesClientForCheckIn(
 	if s.testNewProbeServicesClientForCheckIn != nil {
 		return s.testNewProbeServicesClientForCheckIn(ctx)
 	}
-	client, err := s.NewProbeServicesClient(ctx)
+	client, err := s.newProbeServicesClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -398,12 +398,12 @@ func (s *Session) NewExperimentBuilder(name string) (model.ExperimentBuilder, er
 	return eb, nil
 }
 
-// NewProbeServicesClient creates a new client for talking with the
+// newProbeServicesClient creates a new client for talking with the
 // OONI probe services. This function will benchmark the available
 // probe services, and select the fastest. In case all probe services
 // seem to be down, we try again applying circumvention tactics.
 // This function will fail IMMEDIATELY if given a cancelled context.
-func (s *Session) NewProbeServicesClient(ctx context.Context) (*probeservices.Client, error) {
+func (s *Session) newProbeServicesClient(ctx context.Context) (*probeservices.Client, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err() // helps with testing
 	}
@@ -421,7 +421,7 @@ func (s *Session) NewProbeServicesClient(ctx context.Context) (*probeservices.Cl
 
 // NewSubmitter creates a new submitter instance.
 func (s *Session) NewSubmitter(ctx context.Context) (Submitter, error) {
-	psc, err := s.NewProbeServicesClient(ctx)
+	psc, err := s.newProbeServicesClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -431,7 +431,7 @@ func (s *Session) NewSubmitter(ctx context.Context) (Submitter, error) {
 // newOrchestraClient creates a new orchestra client. This client is registered
 // and logged in with the OONI orchestra. An error is returned on failure.
 func (s *Session) newOrchestraClient(ctx context.Context) (*probeservices.Client, error) {
-	clnt, err := s.NewProbeServicesClient(ctx)
+	clnt, err := s.newProbeServicesClient(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oonimkall/session.go
+++ b/pkg/oonimkall/session.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/kvstore"
 	"github.com/ooni/probe-cli/v3/internal/legacy/assetsdir"
 	"github.com/ooni/probe-cli/v3/internal/model"
-	"github.com/ooni/probe-cli/v3/internal/probeservices"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
 
@@ -127,7 +126,7 @@ type Session struct {
 
 	cl        []context.CancelFunc
 	mtx       sync.Mutex
-	submitter *probeservices.Submitter
+	submitter model.Submitter
 	sessp     *engine.Session
 }
 
@@ -306,11 +305,11 @@ func (sess *Session) Submit(ctx *Context, measurement string) (*SubmitMeasuremen
 	sess.mtx.Lock()
 	defer sess.mtx.Unlock()
 	if sess.submitter == nil {
-		psc, err := sess.sessp.NewProbeServicesClient(ctx.ctx)
+		submitter, err := sess.sessp.NewSubmitter(ctx.ctx)
 		if err != nil {
 			return nil, err
 		}
-		sess.submitter = probeservices.NewSubmitter(psc, sess.sessp.Logger())
+		sess.submitter = submitter
 	}
 	var mm model.Measurement
 	if err := json.Unmarshal([]byte(measurement), &mm); err != nil {


### PR DESCRIPTION
This diff modifies existing code to use (*Session).NewSubmitter() rather than using (*Session).NewProbeServicesClient() and then using (*probeservices.Client).NewSubmitter().

After this change, we're able to hide (*Session).NewProbeServicesClient() and we've reduced the API surface used by clients.

Ideally, we would like clients to only use the engine API. In turn, this will simplify documenting the interactions with the probe services API.

Part of https://github.com/ooni/probe/issues/2700

