### PR TITLE
feat: enable openvpn in the experimental group

### DIFF
--- a/cmd/ooniprobe/internal/nettests/groups.go
+++ b/cmd/ooniprobe/internal/nettests/groups.go
@@ -57,7 +57,7 @@ var All = map[string]Group{
 			DNSCheck{},
 			ECHCheck{},
 			STUNReachability{},
-			RiseupVPN{},
+			OpenVPN{},
 			TorSf{},
 			VanillaTor{},
 		},

--- a/cmd/ooniprobe/internal/nettests/openvpn.go
+++ b/cmd/ooniprobe/internal/nettests/openvpn.go
@@ -1,0 +1,38 @@
+package nettests
+
+import (
+	"context"
+
+	"github.com/ooni/probe-cli/v3/internal/model"
+)
+
+// OpenVPN nettest implementation.
+type OpenVPN struct{}
+
+func (o OpenVPN) loadTargets(ctl *Controller, builder model.ExperimentBuilder) ([]model.ExperimentTarget, error) {
+	config := &model.ExperimentTargetLoaderConfig{
+		CheckInConfig: &model.OOAPICheckInConfig{},
+		Session:       ctl.Session,
+		SourceFiles:   ctl.InputFiles,
+		StaticInputs:  ctl.Inputs,
+	}
+	targetloader := builder.NewTargetLoader(config)
+	targets, err := targetloader.Load(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return ctl.BuildAndSetInputIdxMap(targets)
+}
+
+// Run starts the nettest.
+func (o OpenVPN) Run(ctl *Controller) error {
+	builder, err := ctl.Session.NewExperimentBuilder("openvpn")
+	if err != nil {
+		return err
+	}
+	inputs, err := o.loadTargets(ctl, builder)
+	if err != nil {
+		return err
+	}
+	return ctl.Run(builder, inputs)
+}


### PR DESCRIPTION
Additionally, remove RiseupVPN, that was disabled and is superseded by the generic openvpn test.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2780
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [x] if you changed code inside an experiment, make sure you bump its version number
