### PR TITLE
fix: use correct formatting for openssl patch

### DIFF
--- a/CDEPS/openssl/000.patch
+++ b/CDEPS/openssl/000.patch
@@ -1,10 +1,10 @@
 diff --git a/crypto/comp/c_zlib.c b/crypto/comp/c_zlib.c
-index 0fbab8f014..0dc8ff53d4 100644
+index c90c7b0..3df40ef 100644
 --- a/crypto/comp/c_zlib.c
 +++ b/crypto/comp/c_zlib.c
 @@ -26,6 +26,10 @@ COMP_METHOD *COMP_zlib(void);
  
- # include <zlib.h>
+ #include <zlib.h>
  
 +#ifndef ZLIB_OONI
 +# error "We're not including the correct zlib.h file"

--- a/CDEPS/openssl/001.patch
+++ b/CDEPS/openssl/001.patch
@@ -1,15 +1,15 @@
 diff --git a/include/openssl/opensslv.h.in b/include/openssl/opensslv.h.in
-index 3f47a2ac08..b413461ca7 100644
+index 58b290e..8b1ca96 100644
 --- a/include/openssl/opensslv.h.in
 +++ b/include/openssl/opensslv.h.in
 @@ -13,6 +13,10 @@
- # define OPENSSL_OPENSSLV_H
- # pragma once
+ #define OPENSSL_OPENSSLV_H
+ #pragma once
  
 +/* OPENSSL_OONI is used by dependencies to ensure they are using the
 +   correct OpenSSL headers and not some other headers. */
 +#define OPENSSL_OONI 1
 +
- # ifdef  __cplusplus
+ #ifdef __cplusplus
  extern "C" {
- # endif
+ #endif


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe-cli/issues/1790
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff fixes the openssl patch to use the new formatting style introduces in openssl v3.6.1
