### PR TITLE
fix: upgrade XCODE version for ios gh action

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -38,7 +38,7 @@ jobs:
       # ./internal/cmd/buildtool needs coreutils for sha256 plus GNU build tools
       - run: brew install autoconf automake coreutils libtool
 
-      - run: make EXPECTED_XCODE_VERSION=14.2 ios
+      - run: make EXPECTED_XCODE_VERSION=15.2 ios
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [ ] reference issue for this pull request: <!-- add URL here -->
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

It seems the upgrade for the macos github runner requires the expected xcode version to be 15.2. This diff fixes the issue
