### PR TITLE
Start working on fixing image paths

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Print the lines of the generated docs
         run: wc -l ooni-docs/src/content/docs/probe-engine/*
 
+      - name: Print assets used in docs
+        run: ls ooni-docs/src/assets
+
       - name: Commit changes
         # Only push the docs update when we are in master
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -46,5 +46,5 @@ jobs:
           git config --global user.email "github+backend@ooni.org"
           git config --global user.name "OONI Github Actions Bot"
           git add .
-          git commit -m "auto: update backend docs to ${{ steps.rev_parse.outputs.COMMIT_HASH }}" || echo "No changes to commit"
+          git commit -m "auto: update probe-engine docs to ${{ steps.rev_parse.outputs.COMMIT_HASH }}" || echo "No changes to commit"
           git push origin

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Update docs
         run: |
           mkdir -p ooni-docs/src/content/docs/probe-engine/
-          cp -R dist/docs/img/* ooni-docs/src/assets/
+          mkdir -p ooni-docs/src/assets/images-probe-engine/
+          cp -R dist/docs/img/* ooni-docs/src/assets/images-probe-engine/
           rm -r dist/docs/img
           cp -R dist/docs/* ooni-docs/src/content/docs/probe-engine/
 

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           mkdir -p ooni-docs/src/content/docs/probe-engine/
           cp -R dist/docs/* ooni-docs/src/content/docs/probe-engine/
+          cp -R dist/docs/img/* ooni-docs/src/assets/
 
       - name: Check for conflicting slugs
         run: |

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -25,8 +25,9 @@ jobs:
       - name: Update docs
         run: |
           mkdir -p ooni-docs/src/content/docs/probe-engine/
-          cp -R dist/docs/* ooni-docs/src/content/docs/probe-engine/
           cp -R dist/docs/img/* ooni-docs/src/assets/
+          rm -r dist/docs/img
+          cp -R dist/docs/* ooni-docs/src/content/docs/probe-engine/
 
       - name: Check for conflicting slugs
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@
 /probe-cli.cov
 /tinyjafar
 /tmp-*
+/dist

--- a/script/build_docs.sh
+++ b/script/build_docs.sh
@@ -80,10 +80,9 @@ slug: probe-engine/design/step-by-step
 EOF
 strip_title $BASE_PATH/dd-003-step-by-step.md >> $DOC_PATH
 mkdir -p $DOCS_ROOT/img
-sed -i 's+img/git-probe-cli-netx-deps.png+../../../assets/images-probe-engine/git-probe-cli-netx-deps.png+' $DOC_PATH
-cp $BASE_PATH/img/git-probe-cli-netx-deps.png $DOCS_ROOT/img
-sed -i 's+img/git-probe-cli-change-histogram.png+../../../assets/images-probe-engine/git-probe-cli-change-histogram.png+' $DOC_PATH
-cp $BASE_PATH/img/git-probe-cli-change-histogram.png $DOCS_ROOT/img
+cp -R $BASE_PATH/img/* $DOCS_ROOT/img/
+sed -i '' 's+img/git-probe-cli-netx-deps.png+../../../assets/images-probe-engine/git-probe-cli-netx-deps.png+' $DOC_PATH
+sed -i '' 's+img/git-probe-cli-change-histogram.png+../../../assets/images-probe-engine/git-probe-cli-change-histogram.png+' $DOC_PATH
 
 DOC_PATH=$DOCS_ROOT/04-design-minioonirunv2.md
 cat <<EOF>$DOC_PATH

--- a/script/build_docs.sh
+++ b/script/build_docs.sh
@@ -23,7 +23,10 @@ description: OONI Probe Engine documentation
 slug: probe-engine
 ---
 EOF
-strip_title README.md >> $DOCS_ROOT/00-index.md
+strip_title Readme.md >> $DOCS_ROOT/00-index.md
+mkdir -p $DOCS_ROOT/img
+cp docs/logo.png $DOCS_ROOT/img/
+sed -i 's+docs/logo.png+../../../assets/images-probe-engine/logo.png' $DOC_PATH
 
 # design docs
 BASE_PATH=docs/design
@@ -79,7 +82,6 @@ slug: probe-engine/design/step-by-step
 ---
 EOF
 strip_title $BASE_PATH/dd-003-step-by-step.md >> $DOC_PATH
-mkdir -p $DOCS_ROOT/img
 cp -R $BASE_PATH/img/* $DOCS_ROOT/img/
 sed -i 's+img/git-probe-cli-netx-deps.png+../../../assets/images-probe-engine/git-probe-cli-netx-deps.png+' $DOC_PATH
 sed -i 's+img/git-probe-cli-change-histogram.png+../../../assets/images-probe-engine/git-probe-cli-change-histogram.png+' $DOC_PATH

--- a/script/build_docs.sh
+++ b/script/build_docs.sh
@@ -65,7 +65,7 @@ description: OONI netx package design documentation
 slug: probe-engine/design/netx
 ---
 EOF
-strip_title $BASE_PATH/dd-02-netx.md >> $DOC_PATH
+strip_title $BASE_PATH/dd-002-netx.md >> $DOC_PATH
 
 DOC_PATH=$DOCS_ROOT/03-design-step-by-step.md
 cat <<EOF>$DOC_PATH

--- a/script/build_docs.sh
+++ b/script/build_docs.sh
@@ -26,7 +26,7 @@ EOF
 strip_title Readme.md >> $DOCS_ROOT/00-index.md
 mkdir -p $DOCS_ROOT/img
 cp docs/logo.png $DOCS_ROOT/img/
-sed -i 's+docs/logo.png+../../../assets/images-probe-engine/logo.png+' $DOC_PATH
+sed -i 's+docs/logo.png+../../../assets/images-probe-engine/logo.png+' $DOCS_ROOT/00-index.md
 
 # design docs
 BASE_PATH=docs/design

--- a/script/build_docs.sh
+++ b/script/build_docs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set +ex
 DOCS_ROOT=dist/docs/
 REPO_NAME="ooni/probe-cli"
 COMMIT_HASH=$(git rev-parse --short HEAD)
@@ -78,6 +79,11 @@ slug: probe-engine/design/step-by-step
 ---
 EOF
 strip_title $BASE_PATH/dd-003-step-by-step.md >> $DOC_PATH
+mkdir -p $DOCS_ROOT/img
+sed -i 's+img/git-probe-cli-netx-deps.png+../../../assets/images-probe-engine/git-probe-cli-netx-deps.png+' $DOC_PATH
+cp $BASE_PATH/img/git-probe-cli-netx-deps.png $DOCS_ROOT/img
+sed -i 's+img/git-probe-cli-change-histogram.png+../../../assets/images-probe-engine/git-probe-cli-change-histogram.png+' $DOC_PATH
+cp $BASE_PATH/img/git-probe-cli-change-histogram.png $DOCS_ROOT/img
 
 DOC_PATH=$DOCS_ROOT/04-design-minioonirunv2.md
 cat <<EOF>$DOC_PATH

--- a/script/build_docs.sh
+++ b/script/build_docs.sh
@@ -81,8 +81,8 @@ EOF
 strip_title $BASE_PATH/dd-003-step-by-step.md >> $DOC_PATH
 mkdir -p $DOCS_ROOT/img
 cp -R $BASE_PATH/img/* $DOCS_ROOT/img/
-sed -i '' 's+img/git-probe-cli-netx-deps.png+../../../assets/images-probe-engine/git-probe-cli-netx-deps.png+' $DOC_PATH
-sed -i '' 's+img/git-probe-cli-change-histogram.png+../../../assets/images-probe-engine/git-probe-cli-change-histogram.png+' $DOC_PATH
+sed -i 's+img/git-probe-cli-netx-deps.png+../../../assets/images-probe-engine/git-probe-cli-netx-deps.png+' $DOC_PATH
+sed -i 's+img/git-probe-cli-change-histogram.png+../../../assets/images-probe-engine/git-probe-cli-change-histogram.png+' $DOC_PATH
 
 DOC_PATH=$DOCS_ROOT/04-design-minioonirunv2.md
 cat <<EOF>$DOC_PATH

--- a/script/build_docs.sh
+++ b/script/build_docs.sh
@@ -26,7 +26,7 @@ EOF
 strip_title Readme.md >> $DOCS_ROOT/00-index.md
 mkdir -p $DOCS_ROOT/img
 cp docs/logo.png $DOCS_ROOT/img/
-sed -i 's+docs/logo.png+../../../assets/images-probe-engine/logo.png' $DOC_PATH
+sed -i 's+docs/logo.png+../../../assets/images-probe-engine/logo.png+' $DOC_PATH
 
 # design docs
 BASE_PATH=docs/design


### PR DESCRIPTION
This diff moves assets used in docs to `src/assets` in `ooni/docs` and also replaces the doc references in markdown files to the appropriate location.