### PR TITLE
Fix progress’ percentage output

### DIFF
--- a/cmd/ooniprobe/internal/output/output.go
+++ b/cmd/ooniprobe/internal/output/output.go
@@ -24,7 +24,7 @@ func Progress(key string, perc float64, eta float64, msg string) {
 	log.WithFields(log.Fields{
 		"type":       "progress",
 		"key":        key,
-		"percentage": perc,
+		"percentage": 100.0 * perc,
 		"eta":        eta,
 	}).Info(msg)
 }


### PR DESCRIPTION
## Checklist

- [ ] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [ ] reference issue for this pull request: <!-- add URL here -->
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

Seems like the progress function gives something like `0.7857142857142857% - <description>` instead of `78.57142857142857% - <description>` in the logs.
