### PR TITLE
fix(dnscheck): reinstate richer input loader

### DIFF
--- a/internal/experiment/dnscheck/richerinput.go
+++ b/internal/experiment/dnscheck/richerinput.go
@@ -117,9 +117,183 @@ var defaultInput = []model.ExperimentTarget{
 			DefaultAddrs: "8.8.8.8 8.8.4.4",
 		},
 	},
-
-	// TODO(bassosimone,DecFox): before releasing, we need to either sync up
-	// this list with ./internal/targetloader or implement a backend API.
+	&Target{
+		URL: "https://cloudflare-dns.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+			DefaultAddrs: "1.1.1.1 1.0.0.1",
+		},
+	},
+	&Target{
+		URL: "https://cloudflare-dns.com/dns-query",
+		Config: &Config{
+			DefaultAddrs: "1.1.1.1 1.0.0.1",
+		},
+	},
+	&Target{
+		URL: "https://dns.quad9.net/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+			DefaultAddrs: "9.9.9.9",
+		},
+	},
+	&Target{
+		URL: "https://dns.quad9.net/dns-query",
+		Config: &Config{
+			DefaultAddrs: "9.9.9.9",
+		},
+	},
+	&Target{
+		URL: "https://family.cloudflare-dns.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://family.cloudflare-dns.com/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns11.quad9.net/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns11.quad9.net/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns9.quad9.net/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns9.quad9.net/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns12.quad9.net/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns12.quad9.net/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://1dot1dot1dot1.cloudflare-dns.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://1dot1dot1dot1.cloudflare-dns.com/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns.adguard.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns.adguard.com/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns-family.adguard.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns-family.adguard.com/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns.cloudflare.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns.cloudflare.com/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://adblock.doh.mullvad.net/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://adblock.doh.mullvad.net/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns.alidns.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns.alidns.com/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://doh.opendns.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://doh.opendns.com/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns.nextdns.io/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns.nextdns.io/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns10.quad9.net/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns10.quad9.net/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://security.cloudflare-dns.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://security.cloudflare-dns.com/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns.switch.ch/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns.switch.ch/dns-query",
+		Config: &Config{},
+	},
+	// TODO(DecFox): implement a backend API to serve this list as dnscheck inputs
 }
 
 func (tl *targetLoader) loadFromBackend(_ context.Context) ([]model.ExperimentTarget, error) {

--- a/internal/registry/dnscheck.go
+++ b/internal/registry/dnscheck.go
@@ -22,6 +22,7 @@ func init() {
 			config:           &dnscheck.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputOrStaticDefault,
+			newLoader:        dnscheck.NewLoader,
 		}
 	}
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [ ] reference issue for this pull request: <!-- add URL here -->
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

## Description

This re-instates the richer input loader for dnscheck which was disabled as part of `release v3.23`. It also updates the dnscheck input list to include all experiment targets. In the future, we'll be serving these targets using a backend API.

Fixes https://github.com/ooni/probe/issues/2799
