### PR TITLE
chore: revert tor version for ooni libtor

### DIFF
--- a/internal/cmd/buildtool/android_test.go
+++ b/internal/cmd/buildtool/android_test.go
@@ -1752,12 +1752,12 @@ func TestAndroidBuildCdepsTor(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.20.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.17.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.8.20.tar.gz",
+				"tar", "-xf", "tor-0.4.8.17.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -1841,12 +1841,12 @@ func TestAndroidBuildCdepsTor(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.20.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.17.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.8.20.tar.gz",
+				"tar", "-xf", "tor-0.4.8.17.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -1930,12 +1930,12 @@ func TestAndroidBuildCdepsTor(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.20.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.17.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.8.20.tar.gz",
+				"tar", "-xf", "tor-0.4.8.17.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -2019,12 +2019,12 @@ func TestAndroidBuildCdepsTor(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.20.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.17.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.8.20.tar.gz",
+				"tar", "-xf", "tor-0.4.8.17.tar.gz",
 			},
 		}, {
 			Env: []string{},

--- a/internal/cmd/buildtool/cdepstor.go
+++ b/internal/cmd/buildtool/cdepstor.go
@@ -27,13 +27,13 @@ func cdepsTorBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependencies) {
 	defer restore()
 
 	// See https://github.com/Homebrew/homebrew-core/blob/master/Formula/t/tor.rb
-	cdepsMustFetch("https://www.torproject.org/dist/tor-0.4.8.20.tar.gz")
+	cdepsMustFetch("https://www.torproject.org/dist/tor-0.4.8.17.tar.gz")
 	deps.VerifySHA256( // must be mockable
-		"1bb22328cdd1ee948647bfced571efa78c12fc5064187b41d5254085b5282fa7",
-		"tor-0.4.8.20.tar.gz",
+		"b6a5f44b7eb69e3fa35dbf15524405b44837a481d43d81daddde3ff21fcbb8e9",
+		"tor-0.4.8.17.tar.gz",
 	)
-	must.Run(log.Log, "tar", "-xf", "tor-0.4.8.20.tar.gz")
-	_ = deps.MustChdir("tor-0.4.8.20") // must be mockable
+	must.Run(log.Log, "tar", "-xf", "tor-0.4.8.17.tar.gz")
+	_ = deps.MustChdir("tor-0.4.8.17") // must be mockable
 
 	mydir := filepath.Join(topdir, "CDEPS", "tor")
 	for _, patch := range cdepsMustListPatches(mydir) {

--- a/internal/cmd/buildtool/ios_test.go
+++ b/internal/cmd/buildtool/ios_test.go
@@ -1154,12 +1154,12 @@ func TestIOSBuildCdepsTor(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.20.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.17.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.8.20.tar.gz",
+				"tar", "-xf", "tor-0.4.8.17.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -1244,12 +1244,12 @@ func TestIOSBuildCdepsTor(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.20.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.17.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.8.20.tar.gz",
+				"tar", "-xf", "tor-0.4.8.17.tar.gz",
 			},
 		}, {
 			Env: []string{},
@@ -1334,12 +1334,12 @@ func TestIOSBuildCdepsTor(t *testing.T) {
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.20.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.17.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.8.20.tar.gz",
+				"tar", "-xf", "tor-0.4.8.17.tar.gz",
 			},
 		}, {
 			Env: []string{},

--- a/internal/cmd/buildtool/linuxcdeps_test.go
+++ b/internal/cmd/buildtool/linuxcdeps_test.go
@@ -322,12 +322,12 @@ func TestLinuxCdepsBuildMain(t *testing.T) {
 		expect: []buildtooltest.ExecExpectations{{
 			Env: []string{},
 			Argv: []string{
-				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.20.tar.gz",
+				"curl", "-fsSLO", "https://www.torproject.org/dist/tor-0.4.8.17.tar.gz",
 			},
 		}, {
 			Env: []string{},
 			Argv: []string{
-				"tar", "-xf", "tor-0.4.8.20.tar.gz",
+				"tar", "-xf", "tor-0.4.8.17.tar.gz",
 			},
 		}, {
 			Env: []string{},


### PR DESCRIPTION
## Checklist

- [ ] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [ ] reference issue for this pull request: <!-- add URL here -->
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

It seems that tor-0.4.8.20 seems to be breaking libtor: https://github.com/ooni/probe-cli/actions/runs/19490529462/job/55781718738. This diff reverts back to using 0.4.8.17 until we have a working piece of code with the new version
