### PR TITLE
fix(echcheck): bump version number in tests

### DIFF
--- a/internal/experiment/echcheck/measure_test.go
+++ b/internal/experiment/echcheck/measure_test.go
@@ -14,7 +14,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "echcheck" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.1.2" {
+	if measurer.ExperimentVersion() != "0.2.0" {
 		t.Fatal("unexpected version")
 	}
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2813

## Description

Bring the measure_test.go version in line with measure.go version.

This should make *unit tests* green again.