### PR TITLE
feat: switch orchestrate base url and probe services url

### DIFF
--- a/cmd/ooniprobe/internal/nettests/nettests.go
+++ b/cmd/ooniprobe/internal/nettests/nettests.go
@@ -215,7 +215,7 @@ func (c *Controller) Run(builder model.ExperimentBuilder, inputs []model.Experim
 			// Implementation note: SubmitMeasurement will fail here if we did fail
 			// to open the report but we still want to continue. There will be a
 			// bit of a spew in the logs, perhaps, but stopping seems less efficient.
-			if err := exp.SubmitAndUpdateMeasurementContext(context.Background(), measurement); err != nil {
+			if _, err := exp.SubmitAndUpdateMeasurementContext(context.Background(), measurement); err != nil {
 				log.Debug(color.RedString("failure.measurement_submission"))
 				if err := db.UploadFailed(c.msmts[idx64], err.Error()); err != nil {
 					return errors.Wrap(err, "failed to mark upload as failed")

--- a/internal/cmd/oonireport/oonireport.go
+++ b/internal/cmd/oonireport/oonireport.go
@@ -106,7 +106,7 @@ func submitAll(ctx context.Context, lines []string, subm model.Submitter) (int, 
 	for _, line := range lines {
 		mm := toMeasurement(line)
 		// submit the measurement
-		err := subm.Submit(ctx, mm)
+		_, err := subm.Submit(ctx, mm)
 		if err != nil {
 			return submitted, err
 		}

--- a/internal/engine/experiment.go
+++ b/internal/engine/experiment.go
@@ -104,10 +104,10 @@ func (e *experiment) ReportID() string {
 
 // SubmitAndUpdateMeasurementContext implements [model.Experiment].
 func (e *experiment) SubmitAndUpdateMeasurementContext(
-	ctx context.Context, measurement *model.Measurement) error {
+	ctx context.Context, measurement *model.Measurement) (string, error) {
 	report := e.mrep.Get()
 	if report == nil {
-		return errors.New("report is not open")
+		return "", errors.New("report is not open")
 	}
 	return report.SubmitMeasurement(ctx, measurement)
 }

--- a/internal/engine/experiment_integration_test.go
+++ b/internal/engine/experiment_integration_test.go
@@ -280,7 +280,7 @@ func runexperimentflow(t *testing.T, experiment model.Experiment, input string) 
 	}
 	filename := tempfile.Name()
 	tempfile.Close()
-	err = experiment.SubmitAndUpdateMeasurementContext(ctx, measurement)
+	_, err = experiment.SubmitAndUpdateMeasurementContext(ctx, measurement)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -323,7 +323,7 @@ func TestOpenReportIdempotent(t *testing.T) {
 		t.Fatal("unexpected initial report ID")
 	}
 	ctx := context.Background()
-	if err := exp.SubmitAndUpdateMeasurementContext(ctx, &model.Measurement{}); err == nil {
+	if _, err := exp.SubmitAndUpdateMeasurementContext(ctx, &model.Measurement{}); err == nil {
 		t.Fatal("we should not be able to submit before OpenReport")
 	}
 	err = exp.OpenReportContext(ctx)
@@ -403,7 +403,7 @@ func TestSubmitAndUpdateMeasurementWithClosedReport(t *testing.T) {
 	}
 	exp := builder.NewExperiment()
 	m := new(model.Measurement)
-	err = exp.SubmitAndUpdateMeasurementContext(context.Background(), m)
+	_, err = exp.SubmitAndUpdateMeasurementContext(context.Background(), m)
 	if err == nil {
 		t.Fatal("expected an error here")
 	}

--- a/internal/engine/inputloader_integration_test.go
+++ b/internal/engine/inputloader_integration_test.go
@@ -23,7 +23,7 @@ func TestTargetLoaderInputOrQueryBackendWithNoInput(t *testing.T) {
 	}
 	sess, err := engine.NewSession(context.Background(), engine.SessionConfig{
 		AvailableProbeServices: []model.OOAPIService{{
-			Address: "https://backend-hel.ooni.org/",
+			Address: "https://api.dev.ooni.io/",
 			Type:    "https",
 		}},
 		KVStore:         &kvstore.Memory{},

--- a/internal/engine/session.go
+++ b/internal/engine/session.go
@@ -627,7 +627,7 @@ func (s *Session) getAvailableProbeServicesUnlocked() []model.OOAPIService {
 
 func (s *Session) initOrchestraClient(
 	ctx context.Context, clnt *probeservices.Client,
-	maybeLogin func(ctx context.Context) error,
+	maybeLogin func(ctx context.Context, baseURL string) error,
 ) (*probeservices.Client, error) {
 	// The original implementation has as its only use case that we
 	// were registering and logging in for sending an update regarding
@@ -644,10 +644,12 @@ func (s *Session) initOrchestraClient(
 		SoftwareVersion: "0.1.0-dev",
 		SupportedTests:  []string{"web_connectivity"},
 	}
-	if err := clnt.MaybeRegister(ctx, meta); err != nil {
+
+	orchestrator := probeservices.DefaultOrchestrator()
+	if err := clnt.MaybeRegister(ctx, orchestrator.Address, meta); err != nil {
 		return nil, err
 	}
-	if err := maybeLogin(ctx); err != nil {
+	if err := maybeLogin(ctx, orchestrator.Address); err != nil {
 		return nil, err
 	}
 	return clnt, nil

--- a/internal/engine/session_integration_test.go
+++ b/internal/engine/session_integration_test.go
@@ -94,7 +94,7 @@ func TestSessionTorArgsTorBinary(t *testing.T) {
 	}
 	sess, err := NewSession(context.Background(), SessionConfig{
 		AvailableProbeServices: []model.OOAPIService{{
-			Address: "https://backend-hel.ooni.org",
+			Address: "https://api.dev.ooni.io",
 			Type:    "https",
 		}},
 		Logger:          model.DiscardLogger,
@@ -126,7 +126,7 @@ func TestSessionTorArgsTorBinary(t *testing.T) {
 func newSessionForTestingNoLookupsWithProxyURL(t *testing.T, URL *url.URL) *Session {
 	sess, err := NewSession(context.Background(), SessionConfig{
 		AvailableProbeServices: []model.OOAPIService{{
-			Address: "https://backend-hel.ooni.org",
+			Address: "https://api.dev.ooni.io",
 			Type:    "https",
 		}},
 		Logger:          model.DiscardLogger,
@@ -179,7 +179,7 @@ func TestInitOrchestraClientMaybeRegisterError(t *testing.T) {
 	sess := newSessionForTestingNoLookups(t)
 	defer sess.Close()
 	clnt, err := probeservices.NewClient(sess, model.OOAPIService{
-		Address: "https://backend-hel.ooni.org/",
+		Address: "https://api.dev.ooni.io/",
 		Type:    "https",
 	})
 	if err != nil {
@@ -204,7 +204,7 @@ func TestInitOrchestraClientMaybeLoginError(t *testing.T) {
 	sess := newSessionForTestingNoLookups(t)
 	defer sess.Close()
 	clnt, err := probeservices.NewClient(sess, model.OOAPIService{
-		Address: "https://backend-hel.ooni.org/",
+		Address: "https://api.dev.ooni.io/",
 		Type:    "https",
 	})
 	if err != nil {
@@ -212,7 +212,7 @@ func TestInitOrchestraClientMaybeLoginError(t *testing.T) {
 	}
 	expected := errors.New("mocked error")
 	outclnt, err := sess.initOrchestraClient(
-		ctx, clnt, func(context.Context) error {
+		ctx, clnt, func(context.Context, string) error {
 			return expected
 		},
 	)

--- a/internal/mocks/experiment.go
+++ b/internal/mocks/experiment.go
@@ -22,7 +22,7 @@ type Experiment struct {
 	MockSaveMeasurement func(measurement *model.Measurement, filePath string) error
 
 	MockSubmitAndUpdateMeasurementContext func(
-		ctx context.Context, measurement *model.Measurement) error
+		ctx context.Context, measurement *model.Measurement) (string, error)
 
 	MockOpenReportContext func(ctx context.Context) error
 }
@@ -53,7 +53,7 @@ func (e *Experiment) SaveMeasurement(measurement *model.Measurement, filePath st
 }
 
 func (e *Experiment) SubmitAndUpdateMeasurementContext(
-	ctx context.Context, measurement *model.Measurement) error {
+	ctx context.Context, measurement *model.Measurement) (string, error) {
 	return e.MockSubmitAndUpdateMeasurementContext(ctx, measurement)
 }
 

--- a/internal/mocks/experiment_test.go
+++ b/internal/mocks/experiment_test.go
@@ -93,11 +93,11 @@ func TestExperiment(t *testing.T) {
 	t.Run("SubmitAndUpdateMeasurementContext", func(t *testing.T) {
 		expected := errors.New("mocked err")
 		e := &Experiment{
-			MockSubmitAndUpdateMeasurementContext: func(ctx context.Context, measurement *model.Measurement) error {
-				return expected
+			MockSubmitAndUpdateMeasurementContext: func(ctx context.Context, measurement *model.Measurement) (string, error) {
+				return "", expected
 			},
 		}
-		err := e.SubmitAndUpdateMeasurementContext(context.Background(), &model.Measurement{})
+		_, err := e.SubmitAndUpdateMeasurementContext(context.Background(), &model.Measurement{})
 		if !errors.Is(err, expected) {
 			t.Fatal("unexpected err", err)
 		}

--- a/internal/mocks/submitter.go
+++ b/internal/mocks/submitter.go
@@ -8,10 +8,10 @@ import (
 
 // Submitter mocks model.Submitter.
 type Submitter struct {
-	MockSubmit func(ctx context.Context, m *model.Measurement) error
+	MockSubmit func(ctx context.Context, m *model.Measurement) (string, error)
 }
 
 // Submit calls MockSubmit
-func (s *Submitter) Submit(ctx context.Context, m *model.Measurement) error {
+func (s *Submitter) Submit(ctx context.Context, m *model.Measurement) (string, error) {
 	return s.MockSubmit(ctx, m)
 }

--- a/internal/mocks/submitter_test.go
+++ b/internal/mocks/submitter_test.go
@@ -12,11 +12,11 @@ func TestSubmitter(t *testing.T) {
 	t.Run("Submit", func(t *testing.T) {
 		expect := errors.New("mocked error")
 		s := &Submitter{
-			MockSubmit: func(ctx context.Context, m *model.Measurement) error {
-				return expect
+			MockSubmit: func(ctx context.Context, m *model.Measurement) (string, error) {
+				return "", expect
 			},
 		}
-		err := s.Submit(context.Background(), &model.Measurement{})
+		_, err := s.Submit(context.Background(), &model.Measurement{})
 		if !errors.Is(err, expect) {
 			t.Fatal("unexpected err", err)
 		}

--- a/internal/model/experiment.go
+++ b/internal/model/experiment.go
@@ -186,7 +186,7 @@ type Experiment interface {
 	// SubmitAndUpdateMeasurementContext submits a measurement and updates the
 	// fields whose value has changed as part of the submission.
 	SubmitAndUpdateMeasurementContext(
-		ctx context.Context, measurement *Measurement) error
+		ctx context.Context, measurement *Measurement) (string, error)
 
 	// OpenReportContext will open a report using the given context
 	// to possibly limit the lifetime of this operation.
@@ -322,7 +322,7 @@ type ExperimentTargetLoader interface {
 type Submitter interface {
 	// Submit submits the measurement and updates its
 	// report ID field in case of success.
-	Submit(ctx context.Context, m *Measurement) error
+	Submit(ctx context.Context, m *Measurement) (string, error)
 }
 
 // Saver saves a measurement on some persistent storage.

--- a/internal/oonirun/experiment.go
+++ b/internal/oonirun/experiment.go
@@ -263,10 +263,11 @@ type experimentSubmitterWrapper struct {
 	logger model.Logger
 }
 
-func (sw *experimentSubmitterWrapper) Submit(ctx context.Context, idx int, m *model.Measurement) error {
-	if err := sw.child.Submit(ctx, idx, m); err != nil {
+func (sw *experimentSubmitterWrapper) Submit(ctx context.Context, idx int, m *model.Measurement) (string, error) {
+	mstUID, err := sw.child.Submit(ctx, idx, m)
+	if err != nil {
 		sw.logger.Warnf("submitting measurement failed: %s", err.Error())
 	}
 	// policy: we do not stop the loop if measurement submission fails
-	return nil
+	return mstUID, nil
 }

--- a/internal/oonirun/experiment_test.go
+++ b/internal/oonirun/experiment_test.go
@@ -93,9 +93,9 @@ func TestExperimentRunWithFailureToSubmitAndShuffle(t *testing.T) {
 		newTargetLoaderFn:      nil,
 		newSubmitterFn: func(ctx context.Context) (model.Submitter, error) {
 			subm := &mocks.Submitter{
-				MockSubmit: func(ctx context.Context, m *model.Measurement) error {
+				MockSubmit: func(ctx context.Context, m *model.Measurement) (string, error) {
 					failedToSubmit++
-					return errors.New("mocked error")
+					return "", errors.New("mocked error")
 				},
 			}
 			return subm, nil

--- a/internal/oonirun/inputprocessor.go
+++ b/internal/oonirun/inputprocessor.go
@@ -87,7 +87,7 @@ func (ipsw inputProcessorSaverWrapper) SaveMeasurement(
 // InputProcessorSubmitterWrapper is InputProcessor's
 // wrapper for a Submitter implementation.
 type InputProcessorSubmitterWrapper interface {
-	Submit(ctx context.Context, idx int, m *model.Measurement) error
+	Submit(ctx context.Context, idx int, m *model.Measurement) (string, error)
 }
 
 type inputProcessorSubmitterWrapper struct {
@@ -101,7 +101,7 @@ func NewInputProcessorSubmitterWrapper(submitter Submitter) InputProcessorSubmit
 }
 
 func (ipsw inputProcessorSubmitterWrapper) Submit(
-	ctx context.Context, idx int, m *model.Measurement) error {
+	ctx context.Context, idx int, m *model.Measurement) (string, error) {
 	return ipsw.submitter.Submit(ctx, m)
 }
 
@@ -141,7 +141,7 @@ func (ip *InputProcessor) run(ctx context.Context) (int, error) {
 			return 0, err
 		}
 		meas.AddAnnotations(ip.Annotations)
-		err = ip.Submitter.Submit(ctx, idx, meas)
+		_, err = ip.Submitter.Submit(ctx, idx, meas)
 		if err != nil {
 			// TODO(bassosimone): when re-reading this code, I find it confusing that
 			// we return on error because I am always like "wait, this is not the right

--- a/internal/oonirun/inputprocessor_test.go
+++ b/internal/oonirun/inputprocessor_test.go
@@ -55,9 +55,9 @@ type FakeInputProcessorSubmitter struct {
 }
 
 func (fips *FakeInputProcessorSubmitter) Submit(
-	ctx context.Context, m *model.Measurement) error {
+	ctx context.Context, m *model.Measurement) (string, error) {
 	fips.M = append(fips.M, m)
-	return fips.Err
+	return "", fips.Err
 }
 
 func TestInputProcessorSubmissionFailed(t *testing.T) {

--- a/internal/oonirun/submitter.go
+++ b/internal/oonirun/submitter.go
@@ -46,8 +46,8 @@ func NewSubmitter(ctx context.Context, config SubmitterConfig) (Submitter, error
 
 type stubSubmitter struct{}
 
-func (stubSubmitter) Submit(ctx context.Context, m *model.Measurement) error {
-	return nil
+func (stubSubmitter) Submit(ctx context.Context, m *model.Measurement) (string, error) {
+	return "", nil
 }
 
 var _ Submitter = stubSubmitter{}
@@ -57,7 +57,7 @@ type realSubmitter struct {
 	logger model.Logger
 }
 
-func (rs realSubmitter) Submit(ctx context.Context, m *model.Measurement) error {
+func (rs realSubmitter) Submit(ctx context.Context, m *model.Measurement) (string, error) {
 	rs.logger.Info("submitting measurement to OONI collector; please be patient...")
 	return rs.subm.Submit(ctx, m)
 }

--- a/internal/oonirun/submitter_test.go
+++ b/internal/oonirun/submitter_test.go
@@ -22,7 +22,8 @@ func TestSubmitterNotEnabled(t *testing.T) {
 		t.Fatal("we did not get a stubSubmitter instance")
 	}
 	m := new(model.Measurement)
-	if err := submitter.Submit(ctx, m); err != nil {
+	_, err = submitter.Submit(ctx, m)
+	if err != nil {
 		t.Fatal(err)
 	}
 }
@@ -32,11 +33,11 @@ type FakeSubmitter struct {
 	Error error
 }
 
-func (fs *FakeSubmitter) Submit(ctx context.Context, m *model.Measurement) error {
+func (fs *FakeSubmitter) Submit(ctx context.Context, m *model.Measurement) (string, error) {
 	if fs.Calls != nil {
 		fs.Calls.Add(1)
 	}
-	return fs.Error
+	return "", fs.Error
 }
 
 var _ Submitter = &FakeSubmitter{}
@@ -83,7 +84,7 @@ func TestNewSubmitterWithFailedSubmission(t *testing.T) {
 		t.Fatal(err)
 	}
 	m := new(model.Measurement)
-	err = submitter.Submit(context.Background(), m)
+	_, err = submitter.Submit(context.Background(), m)
 	if !errors.Is(err, expected) {
 		t.Fatalf("not the error we expected: %+v", err)
 	}

--- a/internal/oonirun/v2_test.go
+++ b/internal/oonirun/v2_test.go
@@ -486,7 +486,7 @@ func TestV2MeasureDescriptor(t *testing.T) {
 		// represents a fundamental failure in setting up the experiment
 		sess.MockNewSubmitter = func(ctx context.Context) (model.Submitter, error) {
 			subm := &mocks.Submitter{
-				MockSubmit: func(ctx context.Context, m *model.Measurement) error {
+				MockSubmit: func(ctx context.Context, m *model.Measurement) (string, error) {
 					panic("should not be called")
 				},
 			}

--- a/internal/probeservices/benchselect.go
+++ b/internal/probeservices/benchselect.go
@@ -19,6 +19,14 @@ func Default() []model.OOAPIService {
 	}}
 }
 
+// DefaultOrchestrator returns the defaul orchestrate probe service
+func DefaultOrchestrator() model.OOAPIService {
+	return model.OOAPIService{
+		Address: "https://api.ooni.org",
+		Type:    "orchestrate",
+	}
+}
+
 // SortServices gives priority to https, then cloudfronted, then onion.
 func SortServices(in []model.OOAPIService) (out []model.OOAPIService) {
 	for _, entry := range in {
@@ -53,6 +61,16 @@ func OnlyHTTPS(in []model.OOAPIService) (out []model.OOAPIService) {
 func OnlyFallbacks(in []model.OOAPIService) (out []model.OOAPIService) {
 	for _, entry := range SortServices(in) {
 		if entry.Type != "https" {
+			out = append(out, entry)
+		}
+	}
+	return
+}
+
+// OnlyOrchestrate returns the orchestrate services only
+func OnlyOrchestrate(in []model.OOAPIService) (out []model.OOAPIService) {
+	for _, entry := range in {
+		if entry.Type == "orchestrate" {
 			out = append(out, entry)
 		}
 	}

--- a/internal/probeservices/checkin_test.go
+++ b/internal/probeservices/checkin_test.go
@@ -42,7 +42,7 @@ func TestCheckIn(t *testing.T) {
 		}
 
 		client := newclient()
-		client.BaseURL = "https://backend-hel.ooni.org" // use the test infra
+		client.BaseURL = "https://api.dev.ooni.io" // use the test infra
 
 		ctx := context.Background()
 

--- a/internal/probeservices/collector_test.go
+++ b/internal/probeservices/collector_test.go
@@ -108,7 +108,8 @@ func TestReportLifecycle(t *testing.T) {
 
 		// attempt to submit the measurement to the backend, which should succeed
 		// since we've just opened a report for it
-		if err = report.SubmitMeasurement(context.Background(), &measurement); err != nil {
+		_, err = report.SubmitMeasurement(context.Background(), &measurement)
+		if err != nil {
 			t.Fatal(err)
 		}
 
@@ -168,7 +169,8 @@ func TestReportLifecycle(t *testing.T) {
 
 		// attempt to submit the measurement to the backend, which should succeed
 		// since we've just opened a report for it
-		if err = report.SubmitMeasurement(context.Background(), &measurement); err != nil {
+		_, err = report.SubmitMeasurement(context.Background(), &measurement)
+		if err != nil {
 			t.Fatal(err)
 		}
 
@@ -231,7 +233,8 @@ func TestReportLifecycle(t *testing.T) {
 
 		// attempt to submit the measurement to the backend, which should succeed
 		// since we've just opened a report for it
-		if err = report.SubmitMeasurement(context.Background(), &measurement); err != nil {
+		_, err = report.SubmitMeasurement(context.Background(), &measurement)
+		if err != nil {
 			t.Fatal(err)
 		}
 
@@ -376,7 +379,7 @@ func TestReportLifecycle(t *testing.T) {
 		}
 
 		// update the report
-		err := rc.SubmitMeasurement(context.Background(), &model.Measurement{})
+		_, err := rc.SubmitMeasurement(context.Background(), &model.Measurement{})
 
 		// we do expect an error
 		if !errors.Is(err, netxlite.ECONNRESET) {
@@ -418,7 +421,7 @@ func TestReportLifecycle(t *testing.T) {
 		}
 
 		// update the report
-		err := rc.SubmitMeasurement(context.Background(), &model.Measurement{})
+		_, err := rc.SubmitMeasurement(context.Background(), &model.Measurement{})
 
 		// we do expect an error
 		if err == nil || err.Error() != "unexpected end of JSON input" {
@@ -444,7 +447,7 @@ func TestReportLifecycle(t *testing.T) {
 		}
 
 		// update the report
-		err := rc.SubmitMeasurement(context.Background(), &model.Measurement{})
+		_, err := rc.SubmitMeasurement(context.Background(), &model.Measurement{})
 
 		// we do expect an error
 		if err == nil || err.Error() != `parse "\t\t\t": net/url: invalid control character in URL` {
@@ -665,7 +668,8 @@ func TestReportLifecycle(t *testing.T) {
 
 		// attempt to submit the measurement to the backend, which should succeed
 		// since we've just opened a report for it
-		if err = report.SubmitMeasurement(context.Background(), &measurement); err != nil {
+		_, err = report.SubmitMeasurement(context.Background(), &measurement)
+		if err != nil {
 			t.Fatal(err)
 		}
 
@@ -687,14 +691,14 @@ func (rrc *RecordingReportChannel) CanSubmit(m *model.Measurement) bool {
 	return reflect.DeepEqual(NewReportTemplate(m), rrc.tmpl)
 }
 
-func (rrc *RecordingReportChannel) SubmitMeasurement(ctx context.Context, m *model.Measurement) error {
+func (rrc *RecordingReportChannel) SubmitMeasurement(ctx context.Context, m *model.Measurement) (string, error) {
 	if ctx.Err() != nil {
-		return ctx.Err()
+		return "", ctx.Err()
 	}
 	rrc.mu.Lock()
 	defer rrc.mu.Unlock()
 	rrc.m = append(rrc.m, m)
-	return nil
+	return "", nil
 }
 
 func (rrc *RecordingReportChannel) Close(ctx context.Context) error {
@@ -755,15 +759,18 @@ func TestSubmitterLifecyle(t *testing.T) {
 	submitter := NewSubmitter(rro, log.Log)
 	ctx := context.Background()
 	m1 := makeMeasurementWithoutTemplate("example")
-	if err := submitter.Submit(ctx, m1); err != nil {
+	_, err := submitter.Submit(ctx, m1)
+	if err != nil {
 		t.Fatal(err)
 	}
 	m2 := makeMeasurementWithoutTemplate("example")
-	if err := submitter.Submit(ctx, m2); err != nil {
+	_, err = submitter.Submit(ctx, m2)
+	if err != nil {
 		t.Fatal(err)
 	}
 	m3 := makeMeasurementWithoutTemplate("example_extended")
-	if err := submitter.Submit(ctx, m3); err != nil {
+	_, err = submitter.Submit(ctx, m3)
+	if err != nil {
 		t.Fatal(err)
 	}
 	if len(rro.channels) != 2 {
@@ -783,15 +790,18 @@ func TestSubmitterCannotOpenNewChannel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // fail immediately
 	m1 := makeMeasurementWithoutTemplate("example")
-	if err := submitter.Submit(ctx, m1); !errors.Is(err, context.Canceled) {
+	_, err := submitter.Submit(ctx, m1)
+	if !errors.Is(err, context.Canceled) {
 		t.Fatal("not the error we expected")
 	}
 	m2 := makeMeasurementWithoutTemplate("example")
-	if err := submitter.Submit(ctx, m2); !errors.Is(err, context.Canceled) {
+	_, err = submitter.Submit(ctx, m2)
+	if !errors.Is(err, context.Canceled) {
 		t.Fatal(err)
 	}
 	m3 := makeMeasurementWithoutTemplate("example_extended")
-	if err := submitter.Submit(ctx, m3); !errors.Is(err, context.Canceled) {
+	_, err = submitter.Submit(ctx, m3)
+	if !errors.Is(err, context.Canceled) {
 		t.Fatal(err)
 	}
 	if len(rro.channels) != 0 {

--- a/internal/probeservices/login.go
+++ b/internal/probeservices/login.go
@@ -9,7 +9,7 @@ import (
 )
 
 // MaybeLogin performs login if necessary
-func (c Client) MaybeLogin(ctx context.Context) error {
+func (c Client) MaybeLogin(ctx context.Context, baseURL string) error {
 	state := c.StateFile.Get()
 	if state.Auth() != nil {
 		return nil // we're already good
@@ -20,7 +20,11 @@ func (c Client) MaybeLogin(ctx context.Context) error {
 	}
 	c.LoginCalls.Add(1)
 
-	URL, err := urlx.ResolveReference(c.BaseURL, "/api/v1/login", "")
+	// construct the URL to use
+	if baseURL == "" {
+		baseURL = c.BaseURL // fallback to the client BaseURL if the passed url is empty
+	}
+	URL, err := urlx.ResolveReference(baseURL, "/api/v1/login", "")
 	if err != nil {
 		return err
 	}

--- a/internal/probeservices/login_test.go
+++ b/internal/probeservices/login_test.go
@@ -25,18 +25,50 @@ func TestMaybeLogin(t *testing.T) {
 		clnt := newclient()
 
 		// we need to register first because we don't have state yet
-		if err := clnt.MaybeRegister(context.Background(), MetadataFixture()); err != nil {
+		if err := clnt.MaybeRegister(context.Background(), "", MetadataFixture()); err != nil {
 			t.Fatal(err)
 		}
 
 		// now we try to login and get a token
-		if err := clnt.MaybeLogin(context.Background()); err != nil {
+		if err := clnt.MaybeLogin(context.Background(), ""); err != nil {
 			t.Fatal(err)
 		}
 
 		// do this again, and later on we'll verify that we
 		// did actually issue just a single login call
-		if err := clnt.MaybeLogin(context.Background()); err != nil {
+		if err := clnt.MaybeLogin(context.Background(), ""); err != nil {
+			t.Fatal(err)
+		}
+
+		// make sure we did call login just once: the second call
+		// should not invoke login because we have good state
+		if clnt.LoginCalls.Load() != 1 {
+			t.Fatal("called login API too many times")
+		}
+	})
+
+	// Let's also test that the passes baseURL is given precedence over the client baseURL
+	t.Run("is working with passed baseURL", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skip test in short mode")
+		}
+
+		// create client
+		clnt := newEmptyClient()
+
+		// we need to register first because we don't have state yet
+		if err := clnt.MaybeRegister(context.Background(), "https://api.dev.ooni.io", MetadataFixture()); err != nil {
+			t.Fatal(err)
+		}
+
+		// now we try to login and get a token
+		if err := clnt.MaybeLogin(context.Background(), "https://api.dev.ooni.io"); err != nil {
+			t.Fatal(err)
+		}
+
+		// do this again, and later on we'll verify that we
+		// did actually issue just a single login call
+		if err := clnt.MaybeLogin(context.Background(), "https://api.dev.ooni.io"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -75,18 +107,18 @@ func TestMaybeLogin(t *testing.T) {
 		}
 
 		// we need to register first because we don't have state yet
-		if err := client.MaybeRegister(context.Background(), MetadataFixture()); err != nil {
+		if err := client.MaybeRegister(context.Background(), "", MetadataFixture()); err != nil {
 			t.Fatal(err)
 		}
 
 		// now we try to login and get a token
-		if err := client.MaybeLogin(context.Background()); err != nil {
+		if err := client.MaybeLogin(context.Background(), ""); err != nil {
 			t.Fatal(err)
 		}
 
 		// do this again, and later on we'll verify that we
 		// did actually issue just a single login call
-		if err := client.MaybeLogin(context.Background()); err != nil {
+		if err := client.MaybeLogin(context.Background(), ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -129,18 +161,18 @@ func TestMaybeLogin(t *testing.T) {
 		}
 
 		// we need to register first because we don't have state yet
-		if err := client.MaybeRegister(context.Background(), MetadataFixture()); err != nil {
+		if err := client.MaybeRegister(context.Background(), "", MetadataFixture()); err != nil {
 			t.Fatal(err)
 		}
 
 		// now we try to login and get a token
-		if err := client.MaybeLogin(context.Background()); err != nil {
+		if err := client.MaybeLogin(context.Background(), ""); err != nil {
 			t.Fatal(err)
 		}
 
 		// do this again, and later on we'll verify that we
 		// did actually issue just a single login call
-		if err := client.MaybeLogin(context.Background()); err != nil {
+		if err := client.MaybeLogin(context.Background(), ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -182,7 +214,7 @@ func TestMaybeLogin(t *testing.T) {
 		}))
 
 		// now we try to login and get a token
-		err := client.MaybeLogin(context.Background())
+		err := client.MaybeLogin(context.Background(), "")
 
 		// we do expect an error
 		if !errors.Is(err, netxlite.ECONNRESET) {
@@ -228,7 +260,7 @@ func TestMaybeLogin(t *testing.T) {
 		}))
 
 		// now we try to login and get a token
-		err := client.MaybeLogin(context.Background())
+		err := client.MaybeLogin(context.Background(), "")
 
 		// we do expect an error
 		if err == nil || err.Error() != "unexpected end of JSON input" {
@@ -257,7 +289,7 @@ func TestMaybeLogin(t *testing.T) {
 
 		// now call login and we expect no error because we should
 		// already have what we need to perform a login
-		if err := clnt.MaybeLogin(context.Background()); err != nil {
+		if err := clnt.MaybeLogin(context.Background(), ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -279,7 +311,7 @@ func TestMaybeLogin(t *testing.T) {
 		}
 
 		// now try to login and expect to see we've not registered yet
-		if err := clnt.MaybeLogin(context.Background()); !errors.Is(err, ErrNotRegistered) {
+		if err := clnt.MaybeLogin(context.Background(), ""); !errors.Is(err, ErrNotRegistered) {
 			t.Fatal("unexpected error", err)
 		}
 
@@ -306,7 +338,7 @@ func TestMaybeLogin(t *testing.T) {
 		}))
 
 		// now we try to login and get a token
-		err := client.MaybeLogin(context.Background())
+		err := client.MaybeLogin(context.Background(), "")
 
 		// we do expect an error
 		if err == nil || err.Error() != `parse "\t\t\t": net/url: invalid control character in URL` {

--- a/internal/probeservices/probeservices_test.go
+++ b/internal/probeservices/probeservices_test.go
@@ -16,6 +16,23 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
 )
 
+func newEmptyClient() *Client {
+	client, err := NewClient(
+		&mockable.Session{
+			MockableHTTPClient: http.DefaultClient,
+			MockableLogger:     log.Log,
+		},
+		model.OOAPIService{
+			Address: "",
+			Type:    "https",
+		},
+	)
+	if err != nil {
+		panic(err) // so fail the test
+	}
+	return client
+}
+
 func newclient() *Client {
 	client, err := NewClient(
 		&mockable.Session{
@@ -23,7 +40,7 @@ func newclient() *Client {
 			MockableLogger:     log.Log,
 		},
 		model.OOAPIService{
-			Address: "https://backend-hel.ooni.org/",
+			Address: "https://api.dev.ooni.io",
 			Type:    "https",
 		},
 	)
@@ -579,7 +596,7 @@ func TestGetCredsAndAuthNotLoggedIn(t *testing.T) {
 	}
 
 	clnt := newclient()
-	if err := clnt.MaybeRegister(context.Background(), MetadataFixture()); err != nil {
+	if err := clnt.MaybeRegister(context.Background(), "", MetadataFixture()); err != nil {
 		t.Fatal(err)
 	}
 	creds, auth, err := clnt.GetCredsAndAuth()

--- a/internal/probeservices/psiphon_test.go
+++ b/internal/probeservices/psiphon_test.go
@@ -21,10 +21,10 @@ func TestFetchPsiphonConfig(t *testing.T) {
 	// psiphonflow is the flow with which we invoke the psiphon API
 	psiphonflow := func(t *testing.T, client *Client) ([]byte, error) {
 		// we need to make sure we're registered and logged in
-		if err := client.MaybeRegister(context.Background(), MetadataFixture()); err != nil {
+		if err := client.MaybeRegister(context.Background(), "", MetadataFixture()); err != nil {
 			t.Fatal(err)
 		}
-		if err := client.MaybeLogin(context.Background()); err != nil {
+		if err := client.MaybeLogin(context.Background(), ""); err != nil {
 			t.Fatal(err)
 		}
 

--- a/internal/probeservices/register.go
+++ b/internal/probeservices/register.go
@@ -14,7 +14,7 @@ import (
 )
 
 // MaybeRegister registers this client if not already registered
-func (c Client) MaybeRegister(ctx context.Context, metadata model.OOAPIProbeMetadata) error {
+func (c Client) MaybeRegister(ctx context.Context, baseURL string, metadata model.OOAPIProbeMetadata) error {
 	if !metadata.Valid() {
 		return ErrInvalidMetadata
 	}
@@ -32,7 +32,10 @@ func (c Client) MaybeRegister(ctx context.Context, metadata model.OOAPIProbeMeta
 	}
 
 	// construct the URL to use
-	URL, err := urlx.ResolveReference(c.BaseURL, "/api/v1/register", "")
+	if baseURL == "" {
+		baseURL = c.BaseURL // fallback to the client BaseURL if the passed url is empty
+	}
+	URL, err := urlx.ResolveReference(baseURL, "/api/v1/register", "")
 	if err != nil {
 		return err
 	}

--- a/internal/probeservices/register_test.go
+++ b/internal/probeservices/register_test.go
@@ -25,12 +25,36 @@ func TestMaybeRegister(t *testing.T) {
 		clnt := newclient()
 
 		// attempt to register once
-		if err := clnt.MaybeRegister(context.Background(), MetadataFixture()); err != nil {
+		if err := clnt.MaybeRegister(context.Background(), "", MetadataFixture()); err != nil {
 			t.Fatal(err)
 		}
 
 		// try again (we want to make sure it's idempotent once we've registered)
-		if err := clnt.MaybeRegister(context.Background(), MetadataFixture()); err != nil {
+		if err := clnt.MaybeRegister(context.Background(), "", MetadataFixture()); err != nil {
+			t.Fatal(err)
+		}
+
+		// make sure we indeed only called it once
+		if clnt.RegisterCalls.Load() != 1 {
+			t.Fatal("called register API too many times")
+		}
+	})
+
+	t.Run("is working as intended with the passed baseURL", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skip test in short mode")
+		}
+
+		// create client
+		clnt := newEmptyClient()
+
+		// attempt to register once
+		if err := clnt.MaybeRegister(context.Background(), "https://api.dev.ooni.io", MetadataFixture()); err != nil {
+			t.Fatal(err)
+		}
+
+		// try again (we want to make sure it's idempotent once we've registered)
+		if err := clnt.MaybeRegister(context.Background(), "https://api.dev.ooni.io", MetadataFixture()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -68,12 +92,12 @@ func TestMaybeRegister(t *testing.T) {
 		}
 
 		// attempt to register once
-		if err := client.MaybeRegister(context.Background(), MetadataFixture()); err != nil {
+		if err := client.MaybeRegister(context.Background(), "", MetadataFixture()); err != nil {
 			t.Fatal(err)
 		}
 
 		// try again (we want to make sure it's idempotent once we've registered)
-		if err := client.MaybeRegister(context.Background(), MetadataFixture()); err != nil {
+		if err := client.MaybeRegister(context.Background(), "", MetadataFixture()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -115,12 +139,12 @@ func TestMaybeRegister(t *testing.T) {
 		}
 
 		// attempt to register once
-		if err := client.MaybeRegister(context.Background(), MetadataFixture()); err != nil {
+		if err := client.MaybeRegister(context.Background(), "", MetadataFixture()); err != nil {
 			t.Fatal(err)
 		}
 
 		// try again (we want to make sure it's idempotent once we've registered)
-		if err := client.MaybeRegister(context.Background(), MetadataFixture()); err != nil {
+		if err := client.MaybeRegister(context.Background(), "", MetadataFixture()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -152,7 +176,7 @@ func TestMaybeRegister(t *testing.T) {
 		}
 
 		// attempt to register
-		err := client.MaybeRegister(context.Background(), MetadataFixture())
+		err := client.MaybeRegister(context.Background(), "", MetadataFixture())
 
 		// we do expect an error
 		if !errors.Is(err, netxlite.ECONNRESET) {
@@ -189,7 +213,7 @@ func TestMaybeRegister(t *testing.T) {
 		}
 
 		// attempt to register
-		err := client.MaybeRegister(context.Background(), MetadataFixture())
+		err := client.MaybeRegister(context.Background(), "", MetadataFixture())
 
 		// we do expect an error
 		if err == nil || err.Error() != "unexpected end of JSON input" {
@@ -205,7 +229,7 @@ func TestMaybeRegister(t *testing.T) {
 	t.Run("when metadata is not valid", func(t *testing.T) {
 		// we expect ErrInvalidMetadata when metadata is empty
 		clnt := newclient()
-		err := clnt.MaybeRegister(context.Background(), model.OOAPIProbeMetadata{})
+		err := clnt.MaybeRegister(context.Background(), "", model.OOAPIProbeMetadata{})
 		if !errors.Is(err, ErrInvalidMetadata) {
 			t.Fatal("expected an error here")
 		}
@@ -226,7 +250,7 @@ func TestMaybeRegister(t *testing.T) {
 		}
 
 		// attempt to register, which should immediately succeed
-		if err := clnt.MaybeRegister(context.Background(), MetadataFixture()); err != nil {
+		if err := clnt.MaybeRegister(context.Background(), "", MetadataFixture()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -241,7 +265,7 @@ func TestMaybeRegister(t *testing.T) {
 		clnt.BaseURL = "\t\t\t" // makes it fail
 		ctx := context.Background()
 		metadata := MetadataFixture()
-		err := clnt.MaybeRegister(ctx, metadata)
+		err := clnt.MaybeRegister(ctx, "", metadata)
 		if err == nil || !strings.HasSuffix(err.Error(), "invalid control character in URL") {
 			t.Fatal("expected an error here")
 		}
@@ -255,7 +279,7 @@ func TestMaybeRegister(t *testing.T) {
 		client.BaseURL = "\t\t\t"
 
 		// attempt to register
-		err := client.MaybeRegister(context.Background(), MetadataFixture())
+		err := client.MaybeRegister(context.Background(), "", MetadataFixture())
 
 		// we do expect an error
 		if err == nil || err.Error() != `parse "\t\t\t": net/url: invalid control character in URL` {

--- a/internal/probeservices/tor_test.go
+++ b/internal/probeservices/tor_test.go
@@ -24,10 +24,10 @@ func TestFetchTorTargets(t *testing.T) {
 	// torflow is the flow with which we invoke the tor API
 	torflow := func(t *testing.T, client *Client) (map[string]model.OOAPITorTarget, error) {
 		// we need to make sure we're registered and logged in
-		if err := client.MaybeRegister(context.Background(), MetadataFixture()); err != nil {
+		if err := client.MaybeRegister(context.Background(), "", MetadataFixture()); err != nil {
 			t.Fatal(err)
 		}
-		if err := client.MaybeLogin(context.Background()); err != nil {
+		if err := client.MaybeLogin(context.Background(), ""); err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/oonimkall/session.go
+++ b/pkg/oonimkall/session.go
@@ -302,6 +302,9 @@ type SubmitMeasurementResults struct {
 
 	// UpdatedReportID is the report ID used for the measurement.
 	UpdatedReportID string
+
+	// MeasurementUID is the measurement unique identifier returned from the backend
+	MeasurementUID string
 }
 
 // Submit submits the given measurement and returns the results.
@@ -322,7 +325,8 @@ func (sess *Session) Submit(ctx *Context, measurement string) (*SubmitMeasuremen
 	if err := json.Unmarshal([]byte(measurement), &mm); err != nil {
 		return nil, err
 	}
-	if err := sess.submitter.Submit(ctx.ctx, &mm); err != nil {
+	muid, err := sess.submitter.Submit(ctx.ctx, &mm)
+	if err != nil {
 		return nil, err
 	}
 	data, err := json.Marshal(mm)
@@ -330,6 +334,7 @@ func (sess *Session) Submit(ctx *Context, measurement string) (*SubmitMeasuremen
 	return &SubmitMeasurementResults{
 		UpdatedMeasurement: string(data),
 		UpdatedReportID:    mm.ReportID,
+		MeasurementUID:     muid,
 	}, nil
 }
 

--- a/pkg/oonimkall/session_integration_test.go
+++ b/pkg/oonimkall/session_integration_test.go
@@ -21,7 +21,7 @@ func NewSessionForTestingWithAssetsDir(assetsDir string) (*oonimkall.Session, er
 	return oonimkall.NewSession(&oonimkall.SessionConfig{
 		AssetsDir:        assetsDir,
 		Logger:           log.Log,
-		ProbeServicesURL: "https://backend-hel.ooni.org/",
+		ProbeServicesURL: "https://api.dev.ooni.io",
 		SoftwareName:     "oonimkall-test",
 		SoftwareVersion:  "0.1.0",
 		StateDir:         "../testdata/oonimkall/state",

--- a/pkg/oonimkall/taskmodel.go
+++ b/pkg/oonimkall/taskmodel.go
@@ -112,6 +112,7 @@ type eventMeasurementGeneric struct {
 	Idx          int64  `json:"idx"`
 	Input        string `json:"input"`
 	JSONStr      string `json:"json_str,omitempty"`
+	MeasurementUID string `json:"measurement_uid,omitempty"`
 }
 
 type eventStatusEnd struct {

--- a/pkg/oonimkall/taskrunner.go
+++ b/pkg/oonimkall/taskrunner.go
@@ -352,13 +352,14 @@ func (r *runnerForTask) Run(rootCtx context.Context) {
 		// if possible, submit the measurement to the OONI backend
 		if !r.settings.Options.NoCollector {
 			logger.Info("Submitting measurement... please, be patient")
-			err := experiment.SubmitAndUpdateMeasurementContext(submitCtx, m)
+			muid, err := experiment.SubmitAndUpdateMeasurementContext(submitCtx, m)
 			warnOnFailure(logger, "cannot submit measurement", err)
 			r.emitter.Emit(measurementSubmissionEventName(err), eventMeasurementGeneric{
 				Idx:     int64(idx),
 				Input:   target.Input(),
 				JSONStr: string(data),
 				Failure: measurementSubmissionFailure(err),
+				MeasurementUID: muid,
 			})
 		}
 

--- a/pkg/oonimkall/taskrunner_test.go
+++ b/pkg/oonimkall/taskrunner_test.go
@@ -228,8 +228,8 @@ func TestTaskRunnerRun(t *testing.T) {
 				MockMeasureWithContext: func(ctx context.Context, target model.ExperimentTarget) (*model.Measurement, error) {
 					return &model.Measurement{}, nil
 				},
-				MockSubmitAndUpdateMeasurementContext: func(ctx context.Context, measurement *model.Measurement) error {
-					return nil
+				MockSubmitAndUpdateMeasurementContext: func(ctx context.Context, measurement *model.Measurement) (string, error) {
+					return "", nil
 				},
 			},
 
@@ -667,8 +667,8 @@ func TestTaskRunnerRun(t *testing.T) {
 				},
 			}
 		}
-		fake.Experiment.MockSubmitAndUpdateMeasurementContext = func(ctx context.Context, measurement *model.Measurement) error {
-			return errors.New("cannot submit")
+		fake.Experiment.MockSubmitAndUpdateMeasurementContext = func(ctx context.Context, measurement *model.Measurement) (string, error) {
+			return "", errors.New("cannot submit")
 		}
 		runner.newSession = fake.NewSession
 		events := runAndCollect(runner, emitter)

--- a/pkg/oonimkall/webconnectivity_test.go
+++ b/pkg/oonimkall/webconnectivity_test.go
@@ -156,7 +156,7 @@ func TestWebConnectivityRunnerWithNoError(t *testing.T) {
 func TestWebConnectivityRunWithCancelledContext(t *testing.T) {
 	sess, err := NewSession(&SessionConfig{
 		AssetsDir:        "../testdata/oonimkall/assets",
-		ProbeServicesURL: "https://backend-hel.ooni.org/",
+		ProbeServicesURL: "https://api.dev.ooni.io",
 		SoftwareName:     "oonimkall-test",
 		SoftwareVersion:  "0.1.0",
 		StateDir:         "../testdata/oonimkall/state",


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [ ] reference issue for this pull request: https://github.com/ooni/probe/issues/2846
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff changes the probe-services testing url to `api.dev.ooni.io`. We also change the orchestra service to now make requests to `api.ooni.org` instead of `api.ooni.io`
