### PR TITLE
feat: add fallback domain names for openvpn experiment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/miekg/dns v1.1.59
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/montanaflynn/stats v0.7.1
-	github.com/ooni/minivpn v0.0.6
+	github.com/ooni/minivpn v0.0.7
 	github.com/ooni/netem v0.0.0-20240208095707-608dcbcd82b8
 	github.com/ooni/oocrypto v0.6.2
 	github.com/ooni/oohttp v0.7.3

--- a/go.sum
+++ b/go.sum
@@ -354,8 +354,8 @@ github.com/onsi/ginkgo/v2 v2.17.3/go.mod h1:nP2DPOQoNsQmsVyv5rDA8JkXQoCs6goXIvr/
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.33.0 h1:snPCflnZrpMsy94p4lXVEkHo12lmPnc3vY5XBbreexE=
 github.com/onsi/gomega v1.33.0/go.mod h1:+925n5YtiFsLzzafLUHzVMBpvvRAzrydIBiSIxjX3wY=
-github.com/ooni/minivpn v0.0.6 h1:pGTsYRtofEupMrJL28f1IXO1LJslSI7dEHxSadNgGik=
-github.com/ooni/minivpn v0.0.6/go.mod h1:0KNwmK2Wg9lDbk936XjtxvCq4tPNbK4C3IJvyLwIMrE=
+github.com/ooni/minivpn v0.0.7 h1:fRL6lOivKM+Q23HcN/FFiBftbKTAtz7U8r6cOypBAeM=
+github.com/ooni/minivpn v0.0.7/go.mod h1:0KNwmK2Wg9lDbk936XjtxvCq4tPNbK4C3IJvyLwIMrE=
 github.com/ooni/netem v0.0.0-20240208095707-608dcbcd82b8 h1:kJ2wn19lIP/y9ng85BbFRdWKHK6Er116Bbt5uhqHVD4=
 github.com/ooni/netem v0.0.0-20240208095707-608dcbcd82b8/go.mod h1:b/wAvTR5n92Vk2b0SBmuMU0xO4ZGVrsXtU7zjTby7vw=
 github.com/ooni/oocrypto v0.6.2 h1:gAg24bVP03PNsOkMYGxllxmvlKlBOvyHmFAsdBlFJag=

--- a/internal/experiment/openvpn/endpoint.go
+++ b/internal/experiment/openvpn/endpoint.go
@@ -25,20 +25,12 @@ type endpoint struct {
 	// IPAddr is the IP Address for this endpoint.
 	IPAddr string
 
-	// DomainName is an optional domain name that we use internally to get the IP address.
-	// This is just a convenience field, the experiments should always be done against a canonical IPAddr.
-	DomainName string
-
 	// Obfuscation is any obfuscation method use to connect to this endpoint.
 	// Valid values are: obfs4, none.
 	Obfuscation string
 
 	// Port is the Port for this endpoint.
 	Port string
-
-	// PreferredCountries is an optional array of country codes. Probes in these countries have preference on this
-	// endpoint.
-	PreferredCountries []string
 
 	// Protocol is the tunneling protocol (openvpn, openvpn+obfs4).
 	Protocol string

--- a/internal/experiment/openvpn/endpoint.go
+++ b/internal/experiment/openvpn/endpoint.go
@@ -25,12 +25,20 @@ type endpoint struct {
 	// IPAddr is the IP Address for this endpoint.
 	IPAddr string
 
+	// DomainName is an optional domain name that we use internally to get the IP address.
+	// This is just a convenience field, the experiments should always be done against a canonical IPAddr.
+	DomainName string
+
 	// Obfuscation is any obfuscation method use to connect to this endpoint.
 	// Valid values are: obfs4, none.
 	Obfuscation string
 
 	// Port is the Port for this endpoint.
 	Port string
+
+	// PreferredCountries is an optional array of country codes. Probes in these countries have preference on this
+	// endpoint.
+	PreferredCountries []string
 
 	// Protocol is the tunneling protocol (openvpn, openvpn+obfs4).
 	Protocol string

--- a/internal/experiment/openvpn/openvpn.go
+++ b/internal/experiment/openvpn/openvpn.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	testName        = "openvpn"
-	testVersion     = "0.1.5"
+	testVersion     = "0.1.6"
 	openVPNProtocol = "openvpn"
 )
 

--- a/internal/experiment/openvpn/openvpn_test.go
+++ b/internal/experiment/openvpn/openvpn_test.go
@@ -41,7 +41,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if m.ExperimentName() != "openvpn" {
 		t.Fatal("invalid ExperimentName")
 	}
-	if m.ExperimentVersion() != "0.1.5" {
+	if m.ExperimentVersion() != "0.1.6" {
 		t.Fatal("invalid ExperimentVersion")
 	}
 }

--- a/internal/experiment/openvpn/richerinput.go
+++ b/internal/experiment/openvpn/richerinput.go
@@ -2,13 +2,13 @@ package openvpn
 
 import (
 	"context"
-	"fmt"
 	"slices"
 	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/experimentconfig"
 	"github.com/ooni/probe-cli/v3/internal/legacy/netx"
 	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/targetloading"
 )
 
@@ -147,13 +147,19 @@ func (tl *targetLoader) loadFromDefaultEndpoints() ([]model.ExperimentTarget, er
 		}
 	}
 
-	fmt.Println(">>> ADDRS", addrs)
+	// Remove the bogons
 
-	// TODO: filter bogons (here), return err if nil
+	validAddrs := []string{}
+
+	for _, addr := range addrs {
+		if !netxlite.IsBogon(addr) {
+			validAddrs = append(validAddrs, addr)
+		}
+	}
 
 	tl.loader.Logger.Warnf("Picking from default OpenVPN endpoints")
 	targets := []model.ExperimentTarget{}
-	if inputs, err := pickOONIOpenVPNTargets(addrs); err == nil {
+	if inputs, err := pickOONIOpenVPNTargets(validAddrs); err == nil {
 		for _, url := range inputs {
 			targets = append(targets,
 				&Target{

--- a/internal/experiment/openvpn/richerinput.go
+++ b/internal/experiment/openvpn/richerinput.go
@@ -2,7 +2,6 @@ package openvpn
 
 import (
 	"context"
-	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/experimentconfig"
 	"github.com/ooni/probe-cli/v3/internal/model"
@@ -100,13 +99,6 @@ func (tl *targetLoader) Load(ctx context.Context) ([]model.ExperimentTarget, err
 
 	// Return the hardcoded endpoints.
 	return tl.loadFromDefaultEndpoints()
-}
-
-// TODO: move to targets.
-func lookupHost(ctx context.Context, hostname string, r model.Resolver) ([]string, error) {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	return r.LookupHost(ctx, hostname)
 }
 
 func (tl *targetLoader) loadFromDefaultEndpoints() ([]model.ExperimentTarget, error) {

--- a/internal/experiment/openvpn/richerinput_test.go
+++ b/internal/experiment/openvpn/richerinput_test.go
@@ -3,9 +3,7 @@ package openvpn
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/ooni/probe-cli/v3/internal/mocks"
@@ -165,48 +163,5 @@ func TestTargetLoaderLoad(t *testing.T) {
 				t.Fatal(diff)
 			}
 		})
-	}
-}
-
-func TestTargetLoaderLoadFromBackend(t *testing.T) {
-	loader := &targetloading.Loader{
-		ExperimentName: "openvpn",
-		InputPolicy:    model.InputOrQueryBackend,
-		Logger:         model.DiscardLogger,
-		Session:        &mocks.Session{},
-	}
-	sess := &mocks.Session{}
-	sess.MockFetchOpenVPNConfig = func(context.Context, string, string) (*model.OOAPIVPNProviderConfig, error) {
-		return &model.OOAPIVPNProviderConfig{
-			Provider: "riseupvpn",
-			Config:   &model.OOAPIVPNConfig{},
-			Inputs: []string{
-				"openvpn://target0",
-				"openvpn://target1",
-			},
-			DateUpdated: time.Now(),
-		}, nil
-	}
-	sess.MockProbeCC = func() string {
-		return "IT"
-	}
-	tl := &targetLoader{
-		loader:  loader,
-		options: &Config{},
-		session: sess,
-	}
-	targets, err := tl.Load(context.Background())
-	if err != nil {
-		t.Fatal("expected no error")
-	}
-	fmt.Println("targets", targets)
-	if len(targets) != 2 {
-		t.Fatal("expected 2 targets")
-	}
-	if targets[0].String() != "openvpn://target0" {
-		t.Fatal("expected openvpn://target0")
-	}
-	if targets[1].String() != "openvpn://target1" {
-		t.Fatal("expected openvpn://target1")
 	}
 }

--- a/internal/experiment/openvpn/targets.go
+++ b/internal/experiment/openvpn/targets.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 	"math/rand"
 	"slices"
-	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/legacy/netx"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
-// defaultOONIHostnames is the array of hostnames that will return valid
+// defaultOONIEndpoints is the array of hostnames that will return valid
 // endpoints to be probed. Do note that this is a workaround for the lack
 // of a backend service.
 var defaultOONIEndpoints = []string{
@@ -30,7 +29,6 @@ func sampleN(a []string, n int) []string {
 		n = len(a)
 	}
 
-	rand.Seed(time.Now().UnixNano())
 	sampled := make([]string, 0)
 
 	// Use a map to track indices we've already selected to avoid duplicates

--- a/internal/experiment/openvpn/targets.go
+++ b/internal/experiment/openvpn/targets.go
@@ -5,36 +5,6 @@ import (
 	"math/rand"
 )
 
-// TODO: deprecate, move to function below
-// defaultOpenVPNEndpoints contain a list of all default endpoints
-// to be tried. We will fill in the IP Addresses.
-var defaultOpenVPNEndpoints = []endpoint{
-	{
-		Obfuscation: "none",
-		Port:        "1194",
-		Protocol:    "openvpn",
-		Provider:    "oonivpn",
-		IPAddr:      "",
-		Transport:   "",
-	},
-	{
-		IPAddr:      "",
-		Obfuscation: "none",
-		Port:        "443",
-		Protocol:    "openvpn",
-		Provider:    "oonivpn",
-		Transport:   "tcp",
-	},
-	{
-		IPAddr:      "",
-		Obfuscation: "none",
-		Port:        "53",
-		Protocol:    "openvpn",
-		Provider:    "oonivpn",
-		Transport:   "udp",
-	},
-}
-
 // pickOONIOpenVPNTargets returns an array of input URIs from the list of available endpoints, up to max,
 // for the given transport. By default, we use the first endpoint that resolves to an IP. If reverseOrder
 // is specified, we reverse the list before attempting resolution.

--- a/internal/experiment/openvpn/targets.go
+++ b/internal/experiment/openvpn/targets.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"slices"
+	"time"
 
 	"github.com/ooni/probe-cli/v3/internal/legacy/netx"
 	"github.com/ooni/probe-cli/v3/internal/model"
@@ -96,6 +97,12 @@ func resolveOONIAddresses(logger model.Logger) ([]string, error) {
 	}
 
 	return valid, nil
+}
+
+func lookupHost(ctx context.Context, hostname string, r model.Resolver) ([]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	return r.LookupHost(ctx, hostname)
 }
 
 // pickOONIOpenVPNTargets crafts targets from the passed array of IP addresses.

--- a/internal/experiment/openvpn/targets_test.go
+++ b/internal/experiment/openvpn/targets_test.go
@@ -1,6 +1,7 @@
 package openvpn
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -35,8 +36,8 @@ func Test_resolveTarget(t *testing.T) {
 	}
 }
 
-func Test_defaultOONIOpenVPNTargetUDP(t *testing.T) {
-	url, err := defaultOONIOpenVPNTargetUDP()
+func Test_pickOpenVPNTargets(t *testing.T) {
+	urls, err := pickOONIOpenVPNTargets("udp", "IT", 1, false)
 	if err != nil {
 		if err.Error() == "connection_refused" {
 			// connection_refused is raised when running this test
@@ -46,25 +47,14 @@ func Test_defaultOONIOpenVPNTargetUDP(t *testing.T) {
 		}
 		t.Fatal("unexpected error")
 	}
-	expected := "openvpn://oonivpn.corp/?address=37.218.243.98:1194&transport=udp"
-	if diff := cmp.Diff(url, expected); diff != "" {
-		t.Fatal(diff)
-	}
-}
+	expected := "openvpn://oonivpn.corp?address=37.218.243.98:1194&transport=udp"
 
-func Test_defaultOONIOpenVPNTargetTCP(t *testing.T) {
-	url, err := defaultOONIOpenVPNTargetTCP()
+	got, err := url.QueryUnescape(urls[0])
 	if err != nil {
-		if err.Error() == "connection_refused" {
-			// connection_refused is raised when running this test
-			// on the restricted network for coverage tests.
-			// so we bail out
-			return
-		}
-		t.Fatal("unexpected error")
+		t.Fatal(err)
 	}
-	expected := "openvpn://oonivpn.corp/?address=37.218.243.98:1194&transport=tcp"
-	if diff := cmp.Diff(url, expected); diff != "" {
+
+	if diff := cmp.Diff(got, expected); diff != "" {
 		t.Fatal(diff)
 	}
 }

--- a/internal/experiment/openvpn/targets_test.go
+++ b/internal/experiment/openvpn/targets_test.go
@@ -1,63 +1,8 @@
 package openvpn
 
 import (
-	"net/url"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
 )
-
-func Test_resolveTarget(t *testing.T) {
-	// TODO: mustHaveExternalNetwork() equivalent.
-	if testing.Short() {
-		t.Skip("skip test in short mode")
-	}
-
-	_, err := resolveTarget("google.com")
-
-	if err != nil {
-		if err.Error() == "connection_refused" {
-			// connection_refused is raised when running this test
-			// on the restricted network for coverage tests.
-			// so we bail out
-			return
-		}
-		t.Fatal("should be able to resolve the target")
-	}
-
-	_, err = resolveTarget("nothing.corp")
-	if err == nil {
-		t.Fatal("should not be able to resolve the target")
-	}
-
-	_, err = resolveTarget("asfasfasfasfasfafs.ooni.io")
-	if err == nil {
-		t.Fatal("should not be able to resolve the target")
-	}
-}
-
-func Test_pickOpenVPNTargets(t *testing.T) {
-	urls, err := pickOONIOpenVPNTargets("udp", "IT", 1, false)
-	if err != nil {
-		if err.Error() == "connection_refused" {
-			// connection_refused is raised when running this test
-			// on the restricted network for coverage tests.
-			// so we bail out
-			return
-		}
-		t.Fatal("unexpected error")
-	}
-	expected := "openvpn://oonivpn.corp?address=37.218.243.98:1194&transport=udp"
-
-	got, err := url.QueryUnescape(urls[0])
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if diff := cmp.Diff(got, expected); diff != "" {
-		t.Fatal(diff)
-	}
-}
 
 func Test_pickFromDefaultOONIOpenVPNConfig(t *testing.T) {
 	pick := pickFromDefaultOONIOpenVPNConfig()

--- a/internal/experiment/openvpn/targets_test.go
+++ b/internal/experiment/openvpn/targets_test.go
@@ -2,6 +2,10 @@ package openvpn
 
 import (
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/ooni/probe-cli/v3/internal/model"
 )
 
 func Test_pickFromDefaultOONIOpenVPNConfig(t *testing.T) {
@@ -13,4 +17,61 @@ func Test_pickFromDefaultOONIOpenVPNConfig(t *testing.T) {
 	if pick.SafeCA != defaultCA {
 		t.Fatal("ca unexpected")
 	}
+}
+
+func TestSampleN(t *testing.T) {
+	// Table of test cases
+	tests := []struct {
+		name     string
+		a        []string
+		n        int
+		expected int // Expected length of result
+	}{
+		{"n less than slice length", []string{"a", "b", "c", "d", "e"}, 3, 3},
+		{"n greater than slice length", []string{"a", "b", "c", "d", "e"}, 10, 5},
+		{"n equal to zero", []string{"a", "b", "c", "d", "e"}, 0, 0},
+		{"empty slice", []string{}, 3, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sampleN(tt.a, tt.n)
+
+			// Check the length of the result
+			if len(result) != tt.expected {
+				t.Errorf("Expected %d items, got %d", tt.expected, len(result))
+			}
+
+			// Check for duplicates
+			seen := make(map[string]struct{})
+			for _, v := range result {
+				if _, exists := seen[v]; exists {
+					t.Errorf("Duplicate value %s found", v)
+				}
+				seen[v] = struct{}{}
+			}
+		})
+	}
+}
+
+func Test_resolveOONIAddresses(t *testing.T) {
+	expected := []string{
+		"108.61.164.186",
+		"37.218.243.98",
+	}
+	t.Run("check resolution is what we expect", func(t *testing.T) {
+		if testing.Short() {
+			// this test uses the real internet so we want to skip this in short mode
+			t.Skip("skip test in short mode")
+		}
+
+		got, err := resolveOONIAddresses(model.DiscardLogger)
+		if err != nil {
+			t.Errorf("resolveOONIAddresses() error = %v, wantErr %v", err, nil)
+			return
+		}
+		if diff := cmp.Diff(expected, got, cmpopts.SortSlices(func(x, y string) bool { return x < y })); diff != "" {
+			t.Errorf("Mismatch (-expected +got):\n%s", diff)
+		}
+	})
 }

--- a/internal/experiment/openvpn/targets_test.go
+++ b/internal/experiment/openvpn/targets_test.go
@@ -75,3 +75,33 @@ func Test_resolveOONIAddresses(t *testing.T) {
 		}
 	})
 }
+
+func Test_pickOONIOpenVPNTargets(t *testing.T) {
+	t.Run("empty ip list produces empty targets", func(t *testing.T) {
+		endpoints, err := pickOONIOpenVPNTargets([]string{})
+		if err != nil {
+			t.Fatal("expected nil error")
+		}
+		if len(endpoints) != 0 {
+			t.Fatal("expected empty endpoints")
+		}
+	})
+	t.Run("single-item ip list produces valid targets", func(t *testing.T) {
+		endpoints, err := pickOONIOpenVPNTargets([]string{"1.1.1.1"})
+		if err != nil {
+			t.Fatal("expected nil error")
+		}
+		if len(endpoints) != 4 {
+			t.Fatalf("expected 4 endpoints, got %d", len(endpoints))
+		}
+	})
+	t.Run("2-item ip list produces 6 targets", func(t *testing.T) {
+		endpoints, err := pickOONIOpenVPNTargets([]string{"1.1.1.1", "2.2.2.2"})
+		if err != nil {
+			t.Fatal("expected nil error")
+		}
+		if len(endpoints) != 6 {
+			t.Fatalf("expected 6 endpoints, got %d", len(endpoints))
+		}
+	})
+}


### PR DESCRIPTION
while working on this, I also gave more priority to possible oonirun descriptors passed in the command line.

- Related: #2805

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2805
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [x] if you changed code inside an experiment, make sure you bump its version number

## Description

Add fallback domains for openvpn default endpoints to be probed.