### PR TITLE
chore: upgrade to go1.22.3 in all areas

### DIFF
--- a/Dockerfile.oonith
+++ b/Dockerfile.oonith
@@ -3,7 +3,7 @@
 #
 # Note: The Dockerfile needs to reside in the root of the repo, so that we can
 # copy files into the docker build context.
-FROM golang:1.22.2-bullseye as builder
+FROM golang:1.22.3-bullseye as builder
 ARG BRANCH_NAME=master
 
 WORKDIR /build
@@ -13,7 +13,7 @@ COPY . .
 RUN go run ./internal/cmd/buildtool oohelperd build
 
 ## Image running on the host
-FROM golang:1.22.2-bullseye as runner
+FROM golang:1.22.3-bullseye as runner
 
 WORKDIR /app
 

--- a/Readme.md
+++ b/Readme.md
@@ -72,7 +72,7 @@ builds use the latest commit of the `master` branch.
 To setup development for this repository you need Go >= 1.15. The
 `./script/go.bash` script will automatically download the expected
 version of Go mentioned in the [GOVERSION](GOVERSION) file (i.e.,
-go1.22.2) and use it for building.
+go1.22.3) and use it for building.
 
 You can also bypass `./script/go.bash` and build ooniprobe manually using
 `go build ...` but, in such a case, note that:
@@ -146,10 +146,10 @@ using the correct version of Go. Running this script as follows:
 Is equivalent to running these commands:
 
 ```bash
-go install -v golang.org/dl/go1.22.2@latest
-$HOME/go/bin/go1.22.2 download
+go install -v golang.org/dl/go1.22.3@latest
+$HOME/go/bin/go1.22.3 download
 export GOTOOLCHAIN=local
-$HOME/sdk/go1.22.2/bin/go build -v -ldflags '-s -w' ./internal/cmd/miniooni
+$HOME/sdk/go1.22.3/bin/go build -v -ldflags '-s -w' ./internal/cmd/miniooni
 ```
 
 ### Common build targets


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2841
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff upgrades to use go1.22.3 in all areas in the engine
