### PR TITLE
feat: allow disabling tests enabled tests using checkin

### DIFF
--- a/internal/checkincache/checkincache_test.go
+++ b/internal/checkincache/checkincache_test.go
@@ -65,7 +65,7 @@ func TestGetFeatureFlag(t *testing.T) {
 				return nil, expectedErr
 			},
 		}
-		if GetFeatureFlag(memstore, "antani") {
+		if GetFeatureFlag(memstore, "antani", false) {
 			t.Fatal("expected to see false here")
 		}
 	})
@@ -76,7 +76,7 @@ func TestGetFeatureFlag(t *testing.T) {
 				return []byte(`{`), nil
 			},
 		}
-		if GetFeatureFlag(memstore, "antani") {
+		if GetFeatureFlag(memstore, "antani", false) {
 			t.Fatal("expected to see false here")
 		}
 	})
@@ -88,7 +88,7 @@ func TestGetFeatureFlag(t *testing.T) {
 				return []byte(response), nil
 			},
 		}
-		if GetFeatureFlag(memstore, "antani") {
+		if GetFeatureFlag(memstore, "antani", false) {
 			t.Fatal("expected to see false here")
 		}
 	})
@@ -109,7 +109,7 @@ func TestGetFeatureFlag(t *testing.T) {
 				return data, nil
 			},
 		}
-		if !GetFeatureFlag(memstore, "antani") {
+		if !GetFeatureFlag(memstore, "antani", false) {
 			t.Fatal("expected to see true here")
 		}
 	})
@@ -128,7 +128,7 @@ func TestGetFeatureFlag(t *testing.T) {
 				return data, nil
 			},
 		}
-		if GetFeatureFlag(memstore, "antani") {
+		if GetFeatureFlag(memstore, "antani", false) {
 			t.Fatal("expected to see false here")
 		}
 	})

--- a/internal/probeservices/checkin_test.go
+++ b/internal/probeservices/checkin_test.go
@@ -391,10 +391,10 @@ func TestCheckIn(t *testing.T) {
 		}
 
 		// make sure we have written non-default values into the key-value store
-		if !checkincache.GetFeatureFlag(client.KVStore, "torsf_enabled") {
+		if !checkincache.GetFeatureFlag(client.KVStore, "torsf_enabled", false) {
 			t.Fatal("expected to see true here")
 		}
-		if !checkincache.GetFeatureFlag(client.KVStore, "vanilla_tor_enabled") {
+		if !checkincache.GetFeatureFlag(client.KVStore, "vanilla_tor_enabled", false) {
 			t.Fatal("expected to see true here")
 		}
 		checkinrawdata, err := client.KVStore.Get(checkincache.CheckInFlagsState)
@@ -502,10 +502,10 @@ func TestCheckIn(t *testing.T) {
 		}
 
 		// make sure we are still getting the default values here
-		if checkincache.GetFeatureFlag(client.KVStore, "torsf_enabled") {
+		if checkincache.GetFeatureFlag(client.KVStore, "torsf_enabled", false) {
 			t.Fatal("expected to see false here")
 		}
-		if checkincache.GetFeatureFlag(client.KVStore, "vanilla_tor_enabled") {
+		if checkincache.GetFeatureFlag(client.KVStore, "vanilla_tor_enabled", false) {
 			t.Fatal("expected to see false here")
 		}
 		checkinrawdata, err := client.KVStore.Get(checkincache.CheckInFlagsState)

--- a/internal/registry/factory.go
+++ b/internal/registry/factory.go
@@ -345,7 +345,7 @@ func NewFactory(name string, kvStore model.KeyValueStore, logger model.Logger) (
 	// and improve the LTE implementation so that we can always use it. See the actual
 	// issue test for additional details on this planned A/B test.
 	switch {
-	case name == "web_connectivity" && checkincache.GetFeatureFlag(kvStore, "webconnectivity_0.5"):
+	case name == "web_connectivity" && checkincache.GetFeatureFlag(kvStore, "webconnectivity_0.5", false):
 		// use LTE rather than the normal webconnectivity when the
 		// feature flag has been set through the check-in API
 		logger.Infof("using webconnectivity LTE")
@@ -367,16 +367,19 @@ func NewFactory(name string, kvStore model.KeyValueStore, logger model.Logger) (
 	//
 	// Note: check-in flags expire after 24h.
 	//
-	// TODO(https://github.com/ooni/probe/issues/2554): we need to restructure
-	// how we run experiments to make sure check-in flags are always fresh.
+	//
+	//
 	if factory.enabledByDefault {
-		return factory, nil // enabled by default
+		if !checkincache.ExperimentEnabled(kvStore, name, true) {
+			return nil, fmt.Errorf("%s: %w", name, ErrRequiresForceEnable)
+		}
+		return factory, nil
 	}
 	if os.Getenv(OONI_FORCE_ENABLE_EXPERIMENT) == "1" {
 		return factory, nil // enabled by environment variable
 	}
-	if checkincache.ExperimentEnabled(kvStore, name) {
-		return factory, nil // enabled by check-in
+	if checkincache.ExperimentEnabled(kvStore, name, false) {
+		return factory, nil
 	}
 
 	logger.Warnf(experimentDisabledByCheckInWarning, name)

--- a/internal/registry/factory.go
+++ b/internal/registry/factory.go
@@ -379,7 +379,7 @@ func NewFactory(name string, kvStore model.KeyValueStore, logger model.Logger) (
 		return factory, nil // enabled by environment variable
 	}
 	if checkincache.ExperimentEnabled(kvStore, name, false) {
-		return factory, nil
+		return factory, nil // enabled by check-in
 	}
 
 	logger.Warnf(experimentDisabledByCheckInWarning, name)

--- a/internal/registry/torsf.go
+++ b/internal/registry/torsf.go
@@ -20,7 +20,7 @@ func init() {
 			},
 			canonicalName:    canonicalName,
 			config:           &torsf.Config{},
-			enabledByDefault: false,
+			enabledByDefault: true,
 			inputPolicy:      model.InputNone,
 		}
 	}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: #1706 
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff allows disabling default enabled tests in the engine using the checkin api. The summary of changes are: 

- if a nettest is enabled by the engine but disabled by checkin and the web_connectivity experiment was run in the last 24 hours, the nettest would throw an error and not run 

- if the checkin cache has expired and web_connectivity was not called in the last 24 hours, the nettest will run and switch to default behaviour

Apart from this, the running should WAI i.e., if the nettest is disabled by default in the engine, we will check the `OONI_FORCE_ENABLE_EXPERIMENT` env variable and also the checkin cache. However, if a checkin cache is not found at this point, the test will fail to run and throw an error. It is only when we find an explicit permission from the checkin cache that we allow a disabled test to run
