### PR TITLE
chore: update stuninput to latest TPO snowflake

### DIFF
--- a/internal/stuninput/stuninput.go
+++ b/internal/stuninput/stuninput.go
@@ -12,15 +12,14 @@ import (
 //
 // We should sync with https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/blob/main/projects/tor-expert-bundle/pt_config.json
 var inputs = map[string]bool{
-	"stun.l.google.com:19302": true,
 	"stun.antisip.com:3478":   true,
-	"stun.bluesip.net:3478":   true,
-	"stun.dus.net:3478":       true,
 	"stun.epygi.com:3478":     true,
-	"stun.sonetel.com:3478":   true,
 	"stun.uls.co.za:3478":     true,
 	"stun.voipgate.com:3478":  true,
-	"stun.voys.nl:3478":       true,
+	"stun.mixvoip.com:3478":   true,
+	"stun.nextcloud.com:3478": true,
+	"stun.bethesda.net:3478":  true,
+	"stun.nextcloud.com:443":  true,
 }
 
 // AsSnowflakeInput formats the input in the format


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2841
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff syncs stuninputs with the TPO's snowflake
