### PR TITLE
fix: upgrade to using macos-13 for mac workflows

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build_ios_mobile:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build_darwin_cli:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
         with:
@@ -58,7 +58,7 @@ jobs:
           path: ./CLI/miniooni-darwin-arm64
 
   test_darwin_cli:
-    runs-on: macos-12
+    runs-on: macos-13
     needs: build_darwin_cli
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
         shell: bash
 
   publish_darwin_cli:
-    runs-on: macos-12
+    runs-on: macos-13
     needs: test_darwin_cli
     permissions:
       contents: write

--- a/.github/workflows/netxlite.yml
+++ b/.github/workflows/netxlite.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: [ "ubuntu-22.04", "windows-2022", "macos-12" ]
+        os: [ "ubuntu-22.04", "windows-2022", "macos-13" ]
     steps:
 
       - uses: actions/checkout@v4

--- a/internal/cmd/ghgen/config.go
+++ b/internal/cmd/ghgen/config.go
@@ -55,7 +55,7 @@ const (
 	runsOnUbuntu = "ubuntu-22.04"
 
 	// runsOnMacOS is the macOS system where to run.
-	runsOnMacOS = "macos-12"
+	runsOnMacOS = "macos-13"
 
 	// runsOnWindows is the windows system where to run.
 	runsOnWindows = "windows-2022"


### PR DESCRIPTION
## Checklist

- [ ] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [ ] reference issue for this pull request: <!-- add URL here -->
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

macos-12 has been deprecated and it seems, our workflows are taking quite long in the queue. This should fix it since a macos-13 runner should be more available. 
