### PR TITLE
fix(tlsmiddlebox): make ClientId settable and validate its value

### DIFF
--- a/internal/experiment/tlsmiddlebox/config.go
+++ b/internal/experiment/tlsmiddlebox/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	TestHelper string `ooni:"testhelper URL to use for tracing"`
 
 	// ClientId is the client fingerprint to use
-	ClientId int `ooni:"ClientHello fingerprint to use"`
+	ClientId int64 `ooni:"ClientHello fingerprint to use"`
 }
 
 func (c Config) resolverURL() string {
@@ -73,7 +73,7 @@ func (c Config) testhelper(address string) (URL *url.URL, err error) {
 
 func (c Config) clientid() int {
 	if c.ClientId > 0 {
-		return c.ClientId
+		return int(c.ClientId)
 	}
 	return 0
 }

--- a/internal/experiment/tlsmiddlebox/config_test.go
+++ b/internal/experiment/tlsmiddlebox/config_test.go
@@ -76,8 +76,19 @@ func TestConfig_testhelper(t *testing.T) {
 }
 
 func TestConfig_clientid(t *testing.T) {
-	c := Config{}
-	if c.clientid() != 0 {
-		t.Fatal("invalid default ClientHello ID")
-	}
+	t.Run("without config", func(t *testing.T) {
+		c := Config{}
+		if c.clientid() != 0 {
+			t.Fatal("invalid default ClientHello ID")
+		}
+	})
+
+	t.Run("with config", func(t *testing.T) {
+		c := Config{
+			ClientId: 2,
+		}
+		if c.clientid() != 2 {
+			t.Fatal("invalid ClientHello ID")
+		}
+	})
 }

--- a/internal/experiment/tlsmiddlebox/measurer.go
+++ b/internal/experiment/tlsmiddlebox/measurer.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	testName    = "tlsmiddlebox"
-	testVersion = "0.1.2"
+	testVersion = "0.1.3"
 )
 
 // Measurer performs the measurement.
@@ -49,6 +49,9 @@ var (
 
 	// errInvalidTHScheme indicates that the TH scheme is invalid
 	errInvalidTHScheme = errors.New("th scheme must be tlshandshake")
+
+	// errInvalidClientId indicates that the ClientId is invalid
+	errInvalidClientId = errors.New("ClientId does not match any known fingerprint")
 )
 
 // // Run implements ExperimentMeasurer.Run.
@@ -72,6 +75,9 @@ func (m *Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	}
 	if th.Scheme != "tlshandshake" {
 		return errInvalidTHScheme
+	}
+	if clientId := m.config.clientid(); clientId > 0 && ClientIDs[clientId] == nil {
+		return errInvalidClientId
 	}
 	tk := NewTestKeys()
 	measurement.TestKeys = tk

--- a/internal/experiment/tlsmiddlebox/measurer_test.go
+++ b/internal/experiment/tlsmiddlebox/measurer_test.go
@@ -18,7 +18,7 @@ func TestMeasurerExperimentNameVersion(t *testing.T) {
 	if measurer.ExperimentName() != "tlsmiddlebox" {
 		t.Fatal("unexpected ExperimentName")
 	}
-	if measurer.ExperimentVersion() != "0.1.2" {
+	if measurer.ExperimentVersion() != "0.1.3" {
 		t.Fatal("unexpected ExperimentVersion")
 	}
 }
@@ -78,6 +78,29 @@ func TestMeasurer_input_failure(t *testing.T) {
 	t.Run("with invalid TH scheme", func(t *testing.T) {
 		_, _, err := runHelper(context.Background(), "tlstrace://example.com", "http://google.com", "")
 		if !errors.Is(err, errInvalidTHScheme) {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	t.Run("with invalid ClientId", func(t *testing.T) {
+		m := NewExperimentMeasurer(Config{
+			ClientId: 5, // we only know fingerprints between 1 and 4
+		})
+		meas := &model.Measurement{
+			Input: model.MeasurementInput("tlstrace://example.com"),
+		}
+		sess := &mocks.Session{
+			MockLogger: func() model.Logger {
+				return model.DiscardLogger
+			},
+		}
+		args := &model.ExperimentArgs{
+			Callbacks:   model.NewPrinterCallbacks(model.DiscardLogger),
+			Measurement: meas,
+			Session:     sess,
+		}
+		err := m.Run(context.Background(), args)
+		if !errors.Is(err, errInvalidClientId) {
 			t.Fatal("unexpected error", err)
 		}
 	})

--- a/internal/registry/factory_test.go
+++ b/internal/registry/factory_test.go
@@ -1115,3 +1115,29 @@ func TestExperimentConfigIsAlwaysAPointerToStruct(t *testing.T) {
 		})
 	}
 }
+
+// This test is important because SetOptionAny can only set fields whose
+// kind is int64, bool, or string: any config field exposed as an option
+// through the `ooni` tag must use one of these kinds, otherwise it is
+// impossible to set it with `miniooni -O` and similar interfaces
+func TestExperimentOptionsAreAlwaysSettable(t *testing.T) {
+	for name, ffunc := range AllExperiments {
+		t.Run(name, func(t *testing.T) {
+			factory := ffunc()
+			valueinfo := reflect.ValueOf(factory.config).Elem()
+			typeinfo := valueinfo.Type()
+			for i := 0; i < typeinfo.NumField(); i++ {
+				field := typeinfo.Field(i)
+				if !field.IsExported() || field.Tag.Get("ooni") == "" {
+					continue
+				}
+				switch kind := field.Type.Kind(); kind {
+				case reflect.Int64, reflect.Bool, reflect.String:
+					// nothing
+				default:
+					t.Fatalf("field %s has kind %s, which SetOptionAny cannot set", field.Name, kind)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [ ] reference issue for this pull request: none, found this while poking at experiment options
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: N/A, no data format change
- [x] if you changed code inside an experiment, make sure you bump its version number: 0.1.2 to 0.1.3

## Description

tlsmiddlebox declares its `ClientId` option as `int`, but `SetOptionAny` in internal/registry only knows how to set int64, bool, and string fields. So the option is documented (it has an `ooni` tag and shows up in the options list) but you cannot actually use it. Applying the registry test this PR adds on top of current master:

```
$ go test -count=1 -run 'TestExperimentOptionsAreAlwaysSettable' ./internal/registry/
--- FAIL: TestExperimentOptionsAreAlwaysSettable (0.00s)
    --- FAIL: TestExperimentOptionsAreAlwaysSettable/tlsmiddlebox (0.00s)
        factory_test.go:1138: field ClientId has kind int, which SetOptionAny cannot set
```

`miniooni tlsmiddlebox -O ClientId=2` is where that bites. miniooni passes option values as strings, string values for integer options go through `setOptionInt`, and `SetOptionAny` only routes to `setOptionInt` for fields whose kind is int64. An `int` field falls through to the default branch instead, which returns `unsupported option type: string`. Every other experiment already declares integer options as int64; tlsmiddlebox was the only one using plain int.

There is a second problem behind the first one. OONI Run v2 descriptors apply options with `SetOptionsJSON`, which unmarshals straight into the config struct and bypasses the kind check, so a descriptor can set any `ClientId` it likes. `ClientIDs` in tracing.go is a `map[int]*utls.ClientHelloID` with keys 1 to 4, the lookup silently returns nil for any other key, and `netxlite.NewUTLSConn` dereferences the pointer. Running the measurer with `Config{ClientId: 5}` against a local TLS listener on current master:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xb5ca41]

github.com/ooni/probe-cli/v3/internal/netxlite.NewUTLSConn(...)
	internal/netxlite/utls.go:83
...
github.com/ooni/probe-cli/v3/internal/experiment/tlsmiddlebox.(*Measurer).handshakeWithTTL(...)
	internal/experiment/tlsmiddlebox/tracing.go:100
```

The fix is small: `ClientId` becomes int64 (with `clientid()` casting for the map lookup, so tracing.go is untouched), and `Run` now rejects a ClientId that does not match any known fingerprint, the same way it already rejects an invalid test helper. I picked an error over a silent fallback to the stdlib handshaker because somebody who asked for a Chrome fingerprint should not quietly measure with the wrong ClientHello.

The registry test shown above walks every experiment config and flags any `ooni`-tagged field whose kind `SetOptionAny` cannot set, so a future experiment cannot reintroduce this class of bug.

## Testing

```
$ go test -count=1 -race ./internal/experiment/tlsmiddlebox/ ./internal/registry/
ok  	github.com/ooni/probe-cli/v3/internal/experiment/tlsmiddlebox	61.851s
ok  	github.com/ooni/probe-cli/v3/internal/registry	1.084s
```

New coverage: the invalid ClientId path in `Run`, the non-default `clientid()` value, and the registry-wide option kind check. `go vet` and `gofmt` are clean on both packages.
