### PR TITLE
refactor: construct TargetLoader using ExperimentBuilder

### DIFF
--- a/cmd/ooniprobe/internal/nettests/dnscheck.go
+++ b/cmd/ooniprobe/internal/nettests/dnscheck.go
@@ -4,23 +4,21 @@ import (
 	"context"
 
 	"github.com/ooni/probe-cli/v3/internal/model"
-	"github.com/ooni/probe-cli/v3/internal/targetloading"
 )
 
 // DNSCheck nettest implementation.
 type DNSCheck struct{}
 
-func (n DNSCheck) lookupURLs(ctl *Controller) ([]model.ExperimentTarget, error) {
-	targetloader := &targetloading.Loader{
+func (n DNSCheck) lookupURLs(ctl *Controller, builder model.ExperimentBuilder) ([]model.ExperimentTarget, error) {
+	config := &model.ExperimentTargetLoaderConfig{
 		CheckInConfig: &model.OOAPICheckInConfig{
 			// not needed because we have default static input in the engine
 		},
-		ExperimentName: "dnscheck",
-		InputPolicy:    model.InputOrStaticDefault,
-		Session:        ctl.Session,
-		SourceFiles:    ctl.InputFiles,
-		StaticInputs:   ctl.Inputs,
+		Session:      ctl.Session,
+		SourceFiles:  ctl.InputFiles,
+		StaticInputs: ctl.Inputs,
 	}
+	targetloader := builder.NewTargetLoader(config)
 	testlist, err := targetloader.Load(context.Background())
 	if err != nil {
 		return nil, err
@@ -34,7 +32,7 @@ func (n DNSCheck) Run(ctl *Controller) error {
 	if err != nil {
 		return err
 	}
-	urls, err := n.lookupURLs(ctl)
+	urls, err := n.lookupURLs(ctl, builder)
 	if err != nil {
 		return err
 	}

--- a/cmd/ooniprobe/internal/nettests/stunreachability.go
+++ b/cmd/ooniprobe/internal/nettests/stunreachability.go
@@ -4,23 +4,21 @@ import (
 	"context"
 
 	"github.com/ooni/probe-cli/v3/internal/model"
-	"github.com/ooni/probe-cli/v3/internal/targetloading"
 )
 
 // STUNReachability nettest implementation.
 type STUNReachability struct{}
 
-func (n STUNReachability) lookupURLs(ctl *Controller) ([]model.ExperimentTarget, error) {
-	targetloader := &targetloading.Loader{
+func (n STUNReachability) lookupURLs(ctl *Controller, builder model.ExperimentBuilder) ([]model.ExperimentTarget, error) {
+	config := &model.ExperimentTargetLoaderConfig{
 		CheckInConfig: &model.OOAPICheckInConfig{
 			// not needed because we have default static input in the engine
 		},
-		ExperimentName: "stunreachability",
-		InputPolicy:    model.InputOrStaticDefault,
-		Session:        ctl.Session,
-		SourceFiles:    ctl.InputFiles,
-		StaticInputs:   ctl.Inputs,
+		Session:      ctl.Session,
+		SourceFiles:  ctl.InputFiles,
+		StaticInputs: ctl.Inputs,
 	}
+	targetloader := builder.NewTargetLoader(config)
 	testlist, err := targetloader.Load(context.Background())
 	if err != nil {
 		return nil, err
@@ -34,7 +32,7 @@ func (n STUNReachability) Run(ctl *Controller) error {
 	if err != nil {
 		return err
 	}
-	urls, err := n.lookupURLs(ctl)
+	urls, err := n.lookupURLs(ctl, builder)
 	if err != nil {
 		return err
 	}

--- a/cmd/ooniprobe/internal/nettests/web_connectivity.go
+++ b/cmd/ooniprobe/internal/nettests/web_connectivity.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/apex/log"
 	"github.com/ooni/probe-cli/v3/internal/model"
-	"github.com/ooni/probe-cli/v3/internal/targetloading"
 )
 
-func (n WebConnectivity) lookupURLs(ctl *Controller, categories []string) ([]model.ExperimentTarget, error) {
-	targetloader := &targetloading.Loader{
+func (n WebConnectivity) lookupURLs(
+	ctl *Controller, builder model.ExperimentBuilder, categories []string) ([]model.ExperimentTarget, error) {
+	config := &model.ExperimentTargetLoaderConfig{
 		CheckInConfig: &model.OOAPICheckInConfig{
 			// Setting Charging and OnWiFi to true causes the CheckIn
 			// API to return to us as much URL as possible with the
@@ -21,12 +21,11 @@ func (n WebConnectivity) lookupURLs(ctl *Controller, categories []string) ([]mod
 				CategoryCodes: categories,
 			},
 		},
-		ExperimentName: "web_connectivity",
-		InputPolicy:    model.InputOrQueryBackend,
-		Session:        ctl.Session,
-		SourceFiles:    ctl.InputFiles,
-		StaticInputs:   ctl.Inputs,
+		Session:      ctl.Session,
+		SourceFiles:  ctl.InputFiles,
+		StaticInputs: ctl.Inputs,
 	}
+	targetloader := builder.NewTargetLoader(config)
 	testlist, err := targetloader.Load(context.Background())
 	if err != nil {
 		return nil, err
@@ -39,12 +38,12 @@ type WebConnectivity struct{}
 
 // Run starts the test
 func (n WebConnectivity) Run(ctl *Controller) error {
-	log.Debugf("Enabled category codes are the following %v", ctl.Probe.Config().Nettests.WebsitesEnabledCategoryCodes)
-	urls, err := n.lookupURLs(ctl, ctl.Probe.Config().Nettests.WebsitesEnabledCategoryCodes)
+	builder, err := ctl.Session.NewExperimentBuilder("web_connectivity")
 	if err != nil {
 		return err
 	}
-	builder, err := ctl.Session.NewExperimentBuilder("web_connectivity")
+	log.Debugf("Enabled category codes are the following %v", ctl.Probe.Config().Nettests.WebsitesEnabledCategoryCodes)
+	urls, err := n.lookupURLs(ctl, builder, ctl.Probe.Config().Nettests.WebsitesEnabledCategoryCodes)
 	if err != nil {
 		return err
 	}

--- a/internal/engine/experimentbuilder.go
+++ b/internal/engine/experimentbuilder.go
@@ -22,6 +22,8 @@ type experimentBuilder struct {
 	session *Session
 }
 
+var _ model.ExperimentBuilder = &experimentBuilder{}
+
 // Interruptible implements ExperimentBuilder.Interruptible.
 func (b *experimentBuilder) Interruptible() bool {
 	return b.factory.Interruptible()
@@ -58,6 +60,11 @@ func (b *experimentBuilder) NewExperiment() model.Experiment {
 	experiment := newExperiment(b.session, measurer)
 	experiment.callbacks = b.callbacks
 	return experiment
+}
+
+// NewTargetLoader creates a new [model.ExperimentTargetLoader] instance.
+func (b *experimentBuilder) NewTargetLoader(config *model.ExperimentTargetLoaderConfig) model.ExperimentTargetLoader {
+	return b.factory.NewTargetLoader(config)
 }
 
 // newExperimentBuilder creates a new experimentBuilder instance.

--- a/internal/engine/experimentbuilder_test.go
+++ b/internal/engine/experimentbuilder_test.go
@@ -1,1 +1,51 @@
 package engine
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ooni/probe-cli/v3/internal/model"
+)
+
+func TestExperimentBuilderEngineWebConnectivity(t *testing.T) {
+	// create a session for testing that does not use the network at all
+	sess := newSessionForTestingNoLookups(t)
+
+	// create an experiment builder for Web Connectivity
+	builder, err := sess.NewExperimentBuilder("WebConnectivity")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create suitable loader config
+	config := &model.ExperimentTargetLoaderConfig{
+		CheckInConfig: &model.OOAPICheckInConfig{
+			// nothing
+		},
+		Session:      sess,
+		StaticInputs: nil,
+		SourceFiles:  nil,
+	}
+
+	// create the loader
+	loader := builder.NewTargetLoader(config)
+
+	// create cancelled context to interrupt immediately so that we
+	// don't use the network when running this test
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// attempt to load targets
+	targets, err := loader.Load(ctx)
+
+	// make sure we've got the expected error
+	if !errors.Is(err, context.Canceled) {
+		t.Fatal("unexpected err", err)
+	}
+
+	// make sure there are no targets
+	if len(targets) != 0 {
+		t.Fatal("expected zero length targets")
+	}
+}

--- a/internal/experimentname/experimentname.go
+++ b/internal/experimentname/experimentname.go
@@ -1,0 +1,25 @@
+// Package experimentname contains code to manipulate experiment names.
+package experimentname
+
+import "github.com/ooni/probe-cli/v3/internal/strcasex"
+
+// Canonicalize allows code to provide experiment names
+// in a more flexible way, where we have aliases.
+//
+// Because we allow for uppercase experiment names for backwards
+// compatibility with MK, we need to add some exceptions here when
+// mapping (e.g., DNSCheck => dnscheck).
+func Canonicalize(name string) string {
+	switch name = strcasex.ToSnake(name); name {
+	case "ndt_7":
+		name = "ndt" // since 2020-03-18, we use ndt7 to implement ndt by default
+	case "dns_check":
+		name = "dnscheck"
+	case "stun_reachability":
+		name = "stunreachability"
+	case "web_connectivity@v_0_5":
+		name = "web_connectivity@v0.5"
+	default:
+	}
+	return name
+}

--- a/internal/experimentname/experimentname_test.go
+++ b/internal/experimentname/experimentname_test.go
@@ -1,0 +1,55 @@
+// Package experimentname contains code to manipulate experiment names.
+package experimentname
+
+import "testing"
+
+func TestCanonicalize(t *testing.T) {
+	tests := []struct {
+		input  string
+		expect string
+	}{
+		{
+			input:  "example",
+			expect: "example",
+		},
+		{
+			input:  "Example",
+			expect: "example",
+		},
+		{
+			input:  "ndt7",
+			expect: "ndt",
+		},
+		{
+			input:  "Ndt7",
+			expect: "ndt",
+		},
+		{
+			input:  "DNSCheck",
+			expect: "dnscheck",
+		},
+		{
+			input:  "dns_check",
+			expect: "dnscheck",
+		},
+		{
+			input:  "STUNReachability",
+			expect: "stunreachability",
+		},
+		{
+			input:  "stun_reachability",
+			expect: "stunreachability",
+		},
+		{
+			input:  "WebConnectivity@v0.5",
+			expect: "web_connectivity@v0.5",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := Canonicalize(tt.input); got != tt.expect {
+				t.Errorf("Canonicalize() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}

--- a/internal/mocks/experimentbuilder.go
+++ b/internal/mocks/experimentbuilder.go
@@ -17,7 +17,11 @@ type ExperimentBuilder struct {
 	MockSetCallbacks func(callbacks model.ExperimentCallbacks)
 
 	MockNewExperiment func() model.Experiment
+
+	MockNewTargetLoader func(config *model.ExperimentTargetLoaderConfig) model.ExperimentTargetLoader
 }
+
+var _ model.ExperimentBuilder = &ExperimentBuilder{}
 
 func (eb *ExperimentBuilder) Interruptible() bool {
 	return eb.MockInterruptible()
@@ -45,4 +49,8 @@ func (eb *ExperimentBuilder) SetCallbacks(callbacks model.ExperimentCallbacks) {
 
 func (eb *ExperimentBuilder) NewExperiment() model.Experiment {
 	return eb.MockNewExperiment()
+}
+
+func (eb *ExperimentBuilder) NewTargetLoader(config *model.ExperimentTargetLoaderConfig) model.ExperimentTargetLoader {
+	return eb.MockNewTargetLoader(config)
 }

--- a/internal/mocks/experimentbuilder_test.go
+++ b/internal/mocks/experimentbuilder_test.go
@@ -96,4 +96,16 @@ func TestExperimentBuilder(t *testing.T) {
 			t.Fatal("invalid result")
 		}
 	})
+
+	t.Run("NewTargetLoader", func(t *testing.T) {
+		tloader := &ExperimentTargetLoader{}
+		eb := &ExperimentBuilder{
+			MockNewTargetLoader: func(*model.ExperimentTargetLoaderConfig) model.ExperimentTargetLoader {
+				return tloader
+			},
+		}
+		if out := eb.NewTargetLoader(&model.ExperimentTargetLoaderConfig{}); out != tloader {
+			t.Fatal("invalid result")
+		}
+	})
 }

--- a/internal/model/experiment.go
+++ b/internal/model/experiment.go
@@ -232,8 +232,46 @@ type ExperimentBuilder interface {
 	// SetCallbacks sets the experiment's interactive callbacks.
 	SetCallbacks(callbacks ExperimentCallbacks)
 
-	// NewExperiment creates the experiment instance.
+	// NewExperiment creates the [Experiment] instance.
 	NewExperiment() Experiment
+
+	// NewTargetLoader creates the [ExperimentTargetLoader] instance.
+	NewTargetLoader(config *ExperimentTargetLoaderConfig) ExperimentTargetLoader
+}
+
+// ExperimentTargetLoaderConfig is the configuration to create a new [ExperimentTargetLoader].
+//
+// The zero value is not ready to use; please, init the MANDATORY fields.
+type ExperimentTargetLoaderConfig struct {
+	// CheckInConfig contains OPTIONAL options for the CheckIn API. If not set, then we'll create a
+	// default config. If set but there are fields inside it that are not set, then we will set them
+	// to a default value.
+	CheckInConfig *OOAPICheckInConfig
+
+	// Session is the MANDATORY current measurement session.
+	Session ExperimentTargetLoaderSession
+
+	// StaticInputs contains OPTIONAL input to be added
+	// to the resulting input list if possible.
+	StaticInputs []string
+
+	// SourceFiles contains OPTIONAL files to read input
+	// from. Each file should contain a single input string
+	// per line. We will fail if any file is unreadable
+	// as well as if any file is empty.
+	SourceFiles []string
+}
+
+// ExperimentTargetLoaderSession is the session according to [ExperimentTargetLoader].
+type ExperimentTargetLoaderSession interface {
+	// CheckIn invokes the check-in API.
+	CheckIn(ctx context.Context, config *OOAPICheckInConfig) (*OOAPICheckInResult, error)
+
+	// FetchOpenVPNConfig fetches the OpenVPN experiment configuration.
+	FetchOpenVPNConfig(ctx context.Context, provider, cc string) (*OOAPIVPNProviderConfig, error)
+
+	// Logger returns the logger to use.
+	Logger() Logger
 }
 
 // ExperimentOptionInfo contains info about an experiment option.

--- a/internal/oonirun/experiment_test.go
+++ b/internal/oonirun/experiment_test.go
@@ -165,7 +165,7 @@ func TestExperimentRun(t *testing.T) {
 		ReportFile             string
 		Session                Session
 		newExperimentBuilderFn func(experimentName string) (model.ExperimentBuilder, error)
-		newTargetLoaderFn      func(inputPolicy model.InputPolicy) targetLoader
+		newTargetLoaderFn      func(builder model.ExperimentBuilder) targetLoader
 		newSubmitterFn         func(ctx context.Context) (model.Submitter, error)
 		newSaverFn             func() (model.Saver, error)
 		newInputProcessorFn    func(experiment model.Experiment,
@@ -199,7 +199,7 @@ func TestExperimentRun(t *testing.T) {
 				}
 				return eb, nil
 			},
-			newTargetLoaderFn: func(inputPolicy model.InputPolicy) targetLoader {
+			newTargetLoaderFn: func(builder model.ExperimentBuilder) targetLoader {
 				return &mocks.ExperimentTargetLoader{
 					MockLoad: func(ctx context.Context) ([]model.ExperimentTarget, error) {
 						return nil, errMocked
@@ -223,7 +223,7 @@ func TestExperimentRun(t *testing.T) {
 				}
 				return eb, nil
 			},
-			newTargetLoaderFn: func(inputPolicy model.InputPolicy) targetLoader {
+			newTargetLoaderFn: func(builder model.ExperimentBuilder) targetLoader {
 				return &mocks.ExperimentTargetLoader{
 					MockLoad: func(ctx context.Context) ([]model.ExperimentTarget, error) {
 						return []model.ExperimentTarget{}, nil
@@ -263,7 +263,7 @@ func TestExperimentRun(t *testing.T) {
 				}
 				return eb, nil
 			},
-			newTargetLoaderFn: func(inputPolicy model.InputPolicy) targetLoader {
+			newTargetLoaderFn: func(builder model.ExperimentBuilder) targetLoader {
 				return &mocks.ExperimentTargetLoader{
 					MockLoad: func(ctx context.Context) ([]model.ExperimentTarget, error) {
 						return []model.ExperimentTarget{}, nil
@@ -306,7 +306,7 @@ func TestExperimentRun(t *testing.T) {
 				}
 				return eb, nil
 			},
-			newTargetLoaderFn: func(inputPolicy model.InputPolicy) targetLoader {
+			newTargetLoaderFn: func(builder model.ExperimentBuilder) targetLoader {
 				return &mocks.ExperimentTargetLoader{
 					MockLoad: func(ctx context.Context) ([]model.ExperimentTarget, error) {
 						return []model.ExperimentTarget{}, nil
@@ -352,7 +352,7 @@ func TestExperimentRun(t *testing.T) {
 				}
 				return eb, nil
 			},
-			newTargetLoaderFn: func(inputPolicy model.InputPolicy) targetLoader {
+			newTargetLoaderFn: func(builder model.ExperimentBuilder) targetLoader {
 				return &mocks.ExperimentTargetLoader{
 					MockLoad: func(ctx context.Context) ([]model.ExperimentTarget, error) {
 						return []model.ExperimentTarget{}, nil

--- a/internal/oonirun/experiment_test.go
+++ b/internal/oonirun/experiment_test.go
@@ -67,6 +67,16 @@ func TestExperimentRunWithFailureToSubmitAndShuffle(t *testing.T) {
 						}
 						return exp
 					},
+					MockNewTargetLoader: func(config *model.ExperimentTargetLoaderConfig) model.ExperimentTargetLoader {
+						return &mocks.ExperimentTargetLoader{
+							MockLoad: func(ctx context.Context) ([]model.ExperimentTarget, error) {
+								// Implementation note: the convention for input-less experiments is that
+								// they require a single entry containing an empty input.
+								entry := model.NewOOAPIURLInfoWithDefaultCategoryAndCountry("")
+								return []model.ExperimentTarget{entry}, nil
+							},
+						}
+					},
 				}
 				return eb, nil
 			},

--- a/internal/oonirun/v1_test.go
+++ b/internal/oonirun/v1_test.go
@@ -44,6 +44,16 @@ func newMinimalFakeSession() *mocks.Session {
 					}
 					return exp
 				},
+				MockNewTargetLoader: func(config *model.ExperimentTargetLoaderConfig) model.ExperimentTargetLoader {
+					return &mocks.ExperimentTargetLoader{
+						MockLoad: func(ctx context.Context) ([]model.ExperimentTarget, error) {
+							// Implementation note: the convention for input-less experiments is that
+							// they require a single entry containing an empty input.
+							entry := model.NewOOAPIURLInfoWithDefaultCategoryAndCountry("")
+							return []model.ExperimentTarget{entry}, nil
+						},
+					}
+				},
 			}
 			return eb, nil
 		},

--- a/internal/oonirun/v2_test.go
+++ b/internal/oonirun/v2_test.go
@@ -392,6 +392,16 @@ func TestV2MeasureDescriptor(t *testing.T) {
 					}
 					return exp
 				},
+				MockNewTargetLoader: func(config *model.ExperimentTargetLoaderConfig) model.ExperimentTargetLoader {
+					return &mocks.ExperimentTargetLoader{
+						MockLoad: func(ctx context.Context) ([]model.ExperimentTarget, error) {
+							// Implementation note: the convention for input-less experiments is that
+							// they require a single entry containing an empty input.
+							entry := model.NewOOAPIURLInfoWithDefaultCategoryAndCountry("")
+							return []model.ExperimentTarget{entry}, nil
+						},
+					}
+				},
 			}
 			return eb, nil
 		}

--- a/internal/registry/dash.go
+++ b/internal/registry/dash.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["dash"] = func() *Factory {
+	const canonicalName = "dash"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return dash.NewExperimentMeasurer(
 					*config.(*dash.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &dash.Config{},
 			enabledByDefault: true,
 			interruptible:    true,

--- a/internal/registry/dnscheck.go
+++ b/internal/registry/dnscheck.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["dnscheck"] = func() *Factory {
+	const canonicalName = "dnscheck"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return dnscheck.NewExperimentMeasurer(
 					*config.(*dnscheck.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &dnscheck.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputOrStaticDefault,

--- a/internal/registry/dnsping.go
+++ b/internal/registry/dnsping.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["dnsping"] = func() *Factory {
+	const canonicalName = "dnsping"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return dnsping.NewExperimentMeasurer(
 					*config.(*dnsping.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &dnsping.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputOrStaticDefault,

--- a/internal/registry/dslxtutorial.go
+++ b/internal/registry/dslxtutorial.go
@@ -10,15 +10,17 @@ import (
 )
 
 func init() {
-	AllExperiments["simple_sni"] = func() *Factory {
+	const canonicalName = "simple_sni"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return chapter02.NewExperimentMeasurer(
 					*config.(*chapter02.Config),
 				)
 			},
-			config:      &chapter02.Config{},
-			inputPolicy: model.InputOrQueryBackend,
+			canonicalName: canonicalName,
+			config:        &chapter02.Config{},
+			inputPolicy:   model.InputOrQueryBackend,
 		}
 	}
 }

--- a/internal/registry/echcheck.go
+++ b/internal/registry/echcheck.go
@@ -10,15 +10,17 @@ import (
 )
 
 func init() {
-	AllExperiments["echcheck"] = func() *Factory {
+	const canonicalName = "echcheck"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return echcheck.NewExperimentMeasurer(
 					*config.(*echcheck.Config),
 				)
 			},
-			config:      &echcheck.Config{},
-			inputPolicy: model.InputOptional,
+			canonicalName: canonicalName,
+			config:        &echcheck.Config{},
+			inputPolicy:   model.InputOptional,
 		}
 	}
 }

--- a/internal/registry/example.go
+++ b/internal/registry/example.go
@@ -12,13 +12,15 @@ import (
 )
 
 func init() {
-	AllExperiments["example"] = func() *Factory {
+	const canonicalName = "example"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return example.NewExperimentMeasurer(
 					*config.(*example.Config), "example",
 				)
 			},
+			canonicalName: canonicalName,
 			config: &example.Config{
 				Message:   "Good day from the example experiment!",
 				SleepTime: int64(time.Second),

--- a/internal/registry/factory.go
+++ b/internal/registry/factory.go
@@ -39,6 +39,22 @@ type Factory struct {
 	interruptible bool
 }
 
+// Session is the session definition according to this package.
+type Session = model.ExperimentTargetLoaderSession
+
+// NewTargetLoader creates a new [model.ExperimentTargetLoader] instance.
+func (b *Factory) NewTargetLoader(config *model.ExperimentTargetLoaderConfig) model.ExperimentTargetLoader {
+	return &targetloading.Loader{
+		CheckInConfig:  config.CheckInConfig, // OPTIONAL
+		ExperimentName: b.canonicalName,
+		InputPolicy:    b.inputPolicy,
+		Logger:         config.Session.Logger(),
+		Session:        config.Session,
+		StaticInputs:   config.StaticInputs,
+		SourceFiles:    config.SourceFiles,
+	}
+}
+
 // Interruptible returns whether the experiment is interruptible.
 func (b *Factory) Interruptible() bool {
 	return b.interruptible
@@ -220,22 +236,6 @@ func (b *Factory) fieldbyname(v interface{}, key string) (reflect.Value, error) 
 // NewExperimentMeasurer creates a new [model.ExperimentMeasurer] instance.
 func (b *Factory) NewExperimentMeasurer() model.ExperimentMeasurer {
 	return b.build(b.config)
-}
-
-// Session is the session definition according to this package.
-type Session = model.ExperimentTargetLoaderSession
-
-// NewTargetLoader creates a new [model.ExperimentTargetLoader] instance.
-func (b *Factory) NewTargetLoader(config *model.ExperimentTargetLoaderConfig) model.ExperimentTargetLoader {
-	return &targetloading.Loader{
-		CheckInConfig:  config.CheckInConfig, // OPTIONAL
-		ExperimentName: b.canonicalName,
-		InputPolicy:    b.inputPolicy,
-		Logger:         config.Session.Logger(),
-		Session:        config.Session,
-		StaticInputs:   config.StaticInputs,
-		SourceFiles:    config.SourceFiles,
-	}
 }
 
 // ErrNoSuchExperiment indicates a given experiment does not exist.

--- a/internal/registry/factory.go
+++ b/internal/registry/factory.go
@@ -13,8 +13,8 @@ import (
 	"strconv"
 
 	"github.com/ooni/probe-cli/v3/internal/checkincache"
+	"github.com/ooni/probe-cli/v3/internal/experimentname"
 	"github.com/ooni/probe-cli/v3/internal/model"
-	"github.com/ooni/probe-cli/v3/internal/strcasex"
 	"github.com/ooni/probe-cli/v3/internal/targetloading"
 )
 
@@ -238,27 +238,6 @@ func (b *Factory) NewTargetLoader(config *model.ExperimentTargetLoaderConfig) mo
 	}
 }
 
-// CanonicalizeExperimentName allows code to provide experiment names
-// in a more flexible way, where we have aliases.
-//
-// Because we allow for uppercase experiment names for backwards
-// compatibility with MK, we need to add some exceptions here when
-// mapping (e.g., DNSCheck => dnscheck).
-func CanonicalizeExperimentName(name string) string {
-	switch name = strcasex.ToSnake(name); name {
-	case "ndt_7":
-		name = "ndt" // since 2020-03-18, we use ndt7 to implement ndt by default
-	case "dns_check":
-		name = "dnscheck"
-	case "stun_reachability":
-		name = "stunreachability"
-	case "web_connectivity@v_0_5":
-		name = "web_connectivity@v0.5"
-	default:
-	}
-	return name
-}
-
 // ErrNoSuchExperiment indicates a given experiment does not exist.
 var ErrNoSuchExperiment = errors.New("no such experiment")
 
@@ -305,7 +284,7 @@ const OONI_FORCE_ENABLE_EXPERIMENT = "OONI_FORCE_ENABLE_EXPERIMENT"
 func NewFactory(name string, kvStore model.KeyValueStore, logger model.Logger) (*Factory, error) {
 	// Make sure we are deadling with the canonical experiment name. Historically MK used
 	// names such as WebConnectivity and we want to continue supporting this use case.
-	name = CanonicalizeExperimentName(name)
+	name = experimentname.Canonicalize(name)
 
 	// Handle A/B testing where we dynamically choose LTE for some users. The current policy
 	// only relates to a few users to collect data.

--- a/internal/registry/factory.go
+++ b/internal/registry/factory.go
@@ -15,12 +15,16 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/checkincache"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/strcasex"
+	"github.com/ooni/probe-cli/v3/internal/targetloading"
 )
 
 // Factory allows to construct an experiment measurer.
 type Factory struct {
 	// build is the constructor that build an experiment with the given config.
 	build func(config interface{}) model.ExperimentMeasurer
+
+	// canonicalName is the canonical name of the experiment.
+	canonicalName string
 
 	// config contains the experiment's config.
 	config any
@@ -216,6 +220,22 @@ func (b *Factory) fieldbyname(v interface{}, key string) (reflect.Value, error) 
 // NewExperimentMeasurer creates a new [model.ExperimentMeasurer] instance.
 func (b *Factory) NewExperimentMeasurer() model.ExperimentMeasurer {
 	return b.build(b.config)
+}
+
+// Session is the session definition according to this package.
+type Session = model.ExperimentTargetLoaderSession
+
+// NewTargetLoader creates a new [model.ExperimentTargetLoader] instance.
+func (b *Factory) NewTargetLoader(config *model.ExperimentTargetLoaderConfig) model.ExperimentTargetLoader {
+	return &targetloading.Loader{
+		CheckInConfig:  config.CheckInConfig, // OPTIONAL
+		ExperimentName: b.canonicalName,
+		InputPolicy:    b.inputPolicy,
+		Logger:         config.Session.Logger(),
+		Session:        config.Session,
+		StaticInputs:   config.StaticInputs,
+		SourceFiles:    config.SourceFiles,
+	}
 }
 
 // CanonicalizeExperimentName allows code to provide experiment names

--- a/internal/registry/factory_test.go
+++ b/internal/registry/factory_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/ooni/probe-cli/v3/internal/checkincache"
 	"github.com/ooni/probe-cli/v3/internal/experiment/webconnectivitylte"
+	"github.com/ooni/probe-cli/v3/internal/experimentname"
 	"github.com/ooni/probe-cli/v3/internal/kvstore"
 	"github.com/ooni/probe-cli/v3/internal/model"
 )
@@ -691,7 +692,7 @@ func TestNewFactory(t *testing.T) {
 
 			// get experiment expectations -- note that here we must canonicalize the
 			// experiment name otherwise we won't find it into the map when testing non-canonical names
-			expectations := expectationsMap[CanonicalizeExperimentName(tc.experimentName)]
+			expectations := expectationsMap[experimentname.Canonicalize(tc.experimentName)]
 			if expectations == nil {
 				t.Fatal("no expectations for", tc.experimentName)
 			}

--- a/internal/registry/fbmessenger.go
+++ b/internal/registry/fbmessenger.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["facebook_messenger"] = func() *Factory {
+	const canonicalName = "facebook_messenger"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return fbmessenger.NewExperimentMeasurer(
 					*config.(*fbmessenger.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &fbmessenger.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputNone,

--- a/internal/registry/hhfm.go
+++ b/internal/registry/hhfm.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["http_header_field_manipulation"] = func() *Factory {
+	const canonicalName = "http_header_field_manipulation"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return hhfm.NewExperimentMeasurer(
 					*config.(*hhfm.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &hhfm.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputNone,

--- a/internal/registry/hirl.go
+++ b/internal/registry/hirl.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["http_invalid_request_line"] = func() *Factory {
+	const canonicalName = "http_invalid_request_line"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return hirl.NewExperimentMeasurer(
 					*config.(*hirl.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &hirl.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputNone,

--- a/internal/registry/httphostheader.go
+++ b/internal/registry/httphostheader.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["http_host_header"] = func() *Factory {
+	const canonicalName = "http_host_header"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return httphostheader.NewExperimentMeasurer(
 					*config.(*httphostheader.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &httphostheader.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputOrQueryBackend,

--- a/internal/registry/ndt.go
+++ b/internal/registry/ndt.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["ndt"] = func() *Factory {
+	const canonicalName = "ndt"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return ndt7.NewExperimentMeasurer(
 					*config.(*ndt7.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &ndt7.Config{},
 			enabledByDefault: true,
 			interruptible:    true,

--- a/internal/registry/openvpn.go
+++ b/internal/registry/openvpn.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["openvpn"] = func() *Factory {
+	const canonicalName = "openvpn"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return openvpn.NewExperimentMeasurer(
 					*config.(*openvpn.Config), "openvpn",
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &openvpn.Config{},
 			enabledByDefault: true,
 			interruptible:    true,

--- a/internal/registry/portfiltering.go
+++ b/internal/registry/portfiltering.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["portfiltering"] = func() *Factory {
+	const canonicalName = "portfiltering"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config any) model.ExperimentMeasurer {
 				return portfiltering.NewExperimentMeasurer(
 					config.(portfiltering.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           portfiltering.Config{},
 			enabledByDefault: true,
 			interruptible:    false,

--- a/internal/registry/psiphon.go
+++ b/internal/registry/psiphon.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["psiphon"] = func() *Factory {
+	const canonicalName = "psiphon"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return psiphon.NewExperimentMeasurer(
 					*config.(*psiphon.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &psiphon.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputOptional,

--- a/internal/registry/quicping.go
+++ b/internal/registry/quicping.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["quicping"] = func() *Factory {
+	const canonicalName = "quicping"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return quicping.NewExperimentMeasurer(
 					*config.(*quicping.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &quicping.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputStrictlyRequired,

--- a/internal/registry/riseupvpn.go
+++ b/internal/registry/riseupvpn.go
@@ -10,15 +10,17 @@ import (
 )
 
 func init() {
-	AllExperiments["riseupvpn"] = func() *Factory {
+	const canonicalName = "riseupvpn"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return riseupvpn.NewExperimentMeasurer(
 					*config.(*riseupvpn.Config),
 				)
 			},
-			config:      &riseupvpn.Config{},
-			inputPolicy: model.InputNone,
+			canonicalName: canonicalName,
+			config:        &riseupvpn.Config{},
+			inputPolicy:   model.InputNone,
 		}
 	}
 }

--- a/internal/registry/signal.go
+++ b/internal/registry/signal.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["signal"] = func() *Factory {
+	const canonicalName = "signal"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return signal.NewExperimentMeasurer(
 					*config.(*signal.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &signal.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputNone,

--- a/internal/registry/simplequicping.go
+++ b/internal/registry/simplequicping.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["simplequicping"] = func() *Factory {
+	const canonicalName = "simplequicping"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return simplequicping.NewExperimentMeasurer(
 					*config.(*simplequicping.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &simplequicping.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputStrictlyRequired,

--- a/internal/registry/sniblocking.go
+++ b/internal/registry/sniblocking.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["sni_blocking"] = func() *Factory {
+	const canonicalName = "sni_blocking"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return sniblocking.NewExperimentMeasurer(
 					*config.(*sniblocking.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &sniblocking.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputOrQueryBackend,

--- a/internal/registry/stunreachability.go
+++ b/internal/registry/stunreachability.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["stunreachability"] = func() *Factory {
+	const canonicalName = "stunreachability"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return stunreachability.NewExperimentMeasurer(
 					*config.(*stunreachability.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &stunreachability.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputOrStaticDefault,

--- a/internal/registry/tcpping.go
+++ b/internal/registry/tcpping.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["tcpping"] = func() *Factory {
+	const canonicalName = "tcpping"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return tcpping.NewExperimentMeasurer(
 					*config.(*tcpping.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &tcpping.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputStrictlyRequired,

--- a/internal/registry/telegram.go
+++ b/internal/registry/telegram.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["telegram"] = func() *Factory {
+	const canonicalName = "telegram"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config any) model.ExperimentMeasurer {
 				return telegram.NewExperimentMeasurer(
 					config.(telegram.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           telegram.Config{},
 			enabledByDefault: true,
 			interruptible:    false,

--- a/internal/registry/tlsmiddlebox.go
+++ b/internal/registry/tlsmiddlebox.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["tlsmiddlebox"] = func() *Factory {
+	const canonicalName = "tlsmiddlebox"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return tlsmiddlebox.NewExperimentMeasurer(
 					*config.(*tlsmiddlebox.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &tlsmiddlebox.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputStrictlyRequired,

--- a/internal/registry/tlsping.go
+++ b/internal/registry/tlsping.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["tlsping"] = func() *Factory {
+	const canonicalName = "tlsping"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return tlsping.NewExperimentMeasurer(
 					*config.(*tlsping.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &tlsping.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputStrictlyRequired,

--- a/internal/registry/tlstool.go
+++ b/internal/registry/tlstool.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["tlstool"] = func() *Factory {
+	const canonicalName = "tlstool"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return tlstool.NewExperimentMeasurer(
 					*config.(*tlstool.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &tlstool.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputOrQueryBackend,

--- a/internal/registry/tor.go
+++ b/internal/registry/tor.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["tor"] = func() *Factory {
+	const canonicalName = "tor"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return tor.NewExperimentMeasurer(
 					*config.(*tor.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &tor.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputNone,

--- a/internal/registry/torsf.go
+++ b/internal/registry/torsf.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["torsf"] = func() *Factory {
+	const canonicalName = "torsf"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return torsf.NewExperimentMeasurer(
 					*config.(*torsf.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &torsf.Config{},
 			enabledByDefault: false,
 			inputPolicy:      model.InputNone,

--- a/internal/registry/urlgetter.go
+++ b/internal/registry/urlgetter.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["urlgetter"] = func() *Factory {
+	const canonicalName = "urlgetter"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return urlgetter.NewExperimentMeasurer(
 					*config.(*urlgetter.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &urlgetter.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputStrictlyRequired,

--- a/internal/registry/vanillator.go
+++ b/internal/registry/vanillator.go
@@ -10,14 +10,16 @@ import (
 )
 
 func init() {
-	AllExperiments["vanilla_tor"] = func() *Factory {
+	const canonicalName = "vanilla_tor"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return vanillator.NewExperimentMeasurer(
 					*config.(*vanillator.Config),
 				)
 			},
-			config: &vanillator.Config{},
+			canonicalName: canonicalName,
+			config:        &vanillator.Config{},
 			// We discussed this topic with @aanorbel. On Android this experiment crashes
 			// frequently because of https://github.com/ooni/probe/issues/2406. So, it seems
 			// more cautious to disable it by default and let the check-in API decide.

--- a/internal/registry/webconnectivity.go
+++ b/internal/registry/webconnectivity.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["web_connectivity"] = func() *Factory {
+	const canonicalName = "web_connectivity"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config any) model.ExperimentMeasurer {
 				return webconnectivity.NewExperimentMeasurer(
 					config.(webconnectivity.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           webconnectivity.Config{},
 			enabledByDefault: true,
 			interruptible:    false,

--- a/internal/registry/webconnectivityv05.go
+++ b/internal/registry/webconnectivityv05.go
@@ -12,13 +12,15 @@ import (
 )
 
 func init() {
-	AllExperiments["web_connectivity@v0.5"] = func() *Factory {
+	const canonicalName = "web_connectivity@v0.5"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config any) model.ExperimentMeasurer {
 				return webconnectivitylte.NewExperimentMeasurer(
 					config.(*webconnectivitylte.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &webconnectivitylte.Config{},
 			enabledByDefault: true,
 			interruptible:    false,

--- a/internal/registry/whatsapp.go
+++ b/internal/registry/whatsapp.go
@@ -10,13 +10,15 @@ import (
 )
 
 func init() {
-	AllExperiments["whatsapp"] = func() *Factory {
+	const canonicalName = "whatsapp"
+	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
 				return whatsapp.NewExperimentMeasurer(
 					*config.(*whatsapp.Config),
 				)
 			},
+			canonicalName:    canonicalName,
 			config:           &whatsapp.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputNone,

--- a/internal/targetloading/targetloading.go
+++ b/internal/targetloading/targetloading.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/experiment/openvpn"
 	"github.com/ooni/probe-cli/v3/internal/fsx"
 	"github.com/ooni/probe-cli/v3/internal/model"
-	"github.com/ooni/probe-cli/v3/internal/registry"
 	"github.com/ooni/probe-cli/v3/internal/stuninput"
 )
 
@@ -26,12 +25,8 @@ var (
 	ErrNoStaticInput     = errors.New("no static input for this experiment")
 )
 
-// Session is the session according to a [*Loader].
-type Session interface {
-	CheckIn(ctx context.Context, config *model.OOAPICheckInConfig) (*model.OOAPICheckInResult, error)
-	FetchOpenVPNConfig(ctx context.Context,
-		provider, cc string) (*model.OOAPIVPNProviderConfig, error)
-}
+// Session is the session according to a [*Loader] instance.
+type Session = model.ExperimentTargetLoaderSession
 
 // Logger is the [model.Logger] according to a [*Loader].
 type Logger interface {
@@ -230,7 +225,7 @@ func StaticBareInputForExperiment(name string) ([]string, error) {
 	//
 	// TODO(https://github.com/ooni/probe/issues/2557): server STUNReachability
 	// inputs using richer input (aka check-in v2).
-	switch registry.CanonicalizeExperimentName(name) {
+	switch name {
 	case "dnscheck":
 		return dnsCheckDefaultInput, nil
 	case "stunreachability":
@@ -305,7 +300,7 @@ func (il *Loader) readfile(filepath string, open openFunc) ([]model.ExperimentTa
 
 // loadRemote loads inputs from a remote source.
 func (il *Loader) loadRemote(ctx context.Context) ([]model.ExperimentTarget, error) {
-	switch registry.CanonicalizeExperimentName(il.ExperimentName) {
+	switch il.ExperimentName {
 	case "openvpn":
 		// TODO(ainghazal): given the semantics of the current API call, in an ideal world we'd need to pass
 		// the desired provider here, if known. We only have one provider for now, so I'm acting like YAGNI. Another

--- a/internal/targetloading/targetloading.go
+++ b/internal/targetloading/targetloading.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/ooni/probe-cli/v3/internal/experiment/openvpn"
+	"github.com/ooni/probe-cli/v3/internal/experimentname"
 	"github.com/ooni/probe-cli/v3/internal/fsx"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/stuninput"
@@ -225,7 +226,7 @@ func StaticBareInputForExperiment(name string) ([]string, error) {
 	//
 	// TODO(https://github.com/ooni/probe/issues/2557): server STUNReachability
 	// inputs using richer input (aka check-in v2).
-	switch name {
+	switch experimentname.Canonicalize(name) {
 	case "dnscheck":
 		return dnsCheckDefaultInput, nil
 	case "stunreachability":
@@ -300,7 +301,7 @@ func (il *Loader) readfile(filepath string, open openFunc) ([]model.ExperimentTa
 
 // loadRemote loads inputs from a remote source.
 func (il *Loader) loadRemote(ctx context.Context) ([]model.ExperimentTarget, error) {
-	switch il.ExperimentName {
+	switch experimentname.Canonicalize(il.ExperimentName) {
 	case "openvpn":
 		// TODO(ainghazal): given the semantics of the current API call, in an ideal world we'd need to pass
 		// the desired provider here, if known. We only have one provider for now, so I'm acting like YAGNI. Another

--- a/internal/targetloading/targetloading_test.go
+++ b/internal/targetloading/targetloading_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apex/log"
 	"github.com/google/go-cmp/cmp"
 	"github.com/ooni/probe-cli/v3/internal/mocks"
 	"github.com/ooni/probe-cli/v3/internal/model"
@@ -535,7 +536,7 @@ type TargetLoaderMockableSession struct {
 	Error error
 }
 
-// CheckIn implements TargetLoaderSession.CheckIn.
+// CheckIn implements [Session].
 func (sess *TargetLoaderMockableSession) CheckIn(
 	ctx context.Context, config *model.OOAPICheckInConfig) (*model.OOAPICheckInResult, error) {
 	if sess.Output == nil && sess.Error == nil {
@@ -544,11 +545,17 @@ func (sess *TargetLoaderMockableSession) CheckIn(
 	return sess.Output, sess.Error
 }
 
-// FetchOpenVPNConfig implements TargetLoaderSession.FetchOpenVPNConfig.
+// FetchOpenVPNConfig implements [Session].
 func (sess *TargetLoaderMockableSession) FetchOpenVPNConfig(
 	ctx context.Context, provider, cc string) (*model.OOAPIVPNProviderConfig, error) {
 	runtimex.Assert(!(sess.Error == nil && sess.FetchOpenVPNConfigOutput == nil), "both FetchOpenVPNConfig and Error are nil")
 	return sess.FetchOpenVPNConfigOutput, sess.Error
+}
+
+// Logger implements [Session].
+func (sess *TargetLoaderMockableSession) Logger() model.Logger {
+	// Such that we see some logs when running tests
+	return log.Log
 }
 
 func TestTargetLoaderCheckInFailure(t *testing.T) {


### PR DESCRIPTION
This diff completes the set of preliminary richer input diffs. We build the TargetLoader using the ExperimentBuilder, which in turn uses a registry.Factory under the hood. This means that we can load targets for each experiment, because the actual implementation of the TargetLoader can be experiment dependent.

Part of https://github.com/ooni/probe/issues/2607
