### PR TITLE
fix: upgrade upload-artifact gh action to v4

### DIFF
--- a/.github/workflows/alltests.yml
+++ b/.github/workflows/alltests.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get GOVERSION content
         id: goversion

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,7 +16,7 @@ jobs:
   build_android:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -98,7 +98,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -37,57 +37,57 @@ jobs:
 
       - run: make android
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: oonimkall.aar
           path: ./MOBILE/android/oonimkall.aar
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: oonimkall-sources.jar
           path: ./MOBILE/android/oonimkall-sources.jar
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: oonimkall.pom
           path: ./MOBILE/android/oonimkall.pom
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: miniooni-android-386
           path: ./CLI/miniooni-android-386
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ooniprobe-android-386
           path: ./CLI/ooniprobe-android-386
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: miniooni-android-amd64
           path: ./CLI/miniooni-android-amd64
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ooniprobe-android-amd64
           path: ./CLI/ooniprobe-android-amd64
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: miniooni-android-arm
           path: ./CLI/miniooni-android-arm
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ooniprobe-android-arm
           path: ./CLI/ooniprobe-android-arm
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: miniooni-android-arm64
           path: ./CLI/miniooni-android-arm64
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ooniprobe-android-arm64
           path: ./CLI/ooniprobe-android-arm64

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build docs
         run: make docs

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [ "ubuntu-22.04" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get GOVERSION content
         id: goversion

--- a/.github/workflows/debianrepo.yml
+++ b/.github/workflows/debianrepo.yml
@@ -11,27 +11,27 @@ jobs:
   test_386:
     runs-on: "ubuntu-22.04"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo ./E2E/debian.bash docker i386
       - run: sudo cat DEBIAN_INSTALLED_PACKAGE.txt
 
   test_amd64:
     runs-on: "ubuntu-22.04"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo ./E2E/debian.bash docker amd64
       - run: sudo cat DEBIAN_INSTALLED_PACKAGE.txt
 
   test_arm:
     runs-on: "ubuntu-22.04"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo ./E2E/debian.bash docker armhf
       - run: sudo cat DEBIAN_INSTALLED_PACKAGE.txt
 
   test_arm64:
     runs-on: "ubuntu-22.04"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo ./E2E/debian.bash docker arm64
       - run: sudo cat DEBIAN_INSTALLED_PACKAGE.txt

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get GOVERSION content
         id: goversion

--- a/.github/workflows/go1.22.yml
+++ b/.github/workflows/go1.22.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: magnetikonline/action-golang-cache@v4
         with:

--- a/.github/workflows/gobash.yml
+++ b/.github/workflows/gobash.yml
@@ -34,7 +34,7 @@ jobs:
         system: [ubuntu-latest]
     runs-on: "${{ matrix.system }}"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v4
         with:

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -14,7 +14,7 @@ jobs:
         GO111MODULE: on
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Get GOVERSION content
       id: goversion

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -40,62 +40,62 @@ jobs:
 
       - run: make EXPECTED_XCODE_VERSION=14.2 ios
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: libcrypto.xcframework.zip
           path: ./MOBILE/ios/libcrypto.xcframework.zip
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: libcrypto.podspec
           path: ./MOBILE/ios/libcrypto.podspec
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: libevent.xcframework.zip
           path: ./MOBILE/ios/libevent.xcframework.zip
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: libevent.podspec
           path: ./MOBILE/ios/libevent.podspec
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: libssl.xcframework.zip
           path: ./MOBILE/ios/libssl.xcframework.zip
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: libssl.podspec
           path: ./MOBILE/ios/libssl.podspec
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: libtor.xcframework.zip
           path: ./MOBILE/ios/libtor.xcframework.zip
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: libtor.podspec
           path: ./MOBILE/ios/libtor.podspec
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: libz.xcframework.zip
           path: ./MOBILE/ios/libz.xcframework.zip
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: libz.podspec
           path: ./MOBILE/ios/libz.podspec
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: oonimkall.xcframework.zip
           path: ./MOBILE/ios/oonimkall.xcframework.zip
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: oonimkall.podspec
           path: ./MOBILE/ios/oonimkall.podspec

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -16,7 +16,7 @@ jobs:
   build_ios_mobile:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -106,7 +106,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/libtorlinux.yml
+++ b/.github/workflows/libtorlinux.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get GOVERSION content
         id: goversion

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,12 +42,12 @@ jobs:
 
       - run: make CLI/linux-static-386
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ooniprobe-linux-386
           path: ./CLI/ooniprobe-linux-386
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: miniooni-linux-386
           path: ./CLI/miniooni-linux-386
@@ -103,12 +103,12 @@ jobs:
 
       - run: make CLI/linux-static-amd64
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ooniprobe-linux-amd64
           path: ./CLI/ooniprobe-linux-amd64
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: miniooni-linux-amd64
           path: ./CLI/miniooni-linux-amd64
@@ -202,12 +202,12 @@ jobs:
 
       - run: make CLI/linux-static-armv6
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ooniprobe-linux-armv6
           path: ./CLI/ooniprobe-linux-armv6
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: miniooni-linux-armv6
           path: ./CLI/miniooni-linux-armv6
@@ -266,12 +266,12 @@ jobs:
 
       - run: make CLI/linux-static-armv7
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ooniprobe-linux-armv7
           path: ./CLI/ooniprobe-linux-armv7
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: miniooni-linux-armv7
           path: ./CLI/miniooni-linux-armv7
@@ -330,12 +330,12 @@ jobs:
 
       - run: make CLI/linux-static-arm64
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ooniprobe-linux-arm64
           path: ./CLI/ooniprobe-linux-arm64
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: miniooni-linux-arm64
           path: ./CLI/miniooni-linux-arm64

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,7 +16,7 @@ jobs:
   build_linux_cli_386:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -58,7 +58,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -77,7 +77,7 @@ jobs:
   build_linux_cli_amd64:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build_linux_cli_amd64
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -154,7 +154,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -173,7 +173,7 @@ jobs:
   build_linux_cli_armv6:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -218,7 +218,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -237,7 +237,7 @@ jobs:
   build_linux_cli_armv7:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -282,7 +282,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -301,7 +301,7 @@ jobs:
   build_linux_cli_arm64:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -346,7 +346,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ jobs:
   build_darwin_cli:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -61,7 +61,7 @@ jobs:
     runs-on: macos-12
     needs: build_darwin_cli
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -79,7 +79,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,22 +37,22 @@ jobs:
 
       - run: make CLI/darwin
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ooniprobe-darwin-amd64
           path: ./CLI/ooniprobe-darwin-amd64
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ooniprobe-darwin-arm64
           path: ./CLI/ooniprobe-darwin-arm64
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: miniooni-darwin-amd64
           path: ./CLI/miniooni-darwin-amd64
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: miniooni-darwin-arm64
           path: ./CLI/miniooni-darwin-arm64

--- a/.github/workflows/netxlite.yml
+++ b/.github/workflows/netxlite.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ "ubuntu-22.04", "windows-2022", "macos-12" ]
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get GOVERSION content
         id: goversion

--- a/.github/workflows/oohelperd.yml
+++ b/.github/workflows/oohelperd.yml
@@ -16,7 +16,7 @@ jobs:
     permissions: # See https://github.com/ooni/probe/issues/2154
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get GOVERSION content
         id: goversion

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,22 +40,22 @@ jobs:
 
       - run: make EXPECTED_MINGW_W64_VERSION="10-win32" CLI/windows
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ooniprobe-windows-386.exe
           path: ./CLI/ooniprobe-windows-386.exe
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ooniprobe-windows-amd64.exe
           path: ./CLI/ooniprobe-windows-amd64.exe
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: miniooni-windows-386.exe
           path: ./CLI/miniooni-windows-386.exe
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: miniooni-windows-amd64.exe
           path: ./CLI/miniooni-windows-amd64.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
   build_windows_cli:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -64,7 +64,7 @@ jobs:
     runs-on: windows-2022
     needs: build_windows_cli
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -81,7 +81,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/internal/cmd/ghgen/utils.go
+++ b/internal/cmd/ghgen/utils.go
@@ -30,7 +30,7 @@ func newJob(w io.Writer, name, runsOn, needs string, permissions map[string]stri
 }
 
 func newStepCheckout(w io.Writer) {
-	mustFprintf(w, "      - uses: actions/checkout@v3\n")
+	mustFprintf(w, "      - uses: actions/checkout@v4\n")
 	mustFprintf(w, "        with:\n")
 	mustFprintf(w, "          fetch-depth: 0\n")
 	mustFprintf(w, "\n")

--- a/internal/cmd/ghgen/utils.go
+++ b/internal/cmd/ghgen/utils.go
@@ -64,7 +64,7 @@ func newStepMake(w io.Writer, target string) {
 
 func newStepUploadArtifacts(w io.Writer, artifacts []string) {
 	for _, arti := range artifacts {
-		mustFprintf(w, "      - uses: actions/upload-artifact@v3\n")
+		mustFprintf(w, "      - uses: actions/upload-artifact@v4\n")
 		mustFprintf(w, "        with:\n")
 		mustFprintf(w, "          name: %s\n", filepath.Base(arti))
 		mustFprintf(w, "          path: %s\n", arti)


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This upgrades the github upload-artifact action to v4 since v3 has been deprecated: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ 

We also upgrade the gh checkout action.
