### PR TITLE
fix: dnscheck default input test

### DIFF
--- a/internal/experiment/dnscheck/richerinput_test.go
+++ b/internal/experiment/dnscheck/richerinput_test.go
@@ -103,6 +103,83 @@ var testDefaultInput = []model.ExperimentTarget{
 			DefaultAddrs: "8.8.8.8 8.8.4.4",
 		},
 	},
+	&Target{
+		URL: "https://cloudflare-dns.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+			DefaultAddrs: "1.1.1.1 1.0.0.1",
+		},
+	},
+	&Target{
+		URL: "https://cloudflare-dns.com/dns-query",
+		Config: &Config{
+			DefaultAddrs: "1.1.1.1 1.0.0.1",
+		},
+	},
+	&Target{
+		URL: "https://dns.quad9.net/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+			DefaultAddrs: "9.9.9.9",
+		},
+	},
+	&Target{
+		URL: "https://dns.quad9.net/dns-query",
+		Config: &Config{
+			DefaultAddrs: "9.9.9.9",
+		},
+	},
+	&Target{
+		URL: "https://dns.adguard.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns.adguard.com/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns.alidns.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns.alidns.com/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://doh.opendns.com/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://doh.opendns.com/dns-query",
+		Config: &Config{},
+	},
+	&Target{
+		URL: "https://dns.nextdns.io/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns.nextdns.io/dns-query",
+		Config: &Config{},
+	},
+
+	&Target{
+		URL: "https://dns.switch.ch/dns-query",
+		Config: &Config{
+			HTTP3Enabled: true,
+		},
+	},
+	&Target{
+		URL:    "https://dns.switch.ch/dns-query",
+		Config: &Config{},
+	},
 }
 
 func TestTargetLoaderLoad(t *testing.T) {


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: <!-- add URL here -->
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This fixes the dnscheck default input test observed failing here: https://github.com/ooni/probe-cli/actions/runs/12016869033/job/33497976676#step:5:536.
