### PR TITLE
fix(checkincache): remove stray debug fmt.Println in GetFeatureFlag

### DIFF
--- a/internal/checkincache/checkincache.go
+++ b/internal/checkincache/checkincache.go
@@ -51,7 +51,6 @@ func GetFeatureFlag(kvStore model.KeyValueStore, name string, defaultFlag bool) 
 	if err := json.Unmarshal(data, &wrapper); err != nil {
 		return defaultFlag // as documented
 	}
-	fmt.Println(wrapper)
 	if time.Now().After(wrapper.Expire) {
 		return defaultFlag // as documented
 	}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe-cli/issues/1785
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A
- [ ] if you changed code inside an experiment, make sure you bump its version number: N/A, not an experiment

## Description

Removes a leftover debug `fmt.Println(wrapper)` in `GetFeatureFlag` (internal/checkincache/checkincache.go). It was added in #1707 and prints the raw check-in flags struct to stdout on every call, which in practice means every time an experiment checks whether it's enabled.

This is what's behind the confusing unlabeled lines in the log attached to #1785:

```
{2026-06-25 14:20:32.315561414 +0000 UTC map[openvpn_enabled:false torsf_enabled:false vanilla_tor_enabled:true]}
{2026-06-25 14:20:32.315561414 +0000 UTC map[openvpn_enabled:false torsf_enabled:false vanilla_tor_enabled:true]}
```

Nothing in the codebase reads this output, it's not part of any structured logging path, and it made the reporter think vanilla_tor had run instead of web_connectivity, when really it's just the check-in cache being printed twice because `GetFeatureFlag` gets called twice for that run.

I want to be upfront that this doesn't fix the panic in that same log (`no URLs returned`). That comes from `runtimex.PanicOnError` in `internal/cmd/miniooni/runx.go`, which panics when the check-in API returns zero URLs for the experiment. That looks like a backend/check-in condition, not something this file controls, so I'm leaving it out of scope here rather than guessing at a fix I can't verify.

## Testing

The change is a one-line deletion of an unused-anywhere debug statement, so there's no new behavior to cover. `fmt` is still imported and used (`fmt.Sprintf` in `ExperimentEnabledKey`), and I checked `checkincache_test.go` to confirm none of the existing tests assert on stdout, so this shouldn't affect them.

I don't have a Go toolchain set up in the environment I used to prepare this, so I wasn't able to run `go test`/`go vet` myself here — I did read through the diff and the surrounding file carefully instead. Happy to fix anything CI turns up.
