### PR TITLE
hack: allow using new collector with SNI overrides

### DIFF
--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -352,6 +352,20 @@ func (s *Session) doClose() {
 func (s *Session) GetTestHelpersByName(name string) ([]model.OOAPIService, bool) {
 	defer s.mu.Unlock()
 	s.mu.Lock()
+
+	// TODO(https://github.com/ooni/probe/issues/2703): this change is a quick hack to
+	// make sure we have a way of testing the new TH deployment.
+	//
+	// We definitely NOT MEAN to merge this set of changes.
+	if th := os.Getenv("OONI_WEB_CONNECTIVITY_TH_URL"); th != "" {
+		custom := []model.OOAPIService{{
+			Address: th,
+			Type:    "https",
+			Front:   "",
+		}}
+		return custom, true
+	}
+
 	services, ok := s.availableTestHelpers[name]
 	return services, ok
 }

--- a/internal/enginenetx/bridgespolicy.go
+++ b/internal/enginenetx/bridgespolicy.go
@@ -62,6 +62,7 @@ var bridgesPolicyTestHelpersDomains = []string{
 	"2.th.ooni.org",
 	"3.th.ooni.org",
 	"d33d1gs9kpq1c5.cloudfront.net",
+	"oohelperd.th.prod.ooni.io",
 }
 
 // TODO(bassosimone): this would be slices.Contains when we'll use go1.21


### PR DESCRIPTION
This PR is not meant to be merged. Rather it documents testing the new TH deployment.

See https://github.com/ooni/probe/issues/2703
