### PR TITLE
cleanup: remove asynchronous experiments

### DIFF
--- a/internal/engine/experiment.go
+++ b/internal/engine/experiment.go
@@ -96,104 +96,6 @@ func (e *experiment) ReportID() string {
 	return report.ReportID()
 }
 
-// experimentAsyncWrapper makes a sync experiment behave like it was async
-type experimentAsyncWrapper struct {
-	*experiment
-}
-
-var _ model.ExperimentMeasurerAsync = &experimentAsyncWrapper{}
-
-// RunAsync implements ExperimentMeasurerAsync.RunAsync.
-func (eaw *experimentAsyncWrapper) RunAsync(
-	ctx context.Context, sess model.ExperimentSession, input string,
-	callbacks model.ExperimentCallbacks) (<-chan *model.ExperimentAsyncTestKeys, error) {
-	out := make(chan *model.ExperimentAsyncTestKeys)
-	measurement := eaw.experiment.newMeasurement(input)
-	start := time.Now()
-	args := &model.ExperimentArgs{
-		Callbacks:   eaw.callbacks,
-		Measurement: measurement,
-		Session:     eaw.session,
-	}
-	err := eaw.experiment.measurer.Run(ctx, args)
-	stop := time.Now()
-	if err != nil {
-		return nil, err
-	}
-	go func() {
-		defer close(out) // signal the reader we're done!
-		out <- &model.ExperimentAsyncTestKeys{
-			Extensions:         measurement.Extensions,
-			Input:              measurement.Input,
-			MeasurementRuntime: stop.Sub(start).Seconds(),
-			TestKeys:           measurement.TestKeys,
-			TestHelpers:        measurement.TestHelpers,
-		}
-	}()
-	return out, nil
-}
-
-// MeasureAsync implements [model.Experiment].
-func (e *experiment) MeasureAsync(
-	ctx context.Context, input string) (<-chan *model.Measurement, error) {
-	err := e.session.MaybeLookupLocationContext(ctx) // this already tracks session bytes
-	if err != nil {
-		return nil, err
-	}
-	ctx = bytecounter.WithSessionByteCounter(ctx, e.session.byteCounter)
-	ctx = bytecounter.WithExperimentByteCounter(ctx, e.byteCounter)
-	var async model.ExperimentMeasurerAsync
-	if v, okay := e.measurer.(model.ExperimentMeasurerAsync); okay {
-		async = v
-	} else {
-		async = &experimentAsyncWrapper{e}
-	}
-	in, err := async.RunAsync(ctx, e.session, input, e.callbacks)
-	if err != nil {
-		return nil, err
-	}
-	out := make(chan *model.Measurement)
-	go func() {
-		defer close(out) // we need to signal the consumer we're done
-		for tk := range in {
-			measurement := e.newMeasurement(input)
-			measurement.Extensions = tk.Extensions
-			measurement.Input = tk.Input
-			measurement.MeasurementRuntime = tk.MeasurementRuntime
-			measurement.TestHelpers = tk.TestHelpers
-			measurement.TestKeys = tk.TestKeys
-			if err := model.ScrubMeasurement(measurement, e.session.ProbeIP()); err != nil {
-				// If we fail to scrub the measurement then we are not going to
-				// submit it. Most likely causes of error here are unlikely,
-				// e.g., the TestKeys being not serializable.
-				e.session.Logger().Warnf("can't scrub measurement: %s", err.Error())
-				continue
-			}
-			out <- measurement
-		}
-	}()
-	return out, nil
-}
-
-// MeasureWithContext implements [model.Experiment].
-func (e *experiment) MeasureWithContext(
-	ctx context.Context, input string,
-) (measurement *model.Measurement, err error) {
-	out, err := e.MeasureAsync(ctx, input)
-	if err != nil {
-		return nil, err
-	}
-	for m := range out {
-		if measurement == nil {
-			measurement = m // as documented just return the first one
-		}
-	}
-	if measurement == nil {
-		err = errors.New("experiment returned no measurements")
-	}
-	return
-}
-
 // SubmitAndUpdateMeasurementContext implements [model.Experiment].
 func (e *experiment) SubmitAndUpdateMeasurementContext(
 	ctx context.Context, measurement *model.Measurement) error {
@@ -275,6 +177,79 @@ func (e *experiment) OpenReportContext(ctx context.Context) error {
 	// on success, assign the new report
 	e.mrep.Set(report)
 	return nil
+}
+
+// MeasureWithContext implements [model.Experiment].
+func (e *experiment) MeasureWithContext(ctx context.Context, input string) (*model.Measurement, error) {
+	// Here we ensure that we have already looked up the probe location
+	// information such that we correctly populate the measurement and also
+	// VERY IMPORTANTLY to scrub the IP address from the measurement.
+	//
+	// Also, this SHOULD happen before wrapping the context for byte counting
+	// since MaybeLookupLocationContext already accounts for bytes I/O.
+	//
+	// TODO(bassosimone,DecFox): historically we did this only for measuring
+	// and not for opening a report, which probably is not correct. Because the
+	// function call is idempotent, call it also when opening a report?
+	if err := e.session.MaybeLookupLocationContext(ctx); err != nil {
+		return nil, err
+	}
+
+	// Tweak the context such that the bytes sent and received are accounted
+	// to both the session's byte counter and to the experiment's byte counter.
+	ctx = bytecounter.WithSessionByteCounter(ctx, e.session.byteCounter)
+	ctx = bytecounter.WithExperimentByteCounter(ctx, e.byteCounter)
+
+	// Create a new measurement that the experiment measurer will finish filling
+	// by adding the test keys etc. Please, note that, as of 2024-06-05, we're using
+	// the measurement Input to provide input to an experiment. We'll probably
+	// change this, when we'll have finished implementing richer input.
+	measurement := e.newMeasurement(input)
+
+	// Record when we started the experiment, to compute the runtime.
+	start := time.Now()
+
+	// Prepare the arguments for the experiment measurer
+	args := &model.ExperimentArgs{
+		Callbacks:   e.callbacks,
+		Measurement: measurement,
+		Session:     e.session,
+	}
+
+	// Invoke the measurer. Conventionally, an error being returned here
+	// indicates that something went wrong during the measurement. For example,
+	// it could be that the user provided us with a malformed input. In case
+	// there's censorship, by all means the experiment should return a nil error
+	// and fill the measurement accordingly.
+	err := e.measurer.Run(ctx, args)
+
+	// Record when the experiment finished running.
+	stop := time.Now()
+
+	// Handle the case where there was a fundamental error.
+	if err != nil {
+		return nil, err
+	}
+
+	// Make sure we record the measurement runtime.
+	measurement.MeasurementRuntime = stop.Sub(start).Seconds()
+
+	// Scub the measurement removing the probe IP addr from it. We are 100% sure we know
+	// our own IP addr, since we called MaybeLookupLocation above. Obviously, we aren't
+	// going to submit the measurement in case we can't scrub it, so we just return an error
+	// if this specific corner case happens.
+	//
+	// TODO(bassosimone,DecFox): a dual stack client MAY be such that we discover its IPv4
+	// address but the IPv6 address is present inside the measurement. We should ensure that
+	// we improve our discovering capabilities to also cover this specific case.
+	if err := model.ScrubMeasurement(measurement, e.session.ProbeIP()); err != nil {
+		e.session.Logger().Warnf("can't scrub measurement: %s", err.Error())
+		return nil, err
+	}
+
+	// We're all good! Let us return the measurement to the caller, which will
+	// addtionally take care that we're submitting it, if needed.
+	return measurement, nil
 }
 
 func (e *experiment) newReportTemplate() model.OOAPIReportTemplate {

--- a/internal/engine/experiment.go
+++ b/internal/engine/experiment.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"net/http"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/bytecounter"
@@ -18,24 +19,52 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/version"
 )
 
-// experiment implements Experiment.
+// experimentMutableReport is the mutable experiment.report field.
+//
+// We isolate this into a separate data structure to ease code management. By using this
+// pattern, we don't need to be concerned with locking mutexes multiple times and it's just
+// a matter of using public methods exported by this struct, which are goroutine safe.
+type experimentMutableReport struct {
+	mu     sync.Mutex
+	report probeservices.ReportChannel
+}
+
+// Set atomically sets the report possibly overriding a previously set report.
+//
+// This method is goroutine safe.
+func (emr *experimentMutableReport) Set(report probeservices.ReportChannel) {
+	emr.mu.Lock()
+	emr.report = report
+	emr.mu.Unlock()
+}
+
+// Get atomically gets the report possibly returning nil.
+func (emr *experimentMutableReport) Get() (report probeservices.ReportChannel) {
+	emr.mu.Lock()
+	report = emr.report
+	emr.mu.Unlock()
+	return
+}
+
+// experiment implements [model.Experiment].
 type experiment struct {
 	byteCounter   *bytecounter.Counter
 	callbacks     model.ExperimentCallbacks
 	measurer      model.ExperimentMeasurer
-	report        probeservices.ReportChannel
+	mrep          *experimentMutableReport
 	session       *Session
 	testName      string
 	testStartTime string
 	testVersion   string
 }
 
-// newExperiment creates a new experiment given a measurer.
+// newExperiment creates a new [*experiment] given a [model.ExperimentMeasurer].
 func newExperiment(sess *Session, measurer model.ExperimentMeasurer) *experiment {
 	return &experiment{
 		byteCounter:   bytecounter.New(),
 		callbacks:     model.NewPrinterCallbacks(sess.Logger()),
 		measurer:      measurer,
+		mrep:          &experimentMutableReport{},
 		session:       sess,
 		testName:      measurer.ExperimentName(),
 		testStartTime: model.MeasurementFormatTimeNowUTC(),
@@ -43,46 +72,28 @@ func newExperiment(sess *Session, measurer model.ExperimentMeasurer) *experiment
 	}
 }
 
-// KibiBytesReceived implements Experiment.KibiBytesReceived.
+// KibiBytesReceived implements [model.Experiment].
 func (e *experiment) KibiBytesReceived() float64 {
 	return e.byteCounter.KibiBytesReceived()
 }
 
-// KibiBytesSent implements Experiment.KibiBytesSent.
+// KibiBytesSent implements [model.Experiment].
 func (e *experiment) KibiBytesSent() float64 {
 	return e.byteCounter.KibiBytesSent()
 }
 
-// Name implements Experiment.Name.
+// Name implements [model.Experiment].
 func (e *experiment) Name() string {
 	return e.testName
 }
 
-// ExperimentMeasurementSummaryKeysNotImplemented is the [model.MeasurementSummary] we use when
-// the experiment TestKeys do not provide an implementation of [model.MeasurementSummary].
-type ExperimentMeasurementSummaryKeysNotImplemented struct{}
-
-var _ model.MeasurementSummaryKeys = &ExperimentMeasurementSummaryKeysNotImplemented{}
-
-// IsAnomaly implements MeasurementSummary.
-func (*ExperimentMeasurementSummaryKeysNotImplemented) Anomaly() bool {
-	return false
-}
-
-// MeasurementSummaryKeys returns the [model.MeasurementSummaryKeys] associated with a given measurement.
-func MeasurementSummaryKeys(m *model.Measurement) model.MeasurementSummaryKeys {
-	if tk, ok := m.TestKeys.(model.MeasurementSummaryKeysProvider); ok {
-		return tk.MeasurementSummaryKeys()
-	}
-	return &ExperimentMeasurementSummaryKeysNotImplemented{}
-}
-
-// ReportID implements Experiment.ReportID.
+// ReportID implements [model.Experiment].
 func (e *experiment) ReportID() string {
-	if e.report == nil {
+	report := e.mrep.Get()
+	if report == nil {
 		return ""
 	}
-	return e.report.ReportID()
+	return report.ReportID()
 }
 
 // experimentAsyncWrapper makes a sync experiment behave like it was async
@@ -122,7 +133,7 @@ func (eaw *experimentAsyncWrapper) RunAsync(
 	return out, nil
 }
 
-// MeasureAsync implements Experiment.MeasureAsync.
+// MeasureAsync implements [model.Experiment].
 func (e *experiment) MeasureAsync(
 	ctx context.Context, input string) (<-chan *model.Measurement, error) {
 	err := e.session.MaybeLookupLocationContext(ctx) // this already tracks session bytes
@@ -164,7 +175,7 @@ func (e *experiment) MeasureAsync(
 	return out, nil
 }
 
-// MeasureWithContext implements Experiment.MeasureWithContext.
+// MeasureWithContext implements [model.Experiment].
 func (e *experiment) MeasureWithContext(
 	ctx context.Context, input string,
 ) (measurement *model.Measurement, err error) {
@@ -183,13 +194,13 @@ func (e *experiment) MeasureWithContext(
 	return
 }
 
-// SubmitAndUpdateMeasurementContext implements Experiment.SubmitAndUpdateMeasurementContext.
-func (e *experiment) SubmitAndUpdateMeasurementContext(
-	ctx context.Context, measurement *model.Measurement) error {
-	if e.report == nil {
+// SubmitAndUpdateMeasurementContext implements [model.Experiment].
+func (e *experiment) SubmitAndUpdateMeasurementContext(ctx context.Context, m *model.Measurement) error {
+	report := e.mrep.Get()
+	if report == nil {
 		return errors.New("report is not open")
 	}
-	return e.report.SubmitMeasurement(ctx, measurement)
+	return report.SubmitMeasurement(ctx, m)
 }
 
 // newMeasurement creates a new measurement for this experiment with the given input.
@@ -228,9 +239,12 @@ func (e *experiment) newMeasurement(input string) *model.Measurement {
 
 // OpenReportContext implements Experiment.OpenReportContext.
 func (e *experiment) OpenReportContext(ctx context.Context) error {
-	if e.report != nil {
+	// handle the case where we already opened the report
+	report := e.mrep.Get()
+	if report != nil {
 		return nil // already open
 	}
+
 	// use custom client to have proper byte accounting
 	httpClient := &http.Client{
 		Transport: bytecounter.WrapHTTPTransport(
@@ -244,12 +258,21 @@ func (e *experiment) OpenReportContext(ctx context.Context) error {
 		return err
 	}
 	client.HTTPClient = httpClient // patch HTTP client to use
+
+	// create the report template to open the report
 	template := e.newReportTemplate()
-	e.report, err = client.OpenReport(ctx, template)
+
+	// attempt to open the report
+	report, err = client.OpenReport(ctx, template)
+
+	// handle the error case
 	if err != nil {
 		e.session.logger.Debugf("experiment: probe services error: %s", err.Error())
 		return err
 	}
+
+	// on success, assign the new report
+	e.mrep.Set(report)
 	return nil
 }
 
@@ -265,4 +288,23 @@ func (e *experiment) newReportTemplate() model.OOAPIReportTemplate {
 		TestStartTime:     e.testStartTime,
 		TestVersion:       e.testVersion,
 	}
+}
+
+// ExperimentMeasurementSummaryKeysNotImplemented is the [model.MeasurementSummary] we use when
+// the experiment TestKeys do not provide an implementation of [model.MeasurementSummary].
+type ExperimentMeasurementSummaryKeysNotImplemented struct{}
+
+var _ model.MeasurementSummaryKeys = &ExperimentMeasurementSummaryKeysNotImplemented{}
+
+// IsAnomaly implements MeasurementSummary.
+func (*ExperimentMeasurementSummaryKeysNotImplemented) Anomaly() bool {
+	return false
+}
+
+// MeasurementSummaryKeys returns the [model.MeasurementSummaryKeys] associated with a given measurement.
+func MeasurementSummaryKeys(m *model.Measurement) model.MeasurementSummaryKeys {
+	if tk, ok := m.TestKeys.(model.MeasurementSummaryKeysProvider); ok {
+		return tk.MeasurementSummaryKeys()
+	}
+	return &ExperimentMeasurementSummaryKeysNotImplemented{}
 }

--- a/internal/engine/experiment.go
+++ b/internal/engine/experiment.go
@@ -195,12 +195,13 @@ func (e *experiment) MeasureWithContext(
 }
 
 // SubmitAndUpdateMeasurementContext implements [model.Experiment].
-func (e *experiment) SubmitAndUpdateMeasurementContext(ctx context.Context, m *model.Measurement) error {
+func (e *experiment) SubmitAndUpdateMeasurementContext(
+	ctx context.Context, measurement *model.Measurement) error {
 	report := e.mrep.Get()
 	if report == nil {
 		return errors.New("report is not open")
 	}
-	return report.SubmitMeasurement(ctx, m)
+	return report.SubmitMeasurement(ctx, measurement)
 }
 
 // newMeasurement creates a new measurement for this experiment with the given input.

--- a/internal/engine/experiment.go
+++ b/internal/engine/experiment.go
@@ -234,7 +234,7 @@ func (e *experiment) MeasureWithContext(ctx context.Context, input string) (*mod
 	// Make sure we record the measurement runtime.
 	measurement.MeasurementRuntime = stop.Sub(start).Seconds()
 
-	// Scub the measurement removing the probe IP addr from it. We are 100% sure we know
+	// Scrub the measurement removing the probe IP addr from it. We are 100% sure we know
 	// our own IP addr, since we called MaybeLookupLocation above. Obviously, we aren't
 	// going to submit the measurement in case we can't scrub it, so we just return an error
 	// if this specific corner case happens.

--- a/internal/mocks/experiment.go
+++ b/internal/mocks/experiment.go
@@ -16,8 +16,6 @@ type Experiment struct {
 
 	MockReportID func() string
 
-	MockMeasureAsync func(ctx context.Context, input string) (<-chan *model.Measurement, error)
-
 	MockMeasureWithContext func(
 		ctx context.Context, input string) (measurement *model.Measurement, err error)
 
@@ -43,11 +41,6 @@ func (e *Experiment) Name() string {
 
 func (e *Experiment) ReportID() string {
 	return e.MockReportID()
-}
-
-func (e *Experiment) MeasureAsync(
-	ctx context.Context, input string) (<-chan *model.Measurement, error) {
-	return e.MockMeasureAsync(ctx, input)
 }
 
 func (e *Experiment) MeasureWithContext(

--- a/internal/mocks/experiment_test.go
+++ b/internal/mocks/experiment_test.go
@@ -57,22 +57,6 @@ func TestExperiment(t *testing.T) {
 		}
 	})
 
-	t.Run("MeasureAsync", func(t *testing.T) {
-		expected := errors.New("mocked err")
-		e := &Experiment{
-			MockMeasureAsync: func(ctx context.Context, input string) (<-chan *model.Measurement, error) {
-				return nil, expected
-			},
-		}
-		out, err := e.MeasureAsync(context.Background(), "xo")
-		if !errors.Is(err, expected) {
-			t.Fatal("unexpected err", err)
-		}
-		if out != nil {
-			t.Fatal("expected nil")
-		}
-	})
-
 	t.Run("MeasureWithContext", func(t *testing.T) {
 		expected := errors.New("mocked err")
 		e := &Experiment{

--- a/internal/oonirun/experiment.go
+++ b/internal/oonirun/experiment.go
@@ -242,12 +242,12 @@ type experimentWrapper struct {
 	total int
 }
 
-func (ew *experimentWrapper) MeasureAsync(
-	ctx context.Context, input string, idx int) (<-chan *model.Measurement, error) {
+func (ew *experimentWrapper) MeasureWithContext(
+	ctx context.Context, input string, idx int) (*model.Measurement, error) {
 	if input != "" {
 		ew.logger.Infof("[%d/%d] running with input: %s", idx+1, ew.total, input)
 	}
-	return ew.child.MeasureAsync(ctx, input, idx)
+	return ew.child.MeasureWithContext(ctx, input, idx)
 }
 
 // experimentSubmitterWrapper implements a submission policy where we don't

--- a/internal/oonirun/experiment_test.go
+++ b/internal/oonirun/experiment_test.go
@@ -49,16 +49,11 @@ func TestExperimentRunWithFailureToSubmitAndShuffle(t *testing.T) {
 					},
 					MockNewExperiment: func() model.Experiment {
 						exp := &mocks.Experiment{
-							MockMeasureAsync: func(ctx context.Context, input string) (<-chan *model.Measurement, error) {
-								out := make(chan *model.Measurement)
-								go func() {
-									defer close(out)
-									ff := &testingx.FakeFiller{}
-									var meas model.Measurement
-									ff.Fill(&meas)
-									out <- &meas
-								}()
-								return out, nil
+							MockMeasureWithContext: func(ctx context.Context, input string) (*model.Measurement, error) {
+								ff := &testingx.FakeFiller{}
+								var meas model.Measurement
+								ff.Fill(&meas)
+								return &meas, nil
 							},
 							MockKibiBytesReceived: func() float64 {
 								calledKibiBytesReceived++

--- a/internal/oonirun/inputprocessor.go
+++ b/internal/oonirun/inputprocessor.go
@@ -10,15 +10,13 @@ import (
 // InputProcessorExperiment is the Experiment
 // according to InputProcessor.
 type InputProcessorExperiment interface {
-	MeasureAsync(
-		ctx context.Context, input string) (<-chan *model.Measurement, error)
+	MeasureWithContext(ctx context.Context, input string) (*model.Measurement, error)
 }
 
 // InputProcessorExperimentWrapper is a wrapper for an
 // Experiment that also allow to pass around the input index.
 type InputProcessorExperimentWrapper interface {
-	MeasureAsync(
-		ctx context.Context, input string, idx int) (<-chan *model.Measurement, error)
+	MeasureWithContext(ctx context.Context, input string, idx int) (*model.Measurement, error)
 }
 
 // NewInputProcessorExperimentWrapper creates a new
@@ -32,9 +30,9 @@ type inputProcessorExperimentWrapper struct {
 	exp InputProcessorExperiment
 }
 
-func (ipew inputProcessorExperimentWrapper) MeasureAsync(
-	ctx context.Context, input string, idx int) (<-chan *model.Measurement, error) {
-	return ipew.exp.MeasureAsync(ctx, input)
+func (ipew inputProcessorExperimentWrapper) MeasureWithContext(
+	ctx context.Context, input string, idx int) (*model.Measurement, error) {
+	return ipew.exp.MeasureWithContext(ctx, input)
 }
 
 var _ InputProcessorExperimentWrapper = inputProcessorExperimentWrapper{}
@@ -142,29 +140,21 @@ func (ip *InputProcessor) run(ctx context.Context) (int, error) {
 			return stopMaxRuntime, nil
 		}
 		input := url.URL
-		var measurements []*model.Measurement
-		source, err := ip.Experiment.MeasureAsync(ctx, input, idx)
+		meas, err := ip.Experiment.MeasureWithContext(ctx, input, idx)
 		if err != nil {
 			return 0, err
 		}
-		// NOTE: we don't want to intermix measuring with submitting
-		// therefore we collect all measurements first
-		for meas := range source {
-			measurements = append(measurements, meas)
+		meas.AddAnnotations(ip.Annotations)
+		meas.Options = ip.Options
+		err = ip.Submitter.Submit(ctx, idx, meas)
+		if err != nil {
+			return 0, err
 		}
-		for _, meas := range measurements {
-			meas.AddAnnotations(ip.Annotations)
-			meas.Options = ip.Options
-			err = ip.Submitter.Submit(ctx, idx, meas)
-			if err != nil {
-				return 0, err
-			}
-			// Note: must be after submission because submission modifies
-			// the measurement to include the report ID.
-			err = ip.Saver.SaveMeasurement(idx, meas)
-			if err != nil {
-				return 0, err
-			}
+		// Note: must be after submission because submission modifies
+		// the measurement to include the report ID.
+		err = ip.Saver.SaveMeasurement(idx, meas)
+		if err != nil {
+			return 0, err
 		}
 	}
 	return stopNormal, nil

--- a/internal/oonirun/inputprocessor_test.go
+++ b/internal/oonirun/inputprocessor_test.go
@@ -15,8 +15,8 @@ type FakeInputProcessorExperiment struct {
 	M         []*model.Measurement
 }
 
-func (fipe *FakeInputProcessorExperiment) MeasureAsync(
-	ctx context.Context, input string) (<-chan *model.Measurement, error) {
+func (fipe *FakeInputProcessorExperiment) MeasureWithContext(
+	ctx context.Context, input string) (*model.Measurement, error) {
 	if fipe.Err != nil {
 		return nil, fipe.Err
 	}
@@ -30,12 +30,7 @@ func (fipe *FakeInputProcessorExperiment) MeasureAsync(
 	m.AddAnnotation("foo", "baz") // would be bar below
 	m.Input = model.MeasurementInput(input)
 	fipe.M = append(fipe.M, m)
-	out := make(chan *model.Measurement)
-	go func() {
-		defer close(out)
-		out <- m
-	}()
-	return out, nil
+	return m, nil
 }
 
 func TestInputProcessorMeasurementFailed(t *testing.T) {

--- a/internal/oonirun/v1_test.go
+++ b/internal/oonirun/v1_test.go
@@ -28,16 +28,11 @@ func newMinimalFakeSession() *mocks.Session {
 				},
 				MockNewExperiment: func() model.Experiment {
 					exp := &mocks.Experiment{
-						MockMeasureAsync: func(ctx context.Context, input string) (<-chan *model.Measurement, error) {
-							out := make(chan *model.Measurement)
-							go func() {
-								defer close(out)
-								ff := &testingx.FakeFiller{}
-								var meas model.Measurement
-								ff.Fill(&meas)
-								out <- &meas
-							}()
-							return out, nil
+						MockMeasureWithContext: func(ctx context.Context, input string) (*model.Measurement, error) {
+							ff := &testingx.FakeFiller{}
+							var meas model.Measurement
+							ff.Fill(&meas)
+							return &meas, nil
 						},
 						MockKibiBytesReceived: func() float64 {
 							return 1.1

--- a/internal/oonirun/v2_test.go
+++ b/internal/oonirun/v2_test.go
@@ -379,7 +379,7 @@ func TestV2MeasureDescriptor(t *testing.T) {
 				},
 				MockNewExperiment: func() model.Experiment {
 					exp := &mocks.Experiment{
-						MockMeasureAsync: func(ctx context.Context, input string) (<-chan *model.Measurement, error) {
+						MockMeasureWithContext: func(ctx context.Context, input string) (*model.Measurement, error) {
 							return nil, expected
 						},
 						MockKibiBytesReceived: func() float64 {


### PR DESCRIPTION
We originally developed asynchronous experiments as a mean to support websteps, a nettest that returned more than one measurement per invocation of its Measure method.

Since then, we removed websteps. Therefore, this code is currently technically unused. Additionally, this code further complicates implementing richer input, because it is another way of performing measurements.

As such, in the interest of switfly moving forward with richer input _and_ of simplifying the engine, we are now removing this unused functionality from the tree.

While there, better the documentation of OnProgress and undeprecate functions to open/close reports since it's clear that, for now, using a submitter in cmd/ooniprobe is a bit of a stretch given our current goals. So, it feels best to avoid deprecating until we have nice plan for replacement.

To have more confidence that the job we did is ~correct, we use the following table to cross compare the operations that we previously performed for running sync experiments (i.e., all experiments) in an async way to the code we're using after this diff to run experiments. (Note that the diff itself is such that you can easily see the deleted and the added code inside of the `experiment.go` file.) In both cases, we're looking at the operations performed starting from `MeasureWithContext`.

| Operation                   | Before | After |          
| --------------------------- | ------ | ----- |
| MaybeLookupLocationContext  | yes    | yes   |
| use e.session.byteCounter   | yes    | yes   |
| use e.byteCounter           | yes    | yes   |
| newMeasurement              | yes    | yes   |
| save start time             | yes    | yes   |
| initialize experiment args  | yes    | yes   |
| call measurer.Run           | yes    | yes   |
| save end time               | yes    | yes   |
| compute measurement runtime | yes    | yes   |
| scrub measurement           | yes    | yes   | 
| return measurement          | yes    | yes   |

Part of https://github.com/ooni/probe/issues/2607

Depends on https://github.com/ooni/probe-cli/pull/1612