### PR TITLE
Switch to using cloudflare-ech.com as the target for the ech test

### DIFF
--- a/internal/experiment/echcheck/handshake.go
+++ b/internal/experiment/echcheck/handshake.go
@@ -34,7 +34,9 @@ func handshakeWithEch(ctx context.Context, conn net.Conn, zeroTime time.Time,
 	utlsEchExtension.Id = echExtensionType
 	utlsEchExtension.Data = payload
 
-	return handshakeWithExtension(ctx, conn, zeroTime, address, sni, []utls.TLSExtension{&utlsEchExtension}, logger)
+	hs := handshakeWithExtension(ctx, conn, zeroTime, address, sni, []utls.TLSExtension{&utlsEchExtension}, logger)
+	hs.ECHConfig = "GREASE"
+	return hs
 }
 
 func handshakeMaybePrintWithECH(doprint bool) string {

--- a/internal/experiment/echcheck/handshake.go
+++ b/internal/experiment/echcheck/handshake.go
@@ -17,6 +17,52 @@ import (
 
 const echExtensionType uint16 = 0xfe0d
 
+func connectAndHandshake(
+	ctx context.Context,
+	startTime time.Time,
+	address string, sni string, outerSni string,
+	logger model.Logger) (chan model.ArchivalTLSOrQUICHandshakeResult, error) {
+
+	channel := make(chan model.ArchivalTLSOrQUICHandshakeResult)
+
+	ol := logx.NewOperationLogger(logger, "echcheck: TCPConnect %s", address)
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(ctx, "tcp", address)
+	ol.Stop(err)
+	if err != nil {
+		return nil, netxlite.NewErrWrapper(netxlite.ClassifyGenericError, netxlite.ConnectOperation, err)
+	}
+
+	go func() {
+		var res *model.ArchivalTLSOrQUICHandshakeResult
+		if outerSni == "" {
+			res = handshake(
+				ctx,
+				conn,
+				startTime,
+				address,
+				sni,
+				logger,
+			)
+		} else {
+			res = handshakeWithEch(
+				ctx,
+				conn,
+				startTime,
+				address,
+				outerSni,
+				logger,
+			)
+			// We need to set this explicitly because otherwise it will get
+			// overridden with the outerSni in the case of ECH
+			res.ServerName = sni
+		}
+		channel <- *res
+	}()
+
+	return channel, nil
+}
+
 func handshake(ctx context.Context, conn net.Conn, zeroTime time.Time,
 	address string, sni string, logger model.Logger) *model.ArchivalTLSOrQUICHandshakeResult {
 	return handshakeWithExtension(ctx, conn, zeroTime, address, sni, []utls.TLSExtension{}, logger)
@@ -36,6 +82,7 @@ func handshakeWithEch(ctx context.Context, conn net.Conn, zeroTime time.Time,
 
 	hs := handshakeWithExtension(ctx, conn, zeroTime, address, sni, []utls.TLSExtension{&utlsEchExtension}, logger)
 	hs.ECHConfig = "GREASE"
+	hs.OuterServerName = sni
 	return hs
 }
 

--- a/internal/experiment/echcheck/measure.go
+++ b/internal/experiment/echcheck/measure.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	testName    = "echcheck"
-	testVersion = "0.1.2"
+	testVersion = "0.2.0"
 	defaultURL  = "https://cloudflare-ech.com/cdn-cgi/trace"
 )
 
@@ -30,8 +30,7 @@ var (
 
 // TestKeys contains echcheck test keys.
 type TestKeys struct {
-	Control model.ArchivalTLSOrQUICHandshakeResult `json:"control"`
-	Target  model.ArchivalTLSOrQUICHandshakeResult `json:"target"`
+	TLSHandshakes []*model.ArchivalTLSOrQUICHandshakeResult `json:"tls_handshakes"`
 }
 
 // Measurer performs the measurement.
@@ -124,7 +123,7 @@ func (m *Measurer) Run(
 	control := <-controlChannel
 	target := <-targetChannel
 
-	args.Measurement.TestKeys = TestKeys{Control: control, Target: target}
+	args.Measurement.TestKeys = TestKeys{TLSHandshakes: []*model.ArchivalTLSOrQUICHandshakeResult{&control, &target}}
 
 	return nil
 }

--- a/internal/experiment/echcheck/measure.go
+++ b/internal/experiment/echcheck/measure.go
@@ -17,7 +17,7 @@ import (
 const (
 	testName    = "echcheck"
 	testVersion = "0.1.2"
-	defaultURL  = "https://crypto.cloudflare.com/cdn-cgi/trace"
+	defaultURL  = "https://cloudflare-ech.com/cdn-cgi/trace"
 )
 
 var (

--- a/internal/experiment/echcheck/measure_test.go
+++ b/internal/experiment/echcheck/measure_test.go
@@ -114,10 +114,13 @@ func TestMeasurementSuccessRealWorld(t *testing.T) {
 
 	// check results
 	tk := msrmnt.TestKeys.(TestKeys)
-	if tk.Control.Failure != nil {
-		t.Fatal("unexpected control failure:", *tk.Control.Failure)
-	}
-	if tk.Target.Failure != nil {
-		t.Fatal("unexpected target failure:", *tk.Target.Failure)
+	for _, hs := range tk.TLSHandshakes {
+		if hs.Failure != nil {
+			if hs.ECHConfig == "GREASE" {
+				t.Fatal("unexpected exp failure:", hs.Failure)
+			} else {
+				t.Fatal("unexpected ctrl failure:", hs.Failure)
+			}
+		}
 	}
 }

--- a/internal/model/archival.go
+++ b/internal/model/archival.go
@@ -248,6 +248,7 @@ type ArchivalTLSOrQUICHandshakeResult struct {
 	NoTLSVerify        bool                 `json:"no_tls_verify"`
 	PeerCertificates   []ArchivalBinaryData `json:"peer_certificates"`
 	ServerName         string               `json:"server_name"`
+	ECHConfig          string               `json:"echconfig,omitempty"`
 	T0                 float64              `json:"t0,omitempty"`
 	T                  float64              `json:"t"`
 	Tags               []string             `json:"tags"`

--- a/internal/model/archival.go
+++ b/internal/model/archival.go
@@ -248,6 +248,7 @@ type ArchivalTLSOrQUICHandshakeResult struct {
 	NoTLSVerify        bool                 `json:"no_tls_verify"`
 	PeerCertificates   []ArchivalBinaryData `json:"peer_certificates"`
 	ServerName         string               `json:"server_name"`
+	OuterServerName    string               `json:"outer_server_name,omitempty"`
 	ECHConfig          string               `json:"echconfig,omitempty"`
 	T0                 float64              `json:"t0,omitempty"`
 	T                  float64              `json:"t"`


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1453
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: https://github.com/ooni/spec/pull/297
- [x] if you changed code inside an experiment, make sure you bump its version number

## Description

Changes to the ECHCheck experiment.

* Replace default URL with cloudflare-ech.com
* Add support for performing an additional ECH handshake with a different ClientHelloOuter SNI
* Randomize the order of the handshakes