### PR TITLE
cleanup: SaveMeasurement doesn't belong to Experiment

### DIFF
--- a/cmd/ooniprobe/internal/nettests/nettests.go
+++ b/cmd/ooniprobe/internal/nettests/nettests.go
@@ -231,7 +231,7 @@ func (c *Controller) Run(builder model.ExperimentBuilder, inputs []string) error
 		}
 		// We only save the measurement to disk if we failed to upload the measurement
 		if saveToDisk {
-			if err := exp.SaveMeasurement(measurement, msmt.MeasurementFilePath.String); err != nil {
+			if err := engine.SaveMeasurement(measurement, msmt.MeasurementFilePath.String); err != nil {
 				return errors.Wrap(err, "failed to save measurement on disk")
 			}
 		}

--- a/internal/model/experiment.go
+++ b/internal/model/experiment.go
@@ -196,11 +196,6 @@ type Experiment interface {
 	// when used with an asynchronous experiment.
 	MeasureWithContext(ctx context.Context, input string) (measurement *Measurement, err error)
 
-	// SaveMeasurement saves a measurement on the specified file path.
-	//
-	// Deprecated: new code should use a Saver.
-	SaveMeasurement(measurement *Measurement, filePath string) error
-
 	// SubmitAndUpdateMeasurementContext submits a measurement and updates the
 	// fields whose value has changed as part of the submission.
 	//

--- a/internal/oonirun/experiment.go
+++ b/internal/oonirun/experiment.go
@@ -166,10 +166,9 @@ func (ed *Experiment) newSaver(experiment model.Experiment) (engine.Saver, error
 		return ed.newSaverFn(experiment)
 	}
 	return engine.NewSaver(engine.SaverConfig{
-		Enabled:    !ed.NoJSON,
-		Experiment: experiment,
-		FilePath:   ed.ReportFile,
-		Logger:     ed.Session.Logger(),
+		Enabled:  !ed.NoJSON,
+		FilePath: ed.ReportFile,
+		Logger:   ed.Session.Logger(),
 	})
 }
 


### PR DESCRIPTION
This cleanup may be a bit tangential, but it still makes sense in the context of what I'm doing, i.e., cleaning up the engine API and ensuring we mostly use engine functionality in clients.

While doing this, it occurred to me that I could avoid keeping the SaveMeasurement method attached to an experiment, and I could instead just make it a pure function.

This reduces the complexity of the *engine.Experiment type.

While there, slightly improve testing.

Part of https://github.com/ooni/probe/issues/2700
