### PR TITLE
feat: support oonirun v2.1 in miniooni

### DIFF
--- a/internal/cmd/miniooni/oonirun.go
+++ b/internal/cmd/miniooni/oonirun.go
@@ -30,6 +30,8 @@ func ooniRunMain(ctx context.Context,
 		NoJSON:        currentOptions.NoJSON,
 		Random:        currentOptions.Random,
 		ReportFile:    currentOptions.ReportFile,
+		ProbeCC:       sess.ProbeCC(),
+		ProbeASN:      sess.ProbeASNString(),
 		Session:       sess,
 	}
 	for _, URL := range currentOptions.Inputs {

--- a/internal/experiment/dnscheck/dnscheck.go
+++ b/internal/experiment/dnscheck/dnscheck.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	testName      = "dnscheck"
-	testVersion   = "0.9.2"
+	testVersion   = "0.9.3"
 	defaultDomain = "example.org"
 )
 

--- a/internal/experiment/dnscheck/dnscheck_test.go
+++ b/internal/experiment/dnscheck/dnscheck_test.go
@@ -45,7 +45,7 @@ func TestExperimentNameAndVersion(t *testing.T) {
 	if measurer.ExperimentName() != "dnscheck" {
 		t.Error("unexpected experiment name")
 	}
-	if measurer.ExperimentVersion() != "0.9.2" {
+	if measurer.ExperimentVersion() != "0.9.3" {
 		t.Error("unexpected experiment version")
 	}
 }

--- a/internal/experiment/dnscheck/richerinput.go
+++ b/internal/experiment/dnscheck/richerinput.go
@@ -87,9 +87,9 @@ func (tl *targetLoader) Load(ctx context.Context) ([]model.ExperimentTarget, err
 
 	// Build the list of targets that we should measure.
 	var targets []model.ExperimentTarget
-	for _, input := range inputs {
+	for i, input := range inputs {
 		targets = append(targets, &Target{
-			Config: tl.options,
+			Config: targetloading.PerInputConfig(tl.loader, tl.options, i),
 			URL:    input,
 		})
 	}

--- a/internal/experiment/dnscheck/richerinput_test.go
+++ b/internal/experiment/dnscheck/richerinput_test.go
@@ -2,6 +2,7 @@ package dnscheck
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io/fs"
 	"path/filepath"
@@ -298,6 +299,46 @@ func TestTargetLoaderLoad(t *testing.T) {
 				&Target{
 					URL:    "https://one.one.one.one/dns-query",
 					Config: &Config{},
+				},
+			},
+		},
+
+		{
+			name: "per-input inputs_extra overlays the experiment-wide config",
+			options: &Config{
+				DefaultAddrs: "1.1.1.1 1.0.0.1",
+			},
+			loader: &targetloading.Loader{
+				CheckInConfig:  &model.OOAPICheckInConfig{ /* nothing */ },
+				ExperimentName: "dnscheck",
+				InputPolicy:    model.InputOrStaticDefault,
+				Logger:         model.DiscardLogger,
+				Session:        &mocks.Session{},
+				StaticInputs: []string{
+					"https://dns.cloudflare.com/dns-query",
+					"https://one.one.one.one/dns-query",
+				},
+				StaticInputsConfig: []json.RawMessage{
+					// overrides http3 for the first input only (dnscheck has json tags)
+					json.RawMessage(`{"http3_enabled":true}`),
+					// empty config: the second input keeps the wide config
+					json.RawMessage(`{}`),
+				},
+			},
+			expectErr: nil,
+			expectTargets: []model.ExperimentTarget{
+				&Target{
+					URL: "https://dns.cloudflare.com/dns-query",
+					Config: &Config{
+						DefaultAddrs: "1.1.1.1 1.0.0.1", // preserved from the wide config
+						HTTP3Enabled: true,              // overridden per-input
+					},
+				},
+				&Target{
+					URL: "https://one.one.one.one/dns-query",
+					Config: &Config{
+						DefaultAddrs: "1.1.1.1 1.0.0.1", // unchanged
+					},
 				},
 			},
 		},

--- a/internal/experiment/openvpn/openvpn.go
+++ b/internal/experiment/openvpn/openvpn.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	testName        = "openvpn"
-	testVersion     = "0.1.6"
+	testVersion     = "0.1.7"
 	openVPNProtocol = "openvpn"
 )
 
@@ -32,14 +32,14 @@ var (
 // miniooni's -O flag to find them and set them.
 // TODO(ainghazal): do pass Auth, Cipher and Compress to OpenVPN config options.
 type Config struct {
-	Auth        string `ooni:"OpenVPN authentication to use"`
-	Cipher      string `ooni:"OpenVPN cipher to use"`
-	Compress    string `ooni:"OpenVPN compression to use"`
-	Provider    string `ooni:"VPN provider"`
-	Obfuscation string `ooni:"Obfuscation to use (obfs4, none)"`
-	SafeKey     string `ooni:"key to connect to the OpenVPN endpoint"`
-	SafeCert    string `ooni:"cert to connect to the OpenVPN endpoint"`
-	SafeCA      string `ooni:"ca to connect to the OpenVPN endpoint"`
+	Auth        string `json:"auth,omitempty" ooni:"OpenVPN authentication to use"`
+	Cipher      string `json:"cipher,omitempty" ooni:"OpenVPN cipher to use"`
+	Compress    string `json:"compress,omitempty" ooni:"OpenVPN compression to use"`
+	Provider    string `json:"provider,omitempty" ooni:"VPN provider"`
+	Obfuscation string `json:"obfuscation,omitempty" ooni:"Obfuscation to use (obfs4, none)"`
+	SafeKey     string `json:"safe_key,omitempty" ooni:"key to connect to the OpenVPN endpoint"`
+	SafeCert    string `json:"safe_cert,omitempty" ooni:"cert to connect to the OpenVPN endpoint"`
+	SafeCA      string `json:"safe_ca,omitempty" ooni:"ca to connect to the OpenVPN endpoint"`
 }
 
 // TestKeys contains the experiment's result.

--- a/internal/experiment/openvpn/openvpn_test.go
+++ b/internal/experiment/openvpn/openvpn_test.go
@@ -41,7 +41,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if m.ExperimentName() != "openvpn" {
 		t.Fatal("invalid ExperimentName")
 	}
-	if m.ExperimentVersion() != "0.1.6" {
+	if m.ExperimentVersion() != "0.1.7" {
 		t.Fatal("invalid ExperimentVersion")
 	}
 }

--- a/internal/experiment/openvpn/richerinput.go
+++ b/internal/experiment/openvpn/richerinput.go
@@ -90,9 +90,9 @@ func (tl *targetLoader) Load(ctx context.Context) ([]model.ExperimentTarget, err
 
 	// Build the list of targets that we should measure.
 	var targets []model.ExperimentTarget
-	for _, input := range inputs {
+	for i, input := range inputs {
 		targets = append(targets, &Target{
-			Config: tl.options,
+			Config: targetloading.PerInputConfig(tl.loader, tl.options, i),
 			URL:    input,
 		})
 	}

--- a/internal/experiment/openvpn/richerinput_test.go
+++ b/internal/experiment/openvpn/richerinput_test.go
@@ -2,6 +2,7 @@ package openvpn
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -126,6 +127,47 @@ func TestTargetLoaderLoad(t *testing.T) {
 						SafeCA:   "aa",
 						SafeCert: "bb",
 						SafeKey:  "cc",
+					},
+				},
+			},
+		},
+
+		{
+			name: "per-input inputs_extra overlays the experiment-wide config",
+			options: &Config{
+				SafeCA:   "aa",
+				Provider: "base",
+			},
+			loader: &targetloading.Loader{
+				ExperimentName: "openvpn",
+				InputPolicy:    model.InputOrQueryBackend,
+				Logger:         model.DiscardLogger,
+				Session:        &mocks.Session{},
+				StaticInputs: []string{
+					"openvpn://a.corp/1.1.1.1",
+					"openvpn://b.corp/2.2.2.2",
+				},
+				StaticInputsConfig: []json.RawMessage{
+					// overrides the provider for the first input only
+					json.RawMessage(`{"provider":"riseupvpn"}`),
+					// empty config: the second input keeps the wide config
+					json.RawMessage(`{}`),
+				},
+			},
+			expectErr: nil,
+			expectTargets: []model.ExperimentTarget{
+				&Target{
+					URL: "openvpn://a.corp/1.1.1.1",
+					Config: &Config{
+						SafeCA:   "aa",
+						Provider: "riseupvpn",
+					},
+				},
+				&Target{
+					URL: "openvpn://b.corp/2.2.2.2",
+					Config: &Config{
+						SafeCA:   "aa",
+						Provider: "base",
 					},
 				},
 			},

--- a/internal/model/experiment.go
+++ b/internal/model/experiment.go
@@ -279,11 +279,10 @@ type ExperimentTargetLoaderConfig struct {
 	// to the resulting input list if possible.
 	StaticInputs []string
 
-	// StaticInputsExtra contains OPTIONAL richer-input metadata index-aligned
-	// with StaticInputs. When set, len(StaticInputsExtra) SHOULD equal
-	// len(StaticInputs). Only the category code is honored; the country code
-	// stays at its default value.
-	StaticInputsExtra []OOAPIURLInfo
+	// StaticInputsConfig contains OPTIONAL opaque per-input richer-input config
+	// index-aligned with StaticInputs. When set, len(StaticInputsConfig) SHOULD
+	// equal len(StaticInputs).
+	StaticInputsConfig []json.RawMessage
 
 	// SourceFiles contains OPTIONAL files to read input
 	// from. Each file should contain a single input string

--- a/internal/model/experiment.go
+++ b/internal/model/experiment.go
@@ -279,6 +279,12 @@ type ExperimentTargetLoaderConfig struct {
 	// to the resulting input list if possible.
 	StaticInputs []string
 
+	// StaticInputsExtra contains OPTIONAL richer-input metadata index-aligned
+	// with StaticInputs. When set, len(StaticInputsExtra) SHOULD equal
+	// len(StaticInputs). Only the category code is honored; the country code
+	// stays at its default value.
+	StaticInputsExtra []OOAPIURLInfo
+
 	// SourceFiles contains OPTIONAL files to read input
 	// from. Each file should contain a single input string
 	// per line. We will fail if any file is unreadable

--- a/internal/oonirun/experiment.go
+++ b/internal/oonirun/experiment.go
@@ -39,6 +39,11 @@ type Experiment struct {
 	// Inputs contains the OPTIONAL experiment Inputs
 	Inputs []string
 
+	// InputsExtra contains OPTIONAL richer-input metadata index-aligned with
+	// Inputs (e.g., OONI Run v2.1 per-input category codes). When set, its
+	// length SHOULD match the length of Inputs.
+	InputsExtra []model.OOAPIURLInfo
+
 	// InputFilePaths contains OPTIONAL files to read inputs from.
 	InputFilePaths []string
 
@@ -234,9 +239,10 @@ func (ed *Experiment) newTargetLoader(builder model.ExperimentBuilder) targetLoa
 			OnWiFi:   true, // meaning: not on 4G
 			Charging: true,
 		},
-		StaticInputs: ed.Inputs,
-		SourceFiles:  ed.InputFilePaths,
-		Session:      ed.Session,
+		StaticInputs:      ed.Inputs,
+		StaticInputsExtra: ed.InputsExtra,
+		SourceFiles:       ed.InputFilePaths,
+		Session:           ed.Session,
 	})
 }
 

--- a/internal/oonirun/experiment.go
+++ b/internal/oonirun/experiment.go
@@ -39,10 +39,9 @@ type Experiment struct {
 	// Inputs contains the OPTIONAL experiment Inputs
 	Inputs []string
 
-	// InputsExtra contains OPTIONAL richer-input metadata index-aligned with
-	// Inputs (e.g., OONI Run v2.1 per-input category codes). When set, its
-	// length SHOULD match the length of Inputs.
-	InputsExtra []model.OOAPIURLInfo
+	// InputsExtra contains OPTIONAL opaque per-input richer-input config index-aligned
+	// with Inputs. When set, its length SHOULD match the length of Inputs.
+	InputsExtra []json.RawMessage
 
 	// InputFilePaths contains OPTIONAL files to read inputs from.
 	InputFilePaths []string
@@ -239,10 +238,10 @@ func (ed *Experiment) newTargetLoader(builder model.ExperimentBuilder) targetLoa
 			OnWiFi:   true, // meaning: not on 4G
 			Charging: true,
 		},
-		StaticInputs:      ed.Inputs,
-		StaticInputsExtra: ed.InputsExtra,
-		SourceFiles:       ed.InputFilePaths,
-		Session:           ed.Session,
+		StaticInputs:       ed.Inputs,
+		StaticInputsConfig: ed.InputsExtra,
+		SourceFiles:        ed.InputFilePaths,
+		Session:            ed.Session,
 	})
 }
 

--- a/internal/oonirun/link.go
+++ b/internal/oonirun/link.go
@@ -40,6 +40,12 @@ type LinkConfig struct {
 	// credential.
 	NoCredentials bool
 
+	// ProbeCC is the OPTIONAL probe country code.
+	ProbeCC string
+
+	// ProbeASN is the OPTIONAL probe ASN (e.g., "AS1234").
+	ProbeASN string
+
 	// NoJSON OPTIONALLY indicates we don't want to save measurements to a JSON file.
 	NoJSON bool
 
@@ -79,6 +85,8 @@ func (lr *linkRunner) Run(ctx context.Context) error {
 // 2. OONI Run v1 link with ooni scheme (e.g., ooni://nettest?...)
 //
 // 3. arbitrary URL of the OONI Run v2 descriptor.
+//
+// 4. OONI Run v2 engine-descriptor URL (e.g., https://api.ooni.io/api/v2/oonirun/links/{id}/engine-descriptor/{revision})
 func NewLinkRunner(c *LinkConfig, URL string) LinkRunner {
 	// TODO(bassosimone): add support for v2 deeplinks.
 	out := &linkRunner{

--- a/internal/oonirun/v2.go
+++ b/internal/oonirun/v2.go
@@ -66,9 +66,9 @@ type V2Nettest struct {
 	// Inputs contains inputs for the experiment.
 	Inputs []string `json:"inputs"`
 
-	// InputsExtra contains OPTIONAL per-input metadata parallel to Inputs. When
-	// present, its length SHOULD match the length of Inputs.
-	InputsExtra []V2NettestInputExtra `json:"inputs_extra"`
+	// InputsExtra contains OPTIONAL opaque per-input richer-input config parallel
+	// to Inputs. When present, its length SHOULD match the length of Inputs.
+	InputsExtra []json.RawMessage `json:"inputs_extra"`
 
 	// TargetsName OPTIONALLY names a predefined target list that the OONI Run
 	// backend generates dynamically.
@@ -96,14 +96,6 @@ type V2Nettest struct {
 	TestName string `json:"test_name"`
 }
 
-// V2NettestInputExtra contains OPTIONAL per-input metadata attached to an entry
-// of [V2Nettest.Inputs].
-type V2NettestInputExtra struct {
-	// CategoryCode is the OPTIONAL category code for the corresponding input
-	// (e.g., "NEWS", "HUMR"). It maps to [model.OOAPIURLInfo.CategoryCode].
-	CategoryCode string `json:"category_code,omitempty"`
-}
-
 // v2EngineDescriptorRequest is the request body for the OONI Run v2
 // engine-descriptor endpoint.
 type v2EngineDescriptorRequest struct {
@@ -125,19 +117,6 @@ type v2EngineDescriptorRequest struct {
 	// WebsiteCategoryCodes filters the website targets by category code. An
 	// empty slice lets the backend use its default set of categories.
 	WebsiteCategoryCodes []string `json:"website_category_codes"`
-}
-
-// v2NettestInputsExtraToOOAPIURLInfo converts the OONI Run v2 inputs_extra
-// metadata into the index-aligned [model.OOAPIURLInfo] slice.
-func v2NettestInputsExtraToOOAPIURLInfo(inputsExtra []V2NettestInputExtra) []model.OOAPIURLInfo {
-	if len(inputsExtra) <= 0 {
-		return nil
-	}
-	out := make([]model.OOAPIURLInfo, 0, len(inputsExtra))
-	for _, entry := range inputsExtra {
-		out = append(out, model.OOAPIURLInfo{CategoryCode: entry.CategoryCode})
-	}
-	return out
 }
 
 // isV2EngineDescriptorURL returns whether the URL points to an OONI Run v2
@@ -316,7 +295,7 @@ func V2MeasureDescriptor(ctx context.Context, config *LinkConfig, desc *V2Descri
 			ExtraOptions:           make(map[string]any),
 			InitialOptions:         nettest.Options,
 			Inputs:                 nettest.Inputs,
-			InputsExtra:            v2NettestInputsExtraToOOAPIURLInfo(nettest.InputsExtra),
+			InputsExtra:            nettest.InputsExtra,
 			InputFilePaths:         nil,
 			MaxRuntime:             config.MaxRuntime,
 			Name:                   nettest.TestName,

--- a/internal/oonirun/v2.go
+++ b/internal/oonirun/v2.go
@@ -104,6 +104,19 @@ type V2NettestInputExtra struct {
 	CategoryCode string `json:"category_code,omitempty"`
 }
 
+// v2NettestInputsExtraToOOAPIURLInfo converts the OONI Run v2 inputs_extra
+// metadata into the index-aligned [model.OOAPIURLInfo] slice.
+func v2NettestInputsExtraToOOAPIURLInfo(inputsExtra []V2NettestInputExtra) []model.OOAPIURLInfo {
+	if len(inputsExtra) <= 0 {
+		return nil
+	}
+	out := make([]model.OOAPIURLInfo, 0, len(inputsExtra))
+	for _, entry := range inputsExtra {
+		out = append(out, model.OOAPIURLInfo{CategoryCode: entry.CategoryCode})
+	}
+	return out
+}
+
 // getV2DescriptorFromHTTPSURL GETs a v2Descriptor instance from
 // a static URL (e.g., from a GitHub repo or from a Gist).
 func getV2DescriptorFromHTTPSURL(ctx context.Context, client model.HTTPClient,
@@ -234,6 +247,7 @@ func V2MeasureDescriptor(ctx context.Context, config *LinkConfig, desc *V2Descri
 			ExtraOptions:           make(map[string]any),
 			InitialOptions:         nettest.Options,
 			Inputs:                 nettest.Inputs,
+			InputsExtra:            v2NettestInputsExtraToOOAPIURLInfo(nettest.InputsExtra),
 			InputFilePaths:         nil,
 			MaxRuntime:             config.MaxRuntime,
 			Name:                   nettest.TestName,

--- a/internal/oonirun/v2.go
+++ b/internal/oonirun/v2.go
@@ -104,6 +104,29 @@ type V2NettestInputExtra struct {
 	CategoryCode string `json:"category_code,omitempty"`
 }
 
+// v2EngineDescriptorRequest is the request body for the OONI Run v2
+// engine-descriptor endpoint.
+type v2EngineDescriptorRequest struct {
+	// IsCharging indicates whether the probe is charging.
+	IsCharging bool `json:"is_charging"`
+
+	// RunType is either "timed" or "manual".
+	RunType string `json:"run_type"`
+
+	// ProbeCC is the probe country code.
+	ProbeCC string `json:"probe_cc"`
+
+	// ProbeASN is the probe ASN (e.g., "AS1234").
+	ProbeASN string `json:"probe_asn"`
+
+	// NetworkType is the probe network type (e.g., "wifi").
+	NetworkType string `json:"network_type"`
+
+	// WebsiteCategoryCodes filters the website targets by category code. An
+	// empty slice lets the backend use its default set of categories.
+	WebsiteCategoryCodes []string `json:"website_category_codes"`
+}
+
 // v2NettestInputsExtraToOOAPIURLInfo converts the OONI Run v2 inputs_extra
 // metadata into the index-aligned [model.OOAPIURLInfo] slice.
 func v2NettestInputsExtraToOOAPIURLInfo(inputsExtra []V2NettestInputExtra) []model.OOAPIURLInfo {
@@ -115,6 +138,34 @@ func v2NettestInputsExtraToOOAPIURLInfo(inputsExtra []V2NettestInputExtra) []mod
 		out = append(out, model.OOAPIURLInfo{CategoryCode: entry.CategoryCode})
 	}
 	return out
+}
+
+// isV2EngineDescriptorURL returns whether the URL points to an OONI Run v2
+// engine-descriptor endpoint,
+func isV2EngineDescriptorURL(URL string) bool {
+	return strings.Contains(URL, "/oonirun/links/") && strings.Contains(URL, "/engine-descriptor/")
+}
+
+// getV2EngineDescriptor POSTs the probe context to an OONI Run v2 engine-descriptor
+// URL and returns the resulting descriptor.
+func getV2EngineDescriptor(ctx context.Context, config *LinkConfig,
+	client model.HTTPClient, logger model.Logger, URL string) (*V2Descriptor, error) {
+	request := &v2EngineDescriptorRequest{
+		IsCharging:           true,
+		RunType:              string(model.RunTypeManual),
+		ProbeCC:              config.ProbeCC,
+		ProbeASN:             config.ProbeASN,
+		WebsiteCategoryCodes: []string{},
+	}
+	return httpclientx.PostJSON[*v2EngineDescriptorRequest, *V2Descriptor](
+		ctx,
+		httpclientx.NewEndpoint(URL),
+		request,
+		&httpclientx.Config{
+			Client:    client,
+			Logger:    logger,
+			UserAgent: model.HTTPHeaderUserAgent,
+		})
 }
 
 // getV2DescriptorFromHTTPSURL GETs a v2Descriptor instance from
@@ -188,9 +239,15 @@ func v2DescriptorCacheLoad(fsstore model.KeyValueStore) (*v2DescriptorCache, err
 //
 // - ctx is the context for deadline/cancellation;
 //
+// - config is the link config providing the probe context for the POST branch;
+//
 // - client is the HTTPClient to use;
 //
-// - URL is the URL from which to download/update the OONIRun v2Descriptor.
+// - logger is the logger to use;
+//
+// - URL is the URL from which to download/update the OONIRun v2Descriptor;
+//
+// - auth is the OPTIONAL bearer token used for the static-descriptor GET.
 //
 // Return values:
 //
@@ -200,11 +257,22 @@ func v2DescriptorCacheLoad(fsstore model.KeyValueStore) (*v2DescriptorCache, err
 //
 // - err is the error that occurred, or nil in case of success.
 func (cache *v2DescriptorCache) PullChangesWithoutSideEffects(
-	ctx context.Context, client model.HTTPClient, logger model.Logger,
+	ctx context.Context, config *LinkConfig, client model.HTTPClient, logger model.Logger,
 	URL, auth string) (oldValue, newValue *V2Descriptor, err error) {
 	oldValue = cache.Entries[URL]
-	newValue, err = getV2DescriptorFromHTTPSURL(ctx, client, logger, URL, auth)
+	newValue, err = v2FetchDescriptor(ctx, config, client, logger, URL, auth)
 	return
+}
+
+// v2FetchDescriptor fetches a v2Descriptor from the given URL. It switches on
+// the URL shape: an OONI Run v2 engine-descriptor URL is a POST request with the
+// probe context, while any other URL is a GET request.
+func v2FetchDescriptor(ctx context.Context, config *LinkConfig,
+	client model.HTTPClient, logger model.Logger, URL, auth string) (*V2Descriptor, error) {
+	if isV2EngineDescriptorURL(URL) {
+		return getV2EngineDescriptor(ctx, config, client, logger, URL)
+	}
+	return getV2DescriptorFromHTTPSURL(ctx, client, logger, URL, auth)
 }
 
 // Update updates the given cache entry and writes back onto the disk.
@@ -330,7 +398,7 @@ func v2MeasureHTTPS(ctx context.Context, config *LinkConfig, URL string) error {
 	if err != nil {
 		logger.Warnf("oonirun: failed to retrieve auth token: %v", err)
 	}
-	oldValue, newValue, err := cache.PullChangesWithoutSideEffects(ctx, clnt, logger, URL, auth)
+	oldValue, newValue, err := cache.PullChangesWithoutSideEffects(ctx, config, clnt, logger, URL, auth)
 	if err != nil {
 		return err
 	}

--- a/internal/oonirun/v2.go
+++ b/internal/oonirun/v2.go
@@ -155,6 +155,7 @@ func getV2EngineDescriptor(ctx context.Context, config *LinkConfig,
 		RunType:              string(model.RunTypeManual),
 		ProbeCC:              config.ProbeCC,
 		ProbeASN:             config.ProbeASN,
+		NetworkType:          "wifi",
 		WebsiteCategoryCodes: []string{},
 	}
 	return httpclientx.PostJSON[*v2EngineDescriptorRequest, *V2Descriptor](

--- a/internal/oonirun/v2.go
+++ b/internal/oonirun/v2.go
@@ -32,6 +32,10 @@ var (
 	// v2CountFailedExperiments countes the number of failed experiments
 	// and is useful when testing this package
 	v2CountFailedExperiments = &atomic.Int64{}
+
+	// v2CountSkippedNettests counts the number of nettests we skipped because
+	// they were disabled for the current run type, which is useful for testing.
+	v2CountSkippedNettests = &atomic.Int64{}
 )
 
 // V2Descriptor describes a list of nettests to run together.
@@ -47,6 +51,14 @@ type V2Descriptor struct {
 
 	// Nettests contains the list of nettests to run.
 	Nettests []V2Nettest `json:"nettests"`
+
+	// Revision is the OPTIONAL revision of this descriptor as assigned by the
+	// OONI Run backend.
+	Revision string `json:"revision"`
+
+	// DateCreated is the OPTIONAL creation timestamp of this revision as
+	// assigned by the OONI Run backend.
+	DateCreated string `json:"date_created"`
 }
 
 // V2Nettest specifies how a nettest should run.
@@ -54,14 +66,42 @@ type V2Nettest struct {
 	// Inputs contains inputs for the experiment.
 	Inputs []string `json:"inputs"`
 
+	// InputsExtra contains OPTIONAL per-input metadata parallel to Inputs. When
+	// present, its length SHOULD match the length of Inputs.
+	InputsExtra []V2NettestInputExtra `json:"inputs_extra"`
+
+	// TargetsName OPTIONALLY names a predefined target list that the OONI Run
+	// backend generates dynamically.
+	TargetsName string `json:"targets_name"`
+
 	// Options contains the experiment options. Any option name starting with
 	// `Safe` will be available for the experiment run, but omitted from
 	// the serialized Measurement that the experiment builder will submit
 	// to the OONI backend.
+	//
+	// Deprecated: OONI Run v2.1 removes this field from the spec in favour of
+	// inputs_extra/targets_name.
+	// See here: https://github.com/ooni/spec/blob/master/backends/bk-005-ooni-run-v2.md
 	Options json.RawMessage `json:"options"`
+
+	// IsBackgroundRunEnabled OPTIONALLY indicates whether this nettest runs as
+	// part of background/autoruns. A nil value defaults to true.
+	IsBackgroundRunEnabled *bool `json:"is_background_run_enabled"`
+
+	// IsManualRunEnabled OPTIONALLY indicates whether this nettest runs as part
+	// of a manual run. A nil value defaults to true.
+	IsManualRunEnabled *bool `json:"is_manual_run_enabled"`
 
 	// TestName contains the nettest name.
 	TestName string `json:"test_name"`
+}
+
+// V2NettestInputExtra contains OPTIONAL per-input metadata attached to an entry
+// of [V2Nettest.Inputs].
+type V2NettestInputExtra struct {
+	// CategoryCode is the OPTIONAL category code for the corresponding input
+	// (e.g., "NEWS", "HUMR"). It maps to [model.OOAPIURLInfo.CategoryCode].
+	CategoryCode string `json:"category_code,omitempty"`
 }
 
 // getV2DescriptorFromHTTPSURL GETs a v2Descriptor instance from

--- a/internal/oonirun/v2_test.go
+++ b/internal/oonirun/v2_test.go
@@ -845,9 +845,9 @@ func TestV2MeasureEngineDescriptor(t *testing.T) {
 			Revision: "7",
 			Nettests: []V2Nettest{{
 				Inputs: []string{"https://example.com/"},
-				InputsExtra: []V2NettestInputExtra{{
-					CategoryCode: "NEWS",
-				}},
+				InputsExtra: []json.RawMessage{
+					json.RawMessage(`{"category_code":"NEWS"}`),
+				},
 				Options: json.RawMessage(`{
 					"SleepTime": 10000000
 				}`),

--- a/internal/oonirun/v2_test.go
+++ b/internal/oonirun/v2_test.go
@@ -796,3 +796,129 @@ func Test_readFirstLineFromFile(t *testing.T) {
 		}
 	})
 }
+
+func TestIsV2EngineDescriptorURL(t *testing.T) {
+	tests := []struct {
+		name string
+		URL  string
+		want bool
+	}{{
+		name: "engine-descriptor URL",
+		URL:  "https://api.ooni.io/api/v2/oonirun/links/1234/engine-descriptor/7",
+		want: true,
+	}, {
+		name: "CRUD link URL (not runnable)",
+		URL:  "https://api.ooni.io/api/v2/oonirun/links/1234",
+		want: false,
+	}, {
+		name: "full-descriptor URL (GET, not engine-descriptor)",
+		URL:  "https://api.ooni.io/api/v2/oonirun/links/1234/full-descriptor/7",
+		want: false,
+	}, {
+		name: "arbitrary static descriptor URL",
+		URL:  "https://example.com/descriptor.json",
+		want: false,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isV2EngineDescriptorURL(tt.URL); got != tt.want {
+				t.Fatalf("isV2EngineDescriptorURL(%q) = %v, want %v", tt.URL, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestV2MeasureEngineDescriptor(t *testing.T) {
+	// captured is where we record the request that reached the fake backend
+	var (
+		gotMethod  string
+		gotRequest v2EngineDescriptorRequest
+	)
+
+	// make a local server that emulates the engine-descriptor endpoint: it
+	// records the request and returns a descriptor with concrete inputs.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotRequest)
+
+		descriptor := &V2Descriptor{
+			Revision: "7",
+			Nettests: []V2Nettest{{
+				Inputs: []string{"https://example.com/"},
+				InputsExtra: []V2NettestInputExtra{{
+					CategoryCode: "NEWS",
+				}},
+				Options: json.RawMessage(`{
+					"SleepTime": 10000000
+				}`),
+				TestName: "example",
+			}},
+		}
+		data, err := json.Marshal(descriptor)
+		runtimex.PanicOnError(err, "json.Marshal failed")
+		w.Write(data)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+
+	config := &LinkConfig{
+		AcceptChanges: true,
+		Annotations:   map[string]string{"platform": "linux"},
+		KVStore:       &kvstore.Memory{},
+		NoCollector:   true, // disable collector so we don't submit
+		NoJSON:        true,
+		ProbeCC:       "ZZ",
+		ProbeASN:      "AS0",
+		Session:       newMinimalFakeSession(),
+	}
+
+	// the URL shape must be recognized as an engine-descriptor URL so that
+	// NewLinkRunner routes it to the POST-with-context path.
+	engineURL := server.URL + "/api/v2/oonirun/links/1234/engine-descriptor/7"
+	r := NewLinkRunner(config, engineURL)
+
+	if err := r.Run(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// the endpoint MUST be POSTed, not GETed
+	if gotMethod != http.MethodPost {
+		t.Fatalf("expected POST, got %s", gotMethod)
+	}
+
+	// the request body MUST carry the probe context taken from the LinkConfig
+	if gotRequest.ProbeCC != "ZZ" {
+		t.Fatalf("unexpected probe_cc: %q", gotRequest.ProbeCC)
+	}
+	if gotRequest.ProbeASN != "AS0" {
+		t.Fatalf("unexpected probe_asn: %q", gotRequest.ProbeASN)
+	}
+	if gotRequest.RunType != "manual" {
+		t.Fatalf("unexpected run_type: %q", gotRequest.RunType)
+	}
+	if !gotRequest.IsCharging {
+		t.Fatal("expected is_charging to be true")
+	}
+}
+
+func TestV2MeasureEngineDescriptorFetchError(t *testing.T) {
+	// create and immediately cancel the context so the POST fails
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	config := &LinkConfig{
+		AcceptChanges: true,
+		Annotations:   map[string]string{},
+		KVStore:       &kvstore.Memory{},
+		NoCollector:   true,
+		NoJSON:        true,
+		Session:       newMinimalFakeSession(),
+	}
+
+	engineURL := "https://api.ooni.io/api/v2/oonirun/links/1234/engine-descriptor/7"
+	err := v2MeasureHTTPS(ctx, config, engineURL)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+}

--- a/internal/registry/factory.go
+++ b/internal/registry/factory.go
@@ -50,13 +50,14 @@ type Session = model.ExperimentTargetLoaderSession
 func (b *Factory) NewTargetLoader(config *model.ExperimentTargetLoaderConfig) model.ExperimentTargetLoader {
 	// Construct the default loader used in the non-richer input case.
 	loader := &targetloading.Loader{
-		CheckInConfig:  config.CheckInConfig, // OPTIONAL
-		ExperimentName: b.canonicalName,
-		InputPolicy:    b.inputPolicy,
-		Logger:         config.Session.Logger(),
-		Session:        config.Session,
-		StaticInputs:   config.StaticInputs,
-		SourceFiles:    config.SourceFiles,
+		CheckInConfig:     config.CheckInConfig, // OPTIONAL
+		ExperimentName:    b.canonicalName,
+		InputPolicy:       b.inputPolicy,
+		Logger:            config.Session.Logger(),
+		Session:           config.Session,
+		StaticInputs:      config.StaticInputs,
+		StaticInputsExtra: config.StaticInputsExtra,
+		SourceFiles:       config.SourceFiles,
 	}
 
 	// If an experiment implements richer input, it will use its custom loader

--- a/internal/registry/factory.go
+++ b/internal/registry/factory.go
@@ -50,14 +50,14 @@ type Session = model.ExperimentTargetLoaderSession
 func (b *Factory) NewTargetLoader(config *model.ExperimentTargetLoaderConfig) model.ExperimentTargetLoader {
 	// Construct the default loader used in the non-richer input case.
 	loader := &targetloading.Loader{
-		CheckInConfig:     config.CheckInConfig, // OPTIONAL
-		ExperimentName:    b.canonicalName,
-		InputPolicy:       b.inputPolicy,
-		Logger:            config.Session.Logger(),
-		Session:           config.Session,
-		StaticInputs:      config.StaticInputs,
-		StaticInputsExtra: config.StaticInputsExtra,
-		SourceFiles:       config.SourceFiles,
+		CheckInConfig:      config.CheckInConfig, // OPTIONAL
+		ExperimentName:     b.canonicalName,
+		InputPolicy:        b.inputPolicy,
+		Logger:             config.Session.Logger(),
+		Session:            config.Session,
+		StaticInputs:       config.StaticInputs,
+		StaticInputsConfig: config.StaticInputsConfig,
+		SourceFiles:        config.SourceFiles,
 	}
 
 	// If an experiment implements richer input, it will use its custom loader

--- a/internal/targetloading/targetloading.go
+++ b/internal/targetloading/targetloading.go
@@ -4,6 +4,7 @@ package targetloading
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -101,10 +102,10 @@ type Loader struct {
 	// to the resulting input list if possible.
 	StaticInputs []string
 
-	// StaticInputsExtra contains optional richer-input metadata index-aligned
-	// with StaticInputs. Only the category code is honored; the country code
-	// stays at its default value.
-	StaticInputsExtra []model.OOAPIURLInfo
+	// StaticInputsConfig contains optional opaque per-input richer-input config
+	// index-aligned with StaticInputs; richer-input experiments overlay the raw
+	// JSON onto their per-input config.
+	StaticInputsConfig []json.RawMessage
 
 	// SourceFiles contains optional files to read input
 	// from. Each file should contain a single input string
@@ -263,16 +264,24 @@ func (il *Loader) loadLocal() ([]model.ExperimentTarget, error) {
 		return nil, err
 	}
 	var targets []model.ExperimentTarget
-	for idx, input := range inputs {
-		target := model.NewOOAPIURLInfoWithDefaultCategoryAndCountry(input)
-		if idx < len(il.StaticInputs) && idx < len(il.StaticInputsExtra) {
-			if cat := il.StaticInputsExtra[idx].CategoryCode; cat != "" {
-				target.CategoryCode = cat
-			}
-		}
-		targets = append(targets, target)
+	for _, input := range inputs {
+		targets = append(targets, model.NewOOAPIURLInfoWithDefaultCategoryAndCountry(input))
 	}
 	return targets, nil
+}
+
+// PerInputConfig returns a copy of base with the per-input richer-input config
+// overlaid on top.
+func PerInputConfig[T any](loader *Loader, base *T, idx int) *T {
+	config := *base
+	if idx < len(loader.StaticInputs) && idx < len(loader.StaticInputsConfig) {
+		if raw := loader.StaticInputsConfig[idx]; len(raw) > 0 {
+			if err := json.Unmarshal(raw, &config); err != nil {
+				loader.logger().Warnf("targetloading: cannot parse inputs_extra: %s", err.Error())
+			}
+		}
+	}
+	return &config
 }
 
 // openFunc is the type of the function to open a file.

--- a/internal/targetloading/targetloading.go
+++ b/internal/targetloading/targetloading.go
@@ -101,6 +101,11 @@ type Loader struct {
 	// to the resulting input list if possible.
 	StaticInputs []string
 
+	// StaticInputsExtra contains optional richer-input metadata index-aligned
+	// with StaticInputs. Only the category code is honored; the country code
+	// stays at its default value.
+	StaticInputsExtra []model.OOAPIURLInfo
+
 	// SourceFiles contains optional files to read input
 	// from. Each file should contain a single input string
 	// per line. We will fail if any file is unreadable
@@ -258,8 +263,14 @@ func (il *Loader) loadLocal() ([]model.ExperimentTarget, error) {
 		return nil, err
 	}
 	var targets []model.ExperimentTarget
-	for _, input := range inputs {
-		targets = append(targets, model.NewOOAPIURLInfoWithDefaultCategoryAndCountry(input))
+	for idx, input := range inputs {
+		target := model.NewOOAPIURLInfoWithDefaultCategoryAndCountry(input)
+		if idx < len(il.StaticInputs) && idx < len(il.StaticInputsExtra) {
+			if cat := il.StaticInputsExtra[idx].CategoryCode; cat != "" {
+				target.CategoryCode = cat
+			}
+		}
+		targets = append(targets, target)
 	}
 	return targets, nil
 }

--- a/internal/targetloading/targetloading_test.go
+++ b/internal/targetloading/targetloading_test.go
@@ -2,6 +2,7 @@ package targetloading
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"io/fs"
@@ -146,64 +147,34 @@ func TestTargetLoaderInputOptionalWithInput(t *testing.T) {
 	}
 }
 
-func TestTargetLoaderStaticInputsExtra(t *testing.T) {
-	t.Run("category codes are propagated but country codes are ignored", func(t *testing.T) {
-		il := &Loader{
-			StaticInputs: []string{"https://www.google.com/", "https://ooni.org/"},
-			StaticInputsExtra: []model.OOAPIURLInfo{
-				{CategoryCode: "SRCH"},
-				{CategoryCode: "HUMR", CountryCode: "IT"},
-			},
-			InputPolicy: model.InputOptional,
-		}
-		out, err := il.Load(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		expect := []model.ExperimentTarget{
-			&model.OOAPIURLInfo{
-				CountryCode:  model.DefaultCountryCode,
-				CategoryCode: "SRCH",
-				URL:          "https://www.google.com/",
-			},
-			&model.OOAPIURLInfo{
-				CountryCode:  model.DefaultCountryCode,
-				CategoryCode: "HUMR",
-				URL:          "https://ooni.org/",
-			},
-		}
-		if diff := cmp.Diff(expect, out); diff != "" {
-			t.Fatal(diff)
-		}
-	})
-
-	t.Run("source-file inputs keep the default category and a shorter extra slice falls back", func(t *testing.T) {
-		il := &Loader{
-			StaticInputs: []string{"https://www.google.com/"},
-			StaticInputsExtra: []model.OOAPIURLInfo{
-				{CategoryCode: "SRCH"},
-			},
-			SourceFiles: []string{"testdata/loader1.txt"},
-			InputPolicy: model.InputOptional,
-		}
-		out, err := il.Load(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(out) < 2 {
-			t.Fatal("expected the static input plus at least one file input")
-		}
-		// the first entry is the static input and must carry its category code
-		if out[0].Input() != "https://www.google.com/" || out[0].Category() != "SRCH" {
-			t.Fatal("static input did not get its category code", out[0])
-		}
-		// every subsequent entry comes from the source file and must be default category
-		for _, e := range out[1:] {
-			if e.Category() != model.DefaultCategoryCode {
-				t.Fatal("source-file input should have the default category", e)
-			}
-		}
-	})
+func TestTargetLoaderIgnoresStaticInputsConfig(t *testing.T) {
+	il := &Loader{
+		StaticInputs: []string{"https://www.google.com/", "https://ooni.org/"},
+		StaticInputsConfig: []json.RawMessage{
+			json.RawMessage(`{"category_code":"SRCH"}`),
+			json.RawMessage(`{"category_code":"HUMR","country_code":"IT"}`),
+		},
+		InputPolicy: model.InputOptional,
+	}
+	out, err := il.Load(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	expect := []model.ExperimentTarget{
+		&model.OOAPIURLInfo{
+			CountryCode:  model.DefaultCountryCode,
+			CategoryCode: model.DefaultCategoryCode,
+			URL:          "https://www.google.com/",
+		},
+		&model.OOAPIURLInfo{
+			CountryCode:  model.DefaultCountryCode,
+			CategoryCode: model.DefaultCategoryCode,
+			URL:          "https://ooni.org/",
+		},
+	}
+	if diff := cmp.Diff(expect, out); diff != "" {
+		t.Fatal(diff)
+	}
 }
 
 func TestTargetLoaderInputOptionalNonexistentFile(t *testing.T) {

--- a/internal/targetloading/targetloading_test.go
+++ b/internal/targetloading/targetloading_test.go
@@ -146,6 +146,66 @@ func TestTargetLoaderInputOptionalWithInput(t *testing.T) {
 	}
 }
 
+func TestTargetLoaderStaticInputsExtra(t *testing.T) {
+	t.Run("category codes are propagated but country codes are ignored", func(t *testing.T) {
+		il := &Loader{
+			StaticInputs: []string{"https://www.google.com/", "https://ooni.org/"},
+			StaticInputsExtra: []model.OOAPIURLInfo{
+				{CategoryCode: "SRCH"},
+				{CategoryCode: "HUMR", CountryCode: "IT"},
+			},
+			InputPolicy: model.InputOptional,
+		}
+		out, err := il.Load(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect := []model.ExperimentTarget{
+			&model.OOAPIURLInfo{
+				CountryCode:  model.DefaultCountryCode,
+				CategoryCode: "SRCH",
+				URL:          "https://www.google.com/",
+			},
+			&model.OOAPIURLInfo{
+				CountryCode:  model.DefaultCountryCode,
+				CategoryCode: "HUMR",
+				URL:          "https://ooni.org/",
+			},
+		}
+		if diff := cmp.Diff(expect, out); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
+	t.Run("source-file inputs keep the default category and a shorter extra slice falls back", func(t *testing.T) {
+		il := &Loader{
+			StaticInputs: []string{"https://www.google.com/"},
+			StaticInputsExtra: []model.OOAPIURLInfo{
+				{CategoryCode: "SRCH"},
+			},
+			SourceFiles: []string{"testdata/loader1.txt"},
+			InputPolicy: model.InputOptional,
+		}
+		out, err := il.Load(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(out) < 2 {
+			t.Fatal("expected the static input plus at least one file input")
+		}
+		// the first entry is the static input and must carry its category code
+		if out[0].Input() != "https://www.google.com/" || out[0].Category() != "SRCH" {
+			t.Fatal("static input did not get its category code", out[0])
+		}
+		// every subsequent entry comes from the source file and must be default category
+		for _, e := range out[1:] {
+			if e.Category() != model.DefaultCategoryCode {
+				t.Fatal("source-file input should have the default category", e)
+			}
+		}
+	})
+}
+
 func TestTargetLoaderInputOptionalNonexistentFile(t *testing.T) {
 	il := &Loader{
 		StaticInputs: []string{"https://www.google.com/"},


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe-cli/issues/1717
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff adds support to fetch run descriptors using the engine descriptor URLs as described in oonirun v2.1
