### PR TITLE
feat(openvpn): implement richer input

### DIFF
--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -384,6 +384,9 @@ func (s *Session) FetchOpenVPNConfig(
 		return nil, err
 	}
 
+	// ensure that we have fetched the location before fetching openvpn configuration.
+	s.MaybeLookupLocationContext(ctx)
+
 	// we cannot lock earlier because newOrchestraClient locks the mutex.
 	defer s.mu.Unlock()
 	s.mu.Lock()

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -394,7 +394,7 @@ func (s *Session) FetchOpenVPNConfig(
 	// We cannot lock earlier because newOrchestraClient and
 	// MaybeLookupLocation both lock the mutex.
 	//
-	// TODO(bassosimone,DecFox):  we should consider using the same strategy we used for the
+	// TODO(bassosimone,DecFox): we should consider using the same strategy we used for the
 	// experiments, where we separated mutable state into dedicated types.
 	defer s.mu.Unlock()
 	s.mu.Lock()

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -66,7 +66,6 @@ type Session struct {
 	softwareName             string
 	softwareVersion          string
 	tempDir                  string
-	vpnConfig                map[string]model.OOAPIVPNProviderConfig
 
 	// closeOnce allows us to call Close just once.
 	closeOnce sync.Once
@@ -178,7 +177,6 @@ func NewSession(ctx context.Context, config SessionConfig) (*Session, error) {
 		torArgs:                 config.TorArgs,
 		torBinary:               config.TorBinary,
 		tunnelDir:               config.TunnelDir,
-		vpnConfig:               make(map[string]model.OOAPIVPNProviderConfig),
 	}
 	proxyURL := config.ProxyURL
 	if proxyURL != nil {
@@ -381,9 +379,6 @@ func (s *Session) FetchTorTargets(
 // internal cache. We do this to avoid hitting the API for every input.
 func (s *Session) FetchOpenVPNConfig(
 	ctx context.Context, provider, cc string) (*model.OOAPIVPNProviderConfig, error) {
-	if config, ok := s.vpnConfig[provider]; ok {
-		return &config, nil
-	}
 	clnt, err := s.newOrchestraClient(ctx)
 	if err != nil {
 		return nil, err
@@ -397,7 +392,6 @@ func (s *Session) FetchOpenVPNConfig(
 	if err != nil {
 		return nil, err
 	}
-	s.vpnConfig[provider] = config
 	return &config, nil
 }
 

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -385,9 +385,17 @@ func (s *Session) FetchOpenVPNConfig(
 	}
 
 	// ensure that we have fetched the location before fetching openvpn configuration.
-	s.MaybeLookupLocationContext(ctx)
+	if err := s.MaybeLookupLocationContext(ctx); err != nil {
+		return nil, err
+	}
 
-	// we cannot lock earlier because newOrchestraClient locks the mutex.
+	// IMPORTANT!
+	//
+	// We cannot lock earlier because newOrchestraClient and
+	// MaybeLookupLocation both lock the mutex.
+	//
+	// TODO(bassosimone,DecFox):  we should consider using the same strategy we used for the
+	// experiments, where we separated mutable state into dedicated types.
 	defer s.mu.Unlock()
 	s.mu.Lock()
 

--- a/internal/experiment/dnscheck/dnscheck_test.go
+++ b/internal/experiment/dnscheck/dnscheck_test.go
@@ -60,7 +60,7 @@ func TestDNSCheckFailsWithInvalidInputType(t *testing.T) {
 	}
 	err := measurer.Run(context.Background(), args)
 	if !errors.Is(err, ErrInvalidInputType) {
-		t.Fatal("expected no input error")
+		t.Fatal("expected invalid-input-type error")
 	}
 }
 

--- a/internal/experiment/openvpn/endpoint.go
+++ b/internal/experiment/openvpn/endpoint.go
@@ -1,7 +1,6 @@
 package openvpn
 
 import (
-	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -12,11 +11,12 @@ import (
 	vpnconfig "github.com/ooni/minivpn/pkg/config"
 	vpntracex "github.com/ooni/minivpn/pkg/tracex"
 	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/targetloading"
 )
 
 var (
-	// ErrBadBase64Blob is the error returned when we cannot decode an option passed as base64.
-	ErrBadBase64Blob = errors.New("wrong base64 encoding")
+	ErrInputRequired = targetloading.ErrInputRequired
+	ErrInvalidInput  = targetloading.ErrInvalidInput
 )
 
 // endpoint is a single endpoint to be probed.
@@ -194,7 +194,7 @@ func isValidProvider(provider string) bool {
 	return slices.Contains(APIEnabledProviders, provider)
 }
 
-// mergeOpenVPNConfig gets a properly configured [*vpnconfig.Config] object for the given endpoint.
+// mergeOpenVPNConfig returns a properly configured [*vpnconfig.Config] object for the given endpoint.
 // To obtain that, we merge the endpoint specific configuration with the options passed as richer input targets.
 func mergeOpenVPNConfig(
 	tracer *vpntracex.Tracer,

--- a/internal/experiment/openvpn/endpoint.go
+++ b/internal/experiment/openvpn/endpoint.go
@@ -49,6 +49,9 @@ type endpoint struct {
 // "openvpn://provider.corp/?address=1.2.3.4:1194&transport=udp
 // "openvpn+obfs4://provider.corp/address=1.2.3.4:1194?&cert=deadbeef&iat=0"
 func newEndpointFromInputString(uri string) (*endpoint, error) {
+	if uri == "" {
+		return nil, ErrInputRequired
+	}
 	parsedURL, err := url.Parse(uri)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrInvalidInput, err)
@@ -227,14 +230,4 @@ func mergeOpenVPNConfig(
 	)
 
 	return cfg, nil
-}
-
-func isValidProtocol(s string) bool {
-	if strings.HasPrefix(s, "openvpn://") {
-		return true
-	}
-	if strings.HasPrefix(s, "openvpn+obfs4://") {
-		return true
-	}
-	return false
 }

--- a/internal/experiment/openvpn/endpoint_test.go
+++ b/internal/experiment/openvpn/endpoint_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	vpnconfig "github.com/ooni/minivpn/pkg/config"
 	vpntracex "github.com/ooni/minivpn/pkg/tracex"
 )
 
@@ -272,7 +271,7 @@ func Test_isValidProvider(t *testing.T) {
 	}
 }
 
-func Test_getVPNConfig(t *testing.T) {
+func Test_mergeVPNConfig(t *testing.T) {
 	tracer := vpntracex.NewTracer(time.Now())
 	e := &endpoint{
 		Provider:  "riseupvpn",
@@ -280,13 +279,16 @@ func Test_getVPNConfig(t *testing.T) {
 		Port:      "443",
 		Transport: "udp",
 	}
-	creds := &vpnconfig.OpenVPNOptions{
-		CA:   []byte("ca"),
-		Cert: []byte("cert"),
-		Key:  []byte("key"),
+
+	config := &Config{
+		Auth:     "SHA512",
+		Cipher:   "AES-256-GCM",
+		SafeCA:   "ca",
+		SafeCert: "cert",
+		SafeKey:  "key",
 	}
 
-	cfg, err := getOpenVPNConfig(tracer, nil, e, creds)
+	cfg, err := mergeOpenVPNConfig(tracer, nil, e, config)
 	if err != nil {
 		t.Fatalf("did not expect error, got: %v", err)
 	}
@@ -311,18 +313,18 @@ func Test_getVPNConfig(t *testing.T) {
 	if transport := cfg.OpenVPNOptions().Proto; string(transport) != e.Transport {
 		t.Errorf("expected transport %s, got %s", e.Transport, transport)
 	}
-	if diff := cmp.Diff(cfg.OpenVPNOptions().CA, creds.CA); diff != "" {
+	if diff := cmp.Diff(cfg.OpenVPNOptions().CA, []byte(config.SafeCA)); diff != "" {
 		t.Error(diff)
 	}
-	if diff := cmp.Diff(cfg.OpenVPNOptions().Cert, creds.Cert); diff != "" {
+	if diff := cmp.Diff(cfg.OpenVPNOptions().Cert, []byte(config.SafeCert)); diff != "" {
 		t.Error(diff)
 	}
-	if diff := cmp.Diff(cfg.OpenVPNOptions().Key, creds.Key); diff != "" {
+	if diff := cmp.Diff(cfg.OpenVPNOptions().Key, []byte(config.SafeKey)); diff != "" {
 		t.Error(diff)
 	}
 }
 
-func Test_getVPNConfig_with_unknown_provider(t *testing.T) {
+func Test_mergeOpenVPNConfig_with_unknown_provider(t *testing.T) {
 	tracer := vpntracex.NewTracer(time.Now())
 	e := &endpoint{
 		Provider:  "nsa",
@@ -330,60 +332,16 @@ func Test_getVPNConfig_with_unknown_provider(t *testing.T) {
 		Port:      "443",
 		Transport: "udp",
 	}
-	creds := &vpnconfig.OpenVPNOptions{
-		CA:   []byte("ca"),
-		Cert: []byte("cert"),
-		Key:  []byte("key"),
+	cfg := &Config{
+		SafeCA:   "ca",
+		SafeCert: "cert",
+		SafeKey:  "key",
 	}
-	_, err := getOpenVPNConfig(tracer, nil, e, creds)
+	_, err := mergeOpenVPNConfig(tracer, nil, e, cfg)
 	if !errors.Is(err, ErrInvalidInput) {
 		t.Fatalf("expected invalid input error, got: %v", err)
 	}
 
-}
-
-func Test_extractBase64Blob(t *testing.T) {
-	t.Run("decode good blob", func(t *testing.T) {
-		blob := "base64:dGhlIGJsdWUgb2N0b3B1cyBpcyB3YXRjaGluZw=="
-		decoded, err := maybeExtractBase64Blob(blob)
-		if decoded != "the blue octopus is watching" {
-			t.Fatal("could not decoded blob correctly")
-		}
-		if err != nil {
-			t.Fatal("should not fail with first blob")
-		}
-	})
-	t.Run("try decode without prefix", func(t *testing.T) {
-		blob := "dGhlIGJsdWUgb2N0b3B1cyBpcyB3YXRjaGluZw=="
-		dec, err := maybeExtractBase64Blob(blob)
-		if err != nil {
-			t.Fatal("should fail without prefix")
-		}
-		if dec != blob {
-			t.Fatal("decoded should be the same")
-		}
-	})
-	t.Run("bad base64 blob should fail", func(t *testing.T) {
-		blob := "base64:dGhlIGJsdWUgb2N0b3B1cyBpcyB3YXRjaGluZw"
-		_, err := maybeExtractBase64Blob(blob)
-		if !errors.Is(err, ErrBadBase64Blob) {
-			t.Fatal("bad blob should fail without prefix")
-		}
-	})
-	t.Run("decode empty blob", func(t *testing.T) {
-		blob := "base64:"
-		_, err := maybeExtractBase64Blob(blob)
-		if err != nil {
-			t.Fatal("empty blob should not fail")
-		}
-	})
-	t.Run("illegal base64 data should fail", func(t *testing.T) {
-		blob := "base64:=="
-		_, err := maybeExtractBase64Blob(blob)
-		if !errors.Is(err, ErrBadBase64Blob) {
-			t.Fatal("bad base64 data should fail")
-		}
-	})
 }
 
 func Test_IsValidProtocol(t *testing.T) {

--- a/internal/experiment/openvpn/endpoint_test.go
+++ b/internal/experiment/openvpn/endpoint_test.go
@@ -22,7 +22,25 @@ func Test_newEndpointFromInputString(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "valid endpoint returns good endpoint",
+			name:    "empty input returns error",
+			args:    args{""},
+			want:    nil,
+			wantErr: ErrInputRequired,
+		},
+		{
+			name:    "invalid protocol returns error",
+			args:    args{"bad://foo.bar"},
+			want:    nil,
+			wantErr: ErrInvalidInput,
+		},
+		{
+			name:    "uri with illegal chars returns error",
+			args:    args{"openvpn://\x7f/#"},
+			want:    nil,
+			wantErr: ErrInvalidInput,
+		},
+		{
+			name: "valid input uri returns good endpoint",
 			args: args{"openvpn://riseupvpn.corp/?address=1.1.1.1:1194&transport=tcp"},
 			want: &endpoint{
 				IPAddr:      "1.1.1.1",
@@ -341,23 +359,4 @@ func Test_mergeOpenVPNConfig_with_unknown_provider(t *testing.T) {
 	if !errors.Is(err, ErrInvalidInput) {
 		t.Fatalf("expected invalid input error, got: %v", err)
 	}
-
-}
-
-func Test_IsValidProtocol(t *testing.T) {
-	t.Run("openvpn is valid", func(t *testing.T) {
-		if !isValidProtocol("openvpn://foobar.bar") {
-			t.Error("openvpn:// should be a valid protocol")
-		}
-	})
-	t.Run("openvpn+obfs4 is valid", func(t *testing.T) {
-		if !isValidProtocol("openvpn+obfs4://foobar.bar") {
-			t.Error("openvpn+obfs4:// should be a valid protocol")
-		}
-	})
-	t.Run("openvpn+other is not valid", func(t *testing.T) {
-		if isValidProtocol("openvpn+ss://foobar.bar") {
-			t.Error("openvpn+ss:// should not be a valid protocol")
-		}
-	})
 }

--- a/internal/experiment/openvpn/endpoint_test.go
+++ b/internal/experiment/openvpn/endpoint_test.go
@@ -3,7 +3,6 @@ package openvpn
 import (
 	"errors"
 	"fmt"
-	"sort"
 	"testing"
 	"time"
 
@@ -270,16 +269,6 @@ func Test_endpoint_String(t *testing.T) {
 	}
 }
 
-func Test_endpointList_Shuffle(t *testing.T) {
-	shuffled := DefaultEndpoints.Shuffle()
-	sort.Slice(shuffled, func(i, j int) bool {
-		return shuffled[i].IPAddr < shuffled[j].IPAddr
-	})
-	if diff := cmp.Diff(shuffled, DefaultEndpoints); diff != "" {
-		t.Error(diff)
-	}
-}
-
 func Test_isValidProvider(t *testing.T) {
 	if valid := isValidProvider("riseupvpn"); !valid {
 		t.Fatal("riseup is the only valid provider now")
@@ -289,7 +278,7 @@ func Test_isValidProvider(t *testing.T) {
 	}
 }
 
-func Test_mergeVPNConfig(t *testing.T) {
+func Test_newVPNConfig(t *testing.T) {
 	tracer := vpntracex.NewTracer(time.Now())
 	e := &endpoint{
 		Provider:  "riseupvpn",

--- a/internal/experiment/openvpn/endpoint_test.go
+++ b/internal/experiment/openvpn/endpoint_test.go
@@ -306,7 +306,7 @@ func Test_mergeVPNConfig(t *testing.T) {
 		SafeKey:  "key",
 	}
 
-	cfg, err := mergeOpenVPNConfig(tracer, nil, e, config)
+	cfg, err := newOpenVPNConfig(tracer, nil, e, config)
 	if err != nil {
 		t.Fatalf("did not expect error, got: %v", err)
 	}
@@ -355,7 +355,7 @@ func Test_mergeOpenVPNConfig_with_unknown_provider(t *testing.T) {
 		SafeCert: "cert",
 		SafeKey:  "key",
 	}
-	_, err := mergeOpenVPNConfig(tracer, nil, e, cfg)
+	_, err := newOpenVPNConfig(tracer, nil, e, cfg)
 	if !errors.Is(err, ErrInvalidInput) {
 		t.Fatalf("expected invalid input error, got: %v", err)
 	}

--- a/internal/experiment/openvpn/openvpn.go
+++ b/internal/experiment/openvpn/openvpn.go
@@ -237,7 +237,7 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	}
 
 	// 3. build openvpn config from endpoint and options
-	openvpnConfig, err := mergeOpenVPNConfig(handshakeTracer, sess.Logger(), endpoint, config)
+	openvpnConfig, err := newOpenVPNConfig(handshakeTracer, sess.Logger(), endpoint, config)
 	if err != nil {
 		return err
 	}

--- a/internal/experiment/openvpn/openvpn.go
+++ b/internal/experiment/openvpn/openvpn.go
@@ -120,16 +120,6 @@ func (m Measurer) ExperimentVersion() string {
 	return testVersion
 }
 
-func parseEndpoint(input string) (*endpoint, error) {
-	if input == "" {
-		return nil, ErrInputRequired
-	}
-	if ok := isValidProtocol(input); !ok {
-		return nil, ErrInvalidInput
-	}
-	return newEndpointFromInputString(input)
-}
-
 // AuthMethod is the authentication method used by a provider.
 type AuthMethod string
 
@@ -239,7 +229,7 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	config, input := target.Options, target.URL
 	sess.Logger().Infof("openvpn: using richer input: %+v", input)
 
-	endpoint, err := parseEndpoint(input)
+	endpoint, err := newEndpointFromInputString(input)
 	if err != nil {
 		return err
 	}

--- a/internal/experiment/openvpn/openvpn.go
+++ b/internal/experiment/openvpn/openvpn.go
@@ -206,7 +206,7 @@ func (m *Measurer) FetchProviderCredentials(
 // Run implements model.ExperimentMeasurer.Run.
 // A single run expects exactly ONE input (endpoint), but we can modify whether
 // to test different transports by settings options.
-func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
+func (m *Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	callbacks := args.Callbacks
 	measurement := args.Measurement
 	sess := args.Session

--- a/internal/experiment/openvpn/openvpn.go
+++ b/internal/experiment/openvpn/openvpn.go
@@ -95,21 +95,20 @@ func (tk *TestKeys) AllConnectionsSuccessful() bool {
 }
 
 // Measurer performs the measurement.
-type Measurer struct {
-}
+type Measurer struct{}
 
 // NewExperimentMeasurer creates a new ExperimentMeasurer.
 func NewExperimentMeasurer() model.ExperimentMeasurer {
-	return Measurer{}
+	return &Measurer{}
 }
 
 // ExperimentName implements model.ExperimentMeasurer.ExperimentName.
-func (m Measurer) ExperimentName() string {
+func (m *Measurer) ExperimentName() string {
 	return testName
 }
 
 // ExperimentVersion implements model.ExperimentMeasurer.ExperimentVersion.
-func (m Measurer) ExperimentVersion() string {
+func (m *Measurer) ExperimentVersion() string {
 	return testVersion
 }
 
@@ -174,6 +173,8 @@ func (m *Measurer) connectAndHandshake(
 	}
 }
 
+// TimestampsFromHandshake returns the t0, t and duration of the handshake events.
+// If the passed events are a zero-len array, all of the results will be zero.
 func TimestampsFromHandshake(events []*vpntracex.Event) (float64, float64, float64) {
 	var (
 		t0       float64
@@ -236,6 +237,10 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 		return err
 	}
 
+	// TODO(ainghazal): validate we have valid config for each endpoint.
+	// TODO(ainghazal): validate hostname is a valid IP (ipv4 or 6)
+	// TODO(ainghazal): decide what to do if we have expired certs (abort one measurement or abort the whole experiment?)
+
 	// 3. build openvpn config from endpoint and options
 	openvpnConfig, err := newOpenVPNConfig(handshakeTracer, sess.Logger(), endpoint, config)
 	if err != nil {
@@ -252,10 +257,6 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 
 	// 5. assign the testkeys
 	measurement.TestKeys = tk
-
-	// TODO(ainghazal): validate we have valid config for each endpoint.
-	// TODO(ainghazal): validate hostname is a valid IP (ipv4 or 6)
-	// TODO(ainghazal): decide what to do if we have expired certs (abort one measurement or abort the whole experiment?)
 
 	// Note: if here we return an error, the parent code will assume
 	// something fundamental was wrong and we don't have a measurement

--- a/internal/experiment/openvpn/openvpn.go
+++ b/internal/experiment/openvpn/openvpn.go
@@ -211,7 +211,7 @@ func (m Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	measurement := args.Measurement
 	sess := args.Session
 
-	// 0. obtain the richer input target, config, and input or panic
+	// 0. fail if there's no richer input target
 	if args.Target == nil {
 		return targetloading.ErrInputRequired
 	}

--- a/internal/experiment/openvpn/openvpn.go
+++ b/internal/experiment/openvpn/openvpn.go
@@ -227,9 +227,7 @@ func (m *Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	if !ok {
 		return targetloading.ErrInvalidInputType
 	}
-
 	config, input := target.Options, target.URL
-	sess.Logger().Infof("openvpn: using richer input: %+v", input)
 
 	// 2. obtain the endpoint representation from the input URL
 	endpoint, err := newEndpointFromInputString(input)

--- a/internal/experiment/openvpn/openvpn_test.go
+++ b/internal/experiment/openvpn/openvpn_test.go
@@ -6,11 +6,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apex/log"
 	"github.com/google/go-cmp/cmp"
 	vpntracex "github.com/ooni/minivpn/pkg/tracex"
 	"github.com/ooni/probe-cli/v3/internal/experiment/openvpn"
 	"github.com/ooni/probe-cli/v3/internal/mocks"
 	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/targetloading"
 )
 
 func makeMockSession() *mocks.Session {
@@ -175,6 +177,20 @@ func TestAllConnectionsSuccessful(t *testing.T) {
 	})
 }
 
+func TestOpenVPNFailsWithInvalidInputType(t *testing.T) {
+	measurer := openvpn.NewExperimentMeasurer()
+	args := &model.ExperimentArgs{
+		Callbacks:   model.NewPrinterCallbacks(log.Log),
+		Measurement: new(model.Measurement),
+		Session:     makeMockSession(),
+		Target:      &model.OOAPIURLInfo{}, // not the input type we expect
+	}
+	err := measurer.Run(context.Background(), args)
+	if !errors.Is(err, openvpn.ErrInvalidInputType) {
+		t.Fatal("expected input error")
+	}
+}
+
 func TestBadTargetURLFailure(t *testing.T) {
 	m := openvpn.NewExperimentMeasurer()
 	ctx := context.Background()
@@ -191,7 +207,7 @@ func TestBadTargetURLFailure(t *testing.T) {
 		},
 	}
 	err := m.Run(ctx, args)
-	if !errors.Is(err, openvpn.ErrInvalidInput) {
+	if !errors.Is(err, targetloading.ErrInvalidInput) {
 		t.Fatalf("expected ErrInvalidInput, got %v", err)
 	}
 }

--- a/internal/experiment/openvpn/openvpn_test.go
+++ b/internal/experiment/openvpn/openvpn_test.go
@@ -253,3 +253,18 @@ func TestSuccess(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestTimestampsFromHandshake(t *testing.T) {
+	events := []*vpntracex.Event{{AtTime: 0}, {AtTime: 1}, {AtTime: 2}}
+	t0, tlast, duration := openvpn.TimestampsFromHandshake(events)
+	if t0 != 0 {
+		t.Fatal("expected t0 == 0")
+	}
+	if tlast != 2.0 {
+		t.Fatal("expected t0 == 2")
+	}
+	if duration != 2 {
+		t.Fatal("expected duration == 2")
+	}
+
+}

--- a/internal/experiment/openvpn/openvpn_test.go
+++ b/internal/experiment/openvpn/openvpn_test.go
@@ -221,7 +221,7 @@ func TestVPNInput(t *testing.T) {
 
 func TestMeasurer_FetchProviderCredentials(t *testing.T) {
 	t.Run("Measurer.FetchProviderCredentials calls method in session", func(t *testing.T) {
-		m := openvpn.NewExperimentMeasurer().(openvpn.Measurer)
+		m := openvpn.NewExperimentMeasurer().(*openvpn.Measurer)
 
 		sess := makeMockSession()
 		_, err := m.FetchProviderCredentials(
@@ -234,7 +234,7 @@ func TestMeasurer_FetchProviderCredentials(t *testing.T) {
 	t.Run("Measurer.FetchProviderCredentials raises error if API calls fail", func(t *testing.T) {
 		someError := errors.New("unexpected")
 
-		m := openvpn.NewExperimentMeasurer().(openvpn.Measurer)
+		m := openvpn.NewExperimentMeasurer().(*openvpn.Measurer)
 
 		sess := makeMockSession()
 		sess.MockFetchOpenVPNConfig = func(context.Context, string, string) (*model.OOAPIVPNProviderConfig, error) {

--- a/internal/experiment/openvpn/openvpn_test.go
+++ b/internal/experiment/openvpn/openvpn_test.go
@@ -282,5 +282,4 @@ func TestTimestampsFromHandshake(t *testing.T) {
 	if duration != 2 {
 		t.Fatal("expected duration == 2")
 	}
-
 }

--- a/internal/experiment/openvpn/openvpn_test.go
+++ b/internal/experiment/openvpn/openvpn_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	vpnconfig "github.com/ooni/minivpn/pkg/config"
 	vpntracex "github.com/ooni/minivpn/pkg/tracex"
 	"github.com/ooni/probe-cli/v3/internal/experiment/openvpn"
 	"github.com/ooni/probe-cli/v3/internal/mocks"
@@ -35,11 +34,11 @@ func makeMockSession() *mocks.Session {
 }
 
 func TestNewExperimentMeasurer(t *testing.T) {
-	m := openvpn.NewExperimentMeasurer(openvpn.Config{}, "openvpn")
+	m := openvpn.NewExperimentMeasurer()
 	if m.ExperimentName() != "openvpn" {
 		t.Fatal("invalid ExperimentName")
 	}
-	if m.ExperimentVersion() != "0.1.2" {
+	if m.ExperimentVersion() != "0.1.3" {
 		t.Fatal("invalid ExperimentVersion")
 	}
 }
@@ -58,194 +57,6 @@ func TestNewTestKeys(t *testing.T) {
 	if tk.OpenVPNHandshake == nil {
 		t.Fatal("OpenVPNHandshake not initialized")
 	}
-}
-
-func TestMaybeGetCredentialsFromOptions(t *testing.T) {
-	t.Run("cert auth returns false if cert, key and ca are not all provided", func(t *testing.T) {
-		cfg := openvpn.Config{
-			SafeCA:   "base64:Zm9v",
-			SafeCert: "base64:Zm9v",
-		}
-		ok, err := openvpn.MaybeGetCredentialsFromOptions(cfg, &vpnconfig.OpenVPNOptions{}, openvpn.AuthCertificate)
-		if err != nil {
-			t.Fatal("should not raise error")
-		}
-		if ok {
-			t.Fatal("expected false")
-		}
-	})
-	t.Run("cert auth returns ok if cert, key and ca are all provided", func(t *testing.T) {
-		cfg := openvpn.Config{
-			SafeCA:   "base64:Zm9v",
-			SafeCert: "base64:Zm9v",
-			SafeKey:  "base64:Zm9v",
-		}
-		opts := &vpnconfig.OpenVPNOptions{}
-		ok, err := openvpn.MaybeGetCredentialsFromOptions(cfg, opts, openvpn.AuthCertificate)
-		if err != nil {
-			t.Fatalf("expected err=nil, got %v", err)
-		}
-		if !ok {
-			t.Fatal("expected true")
-		}
-		if diff := cmp.Diff(opts.CA, []byte("foo")); diff != "" {
-			t.Fatal(diff)
-		}
-		if diff := cmp.Diff(opts.Cert, []byte("foo")); diff != "" {
-			t.Fatal(diff)
-		}
-		if diff := cmp.Diff(opts.Key, []byte("foo")); diff != "" {
-			t.Fatal(diff)
-		}
-	})
-	t.Run("cert auth returns false and error if CA base64 is bad blob", func(t *testing.T) {
-		cfg := openvpn.Config{
-			SafeCA:   "base64:Zm9vaaa",
-			SafeCert: "base64:Zm9v",
-			SafeKey:  "base64:Zm9v",
-		}
-		opts := &vpnconfig.OpenVPNOptions{}
-		ok, err := openvpn.MaybeGetCredentialsFromOptions(cfg, opts, openvpn.AuthCertificate)
-		if ok {
-			t.Fatal("expected false")
-		}
-		if !errors.Is(err, openvpn.ErrBadBase64Blob) {
-			t.Fatalf("expected err=ErrBase64Blob, got %v", err)
-		}
-	})
-	t.Run("cert auth returns false and error if key base64 is bad blob", func(t *testing.T) {
-		cfg := openvpn.Config{
-			SafeCA:   "base64:Zm9v",
-			SafeCert: "base64:Zm9v",
-			SafeKey:  "base64:Zm9vaaa",
-		}
-		opts := &vpnconfig.OpenVPNOptions{}
-		ok, err := openvpn.MaybeGetCredentialsFromOptions(cfg, opts, openvpn.AuthCertificate)
-		if ok {
-			t.Fatal("expected false")
-		}
-		if !errors.Is(err, openvpn.ErrBadBase64Blob) {
-			t.Fatalf("expected err=ErrBase64Blob, got %v", err)
-		}
-	})
-	t.Run("cert auth returns false and error if cert base64 is bad blob", func(t *testing.T) {
-		cfg := openvpn.Config{
-			SafeCA:   "base64:Zm9v",
-			SafeCert: "base64:Zm9vaaa",
-			SafeKey:  "base64:Zm9v",
-		}
-		opts := &vpnconfig.OpenVPNOptions{}
-		ok, err := openvpn.MaybeGetCredentialsFromOptions(cfg, opts, openvpn.AuthCertificate)
-		if ok {
-			t.Fatal("expected false")
-		}
-		if !errors.Is(err, openvpn.ErrBadBase64Blob) {
-			t.Fatalf("expected err=ErrBase64Blob, got %v", err)
-		}
-	})
-	t.Run("userpass auth returns error, not yet implemented", func(t *testing.T) {
-		cfg := openvpn.Config{}
-		ok, err := openvpn.MaybeGetCredentialsFromOptions(cfg, &vpnconfig.OpenVPNOptions{}, openvpn.AuthUserPass)
-		if ok {
-			t.Fatal("expected false")
-		}
-		if err != nil {
-			t.Fatalf("expected err=nil, got %v", err)
-		}
-	})
-}
-
-func TestGetCredentialsFromOptionsOrAPI(t *testing.T) {
-	t.Run("non-registered provider raises error", func(t *testing.T) {
-		m := openvpn.NewExperimentMeasurer(openvpn.Config{}, "openvpn").(openvpn.Measurer)
-		ctx := context.Background()
-		sess := makeMockSession()
-		opts, err := m.GetCredentialsFromOptionsOrAPI(ctx, sess, "nsa")
-		if !errors.Is(err, openvpn.ErrInvalidInput) {
-			t.Fatalf("expected err=ErrInvalidInput, got %v", err)
-		}
-		if opts != nil {
-			t.Fatal("expected opts=nil")
-		}
-	})
-	t.Run("providers with userpass auth method raise error, not yet implemented", func(t *testing.T) {
-		m := openvpn.NewExperimentMeasurer(openvpn.Config{}, "openvpn").(openvpn.Measurer)
-		ctx := context.Background()
-		sess := makeMockSession()
-		opts, err := m.GetCredentialsFromOptionsOrAPI(ctx, sess, "tunnelbear")
-		if !errors.Is(err, openvpn.ErrInvalidInput) {
-			t.Fatalf("expected err=ErrInvalidInput, got %v", err)
-		}
-		if opts != nil {
-			t.Fatal("expected opts=nil")
-		}
-	})
-	t.Run("known cert auth provider and creds in options is ok", func(t *testing.T) {
-		config := openvpn.Config{
-			SafeCA:   "base64:Zm9v",
-			SafeCert: "base64:Zm9v",
-			SafeKey:  "base64:Zm9v",
-		}
-		m := openvpn.NewExperimentMeasurer(config, "openvpn").(openvpn.Measurer)
-		ctx := context.Background()
-		sess := makeMockSession()
-		opts, err := m.GetCredentialsFromOptionsOrAPI(ctx, sess, "riseup")
-		if err != nil {
-			t.Fatalf("expected err=nil, got %v", err)
-		}
-		if opts == nil {
-			t.Fatal("expected non-nil options")
-		}
-	})
-	t.Run("known cert auth provider and bad creds in options returns error", func(t *testing.T) {
-		config := openvpn.Config{
-			SafeCA:   "base64:Zm9v",
-			SafeCert: "base64:Zm9v",
-			SafeKey:  "base64:Zm9vaaa",
-		}
-		m := openvpn.NewExperimentMeasurer(config, "openvpn").(openvpn.Measurer)
-		ctx := context.Background()
-		sess := makeMockSession()
-		opts, err := m.GetCredentialsFromOptionsOrAPI(ctx, sess, "riseup")
-		if !errors.Is(err, openvpn.ErrBadBase64Blob) {
-			t.Fatalf("expected err=ErrBadBase64, got %v", err)
-		}
-		if opts != nil {
-			t.Fatal("expected nil opts")
-		}
-	})
-	t.Run("known cert auth provider with null options hits the api", func(t *testing.T) {
-		config := openvpn.Config{}
-		m := openvpn.NewExperimentMeasurer(config, "openvpn").(openvpn.Measurer)
-		ctx := context.Background()
-		sess := makeMockSession()
-		opts, err := m.GetCredentialsFromOptionsOrAPI(ctx, sess, "riseup")
-		if err != nil {
-			t.Fatalf("expected err=nil, got %v", err)
-		}
-		if opts == nil {
-			t.Fatalf("expected not-nil options, got %v", opts)
-		}
-	})
-	t.Run("known cert auth provider with null options hits the api and raises error if api fails", func(t *testing.T) {
-		config := openvpn.Config{}
-		m := openvpn.NewExperimentMeasurer(config, "openvpn").(openvpn.Measurer)
-		ctx := context.Background()
-
-		someError := errors.New("some error")
-		sess := makeMockSession()
-		sess.MockFetchOpenVPNConfig = func(context.Context, string, string) (*model.OOAPIVPNProviderConfig, error) {
-			return nil, someError
-		}
-
-		opts, err := m.GetCredentialsFromOptionsOrAPI(ctx, sess, "riseup")
-		if !errors.Is(err, someError) {
-			t.Fatalf("expected err=someError, got %v", err)
-		}
-		if opts != nil {
-			t.Fatalf("expected nil options, got %v", opts)
-		}
-	})
 }
 
 func TestAddConnectionTestKeys(t *testing.T) {
@@ -364,17 +175,20 @@ func TestAllConnectionsSuccessful(t *testing.T) {
 	})
 }
 
-func TestBadInputFailure(t *testing.T) {
-	m := openvpn.NewExperimentMeasurer(openvpn.Config{}, "openvpn")
+func TestBadTargetURLFailure(t *testing.T) {
+	m := openvpn.NewExperimentMeasurer()
 	ctx := context.Background()
 	sess := makeMockSession()
 	callbacks := model.NewPrinterCallbacks(sess.Logger())
 	measurement := new(model.Measurement)
-	measurement.Input = "openvpn://badprovider/?address=aa"
 	args := &model.ExperimentArgs{
 		Callbacks:   callbacks,
 		Measurement: measurement,
 		Session:     sess,
+		Target: &openvpn.Target{
+			URL:     "openvpn://badprovider/?address=aa",
+			Options: &openvpn.Config{},
+		},
 	}
 	err := m.Run(ctx, args)
 	if !errors.Is(err, openvpn.ErrInvalidInput) {
@@ -391,9 +205,7 @@ func TestVPNInput(t *testing.T) {
 
 func TestMeasurer_FetchProviderCredentials(t *testing.T) {
 	t.Run("Measurer.FetchProviderCredentials calls method in session", func(t *testing.T) {
-		m := openvpn.NewExperimentMeasurer(
-			openvpn.Config{},
-			"openvpn").(openvpn.Measurer)
+		m := openvpn.NewExperimentMeasurer().(openvpn.Measurer)
 
 		sess := makeMockSession()
 		_, err := m.FetchProviderCredentials(
@@ -406,9 +218,7 @@ func TestMeasurer_FetchProviderCredentials(t *testing.T) {
 	t.Run("Measurer.FetchProviderCredentials raises error if API calls fail", func(t *testing.T) {
 		someError := errors.New("unexpected")
 
-		m := openvpn.NewExperimentMeasurer(
-			openvpn.Config{},
-			"openvpn").(openvpn.Measurer)
+		m := openvpn.NewExperimentMeasurer().(openvpn.Measurer)
 
 		sess := makeMockSession()
 		sess.MockFetchOpenVPNConfig = func(context.Context, string, string) (*model.OOAPIVPNProviderConfig, error) {
@@ -424,21 +234,19 @@ func TestMeasurer_FetchProviderCredentials(t *testing.T) {
 }
 
 func TestSuccess(t *testing.T) {
-	m := openvpn.NewExperimentMeasurer(openvpn.Config{
-		Provider: "riseup",
-		SafeCA:   "base64:Zm9v",
-		SafeKey:  "base64:Zm9v",
-		SafeCert: "base64:Zm9v",
-	}, "openvpn")
+	m := openvpn.NewExperimentMeasurer()
 	ctx := context.Background()
 	sess := makeMockSession()
 	callbacks := model.NewPrinterCallbacks(sess.Logger())
 	measurement := new(model.Measurement)
-	measurement.Input = "openvpn://riseupvpn.corp/?address=127.0.0.1:9989&transport=tcp"
 	args := &model.ExperimentArgs{
 		Callbacks:   callbacks,
 		Measurement: measurement,
 		Session:     sess,
+		Target: &openvpn.Target{
+			URL:     "openvpn://riseupvpn.corp/?address=127.0.0.1:9989&transport=tcp",
+			Options: &openvpn.Config{},
+		},
 	}
 	err := m.Run(ctx, args)
 	if err != nil {

--- a/internal/experiment/openvpn/openvpn_test.go
+++ b/internal/experiment/openvpn/openvpn_test.go
@@ -271,15 +271,45 @@ func TestSuccess(t *testing.T) {
 }
 
 func TestTimestampsFromHandshake(t *testing.T) {
-	events := []*vpntracex.Event{{AtTime: 0}, {AtTime: 1}, {AtTime: 2}}
-	t0, tlast, duration := openvpn.TimestampsFromHandshake(events)
-	if t0 != 0 {
-		t.Fatal("expected t0 == 0")
-	}
-	if tlast != 2.0 {
-		t.Fatal("expected t == 2")
-	}
-	if duration != 2 {
-		t.Fatal("expected duration == 2")
-	}
+	t.Run("with more than a single event (common case)", func(t *testing.T) {
+		events := []*vpntracex.Event{{AtTime: 0}, {AtTime: 1}, {AtTime: 2}}
+		t0, tlast, duration := openvpn.TimestampsFromHandshake(events)
+		if t0 != 0 {
+			t.Fatal("expected t0 == 0")
+		}
+		if tlast != 2.0 {
+			t.Fatal("expected t == 2")
+		}
+		if duration != 2 {
+			t.Fatal("expected duration == 2")
+		}
+	})
+
+	t.Run("with a single event", func(t *testing.T) {
+		events := []*vpntracex.Event{{AtTime: 1}}
+		t0, tlast, duration := openvpn.TimestampsFromHandshake(events)
+		if t0 != 1.0 {
+			t.Fatal("expected t0 == 1.0")
+		}
+		if tlast != 1.0 {
+			t.Fatal("expected t == 1.0")
+		}
+		if duration != 0 {
+			t.Fatal("expected duration == 0")
+		}
+	})
+
+	t.Run("with no events", func(t *testing.T) {
+		events := []*vpntracex.Event{}
+		t0, tlast, duration := openvpn.TimestampsFromHandshake(events)
+		if t0 != 0 {
+			t.Fatal("expected t0 == 0")
+		}
+		if tlast != 0 {
+			t.Fatal("expected t == 0")
+		}
+		if duration != 0 {
+			t.Fatal("expected duration == 0")
+		}
+	})
 }

--- a/internal/experiment/openvpn/openvpn_test.go
+++ b/internal/experiment/openvpn/openvpn_test.go
@@ -261,7 +261,7 @@ func TestTimestampsFromHandshake(t *testing.T) {
 		t.Fatal("expected t0 == 0")
 	}
 	if tlast != 2.0 {
-		t.Fatal("expected t0 == 2")
+		t.Fatal("expected t == 2")
 	}
 	if duration != 2 {
 		t.Fatal("expected duration == 2")

--- a/internal/experiment/openvpn/richerinput.go
+++ b/internal/experiment/openvpn/richerinput.go
@@ -103,8 +103,8 @@ func (tl *targetLoader) Load(ctx context.Context) ([]model.ExperimentTarget, err
 	return targets, nil
 }
 
-// TODO(ainghazal): we might want to get both the BaseURL and the HTTPClient from the session,
-// and then deal with the openvpn-specific API calls ourselves within the boundaries of the experiment.
+// TODO(https://github.com/ooni/probe/issues/2755): make the code that fetches experiment private
+// and let the common code export just the bare minimum to make this possible.
 func (tl *targetLoader) loadFromBackend(ctx context.Context) ([]model.ExperimentTarget, error) {
 	if tl.options.Provider == "" {
 		tl.options.Provider = defaultProvider
@@ -126,7 +126,8 @@ func (tl *targetLoader) loadFromBackend(ctx context.Context) ([]model.Experiment
 
 	for _, input := range apiConfig.Inputs {
 		config := &Config{
-			// Auth and Cipher are hardcoded for now.
+			// TODO(ainghazal): Auth and Cipher are hardcoded for now.
+			// Backend should provide them as richer input; and if empty we can use these as defaults.
 			Auth:   "SHA512",
 			Cipher: "AES-256-GCM",
 		}
@@ -135,6 +136,8 @@ func (tl *targetLoader) loadFromBackend(ctx context.Context) ([]model.Experiment
 			config.SafeCA = apiConfig.Config.CA
 			config.SafeCert = apiConfig.Config.Cert
 			config.SafeKey = apiConfig.Config.Key
+		case AuthUserPass:
+			// TODO(ainghazal): implement (surfshark, etc)
 		}
 		targets = append(targets, &Target{
 			URL:     input,

--- a/internal/experiment/openvpn/richerinput.go
+++ b/internal/experiment/openvpn/richerinput.go
@@ -1,0 +1,146 @@
+package openvpn
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/reflectx"
+	"github.com/ooni/probe-cli/v3/internal/targetloading"
+)
+
+// defaultProvider is the provider we will request from API in case we got no provider set
+// in the CLI options.
+var defaultProvider = "riseupvpn"
+
+// providerAuthentication is a map so that we know which kind of credentials we
+// need to fill in the openvpn options for each known provider.
+var providerAuthentication = map[string]AuthMethod{
+	"riseupvpn":     AuthCertificate,
+	"tunnelbearvpn": AuthUserPass,
+	"surfsharkvpn":  AuthUserPass,
+}
+
+// Target is a richer-input target that this experiment should measure.
+type Target struct {
+	// Options contains the configuration.
+	Options *Config
+
+	// URL is the input URL.
+	URL string
+}
+
+var _ model.ExperimentTarget = &Target{}
+
+// Category implements [model.ExperimentTarget].
+func (t *Target) Category() string {
+	return model.DefaultCategoryCode
+}
+
+// Country implements [model.ExperimentTarget].
+func (t *Target) Country() string {
+	return model.DefaultCountryCode
+}
+
+// Input implements [model.ExperimentTarget].
+func (t *Target) Input() string {
+	return t.URL
+}
+
+// String implements [model.ExperimentTarget].
+func (t *Target) String() string {
+	return t.URL
+}
+
+// NewLoader constructs a new [model.ExperimentTargerLoader] instance.
+//
+// This function PANICS if options is not an instance of [*openvpn.Config].
+func NewLoader(loader *targetloading.Loader, gopts any) model.ExperimentTargetLoader {
+	// Panic if we cannot convert the options to the expected type.
+	//
+	// We do not expect a panic here because the type is managed by the registry package.
+	options := gopts.(*Config)
+
+	// Construct the proper loader instance.
+	return &targetLoader{
+		loader:  loader,
+		options: options,
+		session: loader.Session,
+	}
+}
+
+// targetLoader loads targets for this experiment.
+type targetLoader struct {
+	loader  *targetloading.Loader
+	options *Config
+	session targetloading.Session
+}
+
+// Load implements model.ExperimentTargetLoader.
+func (tl *targetLoader) Load(ctx context.Context) ([]model.ExperimentTarget, error) {
+	// If inputs and files are all empty and there are no options, let's use the backend
+	if len(tl.loader.StaticInputs) <= 0 && len(tl.loader.SourceFiles) <= 0 &&
+		reflectx.StructOrStructPtrIsZero(tl.options) {
+		return tl.loadFromBackend(ctx)
+	}
+
+	// Otherwise, attempt to load the static inputs from CLI and files
+	inputs, err := targetloading.LoadStatic(tl.loader)
+
+	// Handle the case where we couldn't load from CLI or files
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the list of targets that we should measure.
+	var targets []model.ExperimentTarget
+	for _, input := range inputs {
+		targets = append(targets, &Target{
+			Options: tl.options,
+			URL:     input,
+		})
+	}
+	return targets, nil
+}
+
+// TODO(ainghazal): we might want to get both the BaseURL and the HTTPClient from the session,
+// and then deal with the openvpn-specific API calls ourselves within the boundaries of the experiment.
+func (tl *targetLoader) loadFromBackend(_ context.Context) ([]model.ExperimentTarget, error) {
+	if tl.options.Provider == "" {
+		tl.options.Provider = defaultProvider
+	}
+
+	targets := make([]model.ExperimentTarget, 0)
+	provider := tl.options.Provider
+
+	// TODO(ainghazal): pass country code too (from session?)
+	apiConfig, err := tl.session.FetchOpenVPNConfig(context.Background(), provider, "XX")
+	if err != nil {
+		return nil, err
+	}
+
+	auth, ok := providerAuthentication[provider]
+	if !ok {
+		return nil, fmt.Errorf("%w: unknown authentication for provider %s", ErrInvalidInput, provider)
+	}
+
+	for _, input := range apiConfig.Inputs {
+		config := &Config{
+			// Auth and Cipher are hardcoded for now.
+			Auth:   "SHA512",
+			Cipher: "AES-256-GCM",
+		}
+		switch auth {
+		case AuthCertificate:
+			config.SafeCA = apiConfig.Config.CA
+			config.SafeCert = apiConfig.Config.Cert
+			config.SafeKey = apiConfig.Config.Key
+		}
+		targets = append(targets, &Target{
+			URL:     input,
+			Options: config,
+		})
+	}
+
+	return targets, nil
+}

--- a/internal/experiment/openvpn/richerinput_test.go
+++ b/internal/experiment/openvpn/richerinput_test.go
@@ -1,0 +1,175 @@
+package openvpn
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/probe-cli/v3/internal/mocks"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/targetloading"
+)
+
+func TestTarget(t *testing.T) {
+	target := &Target{
+		URL: "openvpn://unknown.corp?address=1.1.1.1%3A443&transport=udp",
+		Options: &Config{
+			Auth:     "SHA512",
+			Cipher:   "AES-256-GCM",
+			Provider: "unknown",
+			SafeKey:  "aa",
+			SafeCert: "bb",
+			SafeCA:   "cc",
+		},
+	}
+
+	t.Run("Category", func(t *testing.T) {
+		if target.Category() != model.DefaultCategoryCode {
+			t.Fatal("invalid Category")
+		}
+	})
+
+	t.Run("Country", func(t *testing.T) {
+		if target.Country() != model.DefaultCountryCode {
+			t.Fatal("invalid Country")
+		}
+	})
+
+	t.Run("Input", func(t *testing.T) {
+		if target.Input() != "openvpn://unknown.corp?address=1.1.1.1%3A443&transport=udp" {
+			t.Fatal("invalid Input")
+		}
+	})
+
+	t.Run("String", func(t *testing.T) {
+		if target.String() != "openvpn://unknown.corp?address=1.1.1.1%3A443&transport=udp" {
+			t.Fatal("invalid String")
+		}
+	})
+}
+
+func TestNewLoader(t *testing.T) {
+	// create the pointers we expect to see
+	child := &targetloading.Loader{}
+	options := &Config{}
+
+	// create the loader and cast it to its private type
+	loader := NewLoader(child, options).(*targetLoader)
+
+	// make sure the loader is okay
+	if child != loader.loader {
+		t.Fatal("invalid loader pointer")
+	}
+
+	// make sure the options are okay
+	if options != loader.options {
+		t.Fatal("invalid options pointer")
+	}
+}
+
+func TestTargetLoaderLoad(t *testing.T) {
+	// testcase is a test case implemented by this function
+	type testcase struct {
+		// name is the test case name
+		name string
+
+		// options contains the options to use
+		options *Config
+
+		// loader is the loader to use
+		loader *targetloading.Loader
+
+		// expectErr is the error we expect
+		expectErr error
+
+		// expectResults contains the expected results
+		expectTargets []model.ExperimentTarget
+	}
+
+	cases := []testcase{
+
+		{
+			name: "with options and inputs",
+			options: &Config{
+				SafeCA:   "aa",
+				SafeCert: "bb",
+				SafeKey:  "cc",
+				Provider: "unknown",
+			},
+			loader: &targetloading.Loader{
+				ExperimentName: "openvpn",
+				InputPolicy:    model.InputOrQueryBackend,
+				Logger:         model.DiscardLogger,
+				Session:        &mocks.Session{},
+				StaticInputs: []string{
+					"openvpn://unknown.corp/1.1.1.1",
+				},
+			},
+			expectErr: nil,
+			expectTargets: []model.ExperimentTarget{
+				&Target{
+					URL: "openvpn://unknown.corp/1.1.1.1",
+					Options: &Config{
+						Provider: "unknown",
+						SafeCA:   "aa",
+						SafeCert: "bb",
+						SafeKey:  "cc",
+					},
+				},
+			},
+		},
+		{
+			name: "with just options",
+			options: &Config{
+				Provider: "riseupvpn",
+			},
+			loader: &targetloading.Loader{
+				ExperimentName: "openvpn",
+				InputPolicy:    model.InputOrQueryBackend,
+				Logger:         model.DiscardLogger,
+				Session:        &mocks.Session{},
+				StaticInputs:   []string{},
+				SourceFiles:    []string{},
+			},
+			expectErr:     nil,
+			expectTargets: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// create a target loader using the given config
+			//
+			// note that we use a default test input for results predictability
+			// since the static list may change over time
+			tl := &targetLoader{
+				loader:  tc.loader,
+				options: tc.options,
+			}
+
+			// load targets
+			targets, err := tl.Load(context.Background())
+
+			// make sure error is consistent
+			switch {
+			case err == nil && tc.expectErr == nil:
+				// fallthrough
+
+			case err != nil && tc.expectErr != nil:
+				if !errors.Is(err, tc.expectErr) {
+					t.Fatal("unexpected error", err)
+				}
+				// fallthrough
+
+			default:
+				t.Fatal("expected", tc.expectErr, "got", err)
+			}
+
+			// make sure the targets are consistent
+			if diff := cmp.Diff(tc.expectTargets, targets); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/internal/experiment/openvpn/richerinput_test.go
+++ b/internal/experiment/openvpn/richerinput_test.go
@@ -192,6 +192,9 @@ func TestTargetLoaderLoadFromBackend(t *testing.T) {
 			DateUpdated: time.Now(),
 		}, nil
 	}
+	sess.MockProbeCC = func() string {
+		return "IT"
+	}
 	tl := &targetLoader{
 		loader:  loader,
 		options: &Config{},

--- a/internal/experiment/openvpn/richerinput_test.go
+++ b/internal/experiment/openvpn/richerinput_test.go
@@ -142,9 +142,6 @@ func TestTargetLoaderLoad(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			// create a target loader using the given config
-			//
-			// note that we use a default test input for results predictability
-			// since the static list may change over time
 			tl := &targetLoader{
 				loader:  tc.loader,
 				options: tc.options,

--- a/internal/model/experiment.go
+++ b/internal/model/experiment.go
@@ -278,6 +278,9 @@ type ExperimentTargetLoaderSession interface {
 
 	// Logger returns the logger to use.
 	Logger() Logger
+
+	// ProbeCC returns the probe country code.
+	ProbeCC() string
 }
 
 // ExperimentOptionInfo contains info about an experiment option.

--- a/internal/registry/openvpn.go
+++ b/internal/registry/openvpn.go
@@ -14,15 +14,14 @@ func init() {
 	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
-				return openvpn.NewExperimentMeasurer(
-					*config.(*openvpn.Config), "openvpn",
-				)
+				return openvpn.NewExperimentMeasurer()
 			},
 			canonicalName:    canonicalName,
 			config:           &openvpn.Config{},
 			enabledByDefault: true,
 			interruptible:    true,
 			inputPolicy:      model.InputOrQueryBackend,
+			newLoader:        openvpn.NewLoader,
 		}
 	}
 }

--- a/internal/targetloading/targetloading.go
+++ b/internal/targetloading/targetloading.go
@@ -10,8 +10,6 @@ import (
 	"net/url"
 
 	"github.com/apex/log"
-	// FIXME - move this to the experiment
-	// "github.com/ooni/probe-cli/v3/internal/experiment/openvpn"
 	"github.com/ooni/probe-cli/v3/internal/experimentname"
 	"github.com/ooni/probe-cli/v3/internal/fsx"
 	"github.com/ooni/probe-cli/v3/internal/model"
@@ -163,7 +161,8 @@ func (il *Loader) loadOrQueryBackend(ctx context.Context) ([]model.ExperimentTar
 	if err != nil || len(inputs) > 0 {
 		return inputs, err
 	}
-	return il.loadRemote(ctx)
+	// This assumes that the default experiment for loading remote targets is WebConnectivity.
+	return il.loadRemoteWebConnectivity(ctx)
 }
 
 // TODO(https://github.com/ooni/probe/issues/1390): we need to
@@ -309,21 +308,6 @@ func LoadStatic(config *Loader) ([]string, error) {
 	return inputs, nil
 }
 
-// loadRemote loads inputs from a remote source.
-func (il *Loader) loadRemote(ctx context.Context) ([]model.ExperimentTarget, error) {
-	switch experimentname.Canonicalize(il.ExperimentName) {
-	case "openvpn":
-		// TODO(ainghazal): given the semantics of the current API call, in an ideal world we'd need to pass
-		// the desired provider here, if known. We only have one provider for now, so I'm acting like YAGNI. Another
-		// option is perhaps to coalesce all the known providers per proto into a single API call and let client
-		// pick whatever they want.
-		// This will likely improve after Richer Input is available.
-		return il.loadRemoteOpenVPN(ctx)
-	default:
-		return il.loadRemoteWebConnectivity(ctx)
-	}
-}
-
 // loadRemoteWebConnectivity loads webconnectivity inputs from a remote source.
 func (il *Loader) loadRemoteWebConnectivity(ctx context.Context) ([]model.ExperimentTarget, error) {
 	config := il.CheckInConfig
@@ -359,42 +343,6 @@ func modelOOAPIURLInfoToModelExperimentTarget(
 		})
 	}
 	return
-}
-
-// loadRemoteOpenVPN loads openvpn inputs from a remote source.
-func (il *Loader) loadRemoteOpenVPN(ctx context.Context) ([]model.ExperimentTarget, error) {
-	// VPN Inputs do not match exactly the semantics expected from [model.OOAPIURLInfo],
-	// since OOAPIURLInfo is oriented towards webconnectivity,
-	// but we force VPN targets in the URL and ignore all the other fields.
-	// There's still some level of impedance mismatch here, since it's also possible that
-	// the user of the library wants to use remotes by unknown providers passed via cli options,
-	// oonirun etc; in that case we'll need to extract the provider annotation from the URLs.
-	urls := make([]model.OOAPIURLInfo, 0)
-
-	// The openvpn experiment contains an array of the providers that the API knows about.
-	// We try to get all the remotes from the API for the list of enabled providers.
-	providers := []string{}
-	for _, provider := range providers {
-		// fetchOpenVPNConfig ultimately uses an internal cache in the session to avoid
-		// hitting the API too many times.
-		reply, err := il.fetchOpenVPNConfig(ctx, provider)
-		if err != nil {
-			output := modelOOAPIURLInfoToModelExperimentTarget(urls)
-			return output, err
-		}
-		for _, input := range reply.Inputs {
-			urls = append(urls, model.OOAPIURLInfo{URL: input})
-		}
-	}
-
-	if len(urls) <= 0 {
-		// At some point we might want to return [openvpn.DefaultEndpoints],
-		// but for now we're assuming that no targets means we've disabled
-		// the experiment on the backend.
-		return nil, ErrNoURLsReturned
-	}
-	output := modelOOAPIURLInfoToModelExperimentTarget(urls)
-	return output, nil
 }
 
 // checkIn executes the check-in and filters the returned URLs to exclude

--- a/internal/targetloading/targetloading.go
+++ b/internal/targetloading/targetloading.go
@@ -10,7 +10,8 @@ import (
 	"net/url"
 
 	"github.com/apex/log"
-	"github.com/ooni/probe-cli/v3/internal/experiment/openvpn"
+	// FIXME - move this to the experiment
+	// "github.com/ooni/probe-cli/v3/internal/experiment/openvpn"
 	"github.com/ooni/probe-cli/v3/internal/experimentname"
 	"github.com/ooni/probe-cli/v3/internal/fsx"
 	"github.com/ooni/probe-cli/v3/internal/model"
@@ -372,7 +373,8 @@ func (il *Loader) loadRemoteOpenVPN(ctx context.Context) ([]model.ExperimentTarg
 
 	// The openvpn experiment contains an array of the providers that the API knows about.
 	// We try to get all the remotes from the API for the list of enabled providers.
-	for _, provider := range openvpn.APIEnabledProviders {
+	providers := []string{}
+	for _, provider := range providers {
 		// fetchOpenVPNConfig ultimately uses an internal cache in the session to avoid
 		// hitting the API too many times.
 		reply, err := il.fetchOpenVPNConfig(ctx, provider)

--- a/internal/targetloading/targetloading.go
+++ b/internal/targetloading/targetloading.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/stuninput"
 )
 
-// These errors are returned by the [*Loader].
+// These errors are returned by the [*Loader] or the experiment execution.
 var (
 	ErrNoURLsReturned    = errors.New("no URLs returned")
 	ErrDetectedEmptyFile = errors.New("file did not contain any input")
@@ -24,6 +24,7 @@ var (
 	ErrNoInputExpected   = errors.New("we did not expect any input")
 	ErrNoStaticInput     = errors.New("no static input for this experiment")
 	ErrInvalidInputType  = errors.New("invalid richer input type")
+	ErrInvalidInput      = errors.New("input does not conform to spec")
 )
 
 // Session is the session according to a [*Loader] instance.

--- a/internal/targetloading/targetloading_test.go
+++ b/internal/targetloading/targetloading_test.go
@@ -529,6 +529,9 @@ type TargetLoaderMockableSession struct {
 	// It should be nil when Error is non-nil.
 	FetchOpenVPNConfigOutput *model.OOAPIVPNProviderConfig
 
+	// ProbeCountryCode is the probe country code
+	ProbeCountryCode string
+
 	// Error is the error to be returned by CheckIn. It
 	// should be nil when Output is not-nil.
 	Error error
@@ -548,6 +551,10 @@ func (sess *TargetLoaderMockableSession) FetchOpenVPNConfig(
 	ctx context.Context, provider, cc string) (*model.OOAPIVPNProviderConfig, error) {
 	runtimex.Assert(!(sess.Error == nil && sess.FetchOpenVPNConfigOutput == nil), "both FetchOpenVPNConfig and Error are nil")
 	return sess.FetchOpenVPNConfigOutput, sess.Error
+}
+
+func (sess *TargetLoaderMockableSession) ProbeCC() string {
+	return sess.ProbeCountryCode
 }
 
 // Logger implements [Session].


### PR DESCRIPTION
This commit:

1. modifies `./internal/registry` and its `openvpn.go` file such that `openvpn` has its own private target loader;

2. modifies `./internal/experiment/openvpn` to use the richer input targets to merge the options for the openvpn experiment.

3. removes cache from session after fetching openvpn config

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2600
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request
- [x] if you changed code inside an experiment, make sure you bump its version number


