### PR TITLE
refactor: MeasurementTarget -> MeasurementInput

### DIFF
--- a/internal/engine/experiment.go
+++ b/internal/engine/experiment.go
@@ -197,7 +197,7 @@ func (e *experiment) newMeasurement(input string) *model.Measurement {
 	utctimenow := time.Now().UTC()
 	m := &model.Measurement{
 		DataFormatVersion:         model.OOAPIReportDefaultDataFormatVersion,
-		Input:                     model.MeasurementTarget(input),
+		Input:                     model.MeasurementInput(input),
 		MeasurementStartTime:      utctimenow.Format(model.MeasurementDateFormat),
 		MeasurementStartTimeSaved: utctimenow,
 		ProbeIP:                   model.DefaultProbeIP,

--- a/internal/experiment/dnscheck/dnscheck_test.go
+++ b/internal/experiment/dnscheck/dnscheck_test.go
@@ -182,7 +182,7 @@ func TestDNSCheckWait(t *testing.T) {
 	}
 	measurer := &Measurer{Endpoints: endpoints}
 	run := func(input string) {
-		measurement := model.Measurement{Input: model.MeasurementTarget(input)}
+		measurement := model.Measurement{Input: model.MeasurementInput(input)}
 		args := &model.ExperimentArgs{
 			Callbacks:   model.NewPrinterCallbacks(log.Log),
 			Measurement: &measurement,

--- a/internal/experiment/dnsping/dnsping_test.go
+++ b/internal/experiment/dnsping/dnsping_test.go
@@ -56,7 +56,7 @@ func TestMeasurer_run(t *testing.T) {
 		}
 		ctx := context.Background()
 		meas := &model.Measurement{
-			Input: model.MeasurementTarget(input),
+			Input: model.MeasurementInput(input),
 		}
 		sess := &mocks.Session{
 			MockLogger: func() model.Logger { return model.DiscardLogger },

--- a/internal/experiment/psiphon/psiphon_test.go
+++ b/internal/experiment/psiphon/psiphon_test.go
@@ -51,7 +51,7 @@ func TestRunWithCancelledContext(t *testing.T) {
 func TestRunWithCustomInputAndCancelledContext(t *testing.T) {
 	expected := "http://x.org"
 	measurement := &model.Measurement{
-		Input: model.MeasurementTarget(expected),
+		Input: model.MeasurementInput(expected),
 	}
 	measurer := psiphon.NewExperimentMeasurer(psiphon.Config{})
 	measurer.(*psiphon.Measurer).BeforeGetHook = func(g urlgetter.Getter) {

--- a/internal/experiment/quicping/quicping_test.go
+++ b/internal/experiment/quicping/quicping_test.go
@@ -31,7 +31,7 @@ func TestInvalidHost(t *testing.T) {
 		Repetitions: 1,
 	})
 	measurement := new(model.Measurement)
-	measurement.Input = model.MeasurementTarget("a.a.a.a")
+	measurement.Input = model.MeasurementInput("a.a.a.a")
 	sess := &mockable.Session{MockableLogger: log.Log}
 	args := &model.ExperimentArgs{
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
@@ -55,7 +55,7 @@ func TestURLInput(t *testing.T) {
 		Repetitions: 1,
 	})
 	measurement := new(model.Measurement)
-	measurement.Input = model.MeasurementTarget("https://google.com/")
+	measurement.Input = model.MeasurementInput("https://google.com/")
 	sess := &mockable.Session{MockableLogger: log.Log}
 	args := &model.ExperimentArgs{
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
@@ -79,7 +79,7 @@ func TestSuccess(t *testing.T) {
 	}
 	measurer := NewExperimentMeasurer(Config{})
 	measurement := new(model.Measurement)
-	measurement.Input = model.MeasurementTarget("google.com")
+	measurement.Input = model.MeasurementInput("google.com")
 	sess := &mockable.Session{MockableLogger: log.Log}
 	args := &model.ExperimentArgs{
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
@@ -122,7 +122,7 @@ func TestWithCancelledContext(t *testing.T) {
 
 	measurer := NewExperimentMeasurer(Config{})
 	measurement := new(model.Measurement)
-	measurement.Input = model.MeasurementTarget("google.com")
+	measurement.Input = model.MeasurementInput("google.com")
 	sess := &mockable.Session{MockableLogger: log.Log}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -153,7 +153,7 @@ func TestListenFails(t *testing.T) {
 		},
 	})
 	measurement := new(model.Measurement)
-	measurement.Input = model.MeasurementTarget("google.com")
+	measurement.Input = model.MeasurementInput("google.com")
 	sess := &mockable.Session{MockableLogger: log.Log}
 	args := &model.ExperimentArgs{
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
@@ -201,7 +201,7 @@ func TestWriteFails(t *testing.T) {
 		Repetitions: 1,
 	})
 	measurement := new(model.Measurement)
-	measurement.Input = model.MeasurementTarget("google.com")
+	measurement.Input = model.MeasurementInput("google.com")
 	sess := &mockable.Session{MockableLogger: log.Log}
 	args := &model.ExperimentArgs{
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
@@ -262,7 +262,7 @@ func TestReadFails(t *testing.T) {
 		Repetitions: 1,
 	})
 	measurement := new(model.Measurement)
-	measurement.Input = model.MeasurementTarget("google.com")
+	measurement.Input = model.MeasurementInput("google.com")
 	sess := &mockable.Session{MockableLogger: log.Log}
 	args := &model.ExperimentArgs{
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
@@ -298,7 +298,7 @@ func TestNoResponse(t *testing.T) {
 		Repetitions: 1,
 	})
 	measurement := new(model.Measurement)
-	measurement.Input = model.MeasurementTarget("ooni.org")
+	measurement.Input = model.MeasurementInput("ooni.org")
 	sess := &mockable.Session{MockableLogger: log.Log}
 	args := &model.ExperimentArgs{
 		Callbacks:   model.NewPrinterCallbacks(log.Log),

--- a/internal/experiment/simplequicping/simplequicping_test.go
+++ b/internal/experiment/simplequicping/simplequicping_test.go
@@ -58,7 +58,7 @@ func TestMeasurerRun(t *testing.T) {
 		}
 
 		meas := &model.Measurement{
-			Input: model.MeasurementTarget(input),
+			Input: model.MeasurementInput(input),
 		}
 		sess := &mocks.Session{
 			MockLogger: func() model.Logger { return model.DiscardLogger },

--- a/internal/experiment/sniblocking/sniblocking.go
+++ b/internal/experiment/sniblocking/sniblocking.go
@@ -221,7 +221,7 @@ func processall(
 
 // maybeURLToSNI handles the case where the input is from the test-lists
 // and hence every input is a URL rather than a domain.
-func maybeURLToSNI(input model.MeasurementTarget) (model.MeasurementTarget, error) {
+func maybeURLToSNI(input model.MeasurementInput) (model.MeasurementInput, error) {
 	parsed, err := url.Parse(string(input))
 	if err != nil {
 		return "", err
@@ -229,7 +229,7 @@ func maybeURLToSNI(input model.MeasurementTarget) (model.MeasurementTarget, erro
 	if parsed.Path == string(input) {
 		return input, nil
 	}
-	return model.MeasurementTarget(parsed.Hostname()), nil
+	return model.MeasurementInput(parsed.Hostname()), nil
 }
 
 // Run implements ExperimentMeasurer.Run.

--- a/internal/experiment/sniblocking/sniblocking_test.go
+++ b/internal/experiment/sniblocking/sniblocking_test.go
@@ -445,7 +445,7 @@ func TestMeasurerRun(t *testing.T) {
 			})
 			measurer.(*Measurer).cache = cache
 			measurement := &model.Measurement{
-				Input: model.MeasurementTarget(testsni),
+				Input: model.MeasurementInput(testsni),
 			}
 			args := &model.ExperimentArgs{
 				Callbacks:   model.NewPrinterCallbacks(model.DiscardLogger),

--- a/internal/experiment/stunreachability/stunreachability_test.go
+++ b/internal/experiment/stunreachability/stunreachability_test.go
@@ -46,7 +46,7 @@ func TestRunWithoutInput(t *testing.T) {
 func TestRunWithInvalidURL(t *testing.T) {
 	measurer := NewExperimentMeasurer(Config{})
 	measurement := new(model.Measurement)
-	measurement.Input = model.MeasurementTarget("\t") // <- invalid URL
+	measurement.Input = model.MeasurementInput("\t") // <- invalid URL
 	args := &model.ExperimentArgs{
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
 		Measurement: measurement,
@@ -61,7 +61,7 @@ func TestRunWithInvalidURL(t *testing.T) {
 func TestRunWithNoPort(t *testing.T) {
 	measurer := NewExperimentMeasurer(Config{})
 	measurement := new(model.Measurement)
-	measurement.Input = model.MeasurementTarget("stun://stun.ekiga.net")
+	measurement.Input = model.MeasurementInput("stun://stun.ekiga.net")
 	args := &model.ExperimentArgs{
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
 		Measurement: measurement,
@@ -76,7 +76,7 @@ func TestRunWithNoPort(t *testing.T) {
 func TestRunWithUnsupportedURLScheme(t *testing.T) {
 	measurer := NewExperimentMeasurer(Config{})
 	measurement := new(model.Measurement)
-	measurement.Input = model.MeasurementTarget("https://stun.ekiga.net:3478")
+	measurement.Input = model.MeasurementInput("https://stun.ekiga.net:3478")
 	args := &model.ExperimentArgs{
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
 		Measurement: measurement,
@@ -95,7 +95,7 @@ func TestRunWithInput(t *testing.T) {
 
 	measurer := NewExperimentMeasurer(Config{})
 	measurement := new(model.Measurement)
-	measurement.Input = model.MeasurementTarget(defaultInput)
+	measurement.Input = model.MeasurementInput(defaultInput)
 	args := &model.ExperimentArgs{
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
 		Measurement: measurement,
@@ -127,7 +127,7 @@ func TestCancelledContext(t *testing.T) {
 	cancel() // immediately fail everything
 	measurer := NewExperimentMeasurer(Config{})
 	measurement := new(model.Measurement)
-	measurement.Input = model.MeasurementTarget(defaultInput)
+	measurement.Input = model.MeasurementInput(defaultInput)
 	args := &model.ExperimentArgs{
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
 		Measurement: measurement,
@@ -166,7 +166,7 @@ func TestNewClientFailure(t *testing.T) {
 	}
 	measurer := NewExperimentMeasurer(*config)
 	measurement := new(model.Measurement)
-	measurement.Input = model.MeasurementTarget(defaultInput)
+	measurement.Input = model.MeasurementInput(defaultInput)
 	args := &model.ExperimentArgs{
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
 		Measurement: measurement,
@@ -202,7 +202,7 @@ func TestStartFailure(t *testing.T) {
 	}
 	measurer := NewExperimentMeasurer(*config)
 	measurement := new(model.Measurement)
-	measurement.Input = model.MeasurementTarget(defaultInput)
+	measurement.Input = model.MeasurementInput(defaultInput)
 	args := &model.ExperimentArgs{
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
 		Measurement: measurement,
@@ -242,7 +242,7 @@ func TestReadFailure(t *testing.T) {
 	}
 	measurer := NewExperimentMeasurer(*config)
 	measurement := new(model.Measurement)
-	measurement.Input = model.MeasurementTarget(defaultInput)
+	measurement.Input = model.MeasurementInput(defaultInput)
 	args := &model.ExperimentArgs{
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
 		Measurement: measurement,

--- a/internal/experiment/tcpping/tcpping_test.go
+++ b/internal/experiment/tcpping/tcpping_test.go
@@ -46,7 +46,7 @@ func TestMeasurer_run(t *testing.T) {
 		}
 		ctx := context.Background()
 		meas := &model.Measurement{
-			Input: model.MeasurementTarget(input),
+			Input: model.MeasurementInput(input),
 		}
 		sess := &mocks.Session{
 			MockLogger: func() model.Logger { return model.DiscardLogger },

--- a/internal/experiment/tlsmiddlebox/measurer_test.go
+++ b/internal/experiment/tlsmiddlebox/measurer_test.go
@@ -30,7 +30,7 @@ func TestMeasurer_input_failure(t *testing.T) {
 			SNIControl: sniControl,
 		})
 		meas := &model.Measurement{
-			Input: model.MeasurementTarget(input),
+			Input: model.MeasurementInput(input),
 		}
 		sess := &mocks.Session{
 			MockLogger: func() model.Logger {

--- a/internal/experiment/tlsping/tlsping_test.go
+++ b/internal/experiment/tlsping/tlsping_test.go
@@ -58,7 +58,7 @@ func TestMeasurerRun(t *testing.T) {
 		}
 
 		meas := &model.Measurement{
-			Input: model.MeasurementTarget(input),
+			Input: model.MeasurementInput(input),
 		}
 		sess := &mocks.Session{
 			MockLogger: func() model.Logger { return model.DiscardLogger },

--- a/internal/inputparser/inputparser.go
+++ b/internal/inputparser/inputparser.go
@@ -50,7 +50,7 @@ var ErrUnsupportedScheme = errors.New("inputparser: unsupported URL.Scheme")
 
 // Parse parses the experiment input using the given config and returns
 // to the caller either the resulting URL or an error.
-func Parse(config *Config, input model.MeasurementTarget) (*url.URL, error) {
+func Parse(config *Config, input model.MeasurementInput) (*url.URL, error) {
 	runtimex.Assert(config != nil, "passed nil config")
 	runtimex.Assert(input != "", "passed empty input")
 

--- a/internal/inputparser/inputparser_test.go
+++ b/internal/inputparser/inputparser_test.go
@@ -20,7 +20,7 @@ func TestParse(t *testing.T) {
 		config *Config
 
 		// input is the MANDATORY string-format input-URL to parse.
-		input model.MeasurementTarget
+		input model.MeasurementInput
 
 		// expectURL is the OPTIONAL URL we expect in output.
 		expectURL *url.URL

--- a/internal/model/experiment.go
+++ b/internal/model/experiment.go
@@ -60,7 +60,7 @@ type ExperimentAsyncTestKeys struct {
 	Extensions map[string]int64
 
 	// Input is the input this measurement refers to.
-	Input MeasurementTarget
+	Input MeasurementInput
 
 	// MeasurementRuntime is the total measurement runtime.
 	MeasurementRuntime float64

--- a/internal/model/measurement.go
+++ b/internal/model/measurement.go
@@ -57,7 +57,7 @@ func MeasurementFormatTimeNowUTC() string {
 // MeasurementInput is the target of a OONI measurement.
 type MeasurementInput string
 
-// MarshalJSON serializes the MeasurementTarget.
+// MarshalJSON serializes the [MeasurementInput].
 func (t MeasurementInput) MarshalJSON() ([]byte, error) {
 	if t == "" {
 		return json.Marshal(nil)

--- a/internal/model/measurement.go
+++ b/internal/model/measurement.go
@@ -54,11 +54,11 @@ func MeasurementFormatTimeNowUTC() string {
 	return time.Now().UTC().Format(MeasurementDateFormat)
 }
 
-// MeasurementTarget is the target of a OONI measurement.
-type MeasurementTarget string
+// MeasurementInput is the target of a OONI measurement.
+type MeasurementInput string
 
 // MarshalJSON serializes the MeasurementTarget.
-func (t MeasurementTarget) MarshalJSON() ([]byte, error) {
+func (t MeasurementInput) MarshalJSON() ([]byte, error) {
 	if t == "" {
 		return json.Marshal(nil)
 	}
@@ -84,7 +84,7 @@ type Measurement struct {
 	ID string `json:"id,omitempty"`
 
 	// Input is the measurement input
-	Input MeasurementTarget `json:"input"`
+	Input MeasurementInput `json:"input"`
 
 	// InputHashes contains input hashes
 	InputHashes []string `json:"input_hashes,omitempty"`

--- a/internal/model/measurement.go
+++ b/internal/model/measurement.go
@@ -54,7 +54,7 @@ func MeasurementFormatTimeNowUTC() string {
 	return time.Now().UTC().Format(MeasurementDateFormat)
 }
 
-// MeasurementInput is the target of a OONI measurement.
+// MeasurementInput is the input of an OONI measurement.
 type MeasurementInput string
 
 // MarshalJSON serializes the [MeasurementInput].

--- a/internal/model/measurement_test.go
+++ b/internal/model/measurement_test.go
@@ -21,7 +21,7 @@ func TestMeasurementFormatTimeNowUTC(t *testing.T) {
 }
 
 func TestMeasurementTargetMarshalJSON(t *testing.T) {
-	var mt MeasurementTarget
+	var mt MeasurementInput
 	data, err := json.Marshal(mt)
 	if err != nil {
 		t.Fatal(err)
@@ -83,7 +83,7 @@ func makeMeasurement(config makeMeasurementConfig) *Measurement {
 	return &Measurement{
 		DataFormatVersion:    "0.3.0",
 		ID:                   "bdd20d7a-bba5-40dd-a111-9863d7908572",
-		Input:                MeasurementTarget(config.Input),
+		Input:                MeasurementInput(config.Input),
 		MeasurementStartTime: "2018-11-01 15:33:20",
 		ProbeIP:              config.ProbeIP,
 		ProbeASN:             config.ProbeASN,

--- a/internal/model/measurement_test.go
+++ b/internal/model/measurement_test.go
@@ -20,7 +20,7 @@ func TestMeasurementFormatTimeNowUTC(t *testing.T) {
 	})
 }
 
-func TestMeasurementTargetMarshalJSON(t *testing.T) {
+func TestMeasurementInputMarshalJSON(t *testing.T) {
 	var mt MeasurementInput
 	data, err := json.Marshal(mt)
 	if err != nil {

--- a/internal/oonirun/inputprocessor_test.go
+++ b/internal/oonirun/inputprocessor_test.go
@@ -28,7 +28,7 @@ func (fipe *FakeInputProcessorExperiment) MeasureAsync(
 	// is MERGING annotations as opposed to overwriting them.
 	m.AddAnnotation("antani", "antani")
 	m.AddAnnotation("foo", "baz") // would be bar below
-	m.Input = model.MeasurementTarget(input)
+	m.Input = model.MeasurementInput(input)
 	fipe.M = append(fipe.M, m)
 	out := make(chan *model.Measurement)
 	go func() {

--- a/internal/webconnectivityqa/measurement.go
+++ b/internal/webconnectivityqa/measurement.go
@@ -15,7 +15,7 @@ func newMeasurement(input string, measurer model.ExperimentMeasurer, t0 time.Tim
 		DataFormatVersion:         "0.2.0",
 		Extensions:                nil,
 		ID:                        "",
-		Input:                     model.MeasurementTarget(input),
+		Input:                     model.MeasurementInput(input),
 		InputHashes:               nil,
 		MeasurementStartTime:      t0.Format(model.MeasurementDateFormat),
 		MeasurementStartTimeSaved: t0,


### PR DESCRIPTION
While starting to work on richer input, I realised that it would be very handy to reserve the name "target" to describe a richer input target as the tuple containing options and some input.

However, using such a naming would ~clash with the definition of MeasurementTarget, which is a string definition that is only there to say semantically that the Input field of a measurement is the "thing" that we measure, as well as to apply a specific JSON serialization policy that is consistent with the historical behavior of OONI Probe.

Therefore, for making semantic space for a richer input target, I am going to refactor MeasurementTarget to be MeasurementInput.

No functional change.

Part of https://github.com/ooni/probe/issues/2607.