### PR TITLE
feat(openvpn): add a top-level test key with bootstrap time and handshake failure

### DIFF
--- a/internal/experiment/openvpn/openvpn.go
+++ b/internal/experiment/openvpn/openvpn.go
@@ -210,23 +210,6 @@ func TimestampsFromHandshake(events []*vpntracex.Event) (float64, float64, float
 	return t0, t, duration
 }
 
-// TODO: delete-me
-// FetchProviderCredentials will extract credentials from the configuration we gathered for a given provider.
-/*
-func (m *Measurer) FetchProviderCredentials(
-	ctx context.Context,
-	sess model.ExperimentSession,
-	provider string) (*model.OOAPIVPNProviderConfig, error) {
-	// TODO(ainghazal): pass real country code, can be useful to orchestrate campaigns specific to areas.
-	// Since we have contacted the API previously, this call should use the cached info contained in the session.
-	config, err := sess.FetchOpenVPNConfig(ctx, provider, "XX")
-	if err != nil {
-		return nil, err
-	}
-	return config, nil
-}
-*/
-
 // Run implements model.ExperimentMeasurer.Run.
 // A single run expects exactly ONE input (endpoint), but we can modify whether
 // to test different transports by settings options.

--- a/internal/experiment/openvpn/openvpn.go
+++ b/internal/experiment/openvpn/openvpn.go
@@ -48,7 +48,7 @@ type TestKeys struct {
 	NetworkEvents    []*vpntracex.Event                      `json:"network_events"`
 	TCPConnect       []*model.ArchivalTCPConnectResult       `json:"tcp_connect,omitempty"`
 	OpenVPNHandshake []*model.ArchivalOpenVPNHandshakeResult `json:"openvpn_handshake"`
-	BootstrapTime    float64                                 `json:"bootstrap_time,omitempty"`
+	BootstrapTime    float64                                 `json:"bootstrap_time"`
 	Tunnel           string                                  `json:"tunnel"`
 	Failure          *string                                 `json:"failure"`
 }

--- a/internal/experiment/openvpn/openvpn.go
+++ b/internal/experiment/openvpn/openvpn.go
@@ -72,9 +72,8 @@ type SingleConnection struct {
 	TCPConnect       *model.ArchivalTCPConnectResult       `json:"tcp_connect,omitempty"`
 	OpenVPNHandshake *model.ArchivalOpenVPNHandshakeResult `json:"openvpn_handshake"`
 	NetworkEvents    []*vpntracex.Event                    `json:"network_events"`
-	// TODO(ainghazal): make sure to document in the spec that these network events only cover the handshake.
 	// TODO(ainghazal): in the future, we will want to store more operations under this struct for a single connection,
-	// like pingResults or urlgetter calls.
+	// like pingResults or urlgetter calls. Be sure to modify the spec when that happens.
 }
 
 // AddConnectionTestKeys adds the result of a single OpenVPN connection attempt to the
@@ -92,6 +91,7 @@ func (tk *TestKeys) AddConnectionTestKeys(result *SingleConnection) {
 
 	if result.OpenVPNHandshake.Failure != nil {
 		tk.Failure = result.OpenVPNHandshake.Failure
+		tk.BootstrapTime = 0
 	}
 }
 
@@ -163,6 +163,7 @@ func (m *Measurer) connectAndHandshake(
 
 	t0, t, handshakeTime := TimestampsFromHandshake(handshakeEvents)
 
+	// the bootstrap time is defined to be zero if there's a handshake failure.
 	var bootstrapTime float64
 	if err == nil {
 		bootstrapTime = time.Since(zeroTime).Seconds()
@@ -209,7 +210,9 @@ func TimestampsFromHandshake(events []*vpntracex.Event) (float64, float64, float
 	return t0, t, duration
 }
 
+// TODO: delete-me
 // FetchProviderCredentials will extract credentials from the configuration we gathered for a given provider.
+/*
 func (m *Measurer) FetchProviderCredentials(
 	ctx context.Context,
 	sess model.ExperimentSession,
@@ -222,6 +225,7 @@ func (m *Measurer) FetchProviderCredentials(
 	}
 	return config, nil
 }
+*/
 
 // Run implements model.ExperimentMeasurer.Run.
 // A single run expects exactly ONE input (endpoint), but we can modify whether

--- a/internal/experiment/openvpn/openvpn_test.go
+++ b/internal/experiment/openvpn/openvpn_test.go
@@ -79,7 +79,7 @@ func TestAddConnectionTestKeys(t *testing.T) {
 				TransactionID: 1,
 			},
 			OpenVPNHandshake: &model.ArchivalOpenVPNHandshakeResult{
-				BootstrapTime:  1,
+				HandshakeTime:  1,
 				Endpoint:       "aa",
 				Failure:        nil,
 				IP:             "1.1.1.1",
@@ -111,7 +111,7 @@ func TestAddConnectionTestKeys(t *testing.T) {
 		sc := &openvpn.SingleConnection{
 			TCPConnect: nil,
 			OpenVPNHandshake: &model.ArchivalOpenVPNHandshakeResult{
-				BootstrapTime:  1,
+				HandshakeTime:  1,
 				Endpoint:       "aa",
 				Failure:        nil,
 				IP:             "1.1.1.1",

--- a/internal/experiment/openvpn/openvpn_test.go
+++ b/internal/experiment/openvpn/openvpn_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	vpntracex "github.com/ooni/minivpn/pkg/tracex"
 	"github.com/ooni/probe-cli/v3/internal/experiment/openvpn"
+	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/mocks"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/targetloading"
@@ -40,7 +41,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if m.ExperimentName() != "openvpn" {
 		t.Fatal("invalid ExperimentName")
 	}
-	if m.ExperimentVersion() != "0.1.3" {
+	if m.ExperimentVersion() != "0.1.4" {
 		t.Fatal("invalid ExperimentVersion")
 	}
 }
@@ -219,6 +220,7 @@ func TestVPNInput(t *testing.T) {
 	// TODO(ainghazal): do a real test, get credentials etc.
 }
 
+/*
 func TestMeasurer_FetchProviderCredentials(t *testing.T) {
 	t.Run("Measurer.FetchProviderCredentials calls method in session", func(t *testing.T) {
 		m := openvpn.NewExperimentMeasurer().(*openvpn.Measurer)
@@ -248,6 +250,7 @@ func TestMeasurer_FetchProviderCredentials(t *testing.T) {
 		}
 	})
 }
+*/
 
 func TestSuccess(t *testing.T) {
 	m := openvpn.NewExperimentMeasurer()
@@ -312,4 +315,102 @@ func TestTimestampsFromHandshake(t *testing.T) {
 			t.Fatal("expected duration == 0")
 		}
 	})
+}
+
+func TestBootstrapTimeWithNoFailure(t *testing.T) {
+	bootstrapTime := 1.2305
+	tk := openvpn.NewTestKeys()
+	sc := &openvpn.SingleConnection{
+		BootstrapTime: bootstrapTime,
+		TCPConnect: &model.ArchivalTCPConnectResult{
+			IP:   "1.1.1.1",
+			Port: 1194,
+			Status: model.ArchivalTCPConnectStatus{
+				Blocked: new(bool),
+				Failure: new(string),
+				Success: false,
+			},
+			T0:            0.1,
+			T:             0.9,
+			Tags:          []string{},
+			TransactionID: 1,
+		},
+		OpenVPNHandshake: &model.ArchivalOpenVPNHandshakeResult{
+			HandshakeTime:  1.20,
+			Endpoint:       "aa",
+			Failure:        nil,
+			IP:             "1.1.1.1",
+			Port:           1194,
+			Transport:      "tcp",
+			Provider:       "unknown",
+			OpenVPNOptions: model.ArchivalOpenVPNOptions{},
+			T0:             0.03,
+			T:              1.23,
+			Tags:           []string{},
+			TransactionID:  1,
+		},
+		NetworkEvents: []*vpntracex.Event{},
+	}
+	tk.AddConnectionTestKeys(sc)
+
+	if tk.Failure != nil {
+		t.Fatal("expected nil failure")
+	}
+	if tk.BootstrapTime != bootstrapTime {
+		t.Fatal("wrong bootstrap time")
+	}
+	if tk.Tunnel != "openvpn" {
+		t.Fatal("tunnel should be openvpn")
+	}
+}
+
+func TestBootstrapTimeWithFailure(t *testing.T) {
+	bootstrapTime := 6.1
+
+	handshakeError := errors.New("mocked error")
+	handshakeFailure := measurexlite.NewFailure(handshakeError)
+
+	tk := openvpn.NewTestKeys()
+	sc := &openvpn.SingleConnection{
+		BootstrapTime: bootstrapTime,
+		TCPConnect: &model.ArchivalTCPConnectResult{
+			IP:   "1.1.1.1",
+			Port: 1194,
+			Status: model.ArchivalTCPConnectStatus{
+				Blocked: new(bool),
+				Failure: new(string),
+				Success: false,
+			},
+			T0:            0.1,
+			T:             0.9,
+			Tags:          []string{},
+			TransactionID: 1,
+		},
+		OpenVPNHandshake: &model.ArchivalOpenVPNHandshakeResult{
+			HandshakeTime:  1.20,
+			Endpoint:       "aa",
+			Failure:        handshakeFailure,
+			IP:             "1.1.1.1",
+			Port:           1194,
+			Transport:      "tcp",
+			Provider:       "unknown",
+			OpenVPNOptions: model.ArchivalOpenVPNOptions{},
+			T0:             0.03,
+			T:              1.23,
+			Tags:           []string{},
+			TransactionID:  1,
+		},
+		NetworkEvents: []*vpntracex.Event{},
+	}
+	tk.AddConnectionTestKeys(sc)
+
+	if tk.Failure != handshakeFailure {
+		t.Fatalf("expected handshake failure, got %v", tk.Failure)
+	}
+	if tk.BootstrapTime != 0 {
+		t.Fatalf("wrong bootstrap time: expected 0, got %v", tk.BootstrapTime)
+	}
+	if tk.Tunnel != "openvpn" {
+		t.Fatal("tunnel should be openvpn")
+	}
 }

--- a/internal/experiment/openvpn/openvpn_test.go
+++ b/internal/experiment/openvpn/openvpn_test.go
@@ -213,45 +213,6 @@ func TestBadTargetURLFailure(t *testing.T) {
 	}
 }
 
-func TestVPNInput(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skip test in short mode")
-	}
-	// TODO(ainghazal): do a real test, get credentials etc.
-}
-
-/*
-func TestMeasurer_FetchProviderCredentials(t *testing.T) {
-	t.Run("Measurer.FetchProviderCredentials calls method in session", func(t *testing.T) {
-		m := openvpn.NewExperimentMeasurer().(*openvpn.Measurer)
-
-		sess := makeMockSession()
-		_, err := m.FetchProviderCredentials(
-			context.Background(),
-			sess, "riseup")
-		if err != nil {
-			t.Fatal("expected no error")
-		}
-	})
-	t.Run("Measurer.FetchProviderCredentials raises error if API calls fail", func(t *testing.T) {
-		someError := errors.New("unexpected")
-
-		m := openvpn.NewExperimentMeasurer().(*openvpn.Measurer)
-
-		sess := makeMockSession()
-		sess.MockFetchOpenVPNConfig = func(context.Context, string, string) (*model.OOAPIVPNProviderConfig, error) {
-			return nil, someError
-		}
-		_, err := m.FetchProviderCredentials(
-			context.Background(),
-			sess, "riseup")
-		if !errors.Is(err, someError) {
-			t.Fatalf("expected error %v, got %v", someError, err)
-		}
-	})
-}
-*/
-
 func TestSuccess(t *testing.T) {
 	m := openvpn.NewExperimentMeasurer()
 	ctx := context.Background()
@@ -413,4 +374,11 @@ func TestBootstrapTimeWithFailure(t *testing.T) {
 	if tk.Tunnel != "openvpn" {
 		t.Fatal("tunnel should be openvpn")
 	}
+}
+
+func TestVPNInput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
+	// TODO(ainghazal): do a real test, get credentials etc.
 }

--- a/internal/experiment/openvpn/richerinput_test.go
+++ b/internal/experiment/openvpn/richerinput_test.go
@@ -225,5 +225,4 @@ func TestTargetLoaderLoadFromBackend(t *testing.T) {
 	if targets[1].String() != "openvpn://target1" {
 		t.Fatal("expected openvpn://target1")
 	}
-
 }

--- a/internal/model/archival.go
+++ b/internal/model/archival.go
@@ -399,9 +399,9 @@ type ArchivalNetworkEvent struct {
 
 // ArchivalOpenVPNHandshakeResult contains the result of a OpenVPN handshake.
 type ArchivalOpenVPNHandshakeResult struct {
-	BootstrapTime  float64                `json:"bootstrap_time,omitempty"`
 	Endpoint       string                 `json:"endpoint"`
 	Failure        *string                `json:"failure"`
+	HandshakeTime  float64                `json:"handshake_time,omitempty"`
 	IP             string                 `json:"ip"`
 	Port           int                    `json:"port"`
 	Transport      string                 `json:"transport"`


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2758
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: https://github.com/ooni/spec/pull/295
- [x] if you changed code inside an experiment, make sure you bump its version number


## Description

Add `bootstrap_time` as a top-level test-key, making OpenVPN nettest conforming to `df-009-tunnel`. It also adds  `tunnel` and `failure` keys with the semantics declared in that spec.
