### PR TITLE
chore: fix tor dep hash

### DIFF
--- a/internal/cmd/buildtool/cdepstor.go
+++ b/internal/cmd/buildtool/cdepstor.go
@@ -29,7 +29,7 @@ func cdepsTorBuildMain(globalEnv *cBuildEnv, deps buildtoolmodel.Dependencies) {
 	// See https://github.com/Homebrew/homebrew-core/blob/master/Formula/t/tor.rb
 	cdepsMustFetch("https://www.torproject.org/dist/tor-0.4.8.17.tar.gz")
 	deps.VerifySHA256( // must be mockable
-		"b6a5f44b7eb69e3fa35dbf15524405b44837a481d43d81daddde3ff21fcbb8e9",
+		"79b4725e1d4b887b9e68fd09b0d2243777d5ce3cd471e538583bcf6f9d8cdb56",
 		"tor-0.4.8.17.tar.gz",
 	)
 	must.Run(log.Log, "tar", "-xf", "tor-0.4.8.17.tar.gz")


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: #1745 
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

The hash supplied for tor-0.4.8.17 in #1753 was wrong. This diff fixes it. 
