### PR TITLE
Add ddr experiment

### DIFF
--- a/internal/bytecounter/resolver.go
+++ b/internal/bytecounter/resolver.go
@@ -41,6 +41,11 @@ func (r *ContextAwareSystemResolver) LookupHTTPS(ctx context.Context, domain str
 	return r.wrap(ctx).LookupHTTPS(ctx, domain)
 }
 
+// LookupSVCB implements model.Resolver.
+func (r *ContextAwareSystemResolver) LookupSVCB(ctx context.Context, domain string) ([]*model.SVCB, error) {
+	return r.wrap(ctx).LookupSVCB(ctx, domain)
+}
+
 // LookupHost implements model.Resolver.
 func (r *ContextAwareSystemResolver) LookupHost(ctx context.Context, hostname string) (addrs []string, err error) {
 	return r.wrap(ctx).LookupHost(ctx, hostname)
@@ -104,6 +109,14 @@ func (r *resolver) CloseIdleConnections() {
 func (r *resolver) LookupHTTPS(ctx context.Context, domain string) (*model.HTTPSSvc, error) {
 	r.updateCounterBytesSent(domain, 1)
 	out, err := r.Resolver.LookupHTTPS(ctx, domain)
+	r.updateCounterBytesRecv(err)
+	return out, err
+}
+
+// LookupSVCB implements model.Resolver
+func (r *resolver) LookupSVCB(ctx context.Context, domain string) ([]*model.SVCB, error) {
+	r.updateCounterBytesSent(domain, 1)
+	out, err := r.Resolver.LookupSVCB(ctx, domain)
 	r.updateCounterBytesRecv(err)
 	return out, err
 }

--- a/internal/cmd/oohelper/internal/fake_test.go
+++ b/internal/cmd/oohelper/internal/fake_test.go
@@ -56,6 +56,10 @@ func (c FakeResolver) LookupHTTPS(ctx context.Context, domain string) (*model.HT
 	return nil, errors.New("not implemented")
 }
 
+func (c FakeResolver) LookupSVCB(ctx context.Context, domain string) ([]*model.SVCB, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (c FakeResolver) LookupNS(ctx context.Context, domain string) ([]*net.NS, error) {
 	return nil, errors.New("not implemented")
 }

--- a/internal/engineresolver/resolver.go
+++ b/internal/engineresolver/resolver.go
@@ -88,6 +88,11 @@ func (r *Resolver) LookupHTTPS(ctx context.Context, domain string) (*model.HTTPS
 	return nil, errLookupNotImplemented
 }
 
+// LookupSVCB implements Resolver.LookupSVCB.
+func (r *Resolver) LookupSVCB(ctx context.Context, domain string) ([]*model.SVCB, error) {
+	return nil, errLookupNotImplemented
+}
+
 // LookupNS implements Resolver.LookupNS.
 func (r *Resolver) LookupNS(ctx context.Context, domain string) ([]*net.NS, error) {
 	return nil, errLookupNotImplemented

--- a/internal/experiment/ddr/ddr.go
+++ b/internal/experiment/ddr/ddr.go
@@ -1,0 +1,174 @@
+package ddr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/apex/log"
+	"github.com/miekg/dns"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/netxlite"
+)
+
+const (
+	testName    = "ddr"
+	testVersion = "0.1.0"
+)
+
+type Config struct {
+}
+
+// Measurer performs the measurement.
+type Measurer struct {
+	config Config
+}
+
+// ExperimentName implements ExperimentMeasurer.ExperimentName.
+func (m *Measurer) ExperimentName() string {
+	return testName
+}
+
+// ExperimentVersion implements ExperimentMeasurer.ExperimentVersion.
+func (m *Measurer) ExperimentVersion() string {
+	return testVersion
+}
+
+type DDRResponse struct {
+	Priority int               `json:"priority"`
+	Target   string            `json:"target"`
+	Keys     map[string]string `json:"keys"`
+}
+
+type TestKeys struct {
+	// DDRResponse is the DDR response.
+	DDRResponse []DDRResponse `json:"ddr_responses"`
+
+	// SupportsDDR is true if DDR is supported.
+	SupportsDDR bool `json:"supports_ddr"`
+
+	// Resolver is the resolver used (the system resolver of the host).
+	Resolver string `json:"resolver"`
+
+	// Failure is the failure that occurred, or nil.
+	Failure *string `json:"failure"`
+}
+
+func (m *Measurer) Run(
+	ctx context.Context,
+	args *model.ExperimentArgs) error {
+
+	log.SetLevel(log.DebugLevel)
+	measurement := args.Measurement
+
+	tk := &TestKeys{}
+	measurement.TestKeys = tk
+
+	timeout := 60 * time.Second
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	systemResolver := getSystemResolverAddress()
+	if systemResolver == "" {
+		return errors.New("could not get system resolver")
+	}
+	log.Infof("Using system resolver: %s", systemResolver)
+	tk.Resolver = systemResolver
+
+	// DDR queries are queries of the SVCB type for the _dns.resolver.arpa. domain.
+
+	netx := &netxlite.Netx{}
+	dialer := netx.NewDialerWithoutResolver(log.Log)
+	transport := netxlite.NewUnwrappedDNSOverUDPTransport(
+		dialer, systemResolver)
+	encoder := &netxlite.DNSEncoderMiekg{}
+	query := encoder.Encode(
+		"_dns.resolver.arpa.", // As specified in RFC 9462
+		dns.TypeSVCB,
+		true)
+	resp, err := transport.RoundTrip(ctx, query)
+	if err != nil {
+		failure := err.Error()
+		tk.Failure = &failure
+		return nil
+	}
+
+	reply := &dns.Msg{}
+	err = reply.Unpack(resp.Bytes())
+	if err != nil {
+		unpackError := err.Error()
+		tk.Failure = &unpackError
+		return nil
+	}
+
+	ddrResponse, err := decodeResponse(reply.Answer)
+
+	if err != nil {
+		decodingError := err.Error()
+		tk.Failure = &decodingError
+	} else {
+		tk.DDRResponse = ddrResponse
+	}
+
+	tk.SupportsDDR = len(tk.DDRResponse) > 0
+
+	log.Infof("Gathered DDR Responses: %+v", tk.DDRResponse)
+	return nil
+}
+
+// decodeResponse decodes the response from the DNS query.
+// DDR is only concerned with SVCB records, so we only decode those.
+func decodeResponse(responseFields []dns.RR) ([]DDRResponse, error) {
+	responses := make([]DDRResponse, 0)
+	for _, rr := range responseFields {
+		switch rr := rr.(type) {
+		case *dns.SVCB:
+			parsed, err := parseSvcb(rr)
+			if err != nil {
+				return nil, err
+			}
+			responses = append(responses, parsed)
+		default:
+			return nil, fmt.Errorf("unknown RR type: %T", rr)
+		}
+	}
+	return responses, nil
+}
+
+func parseSvcb(rr *dns.SVCB) (DDRResponse, error) {
+	keys := make(map[string]string)
+	for _, kv := range rr.Value {
+		value := kv.String()
+		key := kv.Key().String()
+		keys[key] = value
+	}
+
+	return DDRResponse{
+		Priority: int(rr.Priority),
+		Target:   rr.Target,
+		Keys:     keys,
+	}, nil
+}
+
+// Get the system resolver address from /etc/resolv.conf
+// This should also be possible via querying the system resolver and checking the response
+func getSystemResolverAddress() string {
+	resolverConfig, err := dns.ClientConfigFromFile("/etc/resolv.conf")
+	if err != nil {
+		return ""
+	}
+
+	if len(resolverConfig.Servers) > 0 {
+		return net.JoinHostPort(resolverConfig.Servers[0], resolverConfig.Port)
+	}
+
+	return ""
+}
+
+func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
+	return &Measurer{
+		config: config,
+	}
+}

--- a/internal/experiment/ddr/ddr_test.go
+++ b/internal/experiment/ddr/ddr_test.go
@@ -3,7 +3,6 @@ package ddr
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/apex/log"
 	"github.com/ooni/probe-cli/v3/internal/mocks"
@@ -47,13 +46,13 @@ func TestMeasurerRun(t *testing.T) {
 		t.Fatal("unexpected Failure")
 	}
 
-	firstAnswer := tk.Queries.Answers[0]
+	firstAnswer := tk.Queries[0].Answers[0]
 
 	if firstAnswer.AnswerType != "SVCB" {
 		t.Fatal("unexpected AnswerType")
 	}
 
-	if tk.Queries.ResolverAddress != "1.1.1.1" {
+	if tk.Queries[0].ResolverAddress != "1.1.1.1:53" {
 		t.Fatal("Resolver should be written to TestKeys")
 	}
 
@@ -132,30 +131,6 @@ func TestMeasurerRunWithCancelledContext(t *testing.T) {
 	err := measurer.Run(ctx, args)
 	if err != nil {
 		t.Fatal("expected no error due to cancelled context")
-	}
-	tk := args.Measurement.TestKeys.(*TestKeys)
-	if tk.Failure == nil || *tk.Failure != "interrupted" {
-		t.Fatal("expected interrupted failure")
-	}
-}
-
-func TestMeasurerRunWithTimeout(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
-	defer cancel()
-
-	measurer := NewExperimentMeasurer(Config{})
-	args := &model.ExperimentArgs{
-		Callbacks:   model.NewPrinterCallbacks(log.Log),
-		Measurement: new(model.Measurement),
-		Session: &mocks.Session{
-			MockLogger: func() model.Logger {
-				return log.Log
-			},
-		},
-	}
-	err := measurer.Run(ctx, args)
-	if err != nil {
-		t.Fatal("expected no error due to context timeout")
 	}
 	tk := args.Measurement.TestKeys.(*TestKeys)
 	if tk.Failure == nil || *tk.Failure != "interrupted" {

--- a/internal/experiment/ddr/ddr_test.go
+++ b/internal/experiment/ddr/ddr_test.go
@@ -1,0 +1,15 @@
+package ddr
+
+import (
+	"testing"
+)
+
+func TestMeasurerExperimentNameVersion(t *testing.T) {
+	measurer := NewExperimentMeasurer(Config{})
+	if measurer.ExperimentName() != "ddr" {
+		t.Fatal("unexpected ExperimentName")
+	}
+	if measurer.ExperimentVersion() != "0.1.0" {
+		t.Fatal("unexpected ExperimentVersion")
+	}
+}

--- a/internal/experiment/ddr/ddr_test.go
+++ b/internal/experiment/ddr/ddr_test.go
@@ -1,7 +1,12 @@
 package ddr
 
 import (
+	"context"
 	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-cli/v3/internal/mocks"
+	"github.com/ooni/probe-cli/v3/internal/model"
 )
 
 func TestMeasurerExperimentNameVersion(t *testing.T) {
@@ -12,4 +17,77 @@ func TestMeasurerExperimentNameVersion(t *testing.T) {
 	if measurer.ExperimentVersion() != "0.1.0" {
 		t.Fatal("unexpected ExperimentVersion")
 	}
+}
+
+func TestMeasurerRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
+
+	oneOneOneOneResolver := "1.1.1.1:53"
+
+	measurer := NewExperimentMeasurer(Config{
+		CustomResolver: &oneOneOneOneResolver,
+	})
+	args := &model.ExperimentArgs{
+		Callbacks:   model.NewPrinterCallbacks(log.Log),
+		Measurement: new(model.Measurement),
+		Session: &mocks.Session{
+			MockLogger: func() model.Logger {
+				return log.Log
+			},
+		},
+	}
+	if err := measurer.Run(context.Background(), args); err != nil {
+		t.Fatal(err)
+	}
+	tk := args.Measurement.TestKeys.(*TestKeys)
+	if tk.Failure != nil {
+		t.Fatal("unexpected Failure")
+	}
+
+	if tk.Resolver != oneOneOneOneResolver {
+		t.Fatal("Resolver should be written to TestKeys")
+	}
+
+	// 1.1.1.1 supports DDR
+	if tk.SupportsDDR != true {
+		t.Fatal("unexpected value for Supports DDR")
+	}
+}
+
+// This test fails because the resolver is a domain name and not an IP address.
+func TestMeasurerFailsWithDomainResolver(t *testing.T) {
+	invalidResolver := "invalid-resolver.example:53"
+
+	tk, _ := runExperiment(invalidResolver)
+	if tk.Failure == nil {
+		t.Fatal("expected Failure")
+	}
+}
+
+func TestMeasurerFailsWithNoPort(t *testing.T) {
+	invalidResolver := "1.1.1.1"
+
+	tk, _ := runExperiment(invalidResolver)
+	if tk.Failure == nil {
+		t.Fatal("expected Failure")
+	}
+}
+
+func runExperiment(resolver string) (*TestKeys, error) {
+	measurer := NewExperimentMeasurer(Config{
+		CustomResolver: &resolver,
+	})
+	args := &model.ExperimentArgs{
+		Callbacks:   model.NewPrinterCallbacks(log.Log),
+		Measurement: new(model.Measurement),
+		Session: &mocks.Session{
+			MockLogger: func() model.Logger {
+				return log.Log
+			},
+		},
+	}
+	err := measurer.Run(context.Background(), args)
+	return args.Measurement.TestKeys.(*TestKeys), err
 }

--- a/internal/experiment/ddr/ddr_test.go
+++ b/internal/experiment/ddr/ddr_test.go
@@ -46,7 +46,13 @@ func TestMeasurerRun(t *testing.T) {
 		t.Fatal("unexpected Failure")
 	}
 
-	if tk.Resolver != oneOneOneOneResolver {
+	firstAnswer := tk.Queries.Answers[0]
+
+	if firstAnswer.AnswerType != "SVCB" {
+		t.Fatal("unexpected AnswerType")
+	}
+
+	if tk.Queries.ResolverAddress != oneOneOneOneResolver {
 		t.Fatal("Resolver should be written to TestKeys")
 	}
 

--- a/internal/experiment/dnscheck/dnscheck.go
+++ b/internal/experiment/dnscheck/dnscheck.go
@@ -172,7 +172,7 @@ func (m *Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 		return ErrUnsupportedURLScheme
 	}
 
-	// Implementation note: we must not return an error from now now. Returning an
+	// Implementation note: we must not return an error from now. Returning an
 	// error means that we don't have a measurement to submit.
 
 	// 4. possibly expand a domain to a list of IP addresses.

--- a/internal/legacy/tracex/event.go
+++ b/internal/legacy/tracex/event.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 	"github.com/ooni/probe-cli/v3/internal/runtimex"
 )
@@ -276,8 +277,10 @@ func (ev *EventWriteOperation) Name() string {
 type EventValue struct {
 	Addresses                   []string      `json:",omitempty"`
 	Address                     string        `json:",omitempty"`
+	DNSQueryType                string        `json:",omitempty"`
 	DNSQuery                    []byte        `json:",omitempty"`
 	DNSResponse                 []byte        `json:",omitempty"`
+	DNSSVCBRespones             []*model.SVCB `json:",omitempty"`
 	Data                        []byte        `json:",omitempty"`
 	Duration                    time.Duration `json:",omitempty"`
 	Err                         FailureStr    `json:",omitempty"`

--- a/internal/legacy/tracex/resolver.go
+++ b/internal/legacy/tracex/resolver.go
@@ -92,6 +92,31 @@ func (r *ResolverSaver) LookupHTTPS(ctx context.Context, domain string) (*model.
 	return r.Resolver.LookupHTTPS(ctx, domain)
 }
 
+func (r *ResolverSaver) LookupSVCB(ctx context.Context, domain string) ([]*model.SVCB, error) {
+	start := time.Now()
+	r.Saver.Write(&EventResolveStart{&EventValue{
+		Address:      r.Resolver.Address(),
+		DNSQueryType: "SVCB",
+		Hostname:     domain,
+		Proto:        r.Network(),
+		Time:         start,
+	}})
+	resp, err := r.Resolver.LookupSVCB(ctx, domain)
+
+	stop := time.Now()
+	r.Saver.Write(&EventResolveDone{&EventValue{
+		Address:         r.Resolver.Address(),
+		DNSQueryType:    "SVCB",
+		DNSSVCBRespones: resp,
+		Duration:        stop.Sub(start),
+		Err:             NewFailureStr(err),
+		Hostname:        domain,
+		Proto:           r.Network(),
+		Time:            stop,
+	}})
+	return resp, err
+}
+
 func (r *ResolverSaver) LookupNS(ctx context.Context, domain string) ([]*net.NS, error) {
 	// TODO(bassosimone): we should probably implement this method
 	return r.Resolver.LookupNS(ctx, domain)

--- a/internal/measurexlite/dns.go
+++ b/internal/measurexlite/dns.go
@@ -85,6 +85,13 @@ func (r *resolverTrace) LookupHTTPS(ctx context.Context, domain string) (*model.
 	return r.r.LookupHTTPS(netxlite.ContextWithTrace(ctx, r.tx), domain)
 }
 
+// LookupSVCB implements model.Resolver.LookupSVCB
+func (r *resolverTrace) LookupSVCB(ctx context.Context, domain string) ([]*model.SVCB, error) {
+	defer r.emiteResolveDone()
+	r.emitResolveStart()
+	return r.r.LookupSVCB(netxlite.ContextWithTrace(ctx, r.tx), domain)
+}
+
 // LookupNS implements model.Resolver.LookupNS
 func (r *resolverTrace) LookupNS(ctx context.Context, domain string) ([]*net.NS, error) {
 	defer r.emiteResolveDone()

--- a/internal/mocks/dnsresponse.go
+++ b/internal/mocks/dnsresponse.go
@@ -16,6 +16,7 @@ type DNSResponse struct {
 	MockBytes            func() []byte
 	MockRcode            func() int
 	MockDecodeHTTPS      func() (*model.HTTPSSvc, error)
+	MockDecodeSVCB       func() ([]*model.SVCB, error)
 	MockDecodeLookupHost func() ([]string, error)
 	MockDecodeNS         func() ([]*net.NS, error)
 	MockDecodeCNAME      func() (string, error)
@@ -37,6 +38,10 @@ func (r *DNSResponse) Rcode() int {
 
 func (r *DNSResponse) DecodeHTTPS() (*model.HTTPSSvc, error) {
 	return r.MockDecodeHTTPS()
+}
+
+func (r *DNSResponse) DecodeSVCB() ([]*model.SVCB, error) {
+	return r.MockDecodeSVCB()
 }
 
 func (r *DNSResponse) DecodeLookupHost() ([]string, error) {

--- a/internal/mocks/resolver.go
+++ b/internal/mocks/resolver.go
@@ -14,6 +14,7 @@ type Resolver struct {
 	MockAddress              func() string
 	MockCloseIdleConnections func()
 	MockLookupHTTPS          func(ctx context.Context, domain string) (*model.HTTPSSvc, error)
+	MockLookupSVCB           func(ctx context.Context, domain string) ([]*model.SVCB, error)
 	MockLookupNS             func(ctx context.Context, domain string) ([]*net.NS, error)
 }
 
@@ -40,6 +41,11 @@ func (r *Resolver) CloseIdleConnections() {
 // LookupHTTPS calls MockLookupHTTPS.
 func (r *Resolver) LookupHTTPS(ctx context.Context, domain string) (*model.HTTPSSvc, error) {
 	return r.MockLookupHTTPS(ctx, domain)
+}
+
+// LookupSVCB calls MockLookupSVCB.
+func (r *Resolver) LookupSVCB(ctx context.Context, domain string) ([]*model.SVCB, error) {
+	return r.MockLookupSVCB(ctx, domain)
 }
 
 // LookupNS calls MockLookupNS.

--- a/internal/model/archival.go
+++ b/internal/model/archival.go
@@ -198,14 +198,14 @@ type ArchivalDNSLookupResult struct {
 
 // ArchivalDNSAnswer is a DNS answer.
 type ArchivalDNSAnswer struct {
-	ASN        int64     `json:"asn,omitempty"`
-	ASOrgName  string    `json:"as_org_name,omitempty"`
-	AnswerType string    `json:"answer_type"`
-	Hostname   string    `json:"hostname,omitempty"`
-	IPv4       string    `json:"ipv4,omitempty"`
-	IPv6       string    `json:"ipv6,omitempty"`
-	TTL        *uint32   `json:"ttl"`
-	SVCB       *SVCBData `json:"svcb,omitempty"` // SVCB-specific data
+	ASN        int64      `json:"asn,omitempty"`
+	ASOrgName  string     `json:"as_org_name,omitempty"`
+	AnswerType string     `json:"answer_type"`
+	Hostname   string     `json:"hostname,omitempty"`
+	IPv4       string     `json:"ipv4,omitempty"`
+	IPv6       string     `json:"ipv6,omitempty"`
+	TTL        *uint32    `json:"ttl"`
+	SVCB       []SVCBData `json:"svcb,omitempty"` // SVCB-specific data
 }
 
 // SVCBData represents details of an SVCB record.

--- a/internal/model/archival.go
+++ b/internal/model/archival.go
@@ -198,13 +198,21 @@ type ArchivalDNSLookupResult struct {
 
 // ArchivalDNSAnswer is a DNS answer.
 type ArchivalDNSAnswer struct {
-	ASN        int64   `json:"asn,omitempty"`
-	ASOrgName  string  `json:"as_org_name,omitempty"`
-	AnswerType string  `json:"answer_type"`
-	Hostname   string  `json:"hostname,omitempty"`
-	IPv4       string  `json:"ipv4,omitempty"`
-	IPv6       string  `json:"ipv6,omitempty"`
-	TTL        *uint32 `json:"ttl"`
+	ASN        int64     `json:"asn,omitempty"`
+	ASOrgName  string    `json:"as_org_name,omitempty"`
+	AnswerType string    `json:"answer_type"`
+	Hostname   string    `json:"hostname,omitempty"`
+	IPv4       string    `json:"ipv4,omitempty"`
+	IPv6       string    `json:"ipv6,omitempty"`
+	TTL        *uint32   `json:"ttl"`
+	SVCB       *SVCBData `json:"svcb,omitempty"` // SVCB-specific data
+}
+
+// SVCBData represents details of an SVCB record.
+type SVCBData struct {
+	Priority   uint16            `json:"priority"`
+	TargetName string            `json:"target_name"`
+	Params     map[string]string `json:"params,omitempty"` // SvcParams key-value pairs
 }
 
 //

--- a/internal/model/netx.go
+++ b/internal/model/netx.go
@@ -29,9 +29,13 @@ type DNSResponse interface {
 	// Rcode returns the response's Rcode.
 	Rcode() int
 
-	// DecodeHTTPS returns information gathered from all the HTTPS
+	// DecodeHTTPS returns information gathered from all the HTTPS/SVCB
 	// records found inside of this response.
 	DecodeHTTPS() (*HTTPSSvc, error)
+
+	// DecodeSVCB returns information gathered from all the SVCB records
+	// found inside of this response.
+	DecodeSVCB() ([]*SVCB, error)
 
 	// DecodeLookupHost returns the addresses in the response matching
 	// the original query type (one of A and AAAA).
@@ -186,6 +190,35 @@ type HTTPSSvc struct {
 	IPv6 []string
 }
 
+// SVCB is the reply to an SVCB DNS query.
+type SVCB struct {
+	// Priority is the priority of the SVCB record.
+	Priority uint16
+
+	// TargetName is the target name of the SVCB record.
+	TargetName string
+
+	// ALPN contains the ALPNs inside the SVCB reply.
+	ALPN []string
+
+	// IPv4 contains the IPv4 hint (which may be empty).
+	IPv4 []string
+
+	// IPv6 contains the IPv6 hint (which may be empty).
+	IPv6 []string
+
+	// Port is the port to use for the connection.
+	Port uint16
+
+	// DoHPath is the path to use for DNS-over-HTTPS.
+	DoHPath string
+
+	// OHttp denotes whether oblivious DNS over HTTPS is supported.
+	OHttp bool
+
+	//This could also include ECH and other SVCB parameters
+}
+
 // MeasuringNetwork defines the constructors required for implementing OONI experiments. All
 // these constructors MUST guarantee proper error wrapping to map Go errors to OONI errors
 // as documented by the [netxlite] package. The [*netxlite.Netx] type is currently the default
@@ -307,6 +340,9 @@ type Resolver interface {
 
 	// LookupNS issues a NS query for a domain.
 	LookupNS(ctx context.Context, domain string) ([]*net.NS, error)
+
+	//LookupSVCB issues a SVCB query for a domain.
+	LookupSVCB(ctx context.Context, domain string) ([]*SVCB, error)
 }
 
 // TLSConn is the type of connection that oohttp expects from

--- a/internal/netxlite/bogon.go
+++ b/internal/netxlite/bogon.go
@@ -59,6 +59,12 @@ func (r *bogonResolver) LookupHTTPS(ctx context.Context, hostname string) (*mode
 	return nil, ErrNoDNSTransport
 }
 
+// LookupSVCB implements Resolver.LookupSVCB
+func (r *bogonResolver) LookupSVCB(ctx context.Context, hostname string) ([]*model.SVCB, error) {
+	// TODO: decide whether we want to implement this method or not
+	return nil, ErrNoDNSTransport
+}
+
 // LookupNS implements Resolver.LookupNS
 func (r *bogonResolver) LookupNS(ctx context.Context, hostname string) ([]*net.NS, error) {
 	// TODO(bassosimone): decide whether we want to implement this method or not

--- a/internal/netxlite/dnsovergetaddrinfo.go
+++ b/internal/netxlite/dnsovergetaddrinfo.go
@@ -148,6 +148,10 @@ func (r *dnsOverGetaddrinfoResponse) DecodeHTTPS() (*model.HTTPSSvc, error) {
 	return nil, ErrNoDNSTransport
 }
 
+func (r *dnsOverGetaddrinfoResponse) DecodeSVCB() ([]*model.SVCB, error) {
+	return nil, ErrNoDNSTransport
+}
+
 func (r *dnsOverGetaddrinfoResponse) DecodeLookupHost() ([]string, error) {
 	if len(r.addrs) <= 0 {
 		return nil, ErrOODNSNoAnswer

--- a/internal/netxlite/resolvercache.go
+++ b/internal/netxlite/resolvercache.go
@@ -113,6 +113,11 @@ func (r *cacheResolver) LookupHTTPS(ctx context.Context, domain string) (*model.
 	return nil, ErrNoDNSTransport
 }
 
+// LookupSVCB implements model.Resolver.LookupSVCB.
+func (r *cacheResolver) LookupSVCB(ctx context.Context, domain string) ([]*model.SVCB, error) {
+	return nil, ErrNoDNSTransport
+}
+
 // LookupNS implements model.Resolver.LookupNS.
 func (r *cacheResolver) LookupNS(ctx context.Context, domain string) ([]*net.NS, error) {
 	return nil, ErrNoDNSTransport

--- a/internal/netxlite/resolvercore.go
+++ b/internal/netxlite/resolvercore.go
@@ -145,6 +145,11 @@ func (r *resolverSystem) LookupHTTPS(
 	return nil, ErrNoDNSTransport
 }
 
+func (r *resolverSystem) LookupSVCB(
+	ctx context.Context, domain string) ([]*model.SVCB, error) {
+	return nil, ErrNoDNSTransport
+}
+
 func (r *resolverSystem) LookupNS(
 	ctx context.Context, domain string) ([]*net.NS, error) {
 	return nil, ErrNoDNSTransport
@@ -188,6 +193,21 @@ func (r *resolverLogger) LookupHTTPS(
 	aaaa := https.IPv6
 	r.Logger.Debugf("%s... %+v %+v %+v in %s", prefix, alpn, a, aaaa, elapsed)
 	return https, nil
+}
+
+func (r *resolverLogger) LookupSVCB(
+	ctx context.Context, domain string) ([]*model.SVCB, error) {
+	prefix := fmt.Sprintf("resolve[SVCB] %s with %s (%s)", domain, r.Network(), r.Address())
+	r.Logger.Debugf("%s...", prefix)
+	start := time.Now()
+	svcb, err := r.Resolver.LookupSVCB(ctx, domain)
+	elapsed := time.Since(start)
+	if err != nil {
+		r.Logger.Debugf("%s... %s in %s", prefix, err, elapsed)
+		return nil, err
+	}
+	r.Logger.Debugf("%s... %+v in %s", prefix, svcb, elapsed)
+	return svcb, nil
 }
 
 func (r *resolverLogger) Address() string {
@@ -243,6 +263,14 @@ func (r *resolverIDNA) LookupHTTPS(
 	return r.Resolver.LookupHTTPS(ctx, host)
 }
 
+func (r *resolverIDNA) LookupSVCB(
+	ctx context.Context, domain string) ([]*model.SVCB, error) {
+	// This does not work here, since we need to query
+	// for _dns.resolver.arpa., which results in
+	// error idna: disallowed rune U+005F because of the underscore.
+	return r.Resolver.LookupSVCB(ctx, domain)
+}
+
 func (r *resolverIDNA) Network() string {
 	return r.Resolver.Network()
 }
@@ -290,6 +318,20 @@ func (r *ResolverShortCircuitIPAddr) LookupHTTPS(ctx context.Context, hostname s
 		return https, nil
 	}
 	return r.Resolver.LookupHTTPS(ctx, hostname)
+}
+
+func (r *ResolverShortCircuitIPAddr) LookupSVCB(ctx context.Context, hostname string) ([]*model.SVCB, error) {
+	if net.ParseIP(hostname) != nil {
+		svcb := &model.SVCB{}
+		if isIPv6(hostname) {
+			svcb.IPv6 = append(svcb.IPv6, hostname)
+		} else {
+			svcb.IPv4 = append(svcb.IPv4, hostname)
+		}
+
+		return []*model.SVCB{svcb}, nil
+	}
+	return r.Resolver.LookupSVCB(ctx, hostname)
 }
 
 func (r *ResolverShortCircuitIPAddr) Network() string {
@@ -363,6 +405,11 @@ func (r *NullResolver) LookupHTTPS(
 	return nil, ErrNoResolver
 }
 
+func (r *NullResolver) LookupSVCB(
+	ctx context.Context, domain string) ([]*model.SVCB, error) {
+	return nil, ErrNoResolver
+}
+
 func (r *NullResolver) LookupNS(
 	ctx context.Context, domain string) ([]*net.NS, error) {
 	return nil, ErrNoResolver
@@ -386,6 +433,15 @@ func (r *resolverErrWrapper) LookupHost(ctx context.Context, hostname string) ([
 func (r *resolverErrWrapper) LookupHTTPS(
 	ctx context.Context, domain string) (*model.HTTPSSvc, error) {
 	out, err := r.Resolver.LookupHTTPS(ctx, domain)
+	if err != nil {
+		return nil, NewErrWrapper(ClassifyResolverError, ResolveOperation, err)
+	}
+	return out, nil
+}
+
+func (r *resolverErrWrapper) LookupSVCB(
+	ctx context.Context, domain string) ([]*model.SVCB, error) {
+	out, err := r.Resolver.LookupSVCB(ctx, domain)
 	if err != nil {
 		return nil, NewErrWrapper(ClassifyResolverError, ResolveOperation, err)
 	}

--- a/internal/netxlite/resolvercore_test.go
+++ b/internal/netxlite/resolvercore_test.go
@@ -198,6 +198,17 @@ func TestResolverSystem(t *testing.T) {
 		}
 	})
 
+	t.Run("LookupSVCB", func(t *testing.T) {
+		r := &resolverSystem{}
+		svcb, err := r.LookupSVCB(context.Background(), "x.org")
+		if !errors.Is(err, ErrNoDNSTransport) {
+			t.Fatal("not the error we expected")
+		}
+		if svcb != nil {
+			t.Fatal("expected nil result")
+		}
+	})
+
 	t.Run("LookupNS", func(t *testing.T) {
 		r := &resolverSystem{}
 		ns, err := r.LookupNS(context.Background(), "x.org")

--- a/internal/netxlite/resolverparallel.go
+++ b/internal/netxlite/resolverparallel.go
@@ -87,6 +87,18 @@ func (r *ParallelResolver) LookupHTTPS(
 	return response.DecodeHTTPS()
 }
 
+// LookupSVCB implements Resolver.LookupSVCB.
+func (r *ParallelResolver) LookupSVCB(
+	ctx context.Context, hostname string) ([]*model.SVCB, error) {
+	encoder := &DNSEncoderMiekg{}
+	query := encoder.Encode(hostname, dns.TypeSVCB, r.Txp.RequiresPadding())
+	response, err := r.Txp.RoundTrip(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	return response.DecodeSVCB()
+}
+
 // parallelResolverResult is the internal representation of a
 // lookup using either the A or the AAAA query type.
 type parallelResolverResult struct {

--- a/internal/netxlite/resolverserial.go
+++ b/internal/netxlite/resolverserial.go
@@ -94,6 +94,17 @@ func (r *SerialResolver) LookupHTTPS(
 	return response.DecodeHTTPS()
 }
 
+func (r *SerialResolver) LookupSVCB(
+	ctx context.Context, hostname string) ([]*model.SVCB, error) {
+	encoder := &DNSEncoderMiekg{}
+	query := encoder.Encode(hostname, dns.TypeSVCB, r.Txp.RequiresPadding())
+	response, err := r.Txp.RoundTrip(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	return response.DecodeSVCB()
+}
+
 func (r *SerialResolver) lookupHostWithRetry(
 	ctx context.Context, hostname string, qtype uint16) ([]string, error) {
 	// QUIRK: retrying has been there since the beginning so we need to

--- a/internal/registry/ddr.go
+++ b/internal/registry/ddr.go
@@ -1,0 +1,28 @@
+package registry
+
+//
+// Registers the `ddr' experiment.
+//
+
+import (
+	"github.com/ooni/probe-cli/v3/internal/experiment/ddr"
+	"github.com/ooni/probe-cli/v3/internal/model"
+)
+
+func init() {
+	const canonicalName = "ddr"
+	AllExperiments[canonicalName] = func() *Factory {
+		return &Factory{
+			build: func(config interface{}) model.ExperimentMeasurer {
+				return ddr.NewExperimentMeasurer(
+					*config.(*ddr.Config),
+				)
+			},
+			canonicalName:    canonicalName,
+			config:           &ddr.Config{},
+			enabledByDefault: true,
+			interruptible:    true,
+			inputPolicy:      model.InputNone,
+		}
+	}
+}

--- a/internal/registry/factory_test.go
+++ b/internal/registry/factory_test.go
@@ -594,7 +594,7 @@ func TestNewFactory(t *testing.T) {
 		},
 		"echcheck": {
 			enabledByDefault: true,
-			inputPolicy: model.InputOptional,
+			inputPolicy:      model.InputOptional,
 		},
 		"example": {
 			enabledByDefault: true,


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2819
- [x] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: https://github.com/ooni/spec/pull/300
- [x] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

As described here: https://github.com/ooni/probe/issues/2819, I would be interested to run experiments of the DDR protocol (RFC 9462). This experiment uses the system resolver, as I am interested in whether the local system resolvers support this protocol (we have already conducted tests using zmap from one vantage point). 

To get the system resolver I am checking /etc/resolve, it should also be possible by querying using the default DNS provider and checking the answer or config, however I did not get this to work.

~~I have no idea about what the spec should look like. Right now I just put the DDR responses as JSON objects into the testkeys. If that is not supported because it could violate the spec, it would also be possible to just insert the string / do some parsing here to get some more useful information (e.g. if DoT or DoH is supported, what the target is...)~~

## TODOs

- [x] Testing
- [x] PR for spec
