### PR TITLE
chore: add flags for android 16k page size

### DIFF
--- a/MOBILE/android/template.pom
+++ b/MOBILE/android/template.pom
@@ -27,12 +27,12 @@
 
   <developers>
     <developer>
-      <name>Simone Basso</name>
-      <email>simone@openobservatory.org</email>
+      <name>Mehul Gulati</name>
+      <email>mehul@openobservatory.org</email>
       <roles>
         <role>Core developer</role>
       </roles>
-      <timezone>Europe/Rome</timezone>
+      <timezone>Asia/Kolkata</timezone>
     </developer>
   </developers>
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-export CGO_LDFLAGS="-Wl,-z,max-page-size=16384"
-
 # Many rules in here break if run in parallel.
 .NOTPARALLEL:
 
@@ -91,7 +89,6 @@ CLI/windows:
 #help: and compiles miniooni and ooniprobe for android CLI usage.
 .PHONY: android
 android: search/for/java
-	echo $$CGO_LDFLAGS
 	./script/go.bash run ./internal/cmd/buildtool android cdeps zlib openssl libevent tor
 	./script/go.bash run ./internal/cmd/buildtool android cli
 	./script/go.bash run ./internal/cmd/buildtool android gomobile

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+export CGO_LDFLAGS="-Wl,-z,max-page-size=16384"
+
 # Many rules in here break if run in parallel.
 .NOTPARALLEL:
 
@@ -89,6 +91,7 @@ CLI/windows:
 #help: and compiles miniooni and ooniprobe for android CLI usage.
 .PHONY: android
 android: search/for/java
+	echo $$CGO_LDFLAGS
 	./script/go.bash run ./internal/cmd/buildtool android cdeps zlib openssl libevent tor
 	./script/go.bash run ./internal/cmd/buildtool android cli
 	./script/go.bash run ./internal/cmd/buildtool android gomobile

--- a/internal/cmd/buildtool/android.go
+++ b/internal/cmd/buildtool/android.go
@@ -99,6 +99,11 @@ func androidBuildGomobile(deps buildtoolmodel.Dependencies) {
 	goPath := filepath.Join(deps.GOPATH(), "bin")
 	envp.Append("PATH", cdepsPrependToPath(goPath))
 
+	// We need to support 16KB page size as per android guidelines
+	//
+	// See https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html
+	envp.Append("CGO_LDFLAGS", "-Wl,-z,max-page-size=16384")
+
 	config := &gomobileConfig{
 		deps:       deps,
 		envp:       envp,


### PR DESCRIPTION
## Description

Add flags for android `16k` page size.

See alignment script on how to verify https://developer.android.com/guide/practices/page-sizes#alignment-use-script
