### PR TITLE
chore: update stun targets

### DIFF
--- a/internal/stuninput/stuninput.go
+++ b/internal/stuninput/stuninput.go
@@ -12,13 +12,14 @@ import (
 //
 // We should sync with https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/blob/main/projects/tor-expert-bundle/pt_config.json
 var inputs = map[string]bool{
-	"stun.epygi.com:3478":     true,
-	"stun.uls.co.za:3478":     true,
-	"stun.voipgate.com:3478":  true,
-	"stun.mixvoip.com:3478":   true,
-	"stun.nextcloud.com:3478": true,
-	"stun.bethesda.net:3478":  true,
-	"stun.nextcloud.com:443":  true,
+	"stun.epygi.com:3478":      true,
+	"stun.uls.co.za:3478":      true,
+	"stun.voipgate.com:3478":   true,
+	"stun.mixvoip.com:3478":    true,
+	"stun.telnyx.com:3478":     true,
+	"stun.hot-chilli.net:3478": true,
+	"stun.fitauto.ru:3478":     true,
+	"stun.m-online.net:3478":   true,
 }
 
 // AsSnowflakeInput formats the input in the format


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe-cli/issues/1790
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff updates stun targets to the latest internal list used by TPO's snowflake
