### PR TITLE
fix: e2e checks for debian installs

### DIFF
--- a/.github/workflows/debianrepo.yml
+++ b/.github/workflows/debianrepo.yml
@@ -6,7 +6,6 @@ on:
       - "master"
       - "release/**"
       - "fullbuild"
-      - debug/e2e-debian
 
 jobs:
   test_386:

--- a/.github/workflows/debianrepo.yml
+++ b/.github/workflows/debianrepo.yml
@@ -6,6 +6,7 @@ on:
       - "master"
       - "release/**"
       - "fullbuild"
+      - debug/e2e-debian
 
 jobs:
   test_386:

--- a/E2E/debian.bash
+++ b/E2E/debian.bash
@@ -11,12 +11,10 @@ install_flow() {
 	export DEBIAN_FRONTEND=noninteractive
 	dpkg --add-architecture "$1"
 	apt-get update
-	apt-get install --yes gnupg dirmngr
+	apt-get install --yes gnupg wget dirmngr
 	mkdir -p /root/.gnupg
 	chmod 700 /root/.gnupg
-	gpg --no-default-keyring --keyring /usr/share/keyrings/ooniprobe-archive-keyring.gpg \
-    --keyserver hkp://keyserver.ubuntu.com:80 \
-    --recv-keys B5A08F01796E7F521861B449372D1FF271F2DD50
+	wget -O- https://ooni.org/ooniprobe.asc | gpg --dearmor | tee /usr/share/keyrings/ooniprobe-archive-keyring.gpg > /dev/null
 	echo "deb [arch=$1 signed-by=/usr/share/keyrings/ooniprobe-archive-keyring.gpg] http://deb.ooni.org/ unstable main" | tee /etc/apt/sources.list.d/ooniprobe.list
 	apt-get update
 	apt-get install --yes ooniprobe-cli

--- a/E2E/debian.bash
+++ b/E2E/debian.bash
@@ -11,7 +11,7 @@ install_flow() {
 	export DEBIAN_FRONTEND=noninteractive
 	dpkg --add-architecture "$1"
 	apt-get update
-	apt-get install --yes gnupg wget dirmngr
+	apt-get install --yes gnupg wget
 	mkdir -p /root/.gnupg
 	chmod 700 /root/.gnupg
 	wget -O- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xB5A08F01796E7F521861B449372D1FF271F2DD50" \

--- a/E2E/debian.bash
+++ b/E2E/debian.bash
@@ -14,7 +14,9 @@ install_flow() {
 	apt-get install --yes gnupg wget dirmngr
 	mkdir -p /root/.gnupg
 	chmod 700 /root/.gnupg
-	wget -O- https://ooni.org/ooniprobe.asc | gpg --dearmor | tee /usr/share/keyrings/ooniprobe-archive-keyring.gpg > /dev/null
+	wget -O- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xB5A08F01796E7F521861B449372D1FF271F2DD50" \
+    | gpg --dearmor \
+    | tee /usr/share/keyrings/ooniprobe-archive-keyring.gpg > /dev/null
 	echo "deb [arch=$1 signed-by=/usr/share/keyrings/ooniprobe-archive-keyring.gpg] http://deb.ooni.org/ unstable main" | tee /etc/apt/sources.list.d/ooniprobe.list
 	apt-get update
 	apt-get install --yes ooniprobe-cli

--- a/E2E/debian.bash
+++ b/E2E/debian.bash
@@ -12,9 +12,10 @@ install_flow() {
 	dpkg --add-architecture "$1"
 	apt-get update
 	apt-get install --yes gnupg
-	wget -O- https://ooni.org/ooniprobe.asc | gpg --dearmor | tee /usr/share/keyrings/ooniprobe-archive-keyring.gpg > /dev/null
-	echo "deb [arch=$1 signed-by=/usr/share/keyrings/ooniprobe-archive-keyring.gpg] http://deb.ooni.org/ unstable main" \
-        | tee /etc/apt/sources.list.d/ooniprobe.list
+	gpg --no-default-keyring --keyring /usr/share/keyrings/ooniprobe-archive-keyring.gpg \
+    --keyserver hkp://keyserver.ubuntu.com:80 \
+    --recv-keys B5A08F01796E7F521861B449372D1FF271F2DD50
+	echo "deb [arch=$1 signed-by=/usr/share/keyrings/ooniprobe-archive-keyring.gpg] http://deb.ooni.org/ unstable main" | tee /etc/apt/sources.list.d/ooniprobe.list
 	apt-get update
 	apt-get install --yes ooniprobe-cli
 	dpkg -l | grep ooniprobe-cli > DEBIAN_INSTALLED_PACKAGE.txt

--- a/E2E/debian.bash
+++ b/E2E/debian.bash
@@ -11,7 +11,9 @@ install_flow() {
 	export DEBIAN_FRONTEND=noninteractive
 	dpkg --add-architecture "$1"
 	apt-get update
-	apt-get install --yes gnupg
+	apt-get install --yes gnupg dirmngr
+	mkdir -p /root/.gnupg
+	chmod 700 /root/.gnupg
 	gpg --no-default-keyring --keyring /usr/share/keyrings/ooniprobe-archive-keyring.gpg \
     --keyserver hkp://keyserver.ubuntu.com:80 \
     --recv-keys B5A08F01796E7F521861B449372D1FF271F2DD50

--- a/E2E/debian.bash
+++ b/E2E/debian.bash
@@ -12,8 +12,9 @@ install_flow() {
 	dpkg --add-architecture "$1"
 	apt-get update
 	apt-get install --yes gnupg
-	apt-key adv --verbose --keyserver hkp://keyserver.ubuntu.com --recv-keys 'B5A08F01796E7F521861B449372D1FF271F2DD50'
-	echo "deb [arch=$1] http://deb.ooni.org/ unstable main" | tee /etc/apt/sources.list.d/ooniprobe.list
+	wget -O- https://ooni.org/ooniprobe.asc | gpg --dearmor | tee /usr/share/keyrings/ooniprobe-archive-keyring.gpg > /dev/null
+	echo "deb [arch=$1 signed-by=/usr/share/keyrings/ooniprobe-archive-keyring.gpg] http://deb.ooni.org/ unstable main" \
+        | tee /etc/apt/sources.list.d/ooniprobe.list
 	apt-get update
 	apt-get install --yes ooniprobe-cli
 	dpkg -l | grep ooniprobe-cli > DEBIAN_INSTALLED_PACKAGE.txt


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe-cli/issues/1727
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff fixes issues with the e2e checks failing to ensure that ooniprobe can be installed on debian.
