### PR TITLE
fix: pass in static linking flags explicitly for mingw userauth deps

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,6 @@ on:
       - "release/**"
       - "fullbuild"
       - "windowsbuild"
-      - fix/windows-static-build
     tags:
       - "v*"
   schedule:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,6 +7,7 @@ on:
       - "release/**"
       - "fullbuild"
       - "windowsbuild"
+      - fix/windows-static-build
     tags:
       - "v*"
   schedule:

--- a/internal/cmd/buildtool/windows.go
+++ b/internal/cmd/buildtool/windows.go
@@ -55,7 +55,7 @@ func windowsBuildPackage(deps buildtoolmodel.Dependencies, goarch string, produc
 		argv.Append("-tags", "ooni_psiphon_config")
 	}
 
-	argv.Append("-ldflags", "-s -w")
+	argv.Append("-ldflags", "-s -w -extldflags=-static")
 	argv.Append("-o", product.DestinationPath("windows", goarch))
 	argv.Append(product.Pkg)
 

--- a/internal/cmd/buildtool/windows_test.go
+++ b/internal/cmd/buildtool/windows_test.go
@@ -34,7 +34,7 @@ func TestWindowsBuildAll(t *testing.T) {
 			},
 			Argv: []string{
 				"go", "build", "-tags", "ooni_psiphon_config",
-				"-ldflags", "-s -w", "-o", "CLI/miniooni-windows-386.exe",
+				"-ldflags", "-s -w -extldflags=-static", "-o", "CLI/miniooni-windows-386.exe",
 				"./internal/cmd/miniooni",
 			},
 		}, {
@@ -46,7 +46,7 @@ func TestWindowsBuildAll(t *testing.T) {
 			},
 			Argv: []string{
 				"go", "build", "-tags", "ooni_psiphon_config",
-				"-ldflags", "-s -w", "-o", "CLI/ooniprobe-windows-386.exe",
+				"-ldflags", "-s -w -extldflags=-static", "-o", "CLI/ooniprobe-windows-386.exe",
 				"./cmd/ooniprobe",
 			},
 		}, {
@@ -58,7 +58,7 @@ func TestWindowsBuildAll(t *testing.T) {
 			},
 			Argv: []string{
 				"go", "build", "-tags", "ooni_psiphon_config",
-				"-ldflags", "-s -w", "-o", "CLI/miniooni-windows-amd64.exe",
+				"-ldflags", "-s -w -extldflags=-static", "-o", "CLI/miniooni-windows-amd64.exe",
 				"./internal/cmd/miniooni",
 			},
 		}, {
@@ -70,7 +70,7 @@ func TestWindowsBuildAll(t *testing.T) {
 			},
 			Argv: []string{
 				"go", "build", "-tags", "ooni_psiphon_config",
-				"-ldflags", "-s -w", "-o", "CLI/ooniprobe-windows-amd64.exe",
+				"-ldflags", "-s -w -extldflags=-static", "-o", "CLI/ooniprobe-windows-amd64.exe",
 				"./cmd/ooniprobe",
 			},
 		}},
@@ -85,7 +85,7 @@ func TestWindowsBuildAll(t *testing.T) {
 				"GOOS=windows",
 			},
 			Argv: []string{
-				"go", "build", "-ldflags", "-s -w", "-o", "CLI/miniooni-windows-386.exe",
+				"go", "build", "-ldflags", "-s -w -extldflags=-static", "-o", "CLI/miniooni-windows-386.exe",
 				"./internal/cmd/miniooni",
 			},
 		}, {
@@ -96,7 +96,7 @@ func TestWindowsBuildAll(t *testing.T) {
 				"GOOS=windows",
 			},
 			Argv: []string{
-				"go", "build", "-ldflags", "-s -w", "-o", "CLI/ooniprobe-windows-386.exe",
+				"go", "build", "-ldflags", "-s -w -extldflags=-static", "-o", "CLI/ooniprobe-windows-386.exe",
 				"./cmd/ooniprobe",
 			},
 		}, {
@@ -107,7 +107,7 @@ func TestWindowsBuildAll(t *testing.T) {
 				"GOOS=windows",
 			},
 			Argv: []string{
-				"go", "build", "-ldflags", "-s -w", "-o", "CLI/miniooni-windows-amd64.exe",
+				"go", "build", "-ldflags", "-s -w -extldflags=-static", "-o", "CLI/miniooni-windows-amd64.exe",
 				"./internal/cmd/miniooni",
 			},
 		}, {
@@ -118,7 +118,7 @@ func TestWindowsBuildAll(t *testing.T) {
 				"GOOS=windows",
 			},
 			Argv: []string{
-				"go", "build", "-ldflags", "-s -w", "-o", "CLI/ooniprobe-windows-amd64.exe",
+				"go", "build", "-ldflags", "-s -w -extldflags=-static", "-o", "CLI/ooniprobe-windows-amd64.exe",
 				"./cmd/ooniprobe",
 			},
 		}},


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe-cli/issues/1809
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff should allow forced static linking for windows targets since userauth drags in deps that are linked dynamically by default on windows
