### PR TITLE
fix: copy psiphon config files while building for desktop

### DIFF
--- a/internal/cmd/buildtool/desktop.go
+++ b/internal/cmd/buildtool/desktop.go
@@ -35,6 +35,7 @@ func desktopSubcommand() *cobra.Command {
 
 // desktopBuildOomobile invokes the oomobile build.
 func desktopBuildOomobile(deps buildtoolmodel.Dependencies, targetOs string) {
+	deps.PsiphonMaybeCopyConfigFiles()
 	deps.GolangCheck()
 
 	config := &gomobileConfig{


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe-cli/issues/1716
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff copies the psiphon config file while building for the engine for desktop
