### PR TITLE
Simplify the dnscheck list

### DIFF
--- a/internal/experiment/dnscheck/richerinput.go
+++ b/internal/experiment/dnscheck/richerinput.go
@@ -201,7 +201,7 @@ var defaultInput = []model.ExperimentTarget{
 // while using the default list for normal runs.
 //
 //lint:ignore U1000 ignore unused var
-var _extendedInput = []model.ExperimentTarget{
+var extendedInput = []model.ExperimentTarget{
 	//
 	// https://dns.google/dns-query
 	//

--- a/internal/experiment/dnscheck/richerinput.go
+++ b/internal/experiment/dnscheck/richerinput.go
@@ -130,46 +130,6 @@ var defaultInput = []model.ExperimentTarget{
 			DefaultAddrs: "1.1.1.1 1.0.0.1",
 		},
 	},
-	// &Target{
-	// 	URL: "https://dns.cloudflare.com/dns-query",
-	// 	Config: &Config{
-	// 		HTTP3Enabled: true,
-	// 	},
-	// },
-	// &Target{
-	// 	URL:    "https://dns.cloudflare.com/dns-query",
-	// 	Config: &Config{},
-	// },
-	// &Target{
-	// 	URL: "https://family.cloudflare-dns.com/dns-query",
-	// 	Config: &Config{
-	// 		HTTP3Enabled: true,
-	// 	},
-	// },
-	// &Target{
-	// 	URL:    "https://family.cloudflare-dns.com/dns-query",
-	// 	Config: &Config{},
-	// },
-	// &Target{
-	// 	URL: "https://1dot1dot1dot1.cloudflare-dns.com/dns-query",
-	// 	Config: &Config{
-	// 		HTTP3Enabled: true,
-	// 	},
-	// },
-	// &Target{
-	// 	URL:    "https://1dot1dot1dot1.cloudflare-dns.com/dns-query",
-	// 	Config: &Config{},
-	// },
-	// &Target{
-	// 	URL: "https://security.cloudflare-dns.com/dns-query",
-	// 	Config: &Config{
-	// 		HTTP3Enabled: true,
-	// 	},
-	// },
-	// &Target{
-	// 	URL:    "https://security.cloudflare-dns.com/dns-query",
-	// 	Config: &Config{},
-	// },
 	&Target{
 		URL: "https://dns.quad9.net/dns-query",
 		Config: &Config{
@@ -183,47 +143,6 @@ var defaultInput = []model.ExperimentTarget{
 			DefaultAddrs: "9.9.9.9",
 		},
 	},
-	// &Target{
-	// 	URL: "https://dns11.quad9.net/dns-query",
-	// 	Config: &Config{
-	// 		HTTP3Enabled: true,
-	// 	},
-	// },
-	// &Target{
-	// 	URL:    "https://dns11.quad9.net/dns-query",
-	// 	Config: &Config{},
-	// },
-	// &Target{
-	// 	URL: "https://dns9.quad9.net/dns-query",
-	// 	Config: &Config{
-	// 		HTTP3Enabled: true,
-	// 	},
-	// },
-	// &Target{
-	// 	URL:    "https://dns9.quad9.net/dns-query",
-	// 	Config: &Config{},
-	// },
-	// &Target{
-	// 	URL: "https://dns12.quad9.net/dns-query",
-	// 	Config: &Config{
-	// 		HTTP3Enabled: true,
-	// 	},
-	// },
-	// &Target{
-	// 	URL:    "https://dns12.quad9.net/dns-query",
-	// 	Config: &Config{},
-	// },
-	// &Target{
-	// 	URL: "https://dns10.quad9.net/dns-query",
-	// 	Config: &Config{
-	// 		HTTP3Enabled: true,
-	// 	},
-	// },
-	// &Target{
-	// 	URL:    "https://dns10.quad9.net/dns-query",
-	// 	Config: &Config{},
-	// },
-
 	&Target{
 		URL: "https://dns.adguard.com/dns-query",
 		Config: &Config{
@@ -234,26 +153,6 @@ var defaultInput = []model.ExperimentTarget{
 		URL:    "https://dns.adguard.com/dns-query",
 		Config: &Config{},
 	},
-	// &Target{
-	// 	URL: "https://dns-family.adguard.com/dns-query",
-	// 	Config: &Config{
-	// 		HTTP3Enabled: true,
-	// 	},
-	// },
-	// &Target{
-	// 	URL:    "https://dns-family.adguard.com/dns-query",
-	// 	Config: &Config{},
-	// },
-	// &Target{
-	// 	URL: "https://adblock.doh.mullvad.net/dns-query",
-	// 	Config: &Config{
-	// 		HTTP3Enabled: true,
-	// 	},
-	// },
-	// &Target{
-	// 	URL:    "https://adblock.doh.mullvad.net/dns-query",
-	// 	Config: &Config{},
-	// },
 	&Target{
 		URL: "https://dns.alidns.com/dns-query",
 		Config: &Config{
@@ -285,6 +184,210 @@ var defaultInput = []model.ExperimentTarget{
 		Config: &Config{},
 	},
 
+	&Target{
+		URL: "https://dns.switch.ch/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns.switch.ch/dns-query",
+		Config: &Config{},
+	},
+}
+
+// extendedInput is an extended input target list for dnscheck.
+// TODO(decfox): we should have a flag to return the extended list in special cases
+// while using the default list for normal runs.
+//
+//lint:ignore U1000 ignore unused var
+var _extendedInput = []model.ExperimentTarget{
+	//
+	// https://dns.google/dns-query
+	//
+	// Measure HTTP/3 first and then HTTP/2 (see https://github.com/ooni/probe/issues/2675).
+	//
+	// Make sure we include the typical IP addresses for the domain.
+	//
+	&Target{
+		URL: "https://dns.google/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+			DefaultAddrs: "8.8.8.8 8.8.4.4",
+		},
+	},
+	&Target{
+		URL: "https://dns.google/dns-query",
+		Config: &Config{
+			DefaultAddrs: "8.8.8.8 8.8.4.4",
+		},
+	},
+	&Target{
+		URL: "https://cloudflare-dns.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+			DefaultAddrs: "1.1.1.1 1.0.0.1",
+		},
+	},
+	&Target{
+		URL: "https://cloudflare-dns.com/dns-query",
+		Config: &Config{
+			DefaultAddrs: "1.1.1.1 1.0.0.1",
+		},
+	},
+	&Target{
+		URL: "https://dns.quad9.net/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+			DefaultAddrs: "9.9.9.9",
+		},
+	},
+	&Target{
+		URL: "https://dns.quad9.net/dns-query",
+		Config: &Config{
+			DefaultAddrs: "9.9.9.9",
+		},
+	},
+	&Target{
+		URL: "https://family.cloudflare-dns.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://family.cloudflare-dns.com/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns11.quad9.net/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns11.quad9.net/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns9.quad9.net/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns9.quad9.net/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns12.quad9.net/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns12.quad9.net/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://1dot1dot1dot1.cloudflare-dns.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://1dot1dot1dot1.cloudflare-dns.com/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns.adguard.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns.adguard.com/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns-family.adguard.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns-family.adguard.com/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns.cloudflare.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns.cloudflare.com/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://adblock.doh.mullvad.net/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://adblock.doh.mullvad.net/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns.alidns.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns.alidns.com/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://doh.opendns.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://doh.opendns.com/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns.nextdns.io/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns.nextdns.io/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns10.quad9.net/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns10.quad9.net/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://security.cloudflare-dns.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://security.cloudflare-dns.com/dns-query",
+		Config: &Config{},
+	},
 	&Target{
 		URL: "https://dns.switch.ch/dns-query",
 		Config: &Config{

--- a/internal/experiment/dnscheck/richerinput.go
+++ b/internal/experiment/dnscheck/richerinput.go
@@ -130,6 +130,46 @@ var defaultInput = []model.ExperimentTarget{
 			DefaultAddrs: "1.1.1.1 1.0.0.1",
 		},
 	},
+	// &Target{
+	// 	URL: "https://dns.cloudflare.com/dns-query",
+	// 	Config: &Config{
+	// 		HTTP3Enabled: true,
+	// 	},
+	// },
+	// &Target{
+	// 	URL:    "https://dns.cloudflare.com/dns-query",
+	// 	Config: &Config{},
+	// },
+	// &Target{
+	// 	URL: "https://family.cloudflare-dns.com/dns-query",
+	// 	Config: &Config{
+	// 		HTTP3Enabled: true,
+	// 	},
+	// },
+	// &Target{
+	// 	URL:    "https://family.cloudflare-dns.com/dns-query",
+	// 	Config: &Config{},
+	// },
+	// &Target{
+	// 	URL: "https://1dot1dot1dot1.cloudflare-dns.com/dns-query",
+	// 	Config: &Config{
+	// 		HTTP3Enabled: true,
+	// 	},
+	// },
+	// &Target{
+	// 	URL:    "https://1dot1dot1dot1.cloudflare-dns.com/dns-query",
+	// 	Config: &Config{},
+	// },
+	// &Target{
+	// 	URL: "https://security.cloudflare-dns.com/dns-query",
+	// 	Config: &Config{
+	// 		HTTP3Enabled: true,
+	// 	},
+	// },
+	// &Target{
+	// 	URL:    "https://security.cloudflare-dns.com/dns-query",
+	// 	Config: &Config{},
+	// },
 	&Target{
 		URL: "https://dns.quad9.net/dns-query",
 		Config: &Config{
@@ -143,56 +183,47 @@ var defaultInput = []model.ExperimentTarget{
 			DefaultAddrs: "9.9.9.9",
 		},
 	},
-	&Target{
-		URL: "https://family.cloudflare-dns.com/dns-query",
-		Config: &Config{
-			HTTP3Enabled: true,
-		},
-	},
-	&Target{
-		URL:    "https://family.cloudflare-dns.com/dns-query",
-		Config: &Config{},
-	},
-	&Target{
-		URL: "https://dns11.quad9.net/dns-query",
-		Config: &Config{
-			HTTP3Enabled: true,
-		},
-	},
-	&Target{
-		URL:    "https://dns11.quad9.net/dns-query",
-		Config: &Config{},
-	},
-	&Target{
-		URL: "https://dns9.quad9.net/dns-query",
-		Config: &Config{
-			HTTP3Enabled: true,
-		},
-	},
-	&Target{
-		URL:    "https://dns9.quad9.net/dns-query",
-		Config: &Config{},
-	},
-	&Target{
-		URL: "https://dns12.quad9.net/dns-query",
-		Config: &Config{
-			HTTP3Enabled: true,
-		},
-	},
-	&Target{
-		URL:    "https://dns12.quad9.net/dns-query",
-		Config: &Config{},
-	},
-	&Target{
-		URL: "https://1dot1dot1dot1.cloudflare-dns.com/dns-query",
-		Config: &Config{
-			HTTP3Enabled: true,
-		},
-	},
-	&Target{
-		URL:    "https://1dot1dot1dot1.cloudflare-dns.com/dns-query",
-		Config: &Config{},
-	},
+	// &Target{
+	// 	URL: "https://dns11.quad9.net/dns-query",
+	// 	Config: &Config{
+	// 		HTTP3Enabled: true,
+	// 	},
+	// },
+	// &Target{
+	// 	URL:    "https://dns11.quad9.net/dns-query",
+	// 	Config: &Config{},
+	// },
+	// &Target{
+	// 	URL: "https://dns9.quad9.net/dns-query",
+	// 	Config: &Config{
+	// 		HTTP3Enabled: true,
+	// 	},
+	// },
+	// &Target{
+	// 	URL:    "https://dns9.quad9.net/dns-query",
+	// 	Config: &Config{},
+	// },
+	// &Target{
+	// 	URL: "https://dns12.quad9.net/dns-query",
+	// 	Config: &Config{
+	// 		HTTP3Enabled: true,
+	// 	},
+	// },
+	// &Target{
+	// 	URL:    "https://dns12.quad9.net/dns-query",
+	// 	Config: &Config{},
+	// },
+	// &Target{
+	// 	URL: "https://dns10.quad9.net/dns-query",
+	// 	Config: &Config{
+	// 		HTTP3Enabled: true,
+	// 	},
+	// },
+	// &Target{
+	// 	URL:    "https://dns10.quad9.net/dns-query",
+	// 	Config: &Config{},
+	// },
+
 	&Target{
 		URL: "https://dns.adguard.com/dns-query",
 		Config: &Config{
@@ -203,36 +234,26 @@ var defaultInput = []model.ExperimentTarget{
 		URL:    "https://dns.adguard.com/dns-query",
 		Config: &Config{},
 	},
-	&Target{
-		URL: "https://dns-family.adguard.com/dns-query",
-		Config: &Config{
-			HTTP3Enabled: true,
-		},
-	},
-	&Target{
-		URL:    "https://dns-family.adguard.com/dns-query",
-		Config: &Config{},
-	},
-	&Target{
-		URL: "https://dns.cloudflare.com/dns-query",
-		Config: &Config{
-			HTTP3Enabled: true,
-		},
-	},
-	&Target{
-		URL:    "https://dns.cloudflare.com/dns-query",
-		Config: &Config{},
-	},
-	&Target{
-		URL: "https://adblock.doh.mullvad.net/dns-query",
-		Config: &Config{
-			HTTP3Enabled: true,
-		},
-	},
-	&Target{
-		URL:    "https://adblock.doh.mullvad.net/dns-query",
-		Config: &Config{},
-	},
+	// &Target{
+	// 	URL: "https://dns-family.adguard.com/dns-query",
+	// 	Config: &Config{
+	// 		HTTP3Enabled: true,
+	// 	},
+	// },
+	// &Target{
+	// 	URL:    "https://dns-family.adguard.com/dns-query",
+	// 	Config: &Config{},
+	// },
+	// &Target{
+	// 	URL: "https://adblock.doh.mullvad.net/dns-query",
+	// 	Config: &Config{
+	// 		HTTP3Enabled: true,
+	// 	},
+	// },
+	// &Target{
+	// 	URL:    "https://adblock.doh.mullvad.net/dns-query",
+	// 	Config: &Config{},
+	// },
 	&Target{
 		URL: "https://dns.alidns.com/dns-query",
 		Config: &Config{
@@ -263,26 +284,7 @@ var defaultInput = []model.ExperimentTarget{
 		URL:    "https://dns.nextdns.io/dns-query",
 		Config: &Config{},
 	},
-	&Target{
-		URL: "https://dns10.quad9.net/dns-query",
-		Config: &Config{
-			HTTP3Enabled: true,
-		},
-	},
-	&Target{
-		URL:    "https://dns10.quad9.net/dns-query",
-		Config: &Config{},
-	},
-	&Target{
-		URL: "https://security.cloudflare-dns.com/dns-query",
-		Config: &Config{
-			HTTP3Enabled: true,
-		},
-	},
-	&Target{
-		URL:    "https://security.cloudflare-dns.com/dns-query",
-		Config: &Config{},
-	},
+
 	&Target{
 		URL: "https://dns.switch.ch/dns-query",
 		Config: &Config{


### PR DESCRIPTION
Trim down the dnscheck list.

Keep only 2 addresses per providers (http3 enabled and not), since measuring the ads or malware blocking endpoints is less important (we only query example.com). The main difference for the malware blocking endpoints would be that the SNI is different, but we can probably generate similar telemetry without doing a full DoH measurement.