### PR TITLE
chore: bump ooniprobe version to 3.27.0-alpha

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Version is the ooniprobe version.
-const Version = "3.26.0-alpha"
+const Version = "3.27.0-alpha"


### PR DESCRIPTION
## Checklist

- [ ] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [ ] reference issue for this pull request: <!-- add URL here -->
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

We are now hacking on 3.27.0-alpha
