### PR TITLE
feat: add health check response for oohelperd

### DIFF
--- a/internal/oohelperd/handler.go
+++ b/internal/oohelperd/handler.go
@@ -148,7 +148,20 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		version.Version,
 	))
 
-	// we only handle the POST method
+	// handle GET method for health check
+	if req.Method == "GET" {
+		metricRequestsCount.WithLabelValues("200", "ok").Inc()
+		resp := map[string]string{
+			"message": "Hello OONItarian!",
+		}
+		data, err := json.Marshal(resp)
+		runtimex.PanicOnError(err, "json.Marshal failed")
+		w.Header().Add("Content-Type", "application/json")
+		w.Write(data)
+		return
+	}
+
+	// we only handle the POST method for response generation
 	if req.Method != "POST" {
 		metricRequestsCount.WithLabelValues("400", "bad_request_method").Inc()
 		w.WriteHeader(400)

--- a/internal/oohelperd/handler_test.go
+++ b/internal/oohelperd/handler_test.go
@@ -100,12 +100,20 @@ func TestHandlerWorkingAsIntended(t *testing.T) {
 
 	expectations := []expectationSpec{{
 		name:            "check for invalid method",
-		reqMethod:       "GET",
+		reqMethod:       "PUT",
 		reqContentType:  "",
 		reqBody:         strings.NewReader(""),
 		respStatusCode:  400,
 		respContentType: "",
 		parseBody:       false,
+	}, {
+		name:            "check for health message",
+		reqMethod:       "GET",
+		reqContentType:  "",
+		reqBody:         strings.NewReader(""),
+		respStatusCode:  200,
+		respContentType: "application/json",
+		parseBody:       true,
 	}, {
 		name:           "check for error reading request body",
 		reqMethod:      "POST",


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [ ] reference issue for this pull request: <!-- add URL here -->
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [x] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff adds a `GET` response for the oohelperd service which passes as a health check in the AWS codepipeline while spinning up targets 
