### PR TITLE
feat: support richer-input config as `InputsExtra` for oonimkall tasks

### DIFF
--- a/pkg/oonimkall/taskmodel.go
+++ b/pkg/oonimkall/taskmodel.go
@@ -19,6 +19,7 @@ package oonimkall
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 
 	"github.com/ooni/probe-cli/v3/internal/model"
@@ -258,6 +259,10 @@ type settings struct {
 	// Inputs contains the inputs. The task will fail if it
 	// requires input and you provide no input.
 	Inputs []string `json:"inputs,omitempty"`
+
+	// InputsExtra contains OPTIONAL opaque per-input richer-input config
+	// index-aligned with Inputs.
+	InputsExtra []json.RawMessage `json:"inputs_extra,omitempty"`
 
 	// LogLevel contains the logs level. See https://git.io/Jv4Rv
 	// for the names of the available log levels.

--- a/pkg/oonimkall/taskrunner.go
+++ b/pkg/oonimkall/taskrunner.go
@@ -200,9 +200,10 @@ func (r *runnerForTask) Run(rootCtx context.Context) {
 			// TODO(https://github.com/ooni/probe/issues/2766): to correctly load Web Connectivity targets
 			// here we need to honour the relevant check-in settings.
 		},
-		Session:      sess,
-		StaticInputs: r.settings.Inputs,
-		SourceFiles:  []string{},
+		Session:            sess,
+		StaticInputs:       r.settings.Inputs,
+		StaticInputsConfig: r.settings.InputsExtra,
+		SourceFiles:        []string{},
 	})
 	loadCtx, loadCancel := context.WithTimeout(rootCtx, 30*time.Second)
 	defer loadCancel()

--- a/pkg/oonimkall/taskrunner_test.go
+++ b/pkg/oonimkall/taskrunner_test.go
@@ -2,6 +2,7 @@ package oonimkall
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -397,6 +398,40 @@ func TestTaskRunnerRun(t *testing.T) {
 			{Key: eventTypeStatusEnd, Count: 1},
 		}
 		assertReducedEventsLike(t, expect, reduced)
+	})
+
+	t.Run("passes inputs_extra to the target loader as StaticInputsConfig", func(t *testing.T) {
+		runner, emitter := newRunnerForTesting()
+
+		// configure per-input richer-input config on the settings
+		inputsExtra := []json.RawMessage{
+			json.RawMessage(`{"provider":"riseupvpn"}`),
+		}
+		runner.settings.Inputs = []string{"openvpn://x.corp/1.1.1.1"}
+		runner.settings.InputsExtra = inputsExtra
+
+		fake := fakeSuccessfulDeps()
+
+		// capture the loader config and short-circuit by failing the load
+		var gotConfig *model.ExperimentTargetLoaderConfig
+		fake.Builder.MockNewTargetLoader = func(config *model.ExperimentTargetLoaderConfig) model.ExperimentTargetLoader {
+			gotConfig = config
+			return &mocks.ExperimentTargetLoader{
+				MockLoad: func(ctx context.Context) ([]model.ExperimentTarget, error) {
+					return nil, errors.New("stop here")
+				},
+			}
+		}
+		runner.newSession = fake.NewSession
+
+		_ = runAndCollect(runner, emitter)
+
+		if gotConfig == nil {
+			t.Fatal("the target loader was never created")
+		}
+		if diff := cmp.Diff(inputsExtra, gotConfig.StaticInputsConfig); diff != "" {
+			t.Fatal(diff)
+		}
 	})
 
 	t.Run("with failure opening report", func(t *testing.T) {


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe-cli/issues/1717
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff introduces `InputsExtra` to the task model which passes the value to the `StaticInputsConfig` to the `ExperimentTargetLoaderConfig`.  Related to https://github.com/ooni/probe-multiplatform/pull/1504
