### PR TITLE
chore: upgrade userauth to v0.1.6

### DIFF
--- a/internal/cmd/buildtool/linuxstatic_test.go
+++ b/internal/cmd/buildtool/linuxstatic_test.go
@@ -24,7 +24,7 @@ func TestLinuxStaticBuildAll(t *testing.T) {
 		return filepath.Join(faketopdir, "internal", "userauth", "lib", "linux", archDir)
 	}
 	userauthInc := filepath.Join(faketopdir, "internal", "userauth", "lib", "include")
-	tarball := "v0.1.5.tar.gz"
+	tarball := "v0.1.6.tar.gz"
 	srcURL := "https://github.com/ooni/ooniprobe-rs/archive/" + tarball
 
 	// userauthExpect returns the userauth build commands for one arch dir.

--- a/internal/cmd/buildtool/userauth.go
+++ b/internal/cmd/buildtool/userauth.go
@@ -33,7 +33,7 @@ const (
 
 	// userauthVersion is the ooniprobe-rs release we use for BOTH the from-source
 	// build and the prebuilt bundle download.
-	userauthVersion = "0.1.5"
+	userauthVersion = "0.1.6"
 
 	// userauthSourceSHA256 pins the source tarball for userauthVersion.
 	userauthSourceSHA256 = "629aff29a75592280ec65c51ad2e22520bae89b26cd403b3a7fafe36d808b751"

--- a/internal/cmd/buildtool/userauth_test.go
+++ b/internal/cmd/buildtool/userauth_test.go
@@ -18,7 +18,7 @@ func TestUserauthBuildStaticlib(t *testing.T) {
 	}
 	incdir := filepath.Join(faketopdir, "internal", "userauth", "lib", "include")
 	header := filepath.Join(incdir, "ooniprobe_userauth.h")
-	tarball := "v0.1.5.tar.gz"
+	tarball := "v0.1.6.tar.gz"
 	srcURL := "https://github.com/ooni/ooniprobe-rs/archive/" + tarball
 
 	// cbindgen returns the header generation command, which does not vary
@@ -267,7 +267,7 @@ func TestUserauthDownloadPrebuilt(t *testing.T) {
 		Env: []string{},
 		Argv: []string{
 			"curl", "-fsSLO",
-			"https://github.com/ooni/ooniprobe-rs/releases/download/v0.1.5/staticlib.tar.gz",
+			"https://github.com/ooni/ooniprobe-rs/releases/download/v0.1.6/staticlib.tar.gz",
 		},
 	}, {
 		Env: []string{},


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [ ] reference issue for this pull request: <!-- add URL here -->
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [ ] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff upgrades the anonymous credentials client package to the latest v0.1.6, which support connection pooling. 
