### PR TITLE
fix: use experiment target as default for ooniprobe cli

### DIFF
--- a/cmd/ooniprobe/internal/nettests/echcheck.go
+++ b/cmd/ooniprobe/internal/nettests/echcheck.go
@@ -14,8 +14,6 @@ func (n ECHCheck) Run(ctl *Controller) error {
 	// providing an input containing an empty string causes the experiment
 	// to recognize the empty string and use the default URL
 	return ctl.Run(builder, []model.ExperimentTarget{
-		model.NewOOAPIURLInfoWithDefaultCategoryAndCountry("https://cloudflare-ech.com/cdn-cgi/trace"),
-		// Use ECH on a non-standard port.
-		model.NewOOAPIURLInfoWithDefaultCategoryAndCountry("https://min-ng.test.defo.ie:15443"),
+		model.NewOOAPIURLInfoWithDefaultCategoryAndCountry(""),
 	})
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe-cli/issues/1725
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff changes the targets for the echcheck experiment in ooniprobe CLI to use the default targets set in the experiment
