### PR TITLE
feat: extend richer input support to nettests

### DIFF
--- a/internal/experiment/quicping/quicping.go
+++ b/internal/experiment/quicping/quicping.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/legacy/legacymodel"
 	"github.com/ooni/probe-cli/v3/internal/legacy/tracex"
 	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/targetloading"
 )
 
 // A connectionID in QUIC
@@ -36,13 +37,21 @@ const (
 	testVersion = "0.1.1"
 )
 
+var (
+	// ErrInputRequired indicates that no richer-input target was provided.
+	ErrInputRequired = targetloading.ErrInputRequired
+
+	// ErrInvalidInputType indicates that the richer-input target has the wrong type.
+	ErrInvalidInputType = targetloading.ErrInvalidInputType
+)
+
 // Config contains the experiment configuration.
 type Config struct {
 	// Repetitions is the number of repetitions for each ping.
-	Repetitions int64 `ooni:"number of times to repeat the measurement"`
+	Repetitions int64 `json:"repetitions,omitempty" ooni:"number of times to repeat the measurement"`
 
 	// Port is the port to test.
-	Port int64 `ooni:"port is the port to test"`
+	Port int64 `json:"port,omitempty" ooni:"port is the port to test"`
 
 	// netListenUDP allows mocking the real net.ListenUDP call
 	netListenUDP func(network string, laddr *net.UDPAddr) (model.UDPLikeConn, error)
@@ -109,9 +118,7 @@ func makeResponse(resp *responseInfo) *SinglePingResponse {
 }
 
 // Measurer performs the measurement.
-type Measurer struct {
-	config Config
-}
+type Measurer struct{}
 
 // ExperimentName implements ExperimentMeasurer.ExperimentName.
 func (m *Measurer) ExperimentName() string {
@@ -151,6 +158,7 @@ type responseInfo struct {
 // sender sends a ping requests to the target hosts every second
 func (m *Measurer) sender(
 	ctx context.Context,
+	config *Config,
 	pconn model.UDPLikeConn,
 	destAddr *net.UDPAddr,
 	out chan<- requestInfo,
@@ -160,7 +168,7 @@ func (m *Measurer) sender(
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
-	for i := int64(0); i < m.config.repetitions(); i++ {
+	for i := int64(0); i < config.repetitions(); i++ {
 		select {
 		case <-ctx.Done():
 			return // user aborted or timeout expired
@@ -227,7 +235,17 @@ func (m *Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	measurement := args.Measurement
 	sess := args.Session
 
-	host := string(measurement.Input)
+	// obtain the richer-input target
+	if args.Target == nil {
+		return ErrInputRequired
+	}
+	target, ok := args.Target.(*Target)
+	if !ok {
+		return ErrInvalidInputType
+	}
+	config := target.Config
+
+	host := target.URL
 	var port = ""
 	// allow URL input
 	if u, err := url.ParseRequestURI(host); err == nil {
@@ -236,14 +254,14 @@ func (m *Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	}
 	var service string
 	if port == "" {
-		port = m.config.port()
+		port = config.port()
 	}
 	service = net.JoinHostPort(host, port)
 	udpAddr, err := net.ResolveUDPAddr("udp", service)
 	if err != nil {
 		return err
 	}
-	rep := m.config.repetitions()
+	rep := config.repetitions()
 	tk := &TestKeys{
 		Domain:      host,
 		Repetitions: rep,
@@ -251,7 +269,7 @@ func (m *Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	measurement.TestKeys = tk
 
 	// create UDP socket
-	pconn, err := m.config.doListenUDP("udp", &net.UDPAddr{})
+	pconn, err := config.doListenUDP("udp", &net.UDPAddr{})
 	if err != nil {
 		return err
 	}
@@ -268,7 +286,7 @@ func (m *Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	pingMap := make(map[string]*pingInfo)
 
 	// start sender and receiver goroutines
-	go m.sender(ctx, pconn, udpAddr, sendInfoChan, sess, measurement)
+	go m.sender(ctx, config, pconn, udpAddr, sendInfoChan, sess, measurement)
 	go m.receiver(ctx, pconn, recvInfoChan, sess, measurement)
 L:
 	for {
@@ -344,6 +362,6 @@ L:
 }
 
 // NewExperimentMeasurer creates a new ExperimentMeasurer.
-func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
-	return &Measurer{config: config}
+func NewExperimentMeasurer() model.ExperimentMeasurer {
+	return &Measurer{}
 }

--- a/internal/experiment/quicping/quicping.go
+++ b/internal/experiment/quicping/quicping.go
@@ -34,7 +34,7 @@ const (
 
 const (
 	testName    = "quicping"
-	testVersion = "0.1.1"
+	testVersion = "0.1.2"
 )
 
 var (

--- a/internal/experiment/quicping/quicping_test.go
+++ b/internal/experiment/quicping/quicping_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestNewExperimentMeasurer(t *testing.T) {
-	measurer := NewExperimentMeasurer(Config{})
+	measurer := NewExperimentMeasurer()
 	if measurer.ExperimentName() != "quicping" {
 		t.Fatal("unexpected name")
 	}
@@ -26,10 +26,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 }
 
 func TestInvalidHost(t *testing.T) {
-	measurer := NewExperimentMeasurer(Config{
-		Port:        443,
-		Repetitions: 1,
-	})
+	measurer := NewExperimentMeasurer()
 	measurement := new(model.Measurement)
 	measurement.Input = model.MeasurementInput("a.a.a.a")
 	sess := &mockable.Session{MockableLogger: log.Log}
@@ -37,6 +34,13 @@ func TestInvalidHost(t *testing.T) {
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
 		Measurement: measurement,
 		Session:     sess,
+		Target: &Target{
+			Config: &Config{
+				Port:        443,
+				Repetitions: 1,
+			},
+			URL: "a.a.a.a",
+		},
 	}
 	err := measurer.Run(context.Background(), args)
 	if err == nil {
@@ -51,9 +55,7 @@ func TestURLInput(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip test in short mode")
 	}
-	measurer := NewExperimentMeasurer(Config{
-		Repetitions: 1,
-	})
+	measurer := NewExperimentMeasurer()
 	measurement := new(model.Measurement)
 	measurement.Input = model.MeasurementInput("https://google.com/")
 	sess := &mockable.Session{MockableLogger: log.Log}
@@ -61,6 +63,12 @@ func TestURLInput(t *testing.T) {
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
 		Measurement: measurement,
 		Session:     sess,
+		Target: &Target{
+			Config: &Config{
+				Repetitions: 1,
+			},
+			URL: "https://google.com/",
+		},
 	}
 	err := measurer.Run(context.Background(), args)
 	if err != nil {
@@ -77,7 +85,7 @@ func TestSuccess(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip test in short mode")
 	}
-	measurer := NewExperimentMeasurer(Config{})
+	measurer := NewExperimentMeasurer()
 	measurement := new(model.Measurement)
 	measurement.Input = model.MeasurementInput("google.com")
 	sess := &mockable.Session{MockableLogger: log.Log}
@@ -85,6 +93,10 @@ func TestSuccess(t *testing.T) {
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
 		Measurement: measurement,
 		Session:     sess,
+		Target: &Target{
+			Config: &Config{},
+			URL:    "google.com",
+		},
 	}
 	err := measurer.Run(context.Background(), args)
 	if err != nil {
@@ -120,7 +132,7 @@ func TestWithCancelledContext(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 
-	measurer := NewExperimentMeasurer(Config{})
+	measurer := NewExperimentMeasurer()
 	measurement := new(model.Measurement)
 	measurement.Input = model.MeasurementInput("google.com")
 	sess := &mockable.Session{MockableLogger: log.Log}
@@ -130,6 +142,10 @@ func TestWithCancelledContext(t *testing.T) {
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
 		Measurement: measurement,
 		Session:     sess,
+		Target: &Target{
+			Config: &Config{},
+			URL:    "google.com",
+		},
 	}
 	err := measurer.Run(ctx, args)
 	if err != nil {
@@ -147,11 +163,7 @@ func TestListenFails(t *testing.T) {
 	}
 
 	expected := errors.New("expected")
-	measurer := NewExperimentMeasurer(Config{
-		netListenUDP: func(network string, laddr *net.UDPAddr) (model.UDPLikeConn, error) {
-			return nil, expected
-		},
-	})
+	measurer := NewExperimentMeasurer()
 	measurement := new(model.Measurement)
 	measurement.Input = model.MeasurementInput("google.com")
 	sess := &mockable.Session{MockableLogger: log.Log}
@@ -159,6 +171,14 @@ func TestListenFails(t *testing.T) {
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
 		Measurement: measurement,
 		Session:     sess,
+		Target: &Target{
+			Config: &Config{
+				netListenUDP: func(network string, laddr *net.UDPAddr) (model.UDPLikeConn, error) {
+					return nil, expected
+				},
+			},
+			URL: "google.com",
+		},
 	}
 	err := measurer.Run(context.Background(), args)
 	if err == nil {
@@ -194,12 +214,7 @@ func TestWriteFails(t *testing.T) {
 			return 0, expected
 		},
 	}
-	measurer := NewExperimentMeasurer(Config{
-		netListenUDP: func(network string, laddr *net.UDPAddr) (model.UDPLikeConn, error) {
-			return pconn, nil
-		},
-		Repetitions: 1,
-	})
+	measurer := NewExperimentMeasurer()
 	measurement := new(model.Measurement)
 	measurement.Input = model.MeasurementInput("google.com")
 	sess := &mockable.Session{MockableLogger: log.Log}
@@ -207,6 +222,15 @@ func TestWriteFails(t *testing.T) {
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
 		Measurement: measurement,
 		Session:     sess,
+		Target: &Target{
+			Config: &Config{
+				netListenUDP: func(network string, laddr *net.UDPAddr) (model.UDPLikeConn, error) {
+					return pconn, nil
+				},
+				Repetitions: 1,
+			},
+			URL: "google.com",
+		},
 	}
 	err := measurer.Run(context.Background(), args)
 	if err != nil {
@@ -255,12 +279,7 @@ func TestReadFails(t *testing.T) {
 			return len(p), nil
 		},
 	}
-	measurer := NewExperimentMeasurer(Config{
-		netListenUDP: func(network string, laddr *net.UDPAddr) (model.UDPLikeConn, error) {
-			return pconn, nil
-		},
-		Repetitions: 1,
-	})
+	measurer := NewExperimentMeasurer()
 	measurement := new(model.Measurement)
 	measurement.Input = model.MeasurementInput("google.com")
 	sess := &mockable.Session{MockableLogger: log.Log}
@@ -268,6 +287,15 @@ func TestReadFails(t *testing.T) {
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
 		Measurement: measurement,
 		Session:     sess,
+		Target: &Target{
+			Config: &Config{
+				netListenUDP: func(network string, laddr *net.UDPAddr) (model.UDPLikeConn, error) {
+					return pconn, nil
+				},
+				Repetitions: 1,
+			},
+			URL: "google.com",
+		},
 	}
 	err := measurer.Run(context.Background(), args)
 	if err != nil {
@@ -294,9 +322,7 @@ func TestNoResponse(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip test in short mode")
 	}
-	measurer := NewExperimentMeasurer(Config{
-		Repetitions: 1,
-	})
+	measurer := NewExperimentMeasurer()
 	measurement := new(model.Measurement)
 	measurement.Input = model.MeasurementInput("ooni.org")
 	sess := &mockable.Session{MockableLogger: log.Log}
@@ -304,6 +330,12 @@ func TestNoResponse(t *testing.T) {
 		Callbacks:   model.NewPrinterCallbacks(log.Log),
 		Measurement: measurement,
 		Session:     sess,
+		Target: &Target{
+			Config: &Config{
+				Repetitions: 1,
+			},
+			URL: "ooni.org",
+		},
 	}
 	err := measurer.Run(context.Background(), args)
 	if err != nil {
@@ -324,7 +356,7 @@ func TestNoResponse(t *testing.T) {
 func TestDissect(t *testing.T) {
 	// destID--srcID: 040b9649d3fd4c038ab6c073966f3921--44d064031288e97646451f
 	versionNegotiationResponse, _ := hex.DecodeString("eb0000000010040b9649d3fd4c038ab6c073966f39210b44d064031288e97646451f00000001ff00001dff00001cff00001b")
-	measurer := NewExperimentMeasurer(Config{})
+	measurer := NewExperimentMeasurer()
 	destID := "040b9649d3fd4c038ab6c073966f3921"
 	_, dst, err := measurer.(*Measurer).dissectVersionNegotiation(versionNegotiationResponse)
 	if err != nil {

--- a/internal/experiment/quicping/quicping_test.go
+++ b/internal/experiment/quicping/quicping_test.go
@@ -20,7 +20,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "quicping" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.1.1" {
+	if measurer.ExperimentVersion() != "0.1.2" {
 		t.Fatal("unexpected version")
 	}
 }

--- a/internal/experiment/quicping/richerinput.go
+++ b/internal/experiment/quicping/richerinput.go
@@ -1,0 +1,91 @@
+package quicping
+
+import (
+	"context"
+
+	"github.com/ooni/probe-cli/v3/internal/experimentconfig"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/targetloading"
+)
+
+// Target is a richer-input target that this experiment should measure.
+type Target struct {
+	// Config contains the configuration.
+	Config *Config
+
+	// URL is the input URL.
+	URL string
+}
+
+var _ model.ExperimentTarget = &Target{}
+
+// Category implements [model.ExperimentTarget].
+func (t *Target) Category() string {
+	return model.DefaultCategoryCode
+}
+
+// Country implements [model.ExperimentTarget].
+func (t *Target) Country() string {
+	return model.DefaultCountryCode
+}
+
+// Input implements [model.ExperimentTarget].
+func (t *Target) Input() string {
+	return t.URL
+}
+
+// Options implements [model.ExperimentTarget].
+func (t *Target) Options() []string {
+	return experimentconfig.DefaultOptionsSerializer(t.Config)
+}
+
+// String implements [model.ExperimentTarget].
+func (t *Target) String() string {
+	return t.URL
+}
+
+// NewLoader constructs a new [model.ExperimentTargetLoader] instance.
+//
+// This function PANICS if options is not an instance of [*quicping.Config].
+func NewLoader(loader *targetloading.Loader, gopts any) model.ExperimentTargetLoader {
+	// Panic if we cannot convert the options to the expected type.
+	//
+	// We do not expect a panic here because the type is managed by the registry package.
+	options := gopts.(*Config)
+
+	return &targetLoader{
+		loader:  loader,
+		options: options,
+	}
+}
+
+// targetLoader loads targets for this experiment.
+type targetLoader struct {
+	loader  *targetloading.Loader
+	options *Config
+}
+
+// Load implements model.ExperimentTargetLoader.
+func (tl *targetLoader) Load(ctx context.Context) ([]model.ExperimentTarget, error) {
+	// Load the static inputs from CLI and files.
+	inputs, err := targetloading.LoadStatic(tl.loader)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the list of targets. Each target starts from the experiment-wide
+	// config with any per-input inputs_extra overlaid on top.
+	var targets []model.ExperimentTarget
+	for i, input := range inputs {
+		targets = append(targets, &Target{
+			Config: targetloading.PerInputConfig(tl.loader, tl.options, i),
+			URL:    input,
+		})
+	}
+
+	// This experiment strictly requires input, so error out when there's none.
+	if len(targets) <= 0 {
+		return nil, ErrInputRequired
+	}
+	return targets, nil
+}

--- a/internal/experiment/quicping/richerinput_test.go
+++ b/internal/experiment/quicping/richerinput_test.go
@@ -1,0 +1,159 @@
+package quicping
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/ooni/probe-cli/v3/internal/mocks"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/targetloading"
+)
+
+func TestTarget(t *testing.T) {
+	target := &Target{
+		URL: "8.8.8.8",
+		Config: &Config{
+			Port:        443,
+			Repetitions: 4,
+		},
+	}
+
+	t.Run("Category", func(t *testing.T) {
+		if target.Category() != model.DefaultCategoryCode {
+			t.Fatal("invalid Category")
+		}
+	})
+
+	t.Run("Country", func(t *testing.T) {
+		if target.Country() != model.DefaultCountryCode {
+			t.Fatal("invalid Country")
+		}
+	})
+
+	t.Run("Input", func(t *testing.T) {
+		if target.Input() != "8.8.8.8" {
+			t.Fatal("invalid Input")
+		}
+	})
+
+	t.Run("Options", func(t *testing.T) {
+		expect := []string{"Repetitions=4", "Port=443"}
+		if diff := cmp.Diff(expect, target.Options()); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
+	t.Run("String", func(t *testing.T) {
+		if target.String() != "8.8.8.8" {
+			t.Fatal("invalid String")
+		}
+	})
+}
+
+func TestNewLoader(t *testing.T) {
+	child := &targetloading.Loader{}
+	options := &Config{}
+	loader := NewLoader(child, options).(*targetLoader)
+	if child != loader.loader {
+		t.Fatal("invalid loader pointer")
+	}
+	if options != loader.options {
+		t.Fatal("invalid options pointer")
+	}
+}
+
+func TestTargetLoaderLoad(t *testing.T) {
+	type testcase struct {
+		name          string
+		options       *Config
+		loader        *targetloading.Loader
+		expectErr     error
+		expectTargets []model.ExperimentTarget
+	}
+
+	cases := []testcase{
+		{
+			name:    "with options and inputs",
+			options: &Config{Repetitions: 3},
+			loader: &targetloading.Loader{
+				ExperimentName: "quicping",
+				InputPolicy:    model.InputStrictlyRequired,
+				Logger:         model.DiscardLogger,
+				Session:        &mocks.Session{},
+				StaticInputs:   []string{"1.1.1.1"},
+			},
+			expectErr: nil,
+			expectTargets: []model.ExperimentTarget{
+				&Target{
+					URL:    "1.1.1.1",
+					Config: &Config{Repetitions: 3},
+				},
+			},
+		},
+
+		{
+			name:    "per-input inputs_extra overlays the experiment-wide config",
+			options: &Config{Repetitions: 3},
+			loader: &targetloading.Loader{
+				ExperimentName: "quicping",
+				InputPolicy:    model.InputStrictlyRequired,
+				Logger:         model.DiscardLogger,
+				Session:        &mocks.Session{},
+				StaticInputs: []string{
+					"1.1.1.1",
+					"8.8.8.8",
+				},
+				StaticInputsConfig: []json.RawMessage{
+					json.RawMessage(`{"port":8443}`),
+					json.RawMessage(`{}`),
+				},
+			},
+			expectErr: nil,
+			expectTargets: []model.ExperimentTarget{
+				&Target{
+					URL:    "1.1.1.1",
+					Config: &Config{Repetitions: 3, Port: 8443}, // overridden per-input
+				},
+				&Target{
+					URL:    "8.8.8.8",
+					Config: &Config{Repetitions: 3}, // unchanged
+				},
+			},
+		},
+
+		{
+			name:    "no input errors because input is strictly required",
+			options: &Config{},
+			loader: &targetloading.Loader{
+				ExperimentName: "quicping",
+				InputPolicy:    model.InputStrictlyRequired,
+				Logger:         model.DiscardLogger,
+				Session:        &mocks.Session{},
+			},
+			expectErr:     targetloading.ErrInputRequired,
+			expectTargets: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tl := &targetLoader{
+				loader:  tc.loader,
+				options: tc.options,
+			}
+			targets, err := tl.Load(context.Background())
+			if !errors.Is(err, tc.expectErr) {
+				t.Fatal("unexpected error", err)
+			}
+			// Config carries an unexported func field (netListenUDP) that cmp
+			// cannot compare, so ignore unexported fields here.
+			if diff := cmp.Diff(tc.expectTargets, targets, cmpopts.IgnoreUnexported(Config{})); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/internal/experiment/simplequicping/richerinput.go
+++ b/internal/experiment/simplequicping/richerinput.go
@@ -1,0 +1,91 @@
+package simplequicping
+
+import (
+	"context"
+
+	"github.com/ooni/probe-cli/v3/internal/experimentconfig"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/targetloading"
+)
+
+// Target is a richer-input target that this experiment should measure.
+type Target struct {
+	// Config contains the configuration.
+	Config *Config
+
+	// URL is the input URL.
+	URL string
+}
+
+var _ model.ExperimentTarget = &Target{}
+
+// Category implements [model.ExperimentTarget].
+func (t *Target) Category() string {
+	return model.DefaultCategoryCode
+}
+
+// Country implements [model.ExperimentTarget].
+func (t *Target) Country() string {
+	return model.DefaultCountryCode
+}
+
+// Input implements [model.ExperimentTarget].
+func (t *Target) Input() string {
+	return t.URL
+}
+
+// Options implements [model.ExperimentTarget].
+func (t *Target) Options() []string {
+	return experimentconfig.DefaultOptionsSerializer(t.Config)
+}
+
+// String implements [model.ExperimentTarget].
+func (t *Target) String() string {
+	return t.URL
+}
+
+// NewLoader constructs a new [model.ExperimentTargetLoader] instance.
+//
+// This function PANICS if options is not an instance of [*simplequicping.Config].
+func NewLoader(loader *targetloading.Loader, gopts any) model.ExperimentTargetLoader {
+	// Panic if we cannot convert the options to the expected type.
+	//
+	// We do not expect a panic here because the type is managed by the registry package.
+	options := gopts.(*Config)
+
+	return &targetLoader{
+		loader:  loader,
+		options: options,
+	}
+}
+
+// targetLoader loads targets for this experiment.
+type targetLoader struct {
+	loader  *targetloading.Loader
+	options *Config
+}
+
+// Load implements model.ExperimentTargetLoader.
+func (tl *targetLoader) Load(ctx context.Context) ([]model.ExperimentTarget, error) {
+	// Load the static inputs from CLI and files.
+	inputs, err := targetloading.LoadStatic(tl.loader)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the list of targets. Each target starts from the experiment-wide
+	// config with any per-input inputs_extra overlaid on top.
+	var targets []model.ExperimentTarget
+	for i, input := range inputs {
+		targets = append(targets, &Target{
+			Config: targetloading.PerInputConfig(tl.loader, tl.options, i),
+			URL:    input,
+		})
+	}
+
+	// This experiment strictly requires input, so error out when there's none.
+	if len(targets) <= 0 {
+		return nil, ErrInputRequired
+	}
+	return targets, nil
+}

--- a/internal/experiment/simplequicping/richerinput_test.go
+++ b/internal/experiment/simplequicping/richerinput_test.go
@@ -1,0 +1,156 @@
+package simplequicping
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/probe-cli/v3/internal/mocks"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/targetloading"
+)
+
+func TestTarget(t *testing.T) {
+	target := &Target{
+		URL: "quichandshake://8.8.8.8:443",
+		Config: &Config{
+			ALPN:        "h3",
+			Repetitions: 4,
+		},
+	}
+
+	t.Run("Category", func(t *testing.T) {
+		if target.Category() != model.DefaultCategoryCode {
+			t.Fatal("invalid Category")
+		}
+	})
+
+	t.Run("Country", func(t *testing.T) {
+		if target.Country() != model.DefaultCountryCode {
+			t.Fatal("invalid Country")
+		}
+	})
+
+	t.Run("Input", func(t *testing.T) {
+		if target.Input() != "quichandshake://8.8.8.8:443" {
+			t.Fatal("invalid Input")
+		}
+	})
+
+	t.Run("Options", func(t *testing.T) {
+		expect := []string{"ALPN=h3", "Repetitions=4"}
+		if diff := cmp.Diff(expect, target.Options()); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
+	t.Run("String", func(t *testing.T) {
+		if target.String() != "quichandshake://8.8.8.8:443" {
+			t.Fatal("invalid String")
+		}
+	})
+}
+
+func TestNewLoader(t *testing.T) {
+	child := &targetloading.Loader{}
+	options := &Config{}
+	loader := NewLoader(child, options).(*targetLoader)
+	if child != loader.loader {
+		t.Fatal("invalid loader pointer")
+	}
+	if options != loader.options {
+		t.Fatal("invalid options pointer")
+	}
+}
+
+func TestTargetLoaderLoad(t *testing.T) {
+	type testcase struct {
+		name          string
+		options       *Config
+		loader        *targetloading.Loader
+		expectErr     error
+		expectTargets []model.ExperimentTarget
+	}
+
+	cases := []testcase{
+		{
+			name:    "with options and inputs",
+			options: &Config{Repetitions: 3},
+			loader: &targetloading.Loader{
+				ExperimentName: "simplequicping",
+				InputPolicy:    model.InputStrictlyRequired,
+				Logger:         model.DiscardLogger,
+				Session:        &mocks.Session{},
+				StaticInputs:   []string{"quichandshake://1.1.1.1:443"},
+			},
+			expectErr: nil,
+			expectTargets: []model.ExperimentTarget{
+				&Target{
+					URL:    "quichandshake://1.1.1.1:443",
+					Config: &Config{Repetitions: 3},
+				},
+			},
+		},
+
+		{
+			name:    "per-input inputs_extra overlays the experiment-wide config",
+			options: &Config{Repetitions: 3},
+			loader: &targetloading.Loader{
+				ExperimentName: "simplequicping",
+				InputPolicy:    model.InputStrictlyRequired,
+				Logger:         model.DiscardLogger,
+				Session:        &mocks.Session{},
+				StaticInputs: []string{
+					"quichandshake://1.1.1.1:443",
+					"quichandshake://8.8.8.8:443",
+				},
+				StaticInputsConfig: []json.RawMessage{
+					json.RawMessage(`{"sni":"example.com"}`),
+					json.RawMessage(`{}`),
+				},
+			},
+			expectErr: nil,
+			expectTargets: []model.ExperimentTarget{
+				&Target{
+					URL:    "quichandshake://1.1.1.1:443",
+					Config: &Config{Repetitions: 3, SNI: "example.com"}, // overridden per-input
+				},
+				&Target{
+					URL:    "quichandshake://8.8.8.8:443",
+					Config: &Config{Repetitions: 3}, // unchanged
+				},
+			},
+		},
+
+		{
+			name:    "no input errors because input is strictly required",
+			options: &Config{},
+			loader: &targetloading.Loader{
+				ExperimentName: "simplequicping",
+				InputPolicy:    model.InputStrictlyRequired,
+				Logger:         model.DiscardLogger,
+				Session:        &mocks.Session{},
+			},
+			expectErr:     targetloading.ErrInputRequired,
+			expectTargets: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tl := &targetLoader{
+				loader:  tc.loader,
+				options: tc.options,
+			}
+			targets, err := tl.Load(context.Background())
+			if !errors.Is(err, tc.expectErr) {
+				t.Fatal("unexpected error", err)
+			}
+			if diff := cmp.Diff(tc.expectTargets, targets); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/internal/experiment/simplequicping/simplequicping.go
+++ b/internal/experiment/simplequicping/simplequicping.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	testName    = "simplequicping"
-	testVersion = "0.2.1"
+	testVersion = "0.2.2"
 )
 
 // Config contains the experiment configuration.

--- a/internal/experiment/simplequicping/simplequicping.go
+++ b/internal/experiment/simplequicping/simplequicping.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
 	"github.com/ooni/probe-cli/v3/internal/netxlite"
+	"github.com/ooni/probe-cli/v3/internal/targetloading"
 	"github.com/quic-go/quic-go"
 )
 
@@ -28,16 +29,16 @@ const (
 // Config contains the experiment configuration.
 type Config struct {
 	// ALPN allows to specify which ALPN or ALPNs to send.
-	ALPN string `ooni:"space separated list of ALPNs to use"`
+	ALPN string `json:"alpn,omitempty" ooni:"space separated list of ALPNs to use"`
 
 	// Delay is the delay between each repetition (in milliseconds).
-	Delay int64 `ooni:"number of milliseconds to wait before sending each ping"`
+	Delay int64 `json:"delay,omitempty" ooni:"number of milliseconds to wait before sending each ping"`
 
 	// Repetitions is the number of repetitions for each ping.
-	Repetitions int64 `ooni:"number of times to repeat the measurement"`
+	Repetitions int64 `json:"repetitions,omitempty" ooni:"number of times to repeat the measurement"`
 
 	// SNI is the SNI value to use.
-	SNI string `ooni:"the SNI value to use"`
+	SNI string `json:"sni,omitempty" ooni:"the SNI value to use"`
 }
 
 func (c *Config) alpn() string {
@@ -84,9 +85,7 @@ type SinglePing struct {
 }
 
 // Measurer performs the measurement.
-type Measurer struct {
-	config Config
-}
+type Measurer struct{}
 
 // ExperimentName implements ExperimentMeasurer.ExperiExperimentName.
 func (m *Measurer) ExperimentName() string {
@@ -99,6 +98,12 @@ func (m *Measurer) ExperimentVersion() string {
 }
 
 var (
+	// ErrInputRequired indicates that no richer-input target was provided.
+	ErrInputRequired = targetloading.ErrInputRequired
+
+	// ErrInvalidInputType indicates that the richer-input target has the wrong type.
+	ErrInvalidInputType = targetloading.ErrInvalidInputType
+
 	// errNoInputProvided indicates you didn't provide any input
 	errNoInputProvided = errors.New("not input provided")
 
@@ -118,10 +123,20 @@ func (m *Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	measurement := args.Measurement
 	sess := args.Session
 
-	if measurement.Input == "" {
+	// obtain the richer-input target
+	if args.Target == nil {
+		return ErrInputRequired
+	}
+	target, ok := args.Target.(*Target)
+	if !ok {
+		return ErrInvalidInputType
+	}
+	config, input := target.Config, target.URL
+
+	if input == "" {
 		return errNoInputProvided
 	}
-	parsed, err := url.Parse(string(measurement.Input))
+	parsed, err := url.Parse(input)
 	if err != nil {
 		return fmt.Errorf("%w: %s", errInputIsNotAnURL, err.Error())
 	}
@@ -134,32 +149,32 @@ func (m *Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	tk := new(TestKeys)
 	measurement.TestKeys = tk
 	out := make(chan *SinglePing)
-	go m.simpleQUICPingLoop(ctx, measurement.MeasurementStartTimeSaved, sess.Logger(), parsed.Host, out)
-	for len(tk.Pings) < int(m.config.repetitions()) {
+	go m.simpleQUICPingLoop(ctx, config, measurement.MeasurementStartTimeSaved, sess.Logger(), parsed.Host, out)
+	for len(tk.Pings) < int(config.repetitions()) {
 		tk.Pings = append(tk.Pings, <-out)
 	}
 	return nil // return nil so we always submit the measurement
 }
 
 // simpleQUICPingLoop sends all the ping requests and emits the results onto the out channel.
-func (m *Measurer) simpleQUICPingLoop(ctx context.Context, zeroTime time.Time,
+func (m *Measurer) simpleQUICPingLoop(ctx context.Context, config *Config, zeroTime time.Time,
 	logger model.Logger, address string, out chan<- *SinglePing) {
-	ticker := time.NewTicker(m.config.delay())
+	ticker := time.NewTicker(config.delay())
 	defer ticker.Stop()
-	for i := int64(0); i < m.config.repetitions(); i++ {
-		go m.simpleQUICPingAsync(ctx, i, zeroTime, logger, address, out)
+	for i := int64(0); i < config.repetitions(); i++ {
+		go m.simpleQUICPingAsync(ctx, config, i, zeroTime, logger, address, out)
 		<-ticker.C
 	}
 }
 
 // simpleQUICPingAsync performs a QUIC ping and emits the result onto the out channel.
-func (m *Measurer) simpleQUICPingAsync(ctx context.Context, index int64,
+func (m *Measurer) simpleQUICPingAsync(ctx context.Context, config *Config, index int64,
 	zeroTime time.Time, logger model.Logger, address string, out chan<- *SinglePing) {
-	out <- m.quicHandshake(ctx, index, zeroTime, logger, address)
+	out <- m.quicHandshake(ctx, config, index, zeroTime, logger, address)
 }
 
 // quicHandshake performs a QUIC handshake and returns the results of these operations to the caller.
-func (m *Measurer) quicHandshake(ctx context.Context, index int64,
+func (m *Measurer) quicHandshake(ctx context.Context, config *Config, index int64,
 	zeroTime time.Time, logger model.Logger, address string) *SinglePing {
 	// TODO(bassosimone): make the timeout user-configurable
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
@@ -168,8 +183,8 @@ func (m *Measurer) quicHandshake(ctx context.Context, index int64,
 		NetworkEvents: []*model.ArchivalNetworkEvent{},
 		QUICHandshake: nil,
 	}
-	sni := m.config.sni(address)
-	alpn := strings.Split(m.config.alpn(), " ")
+	sni := config.sni(address)
+	alpn := strings.Split(config.alpn(), " ")
 	trace := measurexlite.NewTrace(index, zeroTime)
 	ol := logx.NewOperationLogger(logger, "SimpleQUICPing #%d %s %s %v", index, address, sni, alpn)
 	netx := &netxlite.Netx{}
@@ -192,6 +207,6 @@ func (m *Measurer) quicHandshake(ctx context.Context, index int64,
 }
 
 // NewExperimentMeasurer creates a new ExperimentMeasurer.
-func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
-	return &Measurer{config: config}
+func NewExperimentMeasurer() model.ExperimentMeasurer {
+	return &Measurer{}
 }

--- a/internal/experiment/simplequicping/simplequicping_test.go
+++ b/internal/experiment/simplequicping/simplequicping_test.go
@@ -43,12 +43,7 @@ const (
 func TestMeasurerRun(t *testing.T) {
 	// runHelper is an helper function to run this set of tests.
 	runHelper := func(input string) (*model.Measurement, model.ExperimentMeasurer, error) {
-		m := NewExperimentMeasurer(Config{
-			ALPN:        "h3",
-			Delay:       1, // millisecond
-			Repetitions: NPINGS,
-			SNI:         SNI,
-		})
+		m := NewExperimentMeasurer()
 
 		if m.ExperimentName() != "simplequicping" {
 			t.Fatal("invalid experiment name")
@@ -67,6 +62,15 @@ func TestMeasurerRun(t *testing.T) {
 			Callbacks:   model.NewPrinterCallbacks(model.DiscardLogger),
 			Measurement: meas,
 			Session:     sess,
+			Target: &Target{
+				Config: &Config{
+					ALPN:        "h3",
+					Delay:       1, // millisecond
+					Repetitions: NPINGS,
+					SNI:         SNI,
+				},
+				URL: input,
+			},
 		}
 
 		err := m.Run(context.Background(), args)

--- a/internal/experiment/simplequicping/simplequicping_test.go
+++ b/internal/experiment/simplequicping/simplequicping_test.go
@@ -48,7 +48,7 @@ func TestMeasurerRun(t *testing.T) {
 		if m.ExperimentName() != "simplequicping" {
 			t.Fatal("invalid experiment name")
 		}
-		if m.ExperimentVersion() != "0.2.1" {
+		if m.ExperimentVersion() != "0.2.2" {
 			t.Fatal("invalid experiment version")
 		}
 

--- a/internal/experiment/tcpping/richerinput.go
+++ b/internal/experiment/tcpping/richerinput.go
@@ -1,0 +1,91 @@
+package tcpping
+
+import (
+	"context"
+
+	"github.com/ooni/probe-cli/v3/internal/experimentconfig"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/targetloading"
+)
+
+// Target is a richer-input target that this experiment should measure.
+type Target struct {
+	// Config contains the configuration.
+	Config *Config
+
+	// URL is the input URL.
+	URL string
+}
+
+var _ model.ExperimentTarget = &Target{}
+
+// Category implements [model.ExperimentTarget].
+func (t *Target) Category() string {
+	return model.DefaultCategoryCode
+}
+
+// Country implements [model.ExperimentTarget].
+func (t *Target) Country() string {
+	return model.DefaultCountryCode
+}
+
+// Input implements [model.ExperimentTarget].
+func (t *Target) Input() string {
+	return t.URL
+}
+
+// Options implements [model.ExperimentTarget].
+func (t *Target) Options() []string {
+	return experimentconfig.DefaultOptionsSerializer(t.Config)
+}
+
+// String implements [model.ExperimentTarget].
+func (t *Target) String() string {
+	return t.URL
+}
+
+// NewLoader constructs a new [model.ExperimentTargetLoader] instance.
+//
+// This function PANICS if options is not an instance of [*tcpping.Config].
+func NewLoader(loader *targetloading.Loader, gopts any) model.ExperimentTargetLoader {
+	// Panic if we cannot convert the options to the expected type.
+	//
+	// We do not expect a panic here because the type is managed by the registry package.
+	options := gopts.(*Config)
+
+	return &targetLoader{
+		loader:  loader,
+		options: options,
+	}
+}
+
+// targetLoader loads targets for this experiment.
+type targetLoader struct {
+	loader  *targetloading.Loader
+	options *Config
+}
+
+// Load implements model.ExperimentTargetLoader.
+func (tl *targetLoader) Load(ctx context.Context) ([]model.ExperimentTarget, error) {
+	// Load the static inputs from CLI and files.
+	inputs, err := targetloading.LoadStatic(tl.loader)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the list of targets. Each target starts from the experiment-wide
+	// config with any per-input inputs_extra overlaid on top.
+	var targets []model.ExperimentTarget
+	for i, input := range inputs {
+		targets = append(targets, &Target{
+			Config: targetloading.PerInputConfig(tl.loader, tl.options, i),
+			URL:    input,
+		})
+	}
+
+	// This experiment strictly requires input, so error out when there's none.
+	if len(targets) <= 0 {
+		return nil, ErrInputRequired
+	}
+	return targets, nil
+}

--- a/internal/experiment/tcpping/richerinput_test.go
+++ b/internal/experiment/tcpping/richerinput_test.go
@@ -1,0 +1,156 @@
+package tcpping
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/probe-cli/v3/internal/mocks"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/targetloading"
+)
+
+func TestTarget(t *testing.T) {
+	target := &Target{
+		URL: "tcpconnect://8.8.8.8:443",
+		Config: &Config{
+			Delay:       10,
+			Repetitions: 4,
+		},
+	}
+
+	t.Run("Category", func(t *testing.T) {
+		if target.Category() != model.DefaultCategoryCode {
+			t.Fatal("invalid Category")
+		}
+	})
+
+	t.Run("Country", func(t *testing.T) {
+		if target.Country() != model.DefaultCountryCode {
+			t.Fatal("invalid Country")
+		}
+	})
+
+	t.Run("Input", func(t *testing.T) {
+		if target.Input() != "tcpconnect://8.8.8.8:443" {
+			t.Fatal("invalid Input")
+		}
+	})
+
+	t.Run("Options", func(t *testing.T) {
+		expect := []string{"Delay=10", "Repetitions=4"}
+		if diff := cmp.Diff(expect, target.Options()); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
+	t.Run("String", func(t *testing.T) {
+		if target.String() != "tcpconnect://8.8.8.8:443" {
+			t.Fatal("invalid String")
+		}
+	})
+}
+
+func TestNewLoader(t *testing.T) {
+	child := &targetloading.Loader{}
+	options := &Config{}
+	loader := NewLoader(child, options).(*targetLoader)
+	if child != loader.loader {
+		t.Fatal("invalid loader pointer")
+	}
+	if options != loader.options {
+		t.Fatal("invalid options pointer")
+	}
+}
+
+func TestTargetLoaderLoad(t *testing.T) {
+	type testcase struct {
+		name          string
+		options       *Config
+		loader        *targetloading.Loader
+		expectErr     error
+		expectTargets []model.ExperimentTarget
+	}
+
+	cases := []testcase{
+		{
+			name:    "with options and inputs",
+			options: &Config{Repetitions: 3},
+			loader: &targetloading.Loader{
+				ExperimentName: "tcpping",
+				InputPolicy:    model.InputStrictlyRequired,
+				Logger:         model.DiscardLogger,
+				Session:        &mocks.Session{},
+				StaticInputs:   []string{"tcpconnect://1.1.1.1:443"},
+			},
+			expectErr: nil,
+			expectTargets: []model.ExperimentTarget{
+				&Target{
+					URL:    "tcpconnect://1.1.1.1:443",
+					Config: &Config{Repetitions: 3},
+				},
+			},
+		},
+
+		{
+			name:    "per-input inputs_extra overlays the experiment-wide config",
+			options: &Config{Repetitions: 3},
+			loader: &targetloading.Loader{
+				ExperimentName: "tcpping",
+				InputPolicy:    model.InputStrictlyRequired,
+				Logger:         model.DiscardLogger,
+				Session:        &mocks.Session{},
+				StaticInputs: []string{
+					"tcpconnect://1.1.1.1:443",
+					"tcpconnect://8.8.8.8:443",
+				},
+				StaticInputsConfig: []json.RawMessage{
+					json.RawMessage(`{"repetitions":5}`),
+					json.RawMessage(`{}`),
+				},
+			},
+			expectErr: nil,
+			expectTargets: []model.ExperimentTarget{
+				&Target{
+					URL:    "tcpconnect://1.1.1.1:443",
+					Config: &Config{Repetitions: 5}, // overridden per-input
+				},
+				&Target{
+					URL:    "tcpconnect://8.8.8.8:443",
+					Config: &Config{Repetitions: 3}, // unchanged
+				},
+			},
+		},
+
+		{
+			name:    "no input errors because input is strictly required",
+			options: &Config{},
+			loader: &targetloading.Loader{
+				ExperimentName: "tcpping",
+				InputPolicy:    model.InputStrictlyRequired,
+				Logger:         model.DiscardLogger,
+				Session:        &mocks.Session{},
+			},
+			expectErr:     targetloading.ErrInputRequired,
+			expectTargets: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tl := &targetLoader{
+				loader:  tc.loader,
+				options: tc.options,
+			}
+			targets, err := tl.Load(context.Background())
+			if !errors.Is(err, tc.expectErr) {
+				t.Fatal("unexpected error", err)
+			}
+			if diff := cmp.Diff(tc.expectTargets, targets); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/internal/experiment/tcpping/tcpping.go
+++ b/internal/experiment/tcpping/tcpping.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/targetloading"
 )
 
 const (
@@ -23,10 +24,10 @@ const (
 // Config contains the experiment configuration.
 type Config struct {
 	// Delay is the delay between each repetition (in milliseconds).
-	Delay int64 `ooni:"number of milliseconds to wait before sending each ping"`
+	Delay int64 `json:"delay,omitempty" ooni:"number of milliseconds to wait before sending each ping"`
 
 	// Repetitions is the number of repetitions for each ping.
-	Repetitions int64 `ooni:"number of times to repeat the measurement"`
+	Repetitions int64 `json:"repetitions,omitempty" ooni:"number of times to repeat the measurement"`
 }
 
 func (c *Config) delay() time.Duration {
@@ -54,9 +55,7 @@ type SinglePing struct {
 }
 
 // Measurer performs the measurement.
-type Measurer struct {
-	config Config
-}
+type Measurer struct{}
 
 // ExperimentName implements ExperimentMeasurer.ExperiExperimentName.
 func (m *Measurer) ExperimentName() string {
@@ -69,6 +68,12 @@ func (m *Measurer) ExperimentVersion() string {
 }
 
 var (
+	// ErrInputRequired indicates that no richer-input target was provided.
+	ErrInputRequired = targetloading.ErrInputRequired
+
+	// ErrInvalidInputType indicates that the richer-input target has the wrong type.
+	ErrInvalidInputType = targetloading.ErrInvalidInputType
+
 	// errNoInputProvided indicates you didn't provide any input
 	errNoInputProvided = errors.New("not input provided")
 
@@ -87,10 +92,21 @@ func (m *Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	_ = args.Callbacks
 	measurement := args.Measurement
 	sess := args.Session
-	if measurement.Input == "" {
+
+	// obtain the richer-input target
+	if args.Target == nil {
+		return ErrInputRequired
+	}
+	target, ok := args.Target.(*Target)
+	if !ok {
+		return ErrInvalidInputType
+	}
+	config, input := target.Config, target.URL
+
+	if input == "" {
 		return errNoInputProvided
 	}
-	parsed, err := url.Parse(string(measurement.Input))
+	parsed, err := url.Parse(input)
 	if err != nil {
 		return fmt.Errorf("%w: %s", errInputIsNotAnURL, err.Error())
 	}
@@ -103,19 +119,19 @@ func (m *Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	tk := new(TestKeys)
 	measurement.TestKeys = tk
 	out := make(chan *SinglePing)
-	go m.tcpPingLoop(ctx, measurement.MeasurementStartTimeSaved, sess.Logger(), parsed.Host, out)
-	for len(tk.Pings) < int(m.config.repetitions()) {
+	go m.tcpPingLoop(ctx, config, measurement.MeasurementStartTimeSaved, sess.Logger(), parsed.Host, out)
+	for len(tk.Pings) < int(config.repetitions()) {
 		tk.Pings = append(tk.Pings, <-out)
 	}
 	return nil // return nil so we always submit the measurement
 }
 
 // tcpPingLoop sends all the ping requests and emits the results onto the out channel.
-func (m *Measurer) tcpPingLoop(ctx context.Context, zeroTime time.Time,
+func (m *Measurer) tcpPingLoop(ctx context.Context, config *Config, zeroTime time.Time,
 	logger model.Logger, address string, out chan<- *SinglePing) {
-	ticker := time.NewTicker(m.config.delay())
+	ticker := time.NewTicker(config.delay())
 	defer ticker.Stop()
-	for i := int64(0); i < m.config.repetitions(); i++ {
+	for i := int64(0); i < config.repetitions(); i++ {
 		go m.tcpPingAsync(ctx, i, zeroTime, logger, address, out)
 		<-ticker.C
 	}
@@ -146,6 +162,6 @@ func (m *Measurer) tcpConnect(ctx context.Context, index int64,
 }
 
 // NewExperimentMeasurer creates a new ExperimentMeasurer.
-func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
-	return &Measurer{config: config}
+func NewExperimentMeasurer() model.ExperimentMeasurer {
+	return &Measurer{}
 }

--- a/internal/experiment/tcpping/tcpping.go
+++ b/internal/experiment/tcpping/tcpping.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	testName    = "tcpping"
-	testVersion = "0.2.0"
+	testVersion = "0.2.1"
 )
 
 // Config contains the experiment configuration.

--- a/internal/experiment/tcpping/tcpping_test.go
+++ b/internal/experiment/tcpping/tcpping_test.go
@@ -34,10 +34,7 @@ func TestMeasurer_run(t *testing.T) {
 
 	// runHelper is an helper function to run this set of tests.
 	runHelper := func(input string) (*model.Measurement, model.ExperimentMeasurer, error) {
-		m := NewExperimentMeasurer(Config{
-			Delay:       1, // millisecond
-			Repetitions: expectedPings,
-		})
+		m := NewExperimentMeasurer()
 		if m.ExperimentName() != "tcpping" {
 			t.Fatal("invalid experiment name")
 		}
@@ -56,6 +53,13 @@ func TestMeasurer_run(t *testing.T) {
 			Callbacks:   callbacks,
 			Measurement: meas,
 			Session:     sess,
+			Target: &Target{
+				Config: &Config{
+					Delay:       1, // millisecond
+					Repetitions: expectedPings,
+				},
+				URL: input,
+			},
 		}
 		err := m.Run(ctx, args)
 		return meas, m, err

--- a/internal/experiment/tcpping/tcpping_test.go
+++ b/internal/experiment/tcpping/tcpping_test.go
@@ -38,7 +38,7 @@ func TestMeasurer_run(t *testing.T) {
 		if m.ExperimentName() != "tcpping" {
 			t.Fatal("invalid experiment name")
 		}
-		if m.ExperimentVersion() != "0.2.0" {
+		if m.ExperimentVersion() != "0.2.1" {
 			t.Fatal("invalid experiment version")
 		}
 		ctx := context.Background()

--- a/internal/experiment/tlsping/richerinput.go
+++ b/internal/experiment/tlsping/richerinput.go
@@ -1,0 +1,91 @@
+package tlsping
+
+import (
+	"context"
+
+	"github.com/ooni/probe-cli/v3/internal/experimentconfig"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/targetloading"
+)
+
+// Target is a richer-input target that this experiment should measure.
+type Target struct {
+	// Config contains the configuration.
+	Config *Config
+
+	// URL is the input URL.
+	URL string
+}
+
+var _ model.ExperimentTarget = &Target{}
+
+// Category implements [model.ExperimentTarget].
+func (t *Target) Category() string {
+	return model.DefaultCategoryCode
+}
+
+// Country implements [model.ExperimentTarget].
+func (t *Target) Country() string {
+	return model.DefaultCountryCode
+}
+
+// Input implements [model.ExperimentTarget].
+func (t *Target) Input() string {
+	return t.URL
+}
+
+// Options implements [model.ExperimentTarget].
+func (t *Target) Options() []string {
+	return experimentconfig.DefaultOptionsSerializer(t.Config)
+}
+
+// String implements [model.ExperimentTarget].
+func (t *Target) String() string {
+	return t.URL
+}
+
+// NewLoader constructs a new [model.ExperimentTargetLoader] instance.
+//
+// This function PANICS if options is not an instance of [*tlsping.Config].
+func NewLoader(loader *targetloading.Loader, gopts any) model.ExperimentTargetLoader {
+	// Panic if we cannot convert the options to the expected type.
+	//
+	// We do not expect a panic here because the type is managed by the registry package.
+	options := gopts.(*Config)
+
+	return &targetLoader{
+		loader:  loader,
+		options: options,
+	}
+}
+
+// targetLoader loads targets for this experiment.
+type targetLoader struct {
+	loader  *targetloading.Loader
+	options *Config
+}
+
+// Load implements model.ExperimentTargetLoader.
+func (tl *targetLoader) Load(ctx context.Context) ([]model.ExperimentTarget, error) {
+	// Load the static inputs from CLI and files.
+	inputs, err := targetloading.LoadStatic(tl.loader)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the list of targets. Each target starts from the experiment-wide
+	// config with any per-input inputs_extra overlaid on top.
+	var targets []model.ExperimentTarget
+	for i, input := range inputs {
+		targets = append(targets, &Target{
+			Config: targetloading.PerInputConfig(tl.loader, tl.options, i),
+			URL:    input,
+		})
+	}
+
+	// This experiment strictly requires input, so error out when there's none.
+	if len(targets) <= 0 {
+		return nil, ErrInputRequired
+	}
+	return targets, nil
+}

--- a/internal/experiment/tlsping/richerinput_test.go
+++ b/internal/experiment/tlsping/richerinput_test.go
@@ -1,0 +1,156 @@
+package tlsping
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/probe-cli/v3/internal/mocks"
+	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/targetloading"
+)
+
+func TestTarget(t *testing.T) {
+	target := &Target{
+		URL: "tlshandshake://8.8.8.8:443",
+		Config: &Config{
+			ALPN:        "h2",
+			Repetitions: 4,
+		},
+	}
+
+	t.Run("Category", func(t *testing.T) {
+		if target.Category() != model.DefaultCategoryCode {
+			t.Fatal("invalid Category")
+		}
+	})
+
+	t.Run("Country", func(t *testing.T) {
+		if target.Country() != model.DefaultCountryCode {
+			t.Fatal("invalid Country")
+		}
+	})
+
+	t.Run("Input", func(t *testing.T) {
+		if target.Input() != "tlshandshake://8.8.8.8:443" {
+			t.Fatal("invalid Input")
+		}
+	})
+
+	t.Run("Options", func(t *testing.T) {
+		expect := []string{"ALPN=h2", "Repetitions=4"}
+		if diff := cmp.Diff(expect, target.Options()); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
+	t.Run("String", func(t *testing.T) {
+		if target.String() != "tlshandshake://8.8.8.8:443" {
+			t.Fatal("invalid String")
+		}
+	})
+}
+
+func TestNewLoader(t *testing.T) {
+	child := &targetloading.Loader{}
+	options := &Config{}
+	loader := NewLoader(child, options).(*targetLoader)
+	if child != loader.loader {
+		t.Fatal("invalid loader pointer")
+	}
+	if options != loader.options {
+		t.Fatal("invalid options pointer")
+	}
+}
+
+func TestTargetLoaderLoad(t *testing.T) {
+	type testcase struct {
+		name          string
+		options       *Config
+		loader        *targetloading.Loader
+		expectErr     error
+		expectTargets []model.ExperimentTarget
+	}
+
+	cases := []testcase{
+		{
+			name:    "with options and inputs",
+			options: &Config{Repetitions: 3},
+			loader: &targetloading.Loader{
+				ExperimentName: "tlsping",
+				InputPolicy:    model.InputStrictlyRequired,
+				Logger:         model.DiscardLogger,
+				Session:        &mocks.Session{},
+				StaticInputs:   []string{"tlshandshake://1.1.1.1:443"},
+			},
+			expectErr: nil,
+			expectTargets: []model.ExperimentTarget{
+				&Target{
+					URL:    "tlshandshake://1.1.1.1:443",
+					Config: &Config{Repetitions: 3},
+				},
+			},
+		},
+
+		{
+			name:    "per-input inputs_extra overlays the experiment-wide config",
+			options: &Config{Repetitions: 3},
+			loader: &targetloading.Loader{
+				ExperimentName: "tlsping",
+				InputPolicy:    model.InputStrictlyRequired,
+				Logger:         model.DiscardLogger,
+				Session:        &mocks.Session{},
+				StaticInputs: []string{
+					"tlshandshake://1.1.1.1:443",
+					"tlshandshake://8.8.8.8:443",
+				},
+				StaticInputsConfig: []json.RawMessage{
+					json.RawMessage(`{"sni":"example.com"}`),
+					json.RawMessage(`{}`),
+				},
+			},
+			expectErr: nil,
+			expectTargets: []model.ExperimentTarget{
+				&Target{
+					URL:    "tlshandshake://1.1.1.1:443",
+					Config: &Config{Repetitions: 3, SNI: "example.com"}, // overridden per-input
+				},
+				&Target{
+					URL:    "tlshandshake://8.8.8.8:443",
+					Config: &Config{Repetitions: 3}, // unchanged
+				},
+			},
+		},
+
+		{
+			name:    "no input errors because input is strictly required",
+			options: &Config{},
+			loader: &targetloading.Loader{
+				ExperimentName: "tlsping",
+				InputPolicy:    model.InputStrictlyRequired,
+				Logger:         model.DiscardLogger,
+				Session:        &mocks.Session{},
+			},
+			expectErr:     targetloading.ErrInputRequired,
+			expectTargets: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tl := &targetLoader{
+				loader:  tc.loader,
+				options: tc.options,
+			}
+			targets, err := tl.Load(context.Background())
+			if !errors.Is(err, tc.expectErr) {
+				t.Fatal("unexpected error", err)
+			}
+			if diff := cmp.Diff(tc.expectTargets, targets); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/internal/experiment/tlsping/tlsping.go
+++ b/internal/experiment/tlsping/tlsping.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	testName    = "tlsping"
-	testVersion = "0.2.1"
+	testVersion = "0.2.2"
 )
 
 // Config contains the experiment configuration.

--- a/internal/experiment/tlsping/tlsping.go
+++ b/internal/experiment/tlsping/tlsping.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ooni/probe-cli/v3/internal/logx"
 	"github.com/ooni/probe-cli/v3/internal/measurexlite"
 	"github.com/ooni/probe-cli/v3/internal/model"
+	"github.com/ooni/probe-cli/v3/internal/targetloading"
 )
 
 const (
@@ -26,16 +27,16 @@ const (
 // Config contains the experiment configuration.
 type Config struct {
 	// ALPN allows to specify which ALPN or ALPNs to send.
-	ALPN string `ooni:"space separated list of ALPNs to use"`
+	ALPN string `json:"alpn,omitempty" ooni:"space separated list of ALPNs to use"`
 
 	// Delay is the delay between each repetition (in milliseconds).
-	Delay int64 `ooni:"number of milliseconds to wait before sending each ping"`
+	Delay int64 `json:"delay,omitempty" ooni:"number of milliseconds to wait before sending each ping"`
 
 	// Repetitions is the number of repetitions for each ping.
-	Repetitions int64 `ooni:"number of times to repeat the measurement"`
+	Repetitions int64 `json:"repetitions,omitempty" ooni:"number of times to repeat the measurement"`
 
 	// SNI is the SNI value to use.
-	SNI string `ooni:"the SNI value to use"`
+	SNI string `json:"sni,omitempty" ooni:"the SNI value to use"`
 }
 
 func (c *Config) alpn() string {
@@ -83,9 +84,7 @@ type SinglePing struct {
 }
 
 // Measurer performs the measurement.
-type Measurer struct {
-	config Config
-}
+type Measurer struct{}
 
 // ExperimentName implements ExperimentMeasurer.ExperiExperimentName.
 func (m *Measurer) ExperimentName() string {
@@ -98,6 +97,12 @@ func (m *Measurer) ExperimentVersion() string {
 }
 
 var (
+	// ErrInputRequired indicates that no richer-input target was provided.
+	ErrInputRequired = targetloading.ErrInputRequired
+
+	// ErrInvalidInputType indicates that the richer-input target has the wrong type.
+	ErrInvalidInputType = targetloading.ErrInvalidInputType
+
 	// errNoInputProvided indicates you didn't provide any input
 	errNoInputProvided = errors.New("not input provided")
 
@@ -116,10 +121,21 @@ func (m *Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	_ = args.Callbacks
 	measurement := args.Measurement
 	sess := args.Session
-	if measurement.Input == "" {
+
+	// obtain the richer-input target
+	if args.Target == nil {
+		return ErrInputRequired
+	}
+	target, ok := args.Target.(*Target)
+	if !ok {
+		return ErrInvalidInputType
+	}
+	config, input := target.Config, target.URL
+
+	if input == "" {
 		return errNoInputProvided
 	}
-	parsed, err := url.Parse(string(measurement.Input))
+	parsed, err := url.Parse(input)
 	if err != nil {
 		return fmt.Errorf("%w: %s", errInputIsNotAnURL, err.Error())
 	}
@@ -132,33 +148,33 @@ func (m *Measurer) Run(ctx context.Context, args *model.ExperimentArgs) error {
 	tk := new(TestKeys)
 	measurement.TestKeys = tk
 	out := make(chan *SinglePing)
-	go m.tlsPingLoop(ctx, measurement.MeasurementStartTimeSaved, sess.Logger(), parsed.Host, out)
-	for len(tk.Pings) < int(m.config.repetitions()) {
+	go m.tlsPingLoop(ctx, config, measurement.MeasurementStartTimeSaved, sess.Logger(), parsed.Host, out)
+	for len(tk.Pings) < int(config.repetitions()) {
 		tk.Pings = append(tk.Pings, <-out)
 	}
 	return nil // return nil so we always submit the measurement
 }
 
 // tlsPingLoop sends all the ping requests and emits the results onto the out channel.
-func (m *Measurer) tlsPingLoop(ctx context.Context, zeroTime time.Time,
+func (m *Measurer) tlsPingLoop(ctx context.Context, config *Config, zeroTime time.Time,
 	logger model.Logger, address string, out chan<- *SinglePing) {
-	ticker := time.NewTicker(m.config.delay())
+	ticker := time.NewTicker(config.delay())
 	defer ticker.Stop()
-	for i := int64(0); i < m.config.repetitions(); i++ {
-		go m.tlsPingAsync(ctx, i, zeroTime, logger, address, out)
+	for i := int64(0); i < config.repetitions(); i++ {
+		go m.tlsPingAsync(ctx, config, i, zeroTime, logger, address, out)
 		<-ticker.C
 	}
 }
 
 // tlsPingAsync performs a TLS ping and emits the result onto the out channel.
-func (m *Measurer) tlsPingAsync(ctx context.Context, index int64,
+func (m *Measurer) tlsPingAsync(ctx context.Context, config *Config, index int64,
 	zeroTime time.Time, logger model.Logger, address string, out chan<- *SinglePing) {
-	out <- m.tlsConnectAndHandshake(ctx, index, zeroTime, logger, address)
+	out <- m.tlsConnectAndHandshake(ctx, config, index, zeroTime, logger, address)
 }
 
 // tlsConnectAndHandshake performs a TCP connect followed by a TLS handshake
 // and returns the results of these operations to the caller.
-func (m *Measurer) tlsConnectAndHandshake(ctx context.Context, index int64,
+func (m *Measurer) tlsConnectAndHandshake(ctx context.Context, config *Config, index int64,
 	zeroTime time.Time, logger model.Logger, address string) *SinglePing {
 	// TODO(bassosimone): make the timeout user-configurable
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
@@ -170,8 +186,8 @@ func (m *Measurer) tlsConnectAndHandshake(ctx context.Context, index int64,
 	}
 	trace := measurexlite.NewTrace(index, zeroTime)
 	dialer := trace.NewDialerWithoutResolver(logger)
-	alpn := strings.Split(m.config.alpn(), " ")
-	sni := m.config.sni(address)
+	alpn := strings.Split(config.alpn(), " ")
+	sni := config.sni(address)
 	ol := logx.NewOperationLogger(logger, "TLSPing #%d %s %s %v", index, address, sni, alpn)
 	conn, err := dialer.DialContext(ctx, "tcp", address)
 	sp.TCPConnect = trace.FirstTCPConnectOrNil() // record the first connect from the buffer
@@ -184,12 +200,12 @@ func (m *Measurer) tlsConnectAndHandshake(ctx context.Context, index int64,
 	// See https://github.com/ooni/probe/issues/2413 to understand
 	// why we're using nil to force netxlite to use the cached
 	// default Mozilla cert pool.
-	config := &tls.Config{ // #nosec G402 - we need to use a large TLS versions range for measuring
+	tlsConfig := &tls.Config{ // #nosec G402 - we need to use a large TLS versions range for measuring
 		NextProtos: alpn,
 		RootCAs:    nil,
 		ServerName: sni,
 	}
-	_, err = thx.Handshake(ctx, conn, config)
+	_, err = thx.Handshake(ctx, conn, tlsConfig)
 	ol.Stop(err)
 	sp.TLSHandshake = trace.FirstTLSHandshakeOrNil() // record the first handshake from the buffer
 	sp.NetworkEvents = trace.NetworkEvents()
@@ -197,6 +213,6 @@ func (m *Measurer) tlsConnectAndHandshake(ctx context.Context, index int64,
 }
 
 // NewExperimentMeasurer creates a new ExperimentMeasurer.
-func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
-	return &Measurer{config: config}
+func NewExperimentMeasurer() model.ExperimentMeasurer {
+	return &Measurer{}
 }

--- a/internal/experiment/tlsping/tlsping_test.go
+++ b/internal/experiment/tlsping/tlsping_test.go
@@ -48,7 +48,7 @@ func TestMeasurerRun(t *testing.T) {
 		if m.ExperimentName() != "tlsping" {
 			t.Fatal("invalid experiment name")
 		}
-		if m.ExperimentVersion() != "0.2.1" {
+		if m.ExperimentVersion() != "0.2.2" {
 			t.Fatal("invalid experiment version")
 		}
 

--- a/internal/experiment/tlsping/tlsping_test.go
+++ b/internal/experiment/tlsping/tlsping_test.go
@@ -43,12 +43,7 @@ const (
 func TestMeasurerRun(t *testing.T) {
 	// runHelper is an helper function to run this set of tests.
 	runHelper := func(ctx context.Context, input string) (*model.Measurement, model.ExperimentMeasurer, error) {
-		m := NewExperimentMeasurer(Config{
-			ALPN:        "http/1.1",
-			Delay:       1, // millisecond
-			Repetitions: NPINGS,
-			SNI:         SNI,
-		})
+		m := NewExperimentMeasurer()
 
 		if m.ExperimentName() != "tlsping" {
 			t.Fatal("invalid experiment name")
@@ -68,6 +63,15 @@ func TestMeasurerRun(t *testing.T) {
 			Callbacks:   callbacks,
 			Measurement: meas,
 			Session:     sess,
+			Target: &Target{
+				Config: &Config{
+					ALPN:        "http/1.1",
+					Delay:       1, // millisecond
+					Repetitions: NPINGS,
+					SNI:         SNI,
+				},
+				URL: input,
+			},
 		}
 
 		err := m.Run(ctx, args)

--- a/internal/registry/quicping.go
+++ b/internal/registry/quicping.go
@@ -14,14 +14,13 @@ func init() {
 	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
-				return quicping.NewExperimentMeasurer(
-					*config.(*quicping.Config),
-				)
+				return quicping.NewExperimentMeasurer()
 			},
 			canonicalName:    canonicalName,
 			config:           &quicping.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputStrictlyRequired,
+			newLoader:        quicping.NewLoader,
 		}
 	}
 }

--- a/internal/registry/simplequicping.go
+++ b/internal/registry/simplequicping.go
@@ -14,14 +14,13 @@ func init() {
 	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
-				return simplequicping.NewExperimentMeasurer(
-					*config.(*simplequicping.Config),
-				)
+				return simplequicping.NewExperimentMeasurer()
 			},
 			canonicalName:    canonicalName,
 			config:           &simplequicping.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputStrictlyRequired,
+			newLoader:        simplequicping.NewLoader,
 		}
 	}
 }

--- a/internal/registry/tcpping.go
+++ b/internal/registry/tcpping.go
@@ -14,14 +14,13 @@ func init() {
 	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
-				return tcpping.NewExperimentMeasurer(
-					*config.(*tcpping.Config),
-				)
+				return tcpping.NewExperimentMeasurer()
 			},
 			canonicalName:    canonicalName,
 			config:           &tcpping.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputStrictlyRequired,
+			newLoader:        tcpping.NewLoader,
 		}
 	}
 }

--- a/internal/registry/tlsping.go
+++ b/internal/registry/tlsping.go
@@ -14,14 +14,13 @@ func init() {
 	AllExperiments[canonicalName] = func() *Factory {
 		return &Factory{
 			build: func(config interface{}) model.ExperimentMeasurer {
-				return tlsping.NewExperimentMeasurer(
-					*config.(*tlsping.Config),
-				)
+				return tlsping.NewExperimentMeasurer()
 			},
 			canonicalName:    canonicalName,
 			config:           &tlsping.Config{},
 			enabledByDefault: true,
 			inputPolicy:      model.InputStrictlyRequired,
+			newLoader:        tlsping.NewLoader,
 		}
 	}
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/probe-cli/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe-cli/issues/1717
- [ ] if you changed anything related to how experiments work and you need to reflect these changes in the ooni/spec repository, please link to the related ooni/spec pull request: <!-- add URL here -->
- [x] if you changed code inside an experiment, make sure you bump its version number

<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->

## Description

This diff adds richer input support to several experiments as we move to supporting oonirun driven experiment based configurations to experiments in the engine. 
