### PR TITLE
refactor(oonimkall): expose the session close call

### DIFF
--- a/pkg/oonimkall/session.go
+++ b/pkg/oonimkall/session.go
@@ -254,6 +254,13 @@ func (sess *Session) NewContextWithTimeout(timeout int64) *Context {
 	return &Context{cancel: cancel, ctx: ctx}
 }
 
+// Close closes the session. This is done by closing the embedded engine
+// session
+func (sess *Session) Close() error {
+	err := sess.sessp.Close()
+	return err
+}
+
 // GeolocateResults contains the results of session.Geolocate.
 type GeolocateResults struct {
 	// ASN is the autonomous system number.

--- a/pkg/oonimkall/session.go
+++ b/pkg/oonimkall/session.go
@@ -255,7 +255,7 @@ func (sess *Session) NewContextWithTimeout(timeout int64) *Context {
 }
 
 // Close closes the session. This is done by closing the embedded engine
-// session
+// session and ensures that any tunnel (if open) is stopped
 func (sess *Session) Close() error {
 	err := sess.sessp.Close()
 	return err


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2810
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff exposes the `Session.Close` call for the geoip session we initialize in the mobile app. This is required to close the circumvention tunnel before we use start another tunnel as part of the async tasks to run the experiments.
