### PR TITLE
fix: update cdeps version for mobile tests

### DIFF
--- a/internal/cmd/buildtool/android_test.go
+++ b/internal/cmd/buildtool/android_test.go
@@ -702,12 +702,12 @@ func TestAndroidBuildCdepsOpenSSL(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-3.3.1.tar.gz",
+				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-3.4.0.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "openssl-3.3.1.tar.gz",
+				"tar", "-xf", "openssl-3.4.0.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -757,12 +757,12 @@ func TestAndroidBuildCdepsOpenSSL(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-3.3.1.tar.gz",
+				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-3.4.0.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "openssl-3.3.1.tar.gz",
+				"tar", "-xf", "openssl-3.4.0.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -812,12 +812,12 @@ func TestAndroidBuildCdepsOpenSSL(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-3.3.1.tar.gz",
+				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-3.4.0.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "openssl-3.3.1.tar.gz",
+				"tar", "-xf", "openssl-3.4.0.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -867,12 +867,12 @@ func TestAndroidBuildCdepsOpenSSL(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-3.3.1.tar.gz",
+				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-3.4.0.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "openssl-3.3.1.tar.gz",
+				"tar", "-xf", "openssl-3.4.0.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -1738,12 +1738,12 @@ func TestAndroidBuildCdepsTor(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.12.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.8.12.tar.gz",
+				"tar", "-xf", "tor-0.4.8.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -1827,12 +1827,12 @@ func TestAndroidBuildCdepsTor(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.12.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.8.12.tar.gz",
+				"tar", "-xf", "tor-0.4.8.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -1916,12 +1916,12 @@ func TestAndroidBuildCdepsTor(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.12.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.8.12.tar.gz",
+				"tar", "-xf", "tor-0.4.8.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -2005,12 +2005,12 @@ func TestAndroidBuildCdepsTor(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.12.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.8.12.tar.gz",
+				"tar", "-xf", "tor-0.4.8.13.tar.gz",
 			},
 		}, {
 			Env: []string{},

--- a/internal/cmd/buildtool/ios_test.go
+++ b/internal/cmd/buildtool/ios_test.go
@@ -349,12 +349,12 @@ func TestIOSBuildCdepsOpenSSL(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-3.3.1.tar.gz",
+				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-3.4.0.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "openssl-3.3.1.tar.gz",
+				"tar", "-xf", "openssl-3.4.0.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -399,12 +399,12 @@ func TestIOSBuildCdepsOpenSSL(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-3.3.1.tar.gz",
+				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-3.4.0.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "openssl-3.3.1.tar.gz",
+				"tar", "-xf", "openssl-3.4.0.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -449,12 +449,12 @@ func TestIOSBuildCdepsOpenSSL(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-3.3.1.tar.gz",
+				"curl", "-fsSLO", "https://www.openssl.org/source/openssl-3.4.0.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "openssl-3.3.1.tar.gz",
+				"tar", "-xf", "openssl-3.4.0.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -1142,12 +1142,12 @@ func TestIOSBuildCdepsTor(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.12.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.8.12.tar.gz",
+				"tar", "-xf", "tor-0.4.8.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -1232,12 +1232,12 @@ func TestIOSBuildCdepsTor(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.12.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.8.12.tar.gz",
+				"tar", "-xf", "tor-0.4.8.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -1322,12 +1322,12 @@ func TestIOSBuildCdepsTor(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.12.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.13.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.8.12.tar.gz",
+				"tar", "-xf", "tor-0.4.8.13.tar.gz",
 			},
 		}, {
 			Env: []string{},


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2813
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

We missed updating the c dependency versions in the mobile build tests which was leading to the tests failing. This diff fixes the issue. 
