### PR TITLE
refactor: remove dnscheck loader

### DIFF
--- a/docs/design/dd-008-richer-input.md
+++ b/docs/design/dd-008-richer-input.md
@@ -4,7 +4,7 @@
 |--------------|------------------------------------------------|
 | Author       | [@bassosimone](https://github.com/bassosimone) |
 | Last-Updated | 2024-07-02                                     |
-| Reviewed-by  | [@DecFox](https://github.com/DecFox            |
+| Reviewed-by  | [@DecFox](https://github.com/DecFox)           |
 | Status       | living document                                |
 
 This document is a living document documenting our in-progress design

--- a/internal/registry/dnscheck.go
+++ b/internal/registry/dnscheck.go
@@ -22,7 +22,6 @@ func init() {
 			config:           &dnscheck.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputOrStaticDefault,
-			newLoader:        dnscheck.NewLoader,
 		}
 	}
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [ ] reference issue for this pull request: <!-- add URL here -->
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff refactors the dnscheck factory to use the default target loader
