### PR TITLE
CODEOWNERS: add @DecFox

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bassosimone @hellais
+* @bassosimone @hellais @DecFox


### PR DESCRIPTION
This commit adds @DecFox as a code owner for the probe-cli repository.